### PR TITLE
chore(ci): point docs entry at canonical eslint.interlace.tools project

### DIFF
--- a/.github/vercel-apps.json
+++ b/.github/vercel-apps.json
@@ -4,8 +4,8 @@
   "orgId": "team_sZpUs6MAa1BKXZJY6Hq2nfnh",
   "apps": {
     "docs": {
-      "projectId": "prj_DSK82D4vMaxGwSskbRLpT0fnHXps",
-      "productionUrl": "https://interlace.tools",
+      "projectId": "prj_f5DETjxcjOCNlwYpFvH8784SLOGE",
+      "productionUrl": "https://eslint.interlace.tools",
       "rootDirectory": "apps/docs"
     },
     "storybook": {

--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -12,17 +12,17 @@ name: Auto Deploy on Main
 # dependency graph. A path filter would miss those; turbo's `...[<sha>]`
 # selector walks the graph and reports every transitive dependent.
 #
+# Canonical Vercel project mapping (also lives in `.github/vercel-apps.json`):
+#
+#   - docs       → `eslint`                    → https://eslint.interlace.tools
+#   - storybook  → `storybook-interlace-tools` → https://storybook.interlace.tools
+#   - registry   → `ds-interlace-tools`        → https://ds.interlace.tools
+#
 # What is NOT in scope here:
 #
-#   - Per-branch preview deploys remain forbidden per CLAUDE.md (Vercel
-#     git-integration is intentionally NOT enabled on the canonical
-#     `interlace-landing`, `storybook-interlace-tools`, `ds-interlace-tools`
-#     projects). Previews still require an explicit `target=preview` dispatch.
+#   - Per-branch preview deploys remain forbidden per CLAUDE.md. Previews
+#     still require an explicit `target=preview` dispatch.
 #   - Package publishes — `release.yml` owns those, fires on changesets/tags.
-#   - The `eslint` Vercel project (`prj_f5DETjxcjOCNlwYpFvH8784SLOGE` →
-#     https://eslint-one.vercel.app) is NOT in `.github/vercel-apps.json` and
-#     is not deployed here. If it should be wired, add it to vercel-apps.json
-#     first.
 
 on:
   push:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,7 +234,7 @@ dispatches the per-app deploy workflow for each affected app:
 
 | Affected workspace | Dispatched workflow | Production URL |
 |---|---|---|
-| `docs` (or any dep via `...[<sha>]`, eg `@interlace/ui`, `*PHILOSOPHY.md`) | `deploy-docs.yml` (`environment=production`, includes Playwright smoke gate) | https://interlace.tools |
+| `docs` (or any dep via `...[<sha>]`, eg `@interlace/ui`, `*PHILOSOPHY.md`) | `deploy-docs.yml` (`environment=production`, includes Playwright smoke gate) | https://eslint.interlace.tools |
 | `@interlace/storybook` (or any dep, eg `@interlace/ui`) | `deploy.yml` (`app=storybook target=production`) | https://storybook.interlace.tools |
 | `registry` (or any dep, eg `packages/ui/src/primitives/**`) | `deploy.yml` (`app=registry target=production`) | https://ds.interlace.tools |
 


### PR DESCRIPTION
## Summary

- `vercel-apps.json` `docs` entry was pointing at the wrong Vercel project (`interlace-landing` → `https://interlace.tools`), which actually serves the Interlace ecosystem marketing landing — a completely different site from the eslint plugin docs.
- The canonical eslint docs site lives at `https://eslint.interlace.tools`, served by the `eslint` Vercel project (`prj_f5DETjxcjOCNlwYpFvH8784SLOGE`).
- This PR aligns the metadata to reality so the docs entry deploys to the right project. Drops all references to the `eslint-one.vercel.app` Vercel vanity URL.

## Verified by header probe

Title tags revealed which project each URL hits:

| URL | Page title | Project |
|---|---|---|
| `eslint-one.vercel.app` | "ESLint Interlace - Security & Quality…" | `eslint` (vanity) |
| `eslint.interlace.tools` | "ESLint Interlace - Security & Quality…" | `eslint` (canonical) |
| `interlace.tools` | "Interlace — TypeScript-native developer tools" | `interlace-landing` (unrelated) |

## Files touched

| File | Change |
|---|---|
| `.github/vercel-apps.json` | `docs.projectId` → `prj_f5DETjxcjOCNlwYpFvH8784SLOGE`, `docs.productionUrl` → `https://eslint.interlace.tools` |
| `CLAUDE.md` | "Watch the auto-deploy" docs row URL fixed |
| `.github/workflows/auto-deploy.yml` | Removed stale "eslint project not in vercel-apps.json / out of scope" comment block; replaced with canonical project mapping table |

## Test plan

- [x] Header probe confirmed which Vercel project each URL hits (see table above)
- [x] `npm run lint:workflows` — all 33 workflows pass hard checks
- [x] Pre-push lefthook gate green (typecheck, build, tests, markdown-full, lockfile, portability, shim-drift/verify, changelog, workflows)
- [x] No code-level changes; only metadata alignment

## After merge

- This change touches only `.github/**` and `CLAUDE.md` — no workspace inputs in turbo's graph. Expected: `auto-deploy.yml` fires, computes zero affected apps, dispatches zero per-app deploys. Same correct silent path as PR #123.
- Future `gh workflow run deploy.yml -f app=docs` now targets the right project. The canonical `deploy-docs.yml` flow was already using `VERCEL_PROJECT_ID` secret (= eslint project) and is unaffected.
- ⚠ Heads up: the `eslint` Vercel project currently has `rootDirectory: .`; `vercel-apps.json` now claims `apps/docs`. The next `deploy.yml -f app=docs` invocation will self-heal the project to `apps/docs` per `deploy.yml`'s PATCH step (per #113). Verify the next docs deploy succeeds; if `--prebuilt` deploys need `.` we may have to revert rootDirectory in vercel-apps.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)