### PR TITLE
fix(ci): deploy.yml self-heals Vercel project config from vercel-apps.json

### DIFF
--- a/.github/vercel-apps.json
+++ b/.github/vercel-apps.json
@@ -1,19 +1,22 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema",
-  "$comment": "Map of deployable apps in this repo → their Vercel project IDs. Consumed by .github/workflows/deploy.yml. orgId is the same across all Interlace projects. projectIds are public identifiers (not secrets); only VERCEL_TOKEN is a secret.",
+  "$comment": "Map of deployable apps in this repo → their Vercel project IDs and the canonical rootDirectory each project should carry on the dashboard. Consumed by .github/workflows/deploy.yml — the workflow PATCHes the Vercel project before each deploy so the dashboard config can never drift from this file. orgId is the same across all Interlace projects. projectIds are public identifiers (not secrets); only VERCEL_TOKEN is a secret.",
   "orgId": "team_sZpUs6MAa1BKXZJY6Hq2nfnh",
   "apps": {
     "docs": {
       "projectId": "prj_DSK82D4vMaxGwSskbRLpT0fnHXps",
-      "productionUrl": "https://interlace.tools"
+      "productionUrl": "https://interlace.tools",
+      "rootDirectory": "apps/docs"
     },
     "storybook": {
       "projectId": "prj_JyWHBGJ5K3UOeBbRyNIZA6MoRGkf",
-      "productionUrl": "https://storybook.interlace.tools"
+      "productionUrl": "https://storybook.interlace.tools",
+      "rootDirectory": "apps/storybook"
     },
     "registry": {
       "projectId": "prj_veNDMyIAMCyi7fSLVo0ebphyaFoe",
-      "productionUrl": "https://ds.interlace.tools"
+      "productionUrl": "https://ds.interlace.tools",
+      "rootDirectory": "apps/registry"
     }
   }
 }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,14 +65,43 @@ jobs:
           ORG_ID=$(jq -r '.orgId' .github/vercel-apps.json)
           PROJECT_ID=$(jq -r --arg app "${{ inputs.app }}" '.apps[$app].projectId' .github/vercel-apps.json)
           PROD_URL=$(jq -r --arg app "${{ inputs.app }}" '.apps[$app].productionUrl // ""' .github/vercel-apps.json)
+          ROOT_DIR=$(jq -r --arg app "${{ inputs.app }}" '.apps[$app].rootDirectory // ""' .github/vercel-apps.json)
           if [ "$PROJECT_ID" = "null" ] || [ -z "$PROJECT_ID" ]; then
             echo "::error::No Vercel project mapped for app '${{ inputs.app }}' in .github/vercel-apps.json"
+            exit 1
+          fi
+          if [ -z "$ROOT_DIR" ]; then
+            echo "::error::No rootDirectory mapped for app '${{ inputs.app }}' in .github/vercel-apps.json"
             exit 1
           fi
           echo "VERCEL_ORG_ID=$ORG_ID" >> "$GITHUB_ENV"
           echo "VERCEL_PROJECT_ID=$PROJECT_ID" >> "$GITHUB_ENV"
           echo "PRODUCTION_URL=$PROD_URL" >> "$GITHUB_ENV"
-          echo "Resolved: $PROJECT_ID (${{ inputs.app }})"
+          echo "ROOT_DIRECTORY=$ROOT_DIR" >> "$GITHUB_ENV"
+          echo "Resolved: $PROJECT_ID rootDir=$ROOT_DIR (${{ inputs.app }})"
+
+      # Self-heal the Vercel project's dashboard config every deploy so it
+      # can't drift from vercel-apps.json. Resets rootDirectory and nulls
+      # out the Build/Output/Install Command overrides so the app's local
+      # `vercel.json` is the single source of truth for build settings.
+      #
+      # Why this exists: the registry project drifted to rootDirectory=`.`
+      # + buildCommand=`cd ../.. && npx turbo run build --filter=docs`,
+      # which made every prebuilt deploy ship docs content to the registry
+      # domain (404s on /r/*.json). Codifying the heal step here means a
+      # future drift can't break a deploy silently — the next run snaps it
+      # back to what this repo says it should be.
+      - name: Self-heal Vercel project config (rootDirectory + build cmds)
+        run: |
+          set -euo pipefail
+          curl -sf -X PATCH \
+            "https://api.vercel.com/v9/projects/${VERCEL_PROJECT_ID}?teamId=${VERCEL_ORG_ID}" \
+            -H "Authorization: Bearer ${VERCEL_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -nc --arg root "$ROOT_DIRECTORY" \
+              '{rootDirectory: $root, buildCommand: null, outputDirectory: null, installCommand: null, framework: null}')" \
+            -o /dev/null
+          echo "✓ Project config reset: rootDirectory=$ROOT_DIRECTORY, build/output/install/framework → null (use local vercel.json)"
 
       - name: Install Vercel CLI
         run: npm install --global vercel@latest


### PR DESCRIPTION
## Summary

Adds a pre-deploy step to \`deploy.yml\` that PATCHes the Vercel project to:
- \`rootDirectory\` = \`apps/<name>\` (from new \`rootDirectory\` field in \`vercel-apps.json\`)
- \`buildCommand\` / \`outputDirectory\` / \`installCommand\` / \`framework\` = \`null\` (use the app's local \`vercel.json\` / Next.js defaults)

## Why

Earlier today's registry production deploy shipped **docs content** to \`ds.interlace.tools\`, breaking \`/r/*.json\` paths (now all 404). Root cause: the Vercel project for registry had drifted on the dashboard to:

\`\`\`
rootDirectory:    .
buildCommand:     cd ../.. && npx turbo run build --filter=docs
outputDirectory:  public
\`\`\`

Dashboard overrides beat local \`vercel.json\`, so every "deploy registry" run silently shipped docs. Codifying \`.github/vercel-apps.json\` as the source of truth + having \`deploy.yml\` reset the project config every run means future drift can't break a deploy silently.

## After merge: recovery plan

Once this lands, re-run the registry deploy (\`gh workflow run deploy.yml -f app=registry -f target=production\`) and \`ds.interlace.tools/r/index.json\` should come back. Same for storybook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)