### PR TITLE
ci(ci): drop Node 22 from ILB matrix — Node 24 is the only target

### DIFF
--- a/.github/workflows/eslint-version-matrix.yml
+++ b/.github/workflows/eslint-version-matrix.yml
@@ -72,7 +72,7 @@ jobs:
           fi
 
   matrix:
-    name: ${{ matrix.bench }} · node-${{ matrix.node }} · eslint-${{ matrix.eslint }}
+    name: ${{ matrix.bench }} · node24 · eslint-${{ matrix.eslint }}
     needs: gate
     if: needs.gate.outputs.run == 'true'
     runs-on: ubuntu-latest
@@ -80,14 +80,13 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       # Cancel sibling cells on first failure when running the cross-version
-      # matrix — when an ESLint major bumps and breaks one cell, the other
-      # 7 will almost always break the same way. Saves ~7 cells worth of
-      # runner minutes per regression. Override via workflow_dispatch if
-      # you need full results.
+      # matrix — when an ESLint major bumps and breaks one cell, every other
+      # cell will almost always break the same way. Saves runner minutes per
+      # regression. Override via workflow_dispatch if you need full results.
       fail-fast: true
       matrix:
-        node: [22, 24]
-        # All three are supported per docs/ESLINT_VERSION_SUPPORT.md:
+        # Node axis is fixed to 24 (the repo's `engines.node` and `.nvmrc`).
+        # All three ESLint majors are supported per docs/ESLINT_VERSION_SUPPORT.md:
         #   8.x = legacy active (24% share), 9.x = current default (60%),
         #   10.x = forward-looking (9%, released 2026-02-06).
         eslint: ['8.x', '9.x', '10.x']
@@ -96,12 +95,10 @@ jobs:
         include:
           # Pinned-version sanity check on the most-used minor — catches
           # regressions specific to that pin without exploding the matrix.
-          - node: 24
-            eslint: '9.39'
+          - eslint: '9.39'
             bench: arena
             experimental: false
-          - node: 24
-            eslint: '9.39'
+          - eslint: '9.39'
             bench: juliet
             experimental: false
 
@@ -110,7 +107,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: ${{ matrix.node }}
+          node-version-file: .nvmrc
           cache: npm
 
       - run: npm ci
@@ -150,6 +147,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: ilb-${{ matrix.bench }}-node${{ matrix.node }}-eslint${{ matrix.eslint }}-${{ github.run_number }}
+          name: ilb-${{ matrix.bench }}-node24-eslint${{ matrix.eslint }}-${{ github.run_number }}
           path: benchmarks/results/ilb-${{ matrix.bench }}/*.json
           retention-days: 14


### PR DESCRIPTION
## Summary

- Drops the `node: [22, 24]` axis from `.github/workflows/eslint-version-matrix.yml`. The repo's `engines.node` is `24.x`, `.nvmrc` is `24.13.0`, and every other workflow already uses `node-version-file: .nvmrc` — the cross-version matrix was the lone holdout still doubling cell count to also bench Node 22.
- Reduces base matrix from 2 × 3 × 2 = 12 cells to 1 × 3 × 2 = 6 cells (plus the 2 pinned `9.39` include rows, now stripped of their now-meaningless `node: 24` keys).
- Switches `actions/setup-node` to `node-version-file: .nvmrc` so the next Node bump only touches one file instead of N workflows.
- Updates the fail-fast comment (no more "7 sibling cells" math) and hardcodes `node24` in the job-name and artifact templates.

## Scope NOT in this PR

- Published packages' `engines.node` stays at `>=18.0.0` (24 manifests in `packages/`, `apps/`, `tools/`). Tightening those would warn consumers on Node 18/20/22 with `EBADENGINE` on install — separate decision, separate PR if/when we want it.

## Test plan

- [x] `npm run lint:workflows` — 32 workflow files pass hard checks (pre-existing SHA-pin warnings unrelated)
- [x] IDE diagnostics: zero `matrix.node` references remain — confirmed via `grep -n "matrix.node" .github/workflows/eslint-version-matrix.yml` (empty)
- [x] Pre-push lefthook gate: typecheck, build, tests, markdown-full, lockfile, changelog, shim-drift/verify all green
- [ ] CI: the matrix workflow itself only runs `on: pull_request: ready_for_review` (we're draft-or-direct here) and `schedule:` weekly — so its real validation lands on the next ready-for-review PR that touches `packages/eslint-plugin-*/**` or `benchmarks/**`. The remaining required checks on this PR (oxlint, typecheck, vitest, build, etc.) cover the workflow file's YAML correctness and the rest of the repo.

## After merge

- Next time someone bumps Node (e.g. to 26 LTS), update `.nvmrc` once and all CI follows automatically. No more per-workflow rev needed.
- If a flagship-rule regression slips through and is later traced to a Node-version-specific AST quirk, the response is to add that node version back to the matrix surgically — not to reintroduce a permanent 22+24 split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)