### PR TITLE
feat(ci): auto-deploy on main via turbo-affected dispatcher

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -1,0 +1,161 @@
+name: Auto Deploy on Main
+
+# Replaces the manual-only deploy gate for `apps/*` shipping. On every push to
+# `main`, computes which apps are turbo-affected by the new commit range and
+# dispatches the per-app production deploy workflow for each one. Existing
+# manual entry points (`deploy.yml`, `deploy-docs.yml`) are unchanged — they
+# can still be invoked via `gh workflow run` for ad-hoc redeploys / preview
+# targets.
+#
+# Why turbo-affected and not path filters: changes to `packages/ui/**` or
+# `packages/eslint-plugin-*/**` cascade into `apps/docs` via the workspace
+# dependency graph. A path filter would miss those; turbo's `...[<sha>]`
+# selector walks the graph and reports every transitive dependent.
+#
+# What is NOT in scope here:
+#
+#   - Per-branch preview deploys remain forbidden per CLAUDE.md (Vercel
+#     git-integration is intentionally NOT enabled on the canonical
+#     `interlace-landing`, `storybook-interlace-tools`, `ds-interlace-tools`
+#     projects). Previews still require an explicit `target=preview` dispatch.
+#   - Package publishes — `release.yml` owns those, fires on changesets/tags.
+#   - The `eslint` Vercel project (`prj_f5DETjxcjOCNlwYpFvH8784SLOGE` →
+#     https://eslint-one.vercel.app) is NOT in `.github/vercel-apps.json` and
+#     is not deployed here. If it should be wired, add it to vercel-apps.json
+#     first.
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: auto-deploy-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  actions: write   # required to dispatch deploy.yml / deploy-docs.yml
+
+jobs:
+  affected:
+    name: Compute turbo-affected apps
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      docs: ${{ steps.compute.outputs.docs }}
+      storybook: ${{ steps.compute.outputs.storybook }}
+      registry: ${{ steps.compute.outputs.registry }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Need history reaching the previous main commit so turbo can
+          # diff against it. `0` = full clone; for very large repos we'd
+          # tune this, but the eslint monorepo is small enough.
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup
+
+      - id: compute
+        name: Compute affected workspaces vs ${{ github.event.before }}
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+
+          # Edge cases that yield no usable diff base — deploy everything to
+          # be safe. github.event.before is all-zeros on:
+          #   - first push to a new branch (irrelevant here, gated on main)
+          #   - branch creation by force-push from elsewhere
+          # We also fall back if the SHA is unreachable (e.g. force-push
+          # rewriting history past our fetch depth).
+          if [[ -z "$BEFORE_SHA" || "$BEFORE_SHA" == "0000000000000000000000000000000000000000" ]] \
+             || ! git cat-file -e "$BEFORE_SHA^{commit}" 2>/dev/null; then
+            echo "::notice::No usable diff base (BEFORE_SHA=$BEFORE_SHA) — deploying all three apps."
+            {
+              echo "docs=true"
+              echo "storybook=true"
+              echo "registry=true"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Ask turbo which workspaces are affected. `--dry-run=json` emits
+          # one entry per (workspace × task); we collapse to unique workspace
+          # names. `...[<sha>]` selects the workspace AND every dependent.
+          AFFECTED=$(npx --no turbo run build --filter="...[$BEFORE_SHA]" --dry-run=json \
+            | jq -r '.tasks[]?.package' \
+            | sort -u)
+
+          echo "Affected workspaces:"
+          echo "$AFFECTED" | sed 's/^/  /'
+          echo
+
+          # Map workspace name → vercel-apps.json key.
+          # Keep this table in lockstep with `.github/vercel-apps.json`.
+          docs=false; storybook=false; registry=false
+          while IFS= read -r ws; do
+            case "$ws" in
+              docs)                 docs=true ;;
+              "@interlace/storybook") storybook=true ;;
+              registry)             registry=true ;;
+            esac
+          done <<< "$AFFECTED"
+
+          {
+            echo "docs=$docs"
+            echo "storybook=$storybook"
+            echo "registry=$registry"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Dispatch decisions: docs=$docs storybook=$storybook registry=$registry"
+
+  deploy-docs:
+    name: Dispatch deploy-docs.yml
+    needs: affected
+    if: needs.affected.outputs.docs == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Fire deploy-docs.yml (production)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run deploy-docs.yml \
+            --repo ofri-peretz/eslint \
+            --ref main \
+            -f environment=production \
+            -f ref=${{ github.sha }}
+
+  deploy-storybook:
+    name: Dispatch deploy.yml for storybook
+    needs: affected
+    if: needs.affected.outputs.storybook == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Fire deploy.yml (storybook → production)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run deploy.yml \
+            --repo ofri-peretz/eslint \
+            --ref main \
+            -f app=storybook \
+            -f target=production
+
+  deploy-registry:
+    name: Dispatch deploy.yml for registry
+    needs: affected
+    if: needs.affected.outputs.registry == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Fire deploy.yml (registry → production)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run deploy.yml \
+            --repo ofri-peretz/eslint \
+            --ref main \
+            -f app=registry \
+            -f target=production

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,9 +108,13 @@ apply the fix → re-confirm in the browser.
 
 Every code change goes through a PR; `git push origin main` is blocked by
 branch protection. The canonical loop is **branch → commit → push → PR →
-checks → merge → manually trigger `deploy-docs.yml`**. Unlike most projects,
-merging to `main` does **not** ship the docs site here — the deploy is a
-manual workflow that an agent must run and watch (see step 6).
+checks → merge → auto-deploy (turbo-affected) → confirm production URL is
+live**. As of 2026-05-17 (PR #123 / `feat/auto-deploy-on-main`), merges to
+`main` automatically fire the per-app production deploy for every
+turbo-affected app via [`.github/workflows/auto-deploy.yml`](.github/workflows/auto-deploy.yml).
+The manual `deploy-docs.yml` and `deploy.yml` workflows still exist for
+ad-hoc redeploys, preview targets, and emergency rollbacks — they're just
+no longer the only path.
 
 ### 1. Branch from `main`
 
@@ -224,11 +228,27 @@ gh -R ofri-peretz/eslint pr merge <#> --squash --delete-branch
 
 ### 6. Watch the auto-deploy
 
-The docs site uses the **manual** `deploy-docs.yml` flow (per
-[AGENTS.md](./AGENTS.md)); merges to `main` do **not** auto-deploy.
-After merging a docs-touching PR, surface that the manual deploy is
-still pending — don't claim "live" until you've watched the workflow
-run and confirmed at https://eslint.interlace.tools.
+Merging to `main` fires [`auto-deploy.yml`](.github/workflows/auto-deploy.yml).
+It computes turbo-affected workspaces against the previous main commit and
+dispatches the per-app deploy workflow for each affected app:
+
+| Affected workspace | Dispatched workflow | Production URL |
+|---|---|---|
+| `docs` (or any dep via `...[<sha>]`, eg `@interlace/ui`, `*PHILOSOPHY.md`) | `deploy-docs.yml` (`environment=production`, includes Playwright smoke gate) | https://interlace.tools |
+| `@interlace/storybook` (or any dep, eg `@interlace/ui`) | `deploy.yml` (`app=storybook target=production`) | https://storybook.interlace.tools |
+| `registry` (or any dep, eg `packages/ui/src/primitives/**`) | `deploy.yml` (`app=registry target=production`) | https://ds.interlace.tools |
+
+After merging, **don't claim "live"** until:
+
+1. `gh -R ofri-peretz/eslint run list --workflow=auto-deploy.yml --limit=1` shows `completed success` for the new merge commit.
+2. The dispatched per-app workflow(s) also show `completed success` —
+   `gh run list --workflow=deploy-docs.yml --limit=1` etc.
+3. The matching production URL HEADs 2xx.
+
+If `auto-deploy.yml` fires but no per-app workflow ran, no app was
+turbo-affected by the change (e.g. a PR that only touched
+`.github/workflows/**` or root-level docs). That's the expected silent
+path — confirm by checking the `affected` job summary.
 
 For packages: the relevant npm publish workflow fires on the release
 PR/tag, not the merge. Cross-check the release flow in AGENTS.md before


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/auto-deploy.yml`: on every push to `main`, computes turbo-affected workspaces against `github.event.before`, then dispatches the per-app production deploy for each affected app.
- Dispatches the **existing** `deploy-docs.yml` / `deploy.yml` workflows rather than inlining deploy logic — those already self-heal Vercel config from `vercel-apps.json` (per #113) and run Playwright smoke (per `apps/docs/e2e/deploy-smoke.spec.ts`).
- Maps workspace name → app key:
  - `docs` → `deploy-docs.yml`
  - `@interlace/storybook` → `deploy.yml app=storybook`
  - `registry` → `deploy.yml app=registry`
- Updates [CLAUDE.md "Shipping a task"](CLAUDE.md) and ["Watch the auto-deploy"](CLAUDE.md) to describe the new flow; manual workflows remain available for ad-hoc redeploys + previews.

## Why turbo-affected and not `paths:` filters

`packages/ui/**` and `packages/eslint-plugin-*/**` changes cascade into `apps/docs` via the workspace dependency graph. Path filters would miss the transitives. `--filter=...[<sha>]` walks the dep graph and picks up every dependent — verified locally:

```bash
PREV=$(git rev-parse origin/main~1)
npx --no turbo run build --filter="...[$PREV]" --dry-run=json | jq -r '.tasks[]?.package' | sort -u
```

emits `docs` plus every dependency of docs, exactly as needed.

## Why GHA-driven dispatch instead of Vercel-native deploy hooks

Vercel deploy hooks require a git-connected project. The 3 canonical projects (`interlace-landing`, `storybook-interlace-tools`, `ds-interlace-tools`) are intentionally **not** git-connected — per the existing CLAUDE.md rule "Don't enable Vercel's Git-integration preview deploys on non-main branches." Going the hooks route would require either git-connecting (breaking the no-preview rule) or adding `ignoreCommand` workarounds. GHA-driven dispatch preserves the architectural invariant.

## Test plan

- [x] `npm run lint:workflows` — 33 workflow files pass hard checks (warnings pre-existing, unrelated)
- [x] Turbo affected dry-run locally produces `docs` for the most recent merge range (PR #122 deltas)
- [x] Workspace name → app key mapping verified: `apps/docs/package.json` name=`docs`, `apps/storybook/package.json` name=`@interlace/storybook`, `apps/registry/package.json` name=`registry`
- [x] Pre-push lefthook gate green (typecheck, build, tests, markdown-full, lockfile, portability, shim-drift/verify, changelog, workflows)
- [ ] **Validates end-to-end only on merge of this PR**: the workflow's `on: push: [main]` trigger won't fire until this lands. First post-merge push will be the integration test. If it incorrectly skips all dispatches, the fallback path (all-zeros / unreachable `before` SHA) deploys all three apps — safer than silent skip.

## After merge

- Watch the run: `gh -R ofri-peretz/eslint run watch $(gh -R ofri-peretz/eslint run list --workflow=auto-deploy.yml --limit=1 --json databaseId --jq '.[0].databaseId')`
- This very PR changes only `.github/workflows/auto-deploy.yml` and `CLAUDE.md` — neither maps to any app workspace in turbo's graph. Expected behavior: `auto-deploy.yml` fires, the `affected` job runs, no per-app deploy dispatches. That's the correct silent path.

## Out of scope

- The `eslint` Vercel project (`prj_f5DETjxcjOCNlwYpFvH8784SLOGE` → https://eslint-one.vercel.app) is **not** in `.github/vercel-apps.json` and is not deployed by this workflow. If it should be a 4th canonical app, add it to `vercel-apps.json` first; the dispatcher will pick up new entries automatically (just add the case-statement arm).
- Per-branch preview deploys remain forbidden. `deploy.yml -f target=preview` is still the only sanctioned preview path.
- Package npm publishes are still owned by `release.yml`, which fires on changesets/tags — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)