### PR TITLE
feat(workspace): npm→GitHub conversion funnel + GROWTH_PHILOSOPHY

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,23 @@
   <a href="https://www.typescriptlang.org/"><img src="https://img.shields.io/badge/TypeScript-5.9+-blue.svg" alt="TypeScript" /></a>
   <a href="https://nodejs.org/"><img src="https://img.shields.io/badge/Node.js-24+-green.svg" alt="Node.js" /></a>
   <a href="https://vitest.dev/"><img src="https://img.shields.io/badge/Vitest-4.0-6E9F18.svg" alt="Vitest" /></a>
+  <a href="https://github.com/ofri-peretz/eslint"><img src="https://img.shields.io/github/stars/ofri-peretz/eslint?style=flat&logo=github&label=Star" alt="GitHub stars" /></a>
+  <a href="https://dev.to/ofri-peretz"><img src="https://img.shields.io/badge/Dev.to-Follow-0A0A0A?logo=devdotto&logoColor=white" alt="Follow on Dev.to" /></a>
 </p>
 
 <p align="center">
 This monorepo houses battle-tested ESLint plugins, sharable configs, and supporting utilities that help teams enforce architecture, security, and consistency with actionable, LLM-friendly feedback.
+</p>
+
+<!-- INTERLACE:GROWTH_CTA -->
+<p align="center">
+  <strong>⭐ <a href="https://github.com/ofri-peretz/eslint">Star the repo</a></strong> &nbsp;·&nbsp;
+  <a href="https://github.com/ofri-peretz/eslint/subscription">👀 Watch releases</a> &nbsp;·&nbsp;
+  <a href="https://dev.to/ofri-peretz">📨 Follow the writeups</a> &nbsp;·&nbsp;
+  <a href="https://ofriperetz.dev/stats?utm_source=github&utm_medium=referral&utm_campaign=monorepo">📊 Live metrics</a>
+</p>
+<p align="center">
+  <sub>If these plugins caught a real bug for you, a star is the signal that keeps the ecosystem maintained.</sub>
 </p>
 
 ---

--- a/apps/docs/src/__tests__/growth-conversion-lock.test.ts
+++ b/apps/docs/src/__tests__/growth-conversion-lock.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Growth conversion lock — CI guardrail for GROWTH_PHILOSOPHY.md.
+ *
+ * The ecosystem runs at ~29K downloads/month against a handful of GitHub stars
+ * (see agents-repo metrics/surge-analysis-2026-05.md). The conversion funnel —
+ * npm README → GitHub star → Dev.to follow — is the highest-leverage growth
+ * surface, and per CLAUDE.md a CTA that isn't asserted by a test silently
+ * regresses the next time a baseline sync or refactor runs.
+ *
+ * This lock pins the funnel's load-bearing markers:
+ *   - the root README carries the star/follow CTA + a live GitHub-stars badge,
+ *   - every published eslint-plugin-* README carries the INTERLACE:STAR_CTA block,
+ *   - GROWTH_PHILOSOPHY.md exists and states the North Star + the landscape-framing rule.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resolve, join } from 'node:path';
+import { readFileSync, existsSync, readdirSync } from 'node:fs';
+
+const MONOREPO_ROOT = resolve(__dirname, '..', '..', '..', '..');
+const STAR_CTA_MARKER = '<!-- INTERLACE:STAR_CTA:START -->';
+
+function pluginReadmes(): string[] {
+  const packagesDir = join(MONOREPO_ROOT, 'packages');
+  return readdirSync(packagesDir, { withFileTypes: true })
+    .filter((d) => d.isDirectory() && d.name.startsWith('eslint-plugin-'))
+    .map((d) => join(packagesDir, d.name, 'README.md'))
+    .filter((p) => existsSync(p));
+}
+
+describe('growth conversion lock', () => {
+  describe('root README conversion surface', () => {
+    let readme: string;
+    it('root README exists', () => {
+      const p = join(MONOREPO_ROOT, 'README.md');
+      expect(existsSync(p)).toBe(true);
+      readme = readFileSync(p, 'utf-8');
+    });
+
+    it('carries the growth CTA block', () => {
+      expect(readme).toContain('<!-- INTERLACE:GROWTH_CTA -->');
+      expect(readme).toContain('Star the repo');
+      expect(readme).toContain('Follow the writeups');
+    });
+
+    it('shows a live GitHub-stars badge (social proof)', () => {
+      expect(readme).toContain('img.shields.io/github/stars/ofri-peretz/eslint');
+    });
+  });
+
+  describe('every eslint-plugin-* README carries the star/follow CTA', () => {
+    const readmes = pluginReadmes();
+
+    it('discovers the plugin READMEs', () => {
+      expect(readmes.length).toBeGreaterThan(15);
+    });
+
+    it.each(readmes.map((p) => [p.split('/packages/')[1], p] as const))(
+      '%s has the INTERLACE:STAR_CTA block',
+      (_label, path) => {
+        expect(readFileSync(path, 'utf-8')).toContain(STAR_CTA_MARKER);
+      },
+    );
+  });
+
+  describe('GROWTH_PHILOSOPHY.md is codified', () => {
+    const p = join(MONOREPO_ROOT, 'distribution', 'GROWTH_PHILOSOPHY.md');
+
+    it('exists', () => {
+      expect(existsSync(p)).toBe(true);
+    });
+
+    it('states the North Star and the landscape-framing rule', () => {
+      const src = readFileSync(p, 'utf-8');
+      expect(src).toContain('Convert silent adoption into visible community leadership');
+      expect(src).toContain('Landscape framing, never threat framing');
+      expect(src).toContain('download-to-star ratio');
+    });
+  });
+});

--- a/distribution/GROWTH_PHILOSOPHY.md
+++ b/distribution/GROWTH_PHILOSOPHY.md
@@ -1,0 +1,115 @@
+# GROWTH_PHILOSOPHY.md
+
+> The contract for how the Interlace ESLint ecosystem grows as an open-source
+> **brand and community leader** — for humans and agents making concurrent changes.
+> Lives in `distribution/` alongside [`STRATEGY.md`](./STRATEGY.md),
+> [`ECOSYSTEM_LANDSCAPE.md`](./ECOSYSTEM_LANDSCAPE.md), and
+> [`EVALUATION_METRICS.md`](./EVALUATION_METRICS.md). Locked by
+> `apps/docs/src/__tests__/growth-conversion-lock.test.ts`.
+
+## North Star
+
+**Convert silent adoption into visible community leadership.**
+
+Downloads prove people *run* our rules. Leadership is measured by the signals a
+community actually rallies around — **GitHub stars, Dev.to followers, contributors,
+citations, and inbound integrations**. Downloads are necessary but not sufficient;
+the brand's job is to turn the install base into visible advocates.
+
+The motivating data point (see `agents/footprint/metrics/surge-analysis-2026-05.md`):
+in May 2026 the ecosystem ran at ~29K downloads/month against **10 GitHub stars** — a
+~2,900:1 download-to-star ratio (healthy OSS sits at 50:1–500:1). The latent base
+already exists. Growth work is conversion, not acquisition.
+
+## Principles (stable IDs — cite these in PRs)
+
+- **G1 — Conversion over acquisition.** Before chasing new reach, capture the demand
+  already present. The download-to-star ratio is the headline health metric; drive it down.
+- **G2 — Every surface carries the next CTA.** An npm README must invite a GitHub star
+  and a Dev.to follow; the docs site must invite a star; an article must invite a follow.
+  No terminal surfaces. Links to **owned properties** (`*.interlace.tools`, `ofriperetz.dev`)
+  are UTM-tagged per `UTM_PHILOSOPHY.md`; links to GitHub/Dev.to are not (the conversion
+  event is measured on their side, not in PostHog).
+- **G3 — Distribution is a required publish step, not optional.** A formula-correct article
+  at ~0 views is a *distribution* failure, not a content failure. No article is "done" until
+  it has had a distribution pass (Show HN + ≥1 subreddit + an X/LinkedIn post). See the
+  distribution kit and the publishing-queue contract in the agents repo.
+- **G4 — Publish by impact, not by sequence.** The corpus is unambiguous: research /
+  benchmark / named-target-provocative pieces pull 200–1,000 views; "Getting Started"
+  tutorials average ~78 views with ~0 engagement. Tutorials are SEO-fill — never the
+  headline cadence.
+- **G5 — Honesty gate before any public number.** Download spikes must be *attributed*
+  (release re-install vs. genuine discovery) before they become a public claim. A vanity
+  "we crossed N" post that misreads release traffic as discovery damages credibility more
+  than silence. Lead with the engineering/research; let the number be supporting proof.
+- **G6 — Landscape framing, never threat framing.** In all external-facing copy use
+  *peers / the landscape / where we specialize / community leadership*. Never
+  "competitor / threat / beat / win / moat". Enforced alongside
+  `landscape-framing-lock.test.ts`. (Internally, engine portability — "rules portable,
+  runtimes commodity" — is the durable advantage; it surfaces externally as positioning,
+  not as a "moat" claim.)
+- **G7 — Engine portability stays above the fold.** Per `INTEROP_PHILOSOPHY.md`. Never
+  claim "TSC 7 compatible" or "Oxlint fully compatible" — the canonical statuses are
+  `watching` / `automated peer`.
+- **G8 — Lock every growth surface.** A CTA or social-proof element that isn't asserted by
+  a test will silently regress when a baseline sync or refactor runs. Per CLAUDE.md, the
+  fix is half-done without the lock.
+- **G9 — Domain vocabulary over generic metrics.** "Rules shipped", "OWASP coverage %",
+  "download-to-star ratio" — not "page views". Vocabulary is marketing (mirrors
+  `impact_vision`).
+- **G10 — Ratchets, not vanity peaks.** Track monotonic, provenance-backed counts over
+  time (the snapshot time-series, the impact stack). "We kept showing up" is the story;
+  one good week is not.
+
+## The conversion funnel (the contract G2 enforces)
+
+```
+search / npm  →  npm README (★ star CTA + Dev.to follow)         [G2]
+              →  GitHub repo (★ star, 👀 watch, social proof)      [G2, G8]
+              →  Dev.to (follow + writeups)                        [G3, G4]
+              →  docs site (star CTA + live metrics, UTM-tagged)   [G2]
+              →  contributor / integrator                          (the goal)
+```
+
+Each arrow is a measured step. The npm→GitHub arrow is the widest leak today (G1).
+
+## The content formula (corpus-validated)
+
+Wins: **named target + concrete number + provocative-but-true claim**, framed as
+research/value (e.g. "I Benchmarked 17 ESLint Security Plugins. Only One Found Every
+Vulnerability"). Self-critical engineering deep-dives ("a bug in our *own* rule") are
+strong on Hacker News. Flops: "Getting Started", "The X Standard", undated milestones,
+internal post-mortems without fresh data.
+
+## Channel ladder
+
+| Now (active) | Per-piece (opportunistic) | Next (build toward) |
+| --- | --- | --- |
+| Dev.to · npm · GitHub | Hacker News · Reddit | X / LinkedIn · conferences · GitHub Sponsors |
+
+Advance a channel only when the tier below is consistently executed (distribution pass
+on every publish before scaling to new channels).
+
+## Metrics
+
+- **Headline:** download-to-star ratio (drive down). Tracked in the snapshot `github` block.
+- **Conversion:** PostHog funnel events on owned-property CTAs (README→docs, docs→GitHub).
+- **Reach:** per-article views/reactions/comments and post-distribution lift.
+- All feed the Supabase impact stack as ratchets (`/ofri-impact-add`), never hand-edited.
+
+## Enforcement
+
+- `growth-conversion-lock.test.ts` — root README carries the star/follow CTA + stars badge;
+  every `eslint-plugin-*` README carries the `INTERLACE:STAR_CTA` block; this file exists
+  and states the North Star + G6 framing rule.
+- `publishing-queue.md` — distribution-mandatory + impact-ranked (agents repo).
+- `weekly-snapshots.json` — `github` block + download-to-star ratio per capture.
+
+## Non-goals (what this is NOT)
+
+- **Not a follower farm.** No engagement-bait; anti-bot limits on Dev.to (≤5 comments/hr,
+  never two sessions/day) are hard rules.
+- **Not a leaderboard.** We do not rank ourselves against peers (G6); we map a landscape.
+- **Not real-time.** Daily granularity; we optimize the trend, not the dashboard.
+- **Not growth-at-the-cost-of-trust.** No CSP/security regressions, no loosened headers,
+  no wildcard image hosts to make a CTA work (per CLAUDE.md).

--- a/packages/eslint-devkit/README.md
+++ b/packages/eslint-devkit/README.md
@@ -526,6 +526,15 @@ Contributions welcome! See CONTRIBUTING.md (planned).
 
 ---
 
+<!-- INTERLACE:STAR_CTA:START -->
+## ⭐ Support & follow
+
+If the devkit saved you time, **[star the repo](https://github.com/ofri-peretz/eslint)** — stars are the signal that keeps the Interlace ESLint ecosystem maintained — and **[follow the writeups on Dev.to](https://dev.to/ofri-peretz)** for the benchmarks and engineering behind these tools.
+
+[![GitHub stars](https://img.shields.io/github/stars/ofri-peretz/eslint?style=social)](https://github.com/ofri-peretz/eslint)
+
+<!-- INTERLACE:STAR_CTA:END -->
+
 ## Changelog
 
 See [CHANGELOG.md](./CHANGELOG.md) for a list of changes and version history.

--- a/packages/eslint-plugin-browser-security/README.md
+++ b/packages/eslint-plugin-browser-security/README.md
@@ -210,6 +210,15 @@ Part of the **Interlace ESLint Ecosystem** — AI-native security plugins with L
 | [`eslint-plugin-vercel-ai-security`](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-vercel-ai-security.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | Vercel AI SDK security hardening. |
 | [`eslint-plugin-import-next`](https://www.npmjs.com/package/eslint-plugin-import-next) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-import-next.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-import-next) | Next-gen import sorting & architecture. |
 
+<!-- INTERLACE:STAR_CTA:START -->
+## ⭐ Support & follow
+
+If this plugin caught a real bug for you, **[star the repo](https://github.com/ofri-peretz/eslint)** — stars are the signal that keeps the Interlace ESLint ecosystem maintained — and **[follow the writeups on Dev.to](https://dev.to/ofri-peretz)** for the benchmarks and security research behind these rules.
+
+[![GitHub stars](https://img.shields.io/github/stars/ofri-peretz/eslint?style=social)](https://github.com/ofri-peretz/eslint)
+
+<!-- INTERLACE:STAR_CTA:END -->
+
 ## 📄 License
 
 MIT © [Ofri Peretz](https://github.com/ofri-peretz)

--- a/packages/eslint-plugin-conventions/README.md
+++ b/packages/eslint-plugin-conventions/README.md
@@ -108,6 +108,15 @@ Part of the **Interlace ESLint Ecosystem** — AI-native security plugins with L
 | [`eslint-plugin-vercel-ai-security`](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-vercel-ai-security.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | Vercel AI SDK security hardening. |
 | [`eslint-plugin-import-next`](https://www.npmjs.com/package/eslint-plugin-import-next) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-import-next.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-import-next) | Next-gen import sorting & architecture. |
 
+<!-- INTERLACE:STAR_CTA:START -->
+## ⭐ Support & follow
+
+If this plugin caught a real bug for you, **[star the repo](https://github.com/ofri-peretz/eslint)** — stars are the signal that keeps the Interlace ESLint ecosystem maintained — and **[follow the writeups on Dev.to](https://dev.to/ofri-peretz)** for the benchmarks and security research behind these rules.
+
+[![GitHub stars](https://img.shields.io/github/stars/ofri-peretz/eslint?style=social)](https://github.com/ofri-peretz/eslint)
+
+<!-- INTERLACE:STAR_CTA:END -->
+
 ## 📄 License
 
 MIT © [Ofri Peretz](https://github.com/ofri-peretz)

--- a/packages/eslint-plugin-crypto/README.md
+++ b/packages/eslint-plugin-crypto/README.md
@@ -164,6 +164,15 @@ Part of the **Interlace ESLint Ecosystem** — AI-native security plugins with L
 | [`eslint-plugin-vercel-ai-security`](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-vercel-ai-security.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | Vercel AI SDK security hardening. |
 | [`eslint-plugin-import-next`](https://www.npmjs.com/package/eslint-plugin-import-next) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-import-next.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-import-next) | Next-gen import sorting & architecture. |
 
+<!-- INTERLACE:STAR_CTA:START -->
+## ⭐ Support & follow
+
+If this plugin caught a real bug for you, **[star the repo](https://github.com/ofri-peretz/eslint)** — stars are the signal that keeps the Interlace ESLint ecosystem maintained — and **[follow the writeups on Dev.to](https://dev.to/ofri-peretz)** for the benchmarks and security research behind these rules.
+
+[![GitHub stars](https://img.shields.io/github/stars/ofri-peretz/eslint?style=social)](https://github.com/ofri-peretz/eslint)
+
+<!-- INTERLACE:STAR_CTA:END -->
+
 ## 📄 License
 
 MIT © [Ofri Peretz](https://github.com/ofri-peretz)

--- a/packages/eslint-plugin-express-security/README.md
+++ b/packages/eslint-plugin-express-security/README.md
@@ -108,6 +108,15 @@ Part of the **Interlace ESLint Ecosystem** — AI-native security plugins with L
 | [`eslint-plugin-vercel-ai-security`](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-vercel-ai-security.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | Vercel AI SDK security hardening. |
 | [`eslint-plugin-import-next`](https://www.npmjs.com/package/eslint-plugin-import-next) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-import-next.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-import-next) | Next-gen import sorting & architecture. |
 
+<!-- INTERLACE:STAR_CTA:START -->
+## ⭐ Support & follow
+
+If this plugin caught a real bug for you, **[star the repo](https://github.com/ofri-peretz/eslint)** — stars are the signal that keeps the Interlace ESLint ecosystem maintained — and **[follow the writeups on Dev.to](https://dev.to/ofri-peretz)** for the benchmarks and security research behind these rules.
+
+[![GitHub stars](https://img.shields.io/github/stars/ofri-peretz/eslint?style=social)](https://github.com/ofri-peretz/eslint)
+
+<!-- INTERLACE:STAR_CTA:END -->
+
 ## 📄 License
 
 MIT © [Ofri Peretz](https://github.com/ofri-peretz)

--- a/packages/eslint-plugin-import-next/README.md
+++ b/packages/eslint-plugin-import-next/README.md
@@ -156,6 +156,15 @@ Part of the **Interlace ESLint Ecosystem** — AI-native security plugins with L
 | [`eslint-plugin-vercel-ai-security`](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-vercel-ai-security.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | Vercel AI SDK security hardening. |
 | [`eslint-plugin-import-next`](https://www.npmjs.com/package/eslint-plugin-import-next) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-import-next.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-import-next) | Next-gen import sorting & architecture. |
 
+<!-- INTERLACE:STAR_CTA:START -->
+## ⭐ Support & follow
+
+If this plugin caught a real bug for you, **[star the repo](https://github.com/ofri-peretz/eslint)** — stars are the signal that keeps the Interlace ESLint ecosystem maintained — and **[follow the writeups on Dev.to](https://dev.to/ofri-peretz)** for the benchmarks and security research behind these rules.
+
+[![GitHub stars](https://img.shields.io/github/stars/ofri-peretz/eslint?style=social)](https://github.com/ofri-peretz/eslint)
+
+<!-- INTERLACE:STAR_CTA:END -->
+
 ## 📄 License
 
 MIT © [Ofri Peretz](https://github.com/ofri-peretz)

--- a/packages/eslint-plugin-jwt/README.md
+++ b/packages/eslint-plugin-jwt/README.md
@@ -128,6 +128,15 @@ Part of the **Interlace ESLint Ecosystem** — AI-native security plugins with L
 | [`eslint-plugin-vercel-ai-security`](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-vercel-ai-security.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | Vercel AI SDK security hardening. |
 | [`eslint-plugin-import-next`](https://www.npmjs.com/package/eslint-plugin-import-next) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-import-next.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-import-next) | Next-gen import sorting & architecture. |
 
+<!-- INTERLACE:STAR_CTA:START -->
+## ⭐ Support & follow
+
+If this plugin caught a real bug for you, **[star the repo](https://github.com/ofri-peretz/eslint)** — stars are the signal that keeps the Interlace ESLint ecosystem maintained — and **[follow the writeups on Dev.to](https://dev.to/ofri-peretz)** for the benchmarks and security research behind these rules.
+
+[![GitHub stars](https://img.shields.io/github/stars/ofri-peretz/eslint?style=social)](https://github.com/ofri-peretz/eslint)
+
+<!-- INTERLACE:STAR_CTA:END -->
+
 ## 📄 License
 
 MIT © [Ofri Peretz](https://github.com/ofri-peretz)

--- a/packages/eslint-plugin-lambda-security/README.md
+++ b/packages/eslint-plugin-lambda-security/README.md
@@ -152,6 +152,15 @@ Part of the **Interlace ESLint Ecosystem** — AI-native security plugins with L
 | [`eslint-plugin-vercel-ai-security`](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-vercel-ai-security.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | Vercel AI SDK security hardening. |
 | [`eslint-plugin-import-next`](https://www.npmjs.com/package/eslint-plugin-import-next) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-import-next.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-import-next) | Next-gen import sorting & architecture. |
 
+<!-- INTERLACE:STAR_CTA:START -->
+## ⭐ Support & follow
+
+If this plugin caught a real bug for you, **[star the repo](https://github.com/ofri-peretz/eslint)** — stars are the signal that keeps the Interlace ESLint ecosystem maintained — and **[follow the writeups on Dev.to](https://dev.to/ofri-peretz)** for the benchmarks and security research behind these rules.
+
+[![GitHub stars](https://img.shields.io/github/stars/ofri-peretz/eslint?style=social)](https://github.com/ofri-peretz/eslint)
+
+<!-- INTERLACE:STAR_CTA:END -->
+
 ## 📄 License
 
 MIT © [Ofri Peretz](https://github.com/ofri-peretz)

--- a/packages/eslint-plugin-maintainability/README.md
+++ b/packages/eslint-plugin-maintainability/README.md
@@ -97,6 +97,15 @@ Part of the **Interlace ESLint Ecosystem** — AI-native security plugins with L
 | [`eslint-plugin-vercel-ai-security`](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-vercel-ai-security.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | Vercel AI SDK security hardening. |
 | [`eslint-plugin-import-next`](https://www.npmjs.com/package/eslint-plugin-import-next) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-import-next.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-import-next) | Next-gen import sorting & architecture. |
 
+<!-- INTERLACE:STAR_CTA:START -->
+## ⭐ Support & follow
+
+If this plugin caught a real bug for you, **[star the repo](https://github.com/ofri-peretz/eslint)** — stars are the signal that keeps the Interlace ESLint ecosystem maintained — and **[follow the writeups on Dev.to](https://dev.to/ofri-peretz)** for the benchmarks and security research behind these rules.
+
+[![GitHub stars](https://img.shields.io/github/stars/ofri-peretz/eslint?style=social)](https://github.com/ofri-peretz/eslint)
+
+<!-- INTERLACE:STAR_CTA:END -->
+
 ## 📄 License
 
 MIT © [Ofri Peretz](https://github.com/ofri-peretz)

--- a/packages/eslint-plugin-modernization/README.md
+++ b/packages/eslint-plugin-modernization/README.md
@@ -147,6 +147,15 @@ Part of the **Interlace ESLint Ecosystem** — AI-native security plugins with L
 | [`eslint-plugin-vercel-ai-security`](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-vercel-ai-security.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | Vercel AI SDK security hardening. |
 | [`eslint-plugin-import-next`](https://www.npmjs.com/package/eslint-plugin-import-next) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-import-next.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-import-next) | Next-gen import sorting & architecture. |
 
+<!-- INTERLACE:STAR_CTA:START -->
+## ⭐ Support & follow
+
+If this plugin caught a real bug for you, **[star the repo](https://github.com/ofri-peretz/eslint)** — stars are the signal that keeps the Interlace ESLint ecosystem maintained — and **[follow the writeups on Dev.to](https://dev.to/ofri-peretz)** for the benchmarks and security research behind these rules.
+
+[![GitHub stars](https://img.shields.io/github/stars/ofri-peretz/eslint?style=social)](https://github.com/ofri-peretz/eslint)
+
+<!-- INTERLACE:STAR_CTA:END -->
+
 ## 📄 License
 
 MIT © [Ofri Peretz](https://github.com/ofri-peretz)

--- a/packages/eslint-plugin-modularity/README.md
+++ b/packages/eslint-plugin-modularity/README.md
@@ -187,6 +187,15 @@ Part of the **Interlace ESLint Ecosystem** — AI-native security plugins with L
 | [`eslint-plugin-vercel-ai-security`](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-vercel-ai-security.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | Vercel AI SDK security hardening. |
 | [`eslint-plugin-import-next`](https://www.npmjs.com/package/eslint-plugin-import-next) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-import-next.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-import-next) | Next-gen import sorting & architecture. |
 
+<!-- INTERLACE:STAR_CTA:START -->
+## ⭐ Support & follow
+
+If this plugin caught a real bug for you, **[star the repo](https://github.com/ofri-peretz/eslint)** — stars are the signal that keeps the Interlace ESLint ecosystem maintained — and **[follow the writeups on Dev.to](https://dev.to/ofri-peretz)** for the benchmarks and security research behind these rules.
+
+[![GitHub stars](https://img.shields.io/github/stars/ofri-peretz/eslint?style=social)](https://github.com/ofri-peretz/eslint)
+
+<!-- INTERLACE:STAR_CTA:END -->
+
 ## 📄 License
 
 MIT © [Ofri Peretz](https://github.com/ofri-peretz)

--- a/packages/eslint-plugin-mongodb-security/README.md
+++ b/packages/eslint-plugin-mongodb-security/README.md
@@ -130,6 +130,15 @@ Part of the **Interlace ESLint Ecosystem** — AI-native security plugins with L
 | [`eslint-plugin-vercel-ai-security`](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-vercel-ai-security.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | Vercel AI SDK security hardening. |
 | [`eslint-plugin-import-next`](https://www.npmjs.com/package/eslint-plugin-import-next) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-import-next.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-import-next) | Next-gen import sorting & architecture. |
 
+<!-- INTERLACE:STAR_CTA:START -->
+## ⭐ Support & follow
+
+If this plugin caught a real bug for you, **[star the repo](https://github.com/ofri-peretz/eslint)** — stars are the signal that keeps the Interlace ESLint ecosystem maintained — and **[follow the writeups on Dev.to](https://dev.to/ofri-peretz)** for the benchmarks and security research behind these rules.
+
+[![GitHub stars](https://img.shields.io/github/stars/ofri-peretz/eslint?style=social)](https://github.com/ofri-peretz/eslint)
+
+<!-- INTERLACE:STAR_CTA:END -->
+
 ## 📄 License
 
 MIT © [Ofri Peretz](https://github.com/ofri-peretz)

--- a/packages/eslint-plugin-nestjs-security/README.md
+++ b/packages/eslint-plugin-nestjs-security/README.md
@@ -174,6 +174,15 @@ Part of the **Interlace ESLint Ecosystem** — AI-native security plugins with L
 | [`eslint-plugin-vercel-ai-security`](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-vercel-ai-security.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | Vercel AI SDK security hardening. |
 | [`eslint-plugin-import-next`](https://www.npmjs.com/package/eslint-plugin-import-next) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-import-next.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-import-next) | Next-gen import sorting & architecture. |
 
+<!-- INTERLACE:STAR_CTA:START -->
+## ⭐ Support & follow
+
+If this plugin caught a real bug for you, **[star the repo](https://github.com/ofri-peretz/eslint)** — stars are the signal that keeps the Interlace ESLint ecosystem maintained — and **[follow the writeups on Dev.to](https://dev.to/ofri-peretz)** for the benchmarks and security research behind these rules.
+
+[![GitHub stars](https://img.shields.io/github/stars/ofri-peretz/eslint?style=social)](https://github.com/ofri-peretz/eslint)
+
+<!-- INTERLACE:STAR_CTA:END -->
+
 ## 📄 License
 
 MIT © [Ofri Peretz](https://github.com/ofri-peretz)

--- a/packages/eslint-plugin-node-security/README.md
+++ b/packages/eslint-plugin-node-security/README.md
@@ -129,6 +129,15 @@ Part of the **Interlace ESLint Ecosystem** — AI-native security plugins with L
 | [`eslint-plugin-vercel-ai-security`](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-vercel-ai-security.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | Vercel AI SDK security hardening. |
 | [`eslint-plugin-import-next`](https://www.npmjs.com/package/eslint-plugin-import-next) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-import-next.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-import-next) | Next-gen import sorting & architecture. |
 
+<!-- INTERLACE:STAR_CTA:START -->
+## ⭐ Support & follow
+
+If this plugin caught a real bug for you, **[star the repo](https://github.com/ofri-peretz/eslint)** — stars are the signal that keeps the Interlace ESLint ecosystem maintained — and **[follow the writeups on Dev.to](https://dev.to/ofri-peretz)** for the benchmarks and security research behind these rules.
+
+[![GitHub stars](https://img.shields.io/github/stars/ofri-peretz/eslint?style=social)](https://github.com/ofri-peretz/eslint)
+
+<!-- INTERLACE:STAR_CTA:END -->
+
 ## 📄 License
 
 MIT © [Ofri Peretz](https://github.com/ofri-peretz)

--- a/packages/eslint-plugin-operability/README.md
+++ b/packages/eslint-plugin-operability/README.md
@@ -167,6 +167,15 @@ Part of the **Interlace ESLint Ecosystem** — AI-native security plugins with L
 | [`eslint-plugin-vercel-ai-security`](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-vercel-ai-security.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | Vercel AI SDK security hardening. |
 | [`eslint-plugin-import-next`](https://www.npmjs.com/package/eslint-plugin-import-next) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-import-next.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-import-next) | Next-gen import sorting & architecture. |
 
+<!-- INTERLACE:STAR_CTA:START -->
+## ⭐ Support & follow
+
+If this plugin caught a real bug for you, **[star the repo](https://github.com/ofri-peretz/eslint)** — stars are the signal that keeps the Interlace ESLint ecosystem maintained — and **[follow the writeups on Dev.to](https://dev.to/ofri-peretz)** for the benchmarks and security research behind these rules.
+
+[![GitHub stars](https://img.shields.io/github/stars/ofri-peretz/eslint?style=social)](https://github.com/ofri-peretz/eslint)
+
+<!-- INTERLACE:STAR_CTA:END -->
+
 ## 📄 License
 
 MIT © [Ofri Peretz](https://github.com/ofri-peretz)

--- a/packages/eslint-plugin-pg/README.md
+++ b/packages/eslint-plugin-pg/README.md
@@ -135,6 +135,15 @@ Part of the **Interlace ESLint Ecosystem** — AI-native security plugins with L
 | [`eslint-plugin-vercel-ai-security`](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-vercel-ai-security.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | Vercel AI SDK security hardening. |
 | [`eslint-plugin-import-next`](https://www.npmjs.com/package/eslint-plugin-import-next) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-import-next.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-import-next) | Next-gen import sorting & architecture. |
 
+<!-- INTERLACE:STAR_CTA:START -->
+## ⭐ Support & follow
+
+If this plugin caught a real bug for you, **[star the repo](https://github.com/ofri-peretz/eslint)** — stars are the signal that keeps the Interlace ESLint ecosystem maintained — and **[follow the writeups on Dev.to](https://dev.to/ofri-peretz)** for the benchmarks and security research behind these rules.
+
+[![GitHub stars](https://img.shields.io/github/stars/ofri-peretz/eslint?style=social)](https://github.com/ofri-peretz/eslint)
+
+<!-- INTERLACE:STAR_CTA:END -->
+
 ## 📄 License
 
 MIT © [Ofri Peretz](https://github.com/ofri-peretz)

--- a/packages/eslint-plugin-react-a11y/README.md
+++ b/packages/eslint-plugin-react-a11y/README.md
@@ -195,6 +195,15 @@ Part of the **Interlace ESLint Ecosystem** — AI-native security plugins with L
 | [`eslint-plugin-vercel-ai-security`](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-vercel-ai-security.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | Vercel AI SDK security hardening. |
 | [`eslint-plugin-import-next`](https://www.npmjs.com/package/eslint-plugin-import-next) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-import-next.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-import-next) | Next-gen import sorting & architecture. |
 
+<!-- INTERLACE:STAR_CTA:START -->
+## ⭐ Support & follow
+
+If this plugin caught a real bug for you, **[star the repo](https://github.com/ofri-peretz/eslint)** — stars are the signal that keeps the Interlace ESLint ecosystem maintained — and **[follow the writeups on Dev.to](https://dev.to/ofri-peretz)** for the benchmarks and security research behind these rules.
+
+[![GitHub stars](https://img.shields.io/github/stars/ofri-peretz/eslint?style=social)](https://github.com/ofri-peretz/eslint)
+
+<!-- INTERLACE:STAR_CTA:END -->
+
 ## 📄 License
 
 MIT © [Ofri Peretz](https://github.com/ofri-peretz)

--- a/packages/eslint-plugin-react-features/README.md
+++ b/packages/eslint-plugin-react-features/README.md
@@ -138,6 +138,15 @@ Part of the **Interlace ESLint Ecosystem** — AI-native security plugins with L
 | [`eslint-plugin-vercel-ai-security`](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-vercel-ai-security.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | Vercel AI SDK security hardening. |
 | [`eslint-plugin-import-next`](https://www.npmjs.com/package/eslint-plugin-import-next) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-import-next.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-import-next) | Next-gen import sorting & architecture. |
 
+<!-- INTERLACE:STAR_CTA:START -->
+## ⭐ Support & follow
+
+If this plugin caught a real bug for you, **[star the repo](https://github.com/ofri-peretz/eslint)** — stars are the signal that keeps the Interlace ESLint ecosystem maintained — and **[follow the writeups on Dev.to](https://dev.to/ofri-peretz)** for the benchmarks and security research behind these rules.
+
+[![GitHub stars](https://img.shields.io/github/stars/ofri-peretz/eslint?style=social)](https://github.com/ofri-peretz/eslint)
+
+<!-- INTERLACE:STAR_CTA:END -->
+
 ## 📄 License
 
 MIT © [Ofri Peretz](https://github.com/ofri-peretz)

--- a/packages/eslint-plugin-reliability/README.md
+++ b/packages/eslint-plugin-reliability/README.md
@@ -179,6 +179,15 @@ Part of the **Interlace ESLint Ecosystem** — AI-native security plugins with L
 | [`eslint-plugin-vercel-ai-security`](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-vercel-ai-security.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | Vercel AI SDK security hardening. |
 | [`eslint-plugin-import-next`](https://www.npmjs.com/package/eslint-plugin-import-next) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-import-next.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-import-next) | Next-gen import sorting & architecture. |
 
+<!-- INTERLACE:STAR_CTA:START -->
+## ⭐ Support & follow
+
+If this plugin caught a real bug for you, **[star the repo](https://github.com/ofri-peretz/eslint)** — stars are the signal that keeps the Interlace ESLint ecosystem maintained — and **[follow the writeups on Dev.to](https://dev.to/ofri-peretz)** for the benchmarks and security research behind these rules.
+
+[![GitHub stars](https://img.shields.io/github/stars/ofri-peretz/eslint?style=social)](https://github.com/ofri-peretz/eslint)
+
+<!-- INTERLACE:STAR_CTA:END -->
+
 ## 📄 License
 
 MIT © [Ofri Peretz](https://github.com/ofri-peretz)

--- a/packages/eslint-plugin-secure-coding/README.md
+++ b/packages/eslint-plugin-secure-coding/README.md
@@ -129,6 +129,15 @@ Part of the **Interlace ESLint Ecosystem** — AI-native security plugins with L
 | [`eslint-plugin-vercel-ai-security`](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-vercel-ai-security.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | Vercel AI SDK security hardening. |
 | [`eslint-plugin-import-next`](https://www.npmjs.com/package/eslint-plugin-import-next) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-import-next.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-import-next) | Next-gen import sorting & architecture. |
 
+<!-- INTERLACE:STAR_CTA:START -->
+## ⭐ Support & follow
+
+If this plugin caught a real bug for you, **[star the repo](https://github.com/ofri-peretz/eslint)** — stars are the signal that keeps the Interlace ESLint ecosystem maintained — and **[follow the writeups on Dev.to](https://dev.to/ofri-peretz)** for the benchmarks and security research behind these rules.
+
+[![GitHub stars](https://img.shields.io/github/stars/ofri-peretz/eslint?style=social)](https://github.com/ofri-peretz/eslint)
+
+<!-- INTERLACE:STAR_CTA:END -->
+
 ## 📄 License
 
 MIT © [Ofri Peretz](https://github.com/ofri-peretz)

--- a/packages/eslint-plugin-vercel-ai-security/README.md
+++ b/packages/eslint-plugin-vercel-ai-security/README.md
@@ -160,6 +160,15 @@ Part of the **Interlace ESLint Ecosystem** — AI-native security plugins with L
 | [`eslint-plugin-vercel-ai-security`](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-vercel-ai-security.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) | Vercel AI SDK security hardening. |
 | [`eslint-plugin-import-next`](https://www.npmjs.com/package/eslint-plugin-import-next) | [![downloads](https://img.shields.io/npm/dt/eslint-plugin-import-next.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-import-next) | Next-gen import sorting & architecture. |
 
+<!-- INTERLACE:STAR_CTA:START -->
+## ⭐ Support & follow
+
+If this plugin caught a real bug for you, **[star the repo](https://github.com/ofri-peretz/eslint)** — stars are the signal that keeps the Interlace ESLint ecosystem maintained — and **[follow the writeups on Dev.to](https://dev.to/ofri-peretz)** for the benchmarks and security research behind these rules.
+
+[![GitHub stars](https://img.shields.io/github/stars/ofri-peretz/eslint?style=social)](https://github.com/ofri-peretz/eslint)
+
+<!-- INTERLACE:STAR_CTA:END -->
+
 ## 📄 License
 
 MIT © [Ofri Peretz](https://github.com/ofri-peretz)


### PR DESCRIPTION
## Summary

The growth half that ships as code. A live analytics review found the loudest signal in the dataset: **~29K downloads/month against 10 GitHub stars** (~2,900:1; healthy OSS is 50:1–500:1). Silent adoption isn't converting into visible community-leadership signals. This wires the npm→GitHub→Dev.to conversion funnel and codifies the strategy.

- **Root `README.md`** — star/follow CTA block (`<!-- INTERLACE:GROWTH_CTA -->`) + a live GitHub-stars badge + a Dev.to follow badge in the badge row.
- **20 `eslint-plugin-*` READMEs + `@interlace/eslint-devkit`** — a marker-wrapped `INTERLACE:STAR_CTA` block (⭐ star the repo + follow on Dev.to) inserted before the `## 📄 License` anchor. Purely additive — keeps every required section, so `check-readme-structure` and `plugin-readme-description-lock` stay green.
- **`distribution/GROWTH_PHILOSOPHY.md`** — codifies the North Star (*convert silent adoption into visible community leadership*), the funnel contract, the corpus-validated content formula, the channel ladder, and the landscape-not-threat framing (G1–G10). Placed in `distribution/` (with `STRATEGY.md` / `ECOSYSTEM_LANDSCAPE.md`), **not** repo root, so it isn't swept into the design `sync-philosophies` projection.
- **`growth-conversion-lock.test.ts`** — pins the root CTA + stars badge, the `STAR_CTA` block in every plugin README, and the philosophy doc's North Star + framing rule. Per CLAUDE.md a growth surface without a lock silently regresses on the next baseline sync.

## Test plan

- [x] `prettier --check` passes on all 24 changed files (run via the repo's own binary).
- [x] Verified the lock-asserted markers exist in every target file (root README, 21 package READMEs, philosophy doc).
- [x] Confirmed additive-safety against the two README gates (`plugin-template-conformance` validates docs pages, not READMEs; `plugin-readme-description-lock` only checks the Description line + forbids one fallback string — neither touched).
- [ ] CI (oxlint / prettier / tsc / vitest / playwright / build) — watching on this PR.

## After merge

- The 3 supporting-tool READMEs (`eslint-config-interlace`, `eslint-formatter`, `eslint-formatter-sarif`) and the **baseline template** (`agents/interlace/package-baseline/readme-template/README.md.tpl`) still need the same CTA so a future baseline sync doesn't strip it — best done via the `interlace-baseline` skill. Until then the lock test guards drift on the eslint side.
- Owner actions tracked separately: docs-site hero star CTA (extend `homepage-lock`), PostHog funnel events, enable GitHub Sponsors.
- Adding a `*PHILOSOPHY.md` under `distribution/` may mark docs turbo-affected → docs deploy on merge (expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)