### PR TITLE
feat(conventions): no-magic-numbers — extract-const suggestion fixer

### DIFF
--- a/.changeset/no-magic-numbers-suggestion.md
+++ b/.changeset/no-magic-numbers-suggestion.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-conventions": patch
+---
+
+`no-magic-numbers`: add extract-const suggestion fixer. IDEs now offer a one-click "Extract to named constant" action that inserts a `const MAGIC_<value>` declaration before the containing statement and replaces the literal.

--- a/packages/eslint-plugin-conventions/src/rules/conventions/no-magic-numbers.ts
+++ b/packages/eslint-plugin-conventions/src/rules/conventions/no-magic-numbers.ts
@@ -22,7 +22,7 @@ import type { TSESTree, TSESLint } from '@interlace/eslint-devkit';
 import { createRule } from '@interlace/eslint-devkit';
 import { formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
 
-type MessageIds = 'noMagicNumber';
+type MessageIds = 'noMagicNumber' | 'extractConst';
 
 export interface Options {
   /**
@@ -49,6 +49,32 @@ type RuleOptions = [Options?];
 /** Numbers that are universally idiomatic in JS/TS and need no naming. */
 const DEFAULT_IGNORE = new Set<number>([-1, 0, 1, 2]);
 
+/** Build a SCREAMING_SNAKE_CASE const name from a numeric value. */
+function constNameFor(value: number): string {
+  // e.g. 5000 → MAGIC_5000 · -3 → MAGIC_NEG_3 · 1.5 → MAGIC_1_5
+  const prefix = value < 0 ? 'MAGIC_NEG_' : 'MAGIC_';
+  const digits = String(Math.abs(value)).replace('.', '_');
+  return `${prefix}${digits}`;
+}
+
+/**
+ * Walk up the AST to find the nearest statement ancestor that can be used
+ * as the insertion point for a const declaration.
+ */
+function nearestStatement(node: TSESTree.Node): TSESTree.Statement | null {
+  const STATEMENT_TYPES = new Set([
+    'ExpressionStatement', 'VariableDeclaration', 'ReturnStatement',
+    'IfStatement', 'WhileStatement', 'ForStatement', 'ForInStatement',
+    'ForOfStatement', 'ThrowStatement', 'SwitchStatement',
+  ]);
+  let current: TSESTree.Node | undefined = (node as TSESTree.Node & { parent?: TSESTree.Node }).parent;
+  while (current) {
+    if (STATEMENT_TYPES.has(current.type)) return current as TSESTree.Statement;
+    current = (current as TSESTree.Node & { parent?: TSESTree.Node }).parent;
+  }
+  return null;
+}
+
 export const noMagicNumbers = createRule<RuleOptions, MessageIds>({
   name: 'no-magic-numbers',
   meta: {
@@ -58,6 +84,7 @@ export const noMagicNumbers = createRule<RuleOptions, MessageIds>({
       description:
         'Disallow magic numbers (numeric literals without a named constant)',
     },
+    hasSuggestions: true,
     messages: {
       noMagicNumber: formatLLMMessage({
         icon: MessageIcons.INFO,
@@ -68,6 +95,7 @@ export const noMagicNumbers = createRule<RuleOptions, MessageIds>({
         fix: 'const TIMEOUT_MS = {{value}}; // use the named constant everywhere',
         documentationLink: 'https://refactoring.guru/replace-magic-literal',
       }),
+      extractConst: 'Extract {{value}} to a named constant ({{constName}})',
     },
     schema: [
       {
@@ -199,10 +227,32 @@ export const noMagicNumbers = createRule<RuleOptions, MessageIds>({
         if (isBitwiseContext(node)) return;
         if (isPropertyKey(node)) return;
 
+        const constName = constNameFor(value);
+        const sourceCode = context.sourceCode;
+
         context.report({
           node,
           messageId: 'noMagicNumber',
           data: { value: String(value) },
+          suggest: [
+            {
+              messageId: 'extractConst',
+              data: { value: String(value), constName },
+              fix(fixer) {
+                const stmt = nearestStatement(node);
+                if (!stmt) return null;
+                // Determine indentation from the statement's first token.
+                const firstToken = sourceCode.getFirstToken(stmt);
+                if (!firstToken) return null;
+                const col = firstToken.loc.start.column;
+                const indent = ' '.repeat(col);
+                return [
+                  fixer.insertTextBefore(stmt, `const ${constName} = ${value};\n${indent}`),
+                  fixer.replaceText(node, constName),
+                ];
+              },
+            },
+          ],
         });
       },
     };

--- a/packages/eslint-plugin-conventions/src/tests/conventions/no-magic-numbers.test.ts
+++ b/packages/eslint-plugin-conventions/src/tests/conventions/no-magic-numbers.test.ts
@@ -38,22 +38,22 @@ describe('no-magic-numbers', () => {
     invalid: [
       {
         code: 'setTimeout(cb, 5000);',
-        errors: [{ messageId: 'noMagicNumber' }],
+        errors: [{ messageId: 'noMagicNumber', suggestions: [{ messageId: 'extractConst', output: 'const MAGIC_5000 = 5000;\nsetTimeout(cb, MAGIC_5000);' }] }],
       },
       {
         code: 'const limit = users.length > 100 ? users.slice(0, 100) : users;',
         errors: [
-          { messageId: 'noMagicNumber' },
-          { messageId: 'noMagicNumber' },
+          { messageId: 'noMagicNumber', suggestions: [{ messageId: 'extractConst', output: 'const MAGIC_100 = 100;\nconst limit = users.length > MAGIC_100 ? users.slice(0, 100) : users;' }] },
+          { messageId: 'noMagicNumber', suggestions: [{ messageId: 'extractConst', output: 'const MAGIC_100 = 100;\nconst limit = users.length > 100 ? users.slice(0, MAGIC_100) : users;' }] },
         ],
       },
       {
         code: 'if (response.status === 404) {}',
-        errors: [{ messageId: 'noMagicNumber' }],
+        errors: [{ messageId: 'noMagicNumber', suggestions: [{ messageId: 'extractConst', output: 'const MAGIC_404 = 404;\nif (response.status === MAGIC_404) {}' }] }],
       },
       {
         code: 'const scaled = value * 1.5;',
-        errors: [{ messageId: 'noMagicNumber' }],
+        errors: [{ messageId: 'noMagicNumber', suggestions: [{ messageId: 'extractConst', output: 'const MAGIC_1_5 = 1.5;\nconst scaled = value * MAGIC_1_5;' }] }],
       },
     ],
   });
@@ -64,7 +64,7 @@ describe('no-magic-numbers', () => {
       {
         code: 'const x = arr[5];',
         options: [{ ignoreArrayIndexes: false }],
-        errors: [{ messageId: 'noMagicNumber' }],
+        errors: [{ messageId: 'noMagicNumber', suggestions: [{ messageId: 'extractConst', output: 'const MAGIC_5 = 5;\nconst x = arr[MAGIC_5];' }] }],
       },
     ],
   });


### PR DESCRIPTION
## Summary

- Adds `hasSuggestions: true` to `conventions/no-magic-numbers`.
- When the rule flags a magic literal, IDEs (VS Code, WebStorm) now offer a **"Extract to named constant"** suggestion that:
  1. Inserts `const MAGIC_<value> = <value>;` before the containing statement (at the same indentation)
  2. Replaces the magic literal in-place with the new constant name
- Name format: `5000 → MAGIC_5000` · `-3 → MAGIC_NEG_3` · `1.5 → MAGIC_1_5`
- Intentionally a *suggestion* (not a full `fixable` autofix) — the semantic name (`TIMEOUT_MS`, `STATUS_NOT_FOUND`, etc.) is unknown at analysis time. The suggestion gives a rename-ready starting point.

## Test plan

- [x] All 17 existing + new suggestion tests pass (`npm test --workspace=eslint-plugin-conventions`).
- [x] Suggestion `output` asserted for all 5 invalid cases (including `ignoreArrayIndexes: false`).
- [x] Pre-push: oxlint, tests, typecheck, portability, changelog, lockfile all green.

## After merge

`no-magic-numbers` joins the autofix bench as a `hasSuggestions` entry. Users on VS Code get one-click "Extract to named constant" — rename the placeholder to anything meaningful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)