### PR TITLE
fix(node-security): demote no-ssrf to warn — variable naming is not data-flow analysis

### DIFF
--- a/packages/eslint-plugin-node-security/src/index.ts
+++ b/packages/eslint-plugin-node-security/src/index.ts
@@ -117,7 +117,7 @@ const recommendedRules: Record<string, TSESLint.FlatConfig.RuleEntry> = {
   'node-security/no-zip-slip': 'error',
   'node-security/no-arbitrary-file-access': 'error',
   'node-security/no-data-in-temp-storage': 'error',
-  'node-security/no-ssrf': 'error',
+  'node-security/no-ssrf': 'warn',
 
   // Migrated Rules
   'node-security/detect-suspicious-dependencies': 'warn',

--- a/packages/eslint-plugin-node-security/src/rules/no-ssrf/index.ts
+++ b/packages/eslint-plugin-node-security/src/rules/no-ssrf/index.ts
@@ -186,23 +186,23 @@ function hasValidationBefore(node: TSESTree.CallExpression): boolean {
 export const noSsrf = createRule<RuleOptions, MessageIds>({
   name: 'no-ssrf',
   meta: {
-    type: 'problem',
+    type: 'suggestion',
     docs: {
       url: 'https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-node-security/docs/rules/no-ssrf.md',
       description:
-        'Detects HTTP requests with user-controlled URLs (SSRF vulnerability)',
+        'Flags HTTP calls whose URL argument is an identifier with a user-input-sounding name — a heuristic prompt for code review, not a proof of SSRF',
       cwe: 'CWE-918',
-      cvss: 7.5,
+      cvss: 4.0,
     },
     messages: {
       ssrfVulnerability: formatLLMMessage({
         icon: MessageIcons.SECURITY,
-        issueName: 'Server-Side Request Forgery (SSRF)',
+        issueName: 'Possible SSRF — heuristic (CWE-918)',
         cwe: 'CWE-918',
         description:
-          'HTTP request with potentially user-controlled URL. An attacker could access internal services.',
-        severity: 'HIGH',
-        fix: 'Validate URL against an allowlist of permitted hosts before making the request.',
+          'HTTP call whose URL argument name suggests user input. This is a naming heuristic, not data-flow analysis — review whether the URL could originate from an untrusted source at runtime.',
+        severity: 'LOW',
+        fix: 'If the URL comes from user input, validate it against an allowlist of permitted hosts before making the request.',
         documentationLink:
           'https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html',
       }),


### PR DESCRIPTION
## Summary

`no-ssrf` was classified as `type: 'problem'` and `'error'` severity in the flagship config. It fails the structural lint rule litmus test: it fires on `fetch(userUrl)` but stays silent on `fetch(apiBase)` even if both are user-controlled. Renaming the variable changes the rule's behavior — that's a naming heuristic, not AST-structural analysis.

**Changes:**
- `type: 'problem'` → `'suggestion'`
- `severity: HIGH` / `cvss: 7.5` → `LOW` / `4.0`
- Flagship config: `'error'` → `'warn'`
- Message text: explicitly says "naming heuristic" and "review whether"

**Also adds:** `.agent/plugin-rule-scope.md` — the definitive classification of what rules belong in each plugin (structural vs. heuristic, generic vs. framework-specific). Documents which `secure-coding` rules are misplaced and what the litmus test is for future rule proposals.

## Test plan

- [x] `eslint-plugin-node-security` tests: 34 test files, 549 tests — all pass.
- [x] Push hooks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Downgraded SSRF detection severity from errors to warnings in recommended configurations.
  * Updated SSRF detection to be classified as a suggestion rather than a problem.
  * Adjusted messaging to reflect that SSRF detection is heuristic-based and low-severity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->