### PR TITLE
fix(ci): deploy.yml uses cache-aware composite setup (was 6min npm ci)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,9 +54,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v6
+      # Composite setup: node from .nvmrc + cached node_modules + cached
+      # Turbo + cached Next.js / Storybook build artifacts. Skips `npm ci`
+      # on a node_modules cache hit (workspace lockfile didn't change).
+      # Without this the workflow was doing a cold `npm ci` for 2400+
+      # packages on every deploy (~6 minutes); with it, cache-hit runs
+      # restore in seconds and the deploy lands well under 5 min total.
+      - uses: ./.github/actions/setup
         with:
-          node-version: 24
+          next-cache: "true"
+          storybook-cache: "true"
 
       - name: Resolve Vercel project for "${{ inputs.app }}"
         id: project
@@ -109,8 +116,8 @@ jobs:
       - name: Pull Vercel environment (${{ inputs.target }})
         run: vercel pull --yes --environment=${{ inputs.target }} --token="$VERCEL_TOKEN"
 
-      - name: Install workspace dependencies
-        run: npm ci --no-audit --no-fund
+      # Workspace deps were installed (or restored from cache) by the
+      # composite setup above; no second `npm ci` here.
 
       - name: Build with Vercel
         run: |


### PR DESCRIPTION
## Why

Previous deploy.yml did a cold-cache `npm ci` for 2400+ workspace packages on every run — ~6 minutes by itself, which ate the entire 15-min job timeout and caused registry + storybook deploys to cancel mid-build.

deploy-docs.yml has been working fine because it routes through `./.github/actions/setup`, the composite action that already exists in this repo for caching node_modules / npm / turbo / next / storybook-static.

This PR just swaps the raw `actions/setup-node + npm ci` for that composite, with `next-cache` and `storybook-cache` enabled.

## After merge

Re-run docs/registry/storybook deploys; cache-hit runs should land in under 5 minutes total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)