### PR TITLE
fix(workspace): guard lefthook install for Vercel deploys

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "node": "24.x"
   },
   "scripts": {
-    "prepare": "lefthook install",
+    "prepare": "[ -d .git ] && lefthook install || true",
     "ci:local": "lefthook run pre-push --all-files --force",
     "lint:workflows": "tsx scripts/lint-workflows.ts",
     "lint:workflows:actionlint": "actionlint",


### PR DESCRIPTION
Vercel build env has no `.git`, so `lefthook install` 128s with "Stopping at filesystem boundary" and aborts every deploy that runs the workspace prepare script (eslint root, apps/docs, apps/registry).

Mirror the serverless repo pattern but slightly safer: guard with `[ -d .git ]` so it only runs in a real git repo. CI/Vercel: silent skip. Local devs: still installs hooks normally.

Unblocks the four eslint Vercel deploys that failed tonight after the PostHog env-var rollout (build log: `Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the installation process to gracefully handle environments where Git hooks may not be applicable, preventing unnecessary setup errors during package installation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ofri-peretz/eslint/pull/134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->