### PR TITLE
fix(storybook): vercel.json buildCommand actually builds storybook in CI

### DIFF
--- a/apps/storybook/vercel.json
+++ b/apps/storybook/vercel.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "echo 'static deploy — storybook-static/ is pre-built locally; rebuild with `npx turbo run build-storybook --filter=@interlace/storybook` then `vercel deploy --prod`'",
+  "buildCommand": "cd ../.. && npx turbo run build-storybook --filter=@interlace/storybook",
   "outputDirectory": "storybook-static",
-  "installCommand": "echo 'no install needed for static deploy'",
+  "installCommand": "cd ../.. && npm install --include=dev --no-audit --no-fund",
   "framework": null,
   "git": {
     "deploymentEnabled": {


### PR DESCRIPTION
## Summary

Replaces the placeholder \`echo\` buildCommand with a real turbo build invocation, so CI deploys can actually produce the \`storybook-static/\` output Vercel expects.

## Why

Storybook deploy via \`deploy.yml\` just failed with:

\`\`\`
Error: No Output Directory named "storybook-static" found after the Build completed.
\`\`\`

The old buildCommand was \`echo 'static deploy — rebuild locally...'\` — useful when a human ran \`npx turbo run build-storybook\` then \`vercel deploy --prod\` from a local shell, but breaks CI deploys (which go through \`vercel build\`). Same root-relative \`cd ../.. && npx turbo run …\` pattern that \`apps/registry/vercel.json\` already uses, so the project's existing CI workflow can ship storybook end-to-end.

## After merge

Re-trigger: \`gh workflow run deploy.yml -f app=storybook -f target=production\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)