### PR TITLE
fix(storybook): default to Canvas so Controls + A11y panels are visible

### DIFF
--- a/apps/storybook/.storybook/preview.ts
+++ b/apps/storybook/.storybook/preview.ts
@@ -76,7 +76,15 @@ const preview: Preview = {
       defaultTheme: 'light',
     }),
   ],
-  tags: ['autodocs'],
+  // No global `autodocs` tag. With autodocs on, every component's sidebar
+  // entry becomes "Docs" as the default child, and the Docs view doesn't
+  // render the Controls / Actions / Interactions / Accessibility bottom
+  // panels — those are Canvas-only. Removing the tag means clicking a
+  // component takes the user straight to its first story (Canvas view)
+  // where every addon panel + populated Controls table is visible.
+  // Stories that genuinely want an auto-generated docs page can opt in
+  // per-meta via `tags: ['autodocs']`. MDX-driven docs (Welcome.mdx,
+  // tokens/ColorContrast.stories.tsx) remain unaffected.
 };
 
 export default preview;


### PR DESCRIPTION
## Summary

User report: "We see no controls, accessibility addon is not configured."

The addons were configured correctly all along (`@storybook/addon-a11y` is loaded, Controls is built into Storybook 10 core). The bug was the **default landing view**: with `tags: ['autodocs']` set globally in `preview.ts`, every component's sidebar entry expanded to a "Docs" child as the default landing. The Docs view does **not** render the Controls / Actions / Interactions / Accessibility bottom panels — those tabs are Canvas-only.

So a user clicked "RadioGroup" → landed on `/?path=/docs/primitives-radio-group--docs` → saw a story preview with a source-code dump and no panels → reported the addons as missing.

## Fix

Remove the single global `tags: ['autodocs']` line. Now:

- Each component's sidebar entry expands directly to its stories (Default / Variants / Sizes / …). No "Docs" child entry.
- Clicking a component navigates to the first story in Canvas view.
- The bottom panel shows **Controls** (populated from each story's `args` + the component's `argTypes`), **Actions**, **Interactions**, **Accessibility** — all of which already existed via `@storybook/addon-a11y` + Storybook 10 core controls.
- Stories that genuinely want an auto-generated Docs page can opt in per-meta via `tags: ['autodocs']`.
- The Welcome MDX and `tokens/ColorContrast.stories.tsx` docs are unaffected — they're MDX-driven, not autodocs-driven.

## Test plan

- [x] `npm run build-storybook` — clean
- [x] Local static serve: navigated to RadioGroup, Button — Canvas view loads, bottom panel shows Controls / Actions / Interactions / Accessibility tabs
- [x] Controls panel populated for Button (children / variant / size from `argTypes`) and shows the helpful "Interactive story playground" empty-state for RadioGroup (no args defined — expected, not a bug)
- [x] Welcome MDX still renders (`/?path=/docs/welcome--docs`)
- [ ] CI green
- [ ] Production verify: navigate to `https://storybook.interlace.tools` → click any component → Canvas + panels visible

## Known follow-up (not in this PR)

`storybook dev` (local hot-reload mode) returns `500 Missing field 'moduleType'` on `/iframe.html` requests after the Vite 7→8 + plugin-react 5→6 stack bump from PR #125. **Production storybook build + deploy is unaffected** — only the dev workflow. Likely Storybook 10.4.0 + Vite 8 indexer mismatch; fix candidates are pinning Storybook to `10.5.0-alpha.0` (next tag) or reverting Vite to 7. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)