### PR TITLE
feat(docs): default theme follows visitor's local clock

### DIFF
--- a/apps/docs/src/__tests__/theme-time-lock.test.ts
+++ b/apps/docs/src/__tests__/theme-time-lock.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Theme-Time Behavior Lock Tests
+ *
+ * Locks the time-of-day default-theme contract:
+ *   06:00–17:59 local → light
+ *   18:00–05:59 local → dark
+ *
+ * Plus the integration points (inline <head> script + ThemeTimeSync component
+ * mounted in root layout) that make the contract observable without FOUC.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { getTimeBasedTheme, THEME_TIME_INLINE_SCRIPT } from '@/lib/theme-time';
+
+describe('getTimeBasedTheme: hour boundary contract', () => {
+  const at = (hour: number, minute = 0) =>
+    new Date(2026, 4, 17, hour, minute);
+
+  it('05:59 → dark (last minute of night)', () => {
+    expect(getTimeBasedTheme(at(5, 59))).toBe('dark');
+  });
+
+  it('06:00 → light (first minute of day)', () => {
+    expect(getTimeBasedTheme(at(6, 0))).toBe('light');
+  });
+
+  it('12:00 → light (noon)', () => {
+    expect(getTimeBasedTheme(at(12))).toBe('light');
+  });
+
+  it('17:59 → light (last minute of day)', () => {
+    expect(getTimeBasedTheme(at(17, 59))).toBe('light');
+  });
+
+  it('18:00 → dark (first minute of night)', () => {
+    expect(getTimeBasedTheme(at(18, 0))).toBe('dark');
+  });
+
+  it('23:59 → dark (just before midnight)', () => {
+    expect(getTimeBasedTheme(at(23, 59))).toBe('dark');
+  });
+
+  it('00:00 → dark (midnight)', () => {
+    expect(getTimeBasedTheme(at(0, 0))).toBe('dark');
+  });
+});
+
+describe('THEME_TIME_INLINE_SCRIPT: structural contract', () => {
+  it('uses the 06:00 / 18:00 boundary', () => {
+    expect(THEME_TIME_INLINE_SCRIPT).toContain('hour >= 6 && hour < 18');
+  });
+
+  it('reads the explicit user-pick key', () => {
+    expect(THEME_TIME_INLINE_SCRIPT).toContain("'theme-user-pick'");
+  });
+
+  it('writes the next-themes storage key', () => {
+    expect(THEME_TIME_INLINE_SCRIPT).toContain("setItem('theme'");
+  });
+
+  it('applies the resolved class to <html>', () => {
+    expect(THEME_TIME_INLINE_SCRIPT).toContain('classList.add(theme)');
+  });
+
+  it('clears any pre-existing light/dark class to avoid double-mode', () => {
+    expect(THEME_TIME_INLINE_SCRIPT).toContain("classList.remove('light','dark')");
+  });
+
+  it('sets color-scheme for native form controls / scrollbars', () => {
+    expect(THEME_TIME_INLINE_SCRIPT).toContain('colorScheme');
+  });
+
+  it('is wrapped in try/catch (private mode / blocked storage)', () => {
+    expect(THEME_TIME_INLINE_SCRIPT).toContain('try');
+    expect(THEME_TIME_INLINE_SCRIPT).toContain('catch');
+  });
+});
+
+describe('THEME_TIME_INLINE_SCRIPT: executable behaviour', () => {
+  function run(hour: number, pick?: 'light' | 'dark') {
+    const store: Record<string, string> = {};
+    if (pick) store['theme-user-pick'] = pick;
+    const ls = {
+      getItem: (k: string) => (k in store ? store[k] : null),
+      setItem: (k: string, v: string) => {
+        store[k] = v;
+      },
+    };
+    const fakeDate = function () {
+      return { getHours: () => hour };
+    } as unknown as DateConstructor;
+
+    document.documentElement.className = '';
+    document.documentElement.style.colorScheme = '';
+
+    new Function('localStorage', 'Date', 'document', THEME_TIME_INLINE_SCRIPT)(
+      ls,
+      fakeDate,
+      document
+    );
+
+    return {
+      cls: document.documentElement.className,
+      colorScheme: document.documentElement.style.colorScheme,
+      stored: store['theme'],
+    };
+  }
+
+  it('08:00 with no user pick → light, persisted to next-themes key', () => {
+    const { cls, colorScheme, stored } = run(8);
+    expect(cls).toContain('light');
+    expect(colorScheme).toBe('light');
+    expect(stored).toBe('light');
+  });
+
+  it('20:00 with no user pick → dark, persisted to next-themes key', () => {
+    const { cls, colorScheme, stored } = run(20);
+    expect(cls).toContain('dark');
+    expect(colorScheme).toBe('dark');
+    expect(stored).toBe('dark');
+  });
+
+  it('22:00 with user-pick=light → light (override wins over time)', () => {
+    const { cls, stored } = run(22, 'light');
+    expect(cls).toContain('light');
+    expect(stored).toBe('light');
+  });
+
+  it('10:00 with user-pick=dark → dark (override wins over time)', () => {
+    const { cls, stored } = run(10, 'dark');
+    expect(cls).toContain('dark');
+    expect(stored).toBe('dark');
+  });
+});
+
+describe('layout.tsx: time-based theme integration', () => {
+  const layout = readFileSync(
+    join(process.cwd(), 'src/app/layout.tsx'),
+    'utf-8'
+  );
+
+  it('imports the inline script source', () => {
+    expect(layout).toContain("from '@/lib/theme-time'");
+    expect(layout).toContain('THEME_TIME_INLINE_SCRIPT');
+  });
+
+  it('embeds the inline script in <head> via dangerouslySetInnerHTML', () => {
+    expect(layout).toContain('dangerouslySetInnerHTML');
+    expect(layout).toMatch(
+      /dangerouslySetInnerHTML=\{\{\s*__html:\s*THEME_TIME_INLINE_SCRIPT\s*\}\}/
+    );
+  });
+
+  it('mounts <ThemeTimeSync /> inside <RootProvider>', () => {
+    expect(layout).toContain("from '@/components/theme-time-sync'");
+    expect(layout).toContain('<ThemeTimeSync />');
+  });
+});

--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -4,7 +4,9 @@ import { Inter } from 'next/font/google';
 import type { Metadata } from 'next';
 import { TooltipProvider } from '#interlace/components/ui/tooltip';
 import { CodeBlockLabeller } from '@/components/a11y/code-block-labeller';
+import { ThemeTimeSync } from '@/components/theme-time-sync';
 import { SITE_ORIGIN } from '@/lib/site-config';
+import { THEME_TIME_INLINE_SCRIPT } from '@/lib/theme-time';
 
 const inter = Inter({
   subsets: ['latin'],
@@ -82,6 +84,12 @@ export default function Layout({ children }: LayoutProps<'/'>) {
   return (
     <html lang="en" className={inter.className} suppressHydrationWarning>
       <head>
+        {/* Time-based default theme. Runs synchronously before next-themes
+            hydrates so the right class lands on <html> before first paint.
+            Respects an explicit user pick stored via <ThemeTimeSync />. */}
+        <script
+          dangerouslySetInnerHTML={{ __html: THEME_TIME_INLINE_SCRIPT }}
+        />
         {/* DNS prefetch for external domains - reduces lookup time */}
         <link rel="dns-prefetch" href="https://media.dev.to" />
         <link rel="dns-prefetch" href="https://dev-to-uploads.s3.amazonaws.com" />
@@ -101,9 +109,14 @@ export default function Layout({ children }: LayoutProps<'/'>) {
         >
           Skip to main content
         </a>
-        {/* Dark is the default theme — branded cosmic hero looks best on a dark
-            canvas, and the rest of the surface is AAA-tuned for near-black. */}
+        {/* Default theme is time-of-day based (see THEME_TIME_INLINE_SCRIPT in
+            src/lib/theme-time.ts): 06:00–17:59 → light, 18:00–05:59 → dark,
+            per the visitor's local clock. The `defaultTheme: 'dark'` below is
+            only the SSR fallback before the inline script runs; <ThemeTimeSync />
+            captures explicit user toggles so they override the time default on
+            subsequent visits. */}
         <RootProvider theme={{ defaultTheme: 'dark' }}>
+          <ThemeTimeSync />
           <TooltipProvider delay={250}>{children}</TooltipProvider>
           <CodeBlockLabeller />
         </RootProvider>

--- a/apps/docs/src/components/theme-time-sync.tsx
+++ b/apps/docs/src/components/theme-time-sync.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useTheme } from 'next-themes';
+
+// Records the user's explicit theme toggle so the inline time-based script in
+// <head> can stop overriding it on subsequent loads. The first observed theme
+// value belongs to the inline script (auto or already-stored pick) — only
+// changes after that count as a user action.
+export function ThemeTimeSync() {
+  const { theme } = useTheme();
+  const initialised = useRef(false);
+
+  useEffect(() => {
+    if (theme === undefined) return;
+    if (!initialised.current) {
+      initialised.current = true;
+      return;
+    }
+    if (theme === 'light' || theme === 'dark') {
+      try {
+        localStorage.setItem('theme-user-pick', theme);
+      } catch {}
+    }
+  }, [theme]);
+
+  return null;
+}

--- a/apps/docs/src/lib/theme-time.ts
+++ b/apps/docs/src/lib/theme-time.ts
@@ -1,0 +1,28 @@
+export type ResolvedTheme = 'light' | 'dark';
+
+export function getTimeBasedTheme(date: Date): ResolvedTheme {
+  const hour = date.getHours();
+  return hour >= 6 && hour < 18 ? 'light' : 'dark';
+}
+
+// Mirror of getTimeBasedTheme. Inlined into <head> so the right class lands on
+// <html> before next-themes hydrates (no FOUC). Edits MUST stay in sync with
+// the TS helper above — locked by src/__tests__/theme-time-lock.test.ts.
+export const THEME_TIME_INLINE_SCRIPT = `(function(){
+  try {
+    var ls = localStorage;
+    var pick = ls.getItem('theme-user-pick');
+    var theme;
+    if (pick === 'light' || pick === 'dark') {
+      theme = pick;
+    } else {
+      var hour = new Date().getHours();
+      theme = (hour >= 6 && hour < 18) ? 'light' : 'dark';
+    }
+    ls.setItem('theme', theme);
+    var d = document.documentElement;
+    d.classList.remove('light','dark');
+    d.classList.add(theme);
+    d.style.colorScheme = theme;
+  } catch(e){}
+})();`;


### PR DESCRIPTION
## Summary

- Replace static `defaultTheme: 'dark'` on the root `<RootProvider>` with a time-of-day default applied site-wide: **06:00–17:59 local → light, 18:00–05:59 local → dark**.
- Inline `<head>` script (`THEME_TIME_INLINE_SCRIPT`) runs synchronously **before** `next-themes` hydrates, so the right `light`/`dark` class lands on `<html>` before first paint — no FOUC, no AAA-contrast flash on the cosmic hero.
- `<ThemeTimeSync />` client component captures explicit user toggles (persists to `localStorage['theme-user-pick']`); on the next visit the inline script reads that key and skips the time-based override, so an explicit pick always wins.
- 21-assertion regression lock (`src/__tests__/theme-time-lock.test.ts`) covers the hour boundaries, the script's structural contract, executable behaviour with stubbed `localStorage` + `Date`, and the layout.tsx integration — per CLAUDE.md "Regressions are the issue. Lock everything you fix."

## Scope

The theme provider is global in this app, so this affects **every route** — home, docs, articles, scorecard, stats, play. Splitting providers per route would cause a theme flicker on client navigation; the time-of-day default is one of those things that should be globally consistent.

## What changed

| File | Lines | Role |
|---|---|---|
| `apps/docs/src/lib/theme-time.ts` | +28 | Pure helper `getTimeBasedTheme(date)` + `THEME_TIME_INLINE_SCRIPT` mirror string |
| `apps/docs/src/components/theme-time-sync.tsx` | +28 | Client component, mounted inside `<RootProvider>`, persists user toggles |
| `apps/docs/src/app/layout.tsx` | +15 / −2 | Embeds inline script in `<head>`; mounts `<ThemeTimeSync />` inside `<RootProvider>` |
| `apps/docs/src/__tests__/theme-time-lock.test.ts` | +160 | 21 lock assertions — boundaries, script contract, executable behaviour, layout integration |

No new runtime deps (`next-themes` was already in the tree via `fumadocs-ui`). CSP/headers untouched. No `next/image` `remotePatterns` changes.

## Test plan

- [x] `npm run test -w docs -- src/__tests__/theme-time-lock.test.ts` → **21/21 passing** locally
- [x] `npm run test -w docs -- src/__tests__/homepage-lock.test.tsx src/__tests__/articles-page-lock.test.tsx` → **197/197 passing** (no regression in adjacent locks)
- [x] `tsc --noEmit` clean on all four files touched
- [x] Pre-commit hook (lefthook: `stale-build-artifacts`, `shim-drift`, `tests-affected`) — green
- [x] Pre-push hook (`typecheck`, `lockfile`, `build`) — green
- [ ] CI: oxlint, Prettier, Vitest, Playwright (e2e + a11y), Build — pending on this PR
- [ ] Manual: visit at ≥18:00 local → expect dark default; visit at 06:00–17:59 → expect light default; toggle theme → reload → expect chosen theme to persist regardless of hour

## Behaviour notes

- **First-time visitor**: gets the time-based default on first paint.
- **Returning visitor who toggled before this change**: gets the time-based default once (no migration shipped); can re-toggle to lock in their preference.
- **Returning visitor who toggles after this change**: their pick is persisted to `localStorage['theme-user-pick']` and wins forever after, regardless of hour.
- **Private mode / storage blocked**: inline script's `try { … } catch` swallows the failure; falls back to whatever `next-themes`' `defaultTheme: 'dark'` provides (current behaviour).

## After merge

Auto-deploy fires for `docs` (`auto-deploy.yml` → `deploy-docs.yml`, environment=production, includes Playwright smoke gate). Production URL: https://eslint.interlace.tools. Watch for theme flicker on first navigation — that's the highest-risk regression class for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Time-based automatic theming: the app now switches between light theme during daytime (6 AM–6 PM) and dark theme at night. User manual selections persist locally and override automatic switching.

* **Tests**
  * Added test suite for time-based theme switching and persistence behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ofri-peretz/eslint/pull/128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->