### PR TITLE
fix(ci): deploy.yml passes --archive=tgz to vercel deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,12 +93,16 @@ jobs:
 
       - name: Deploy
         id: deploy
+        # --archive=tgz packs the build output into a single tarball before
+        # upload; without it Vercel rejects any deployment >15000 files
+        # (registry's prebuild + node_modules tree easily clears that). See
+        # commit 6216fc91 which applied the same flag to deploy-docs.yml.
         run: |
           set -euo pipefail
           if [ "${{ inputs.target }}" = "production" ]; then
-            URL=$(vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN")
+            URL=$(vercel deploy --prebuilt --prod --archive=tgz --token="$VERCEL_TOKEN")
           else
-            URL=$(vercel deploy --prebuilt --token="$VERCEL_TOKEN")
+            URL=$(vercel deploy --prebuilt --archive=tgz --token="$VERCEL_TOKEN")
           fi
           echo "url=$URL" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary

Adds \`--archive=tgz\` to both \`vercel deploy\` invocations in \`deploy.yml\` so manual app deploys can ship — same fix commit \`6216fc91\` applied to \`deploy-docs.yml\`.

## Why

Registry production deploy just failed on the 15k-file ceiling:

\`\`\`
Error: Invalid request: \`files\` should NOT have more than 15000 items, received 20659.
Try using \`--archive=tgz\` to limit the amount of files you upload.
\`\`\`

Every prebuilt output ships node_modules + dist + .vercel/output → easily past the threshold. Without this flag, no app deploy via this workflow can ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment configuration to improve build artifact handling and overall deployment reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ofri-peretz/eslint/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->