### PR TITLE
feat(docs): peak-value star/follow CTA on every rule page

### DIFF
--- a/apps/docs/src/__tests__/rule-cta-lock.test.ts
+++ b/apps/docs/src/__tests__/rule-cta-lock.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Lock: the peak-value rule-page conversion CTA stays wired.
+ *
+ * The rule docs page is the single highest-gratitude surface we have — it's
+ * where a developer lands right after a rule caught something in their code.
+ * The `RuleValueCTA` is the star/follow ask on that page, and the typed
+ * `rule_page:cta_click` event is how we measure whether it converts. A refactor
+ * that drops either silently re-opens the biggest leak in the funnel
+ * (GROWTH_PHILOSOPHY.md: download-to-star) with zero signal. This pins it.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const SRC = join(__dirname, '..');
+const read = (rel: string) => readFileSync(join(SRC, rel), 'utf8');
+
+describe('rule-page conversion CTA lock', () => {
+  it('renders RuleValueCTA on every rule page (wired into remote-rule-doc)', () => {
+    const doc = read('components/docs/remote-rule-doc.tsx');
+    expect(doc).toMatch(/import\s+\{\s*RuleValueCTA\s*\}/);
+    expect(doc).toMatch(/<RuleValueCTA\s+plugin=\{plugin\}\s+rule=\{rule\}\s*\/>/);
+  });
+
+  it('asks for both conversions — Dev.to follow and GitHub star', () => {
+    const cta = read('components/docs/rule-value-cta.tsx');
+    expect(cta).toContain('https://github.com/ofri-peretz/eslint');
+    expect(cta).toContain('https://dev.to/ofri-peretz');
+    expect(cta).toMatch(/action:\s*'follow'/);
+    expect(cta).toMatch(/action:\s*'star'/);
+  });
+
+  it('keeps the rule_page:cta_click event typed so the conversion is measurable', () => {
+    const analytics = read('lib/analytics.ts');
+    expect(analytics).toMatch(/'rule_page:cta_click':\s*\{[^}]*action:\s*'star'\s*\|\s*'follow'/);
+  });
+});

--- a/apps/docs/src/components/docs/remote-rule-doc.tsx
+++ b/apps/docs/src/components/docs/remote-rule-doc.tsx
@@ -6,6 +6,7 @@
 
 import { RemoteMarkdown } from '@interlace/ui/fumadocs/remote-markdown';
 import { compileRemoteMDX } from '@/lib/mdx-compiler';
+import { RuleValueCTA } from './rule-value-cta';
 
 const GITHUB_RAW_BASE =
   'https://raw.githubusercontent.com/ofri-peretz/eslint/main/packages';
@@ -59,20 +60,23 @@ export async function RemoteRuleDoc({ plugin, rule }: RemoteRuleDocProps) {
   );
 
   return (
-    <RemoteMarkdown
-      url={url}
-      revalidate={21600}
-      fallback={fallback}
-      className="remote-rule-doc"
-      source={{
-        variant: 'rule',
-        label: `${rule}.md`,
-        sourceUrl: githubUrl,
-        cacheWindowLabel: '6 hours',
-      }}
-      preprocess={cleanRuleDoc}
-      compile={(source) => compileRemoteMDX(source, { pluginName: plugin })}
-    />
+    <>
+      <RemoteMarkdown
+        url={url}
+        revalidate={21600}
+        fallback={fallback}
+        className="remote-rule-doc"
+        source={{
+          variant: 'rule',
+          label: `${rule}.md`,
+          sourceUrl: githubUrl,
+          cacheWindowLabel: '6 hours',
+        }}
+        preprocess={cleanRuleDoc}
+        compile={(source) => compileRemoteMDX(source, { pluginName: plugin })}
+      />
+      <RuleValueCTA plugin={plugin} rule={rule} />
+    </>
   );
 }
 

--- a/apps/docs/src/components/docs/rule-value-cta.tsx
+++ b/apps/docs/src/components/docs/rule-value-cta.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+/**
+ * RuleValueCTA — the peak-value conversion ask on every rule page.
+ *
+ * Rendered directly after a rule's documentation. This is the page a developer
+ * lands on right after the rule caught something in their code (the editor
+ * "see docs" link), so it's the highest-gratitude moment we have. Per
+ * CTA_PHILOSOPHY.md: quiet, reason-first ("get new coverage" / "the
+ * benchmarks"), and the lower-friction *follow* before the *star*.
+ *
+ * Each click is a typed analytics event (`rule_page:cta_click`) so we can
+ * measure rule-page → adoption conversion. The docs-site rule page is the
+ * *instrumented* mirror of the un-trackable GitHub rule-doc CTA — the copy that
+ * wins here is the copy we reuse there.
+ */
+import Link from 'next/link';
+import { Rss, Star } from 'lucide-react';
+import { Button } from '@interlace/ui/button';
+
+import { track } from '@/lib/analytics';
+
+const REPO_URL = 'https://github.com/ofri-peretz/eslint';
+const DEVTO_URL = 'https://dev.to/ofri-peretz';
+
+export function RuleValueCTA({ plugin, rule }: { plugin: string; rule: string }) {
+  return (
+    <aside className="mt-10 rounded-lg border border-fd-border bg-fd-muted/30 p-5">
+      <p className="text-sm text-fd-muted-foreground">
+        <strong className="font-semibold text-fd-foreground">
+          Did this rule catch something?
+        </strong>{' '}
+        Star the repo to get new CWE coverage as we ship it — or follow the
+        AI-code-security benchmarks behind these rules.
+      </p>
+      <div className="mt-4 flex flex-wrap gap-3">
+        <Button
+          render={
+            <Link
+              href={DEVTO_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() =>
+                track('rule_page:cta_click', { action: 'follow', plugin, rule })
+              }
+            />
+          }
+          variant="default"
+          size="sm"
+        >
+          <Rss />
+          Follow the benchmarks
+        </Button>
+        <Button
+          render={
+            <Link
+              href={REPO_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() =>
+                track('rule_page:cta_click', { action: 'star', plugin, rule })
+              }
+            />
+          }
+          variant="outline"
+          size="sm"
+        >
+          <Star className="fill-amber-400 text-amber-500" />
+          Star on GitHub
+        </Button>
+      </div>
+    </aside>
+  );
+}
+
+export default RuleValueCTA;

--- a/apps/docs/src/lib/analytics.ts
+++ b/apps/docs/src/lib/analytics.ts
@@ -50,6 +50,10 @@ export interface TrackedEventMap {
   // Homepage hero → GitHub star CTA. The npm→GitHub arrow is the widest leak
   // in the conversion funnel (GROWTH_PHILOSOPHY.md G1/G2); this measures it.
   'homepage:star_click': { stars: number | null };
+  // Peak-value rule-page CTA (RuleValueCTA): the ask shown right after a rule
+  // caught something. `follow` (Dev.to) and `star` (GitHub) tracked separately
+  // so we can see which conversion the rule-page traffic actually takes.
+  'rule_page:cta_click': { action: 'star' | 'follow'; plugin: string; rule: string };
   // Stats / scorecard page CTAs (star, install, docs links).
   'stats:cta_click': { action: 'star' | 'plugin_install' | 'plugin_docs'; plugin?: string };
   // Flagship / scorecard page CTAs.


### PR DESCRIPTION
## Summary

Targets the headline growth gap (GROWTH_PHILOSOPHY.md): **~18K npm installs/mo → 10 GitHub stars (~1,815:1 download-to-star).** The fix isn't more reach — it's converting the installers we already have, at the one moment they're most grateful.

**The insight from the audit:** when a rule fires, the editor's "see docs" link (`meta.docs.url`) sends the developer to the rule's docs page — *right after the rule caught a real bug.* That page is the highest-gratitude surface in the whole product, and it had **no ask on it.** We were putting people on the launchpad without handing them the button.

**This PR adds `RuleValueCTA` after every rule's documentation:**
- A quiet, reason-first block: *"Did this rule catch something?"* → **Follow the benchmarks** (Dev.to) + **Star on GitHub**.
- **Follow before star** — lower friction, and the benchmark series is a genuine value exchange (Dev.to followers 228→406 prove it works).
- Each click is a typed **`rule_page:cta_click`** event (`action: 'star' | 'follow'`, plugin, rule) → so we can finally **measure** rule-page → adoption conversion. The docs-site rule page is the *instrumented mirror* of the un-trackable GitHub rule-doc CTA; the copy that wins here is the copy we reuse there.

## Test plan

- [x] `prettier --check` clean on all 4 files.
- [x] `fd-*` design tokens confirmed in use across the docs (valid).
- [x] Button `variant` (`default`/`outline`) + `size="sm"` verified against `@interlace/ui/button` (matches the existing `StarButton`).
- [x] **Lock added** — `apps/docs/src/__tests__/rule-cta-lock.test.ts` pins: the CTA stays wired into `remote-rule-doc`, both conversions (Dev.to + GitHub) are present, and the `rule_page:cta_click` event stays typed. Reverting any of those turns it red.
- [ ] CI: typecheck / vitest / build / playwright (local lefthook was unavailable, so CI is the gate).

## After merge

The rule-page CTA goes live + starts emitting `rule_page:cta_click` into PostHog (analytics was fixed earlier today) — first time we can watch this conversion.

**Fast follow-ups (not in this PR, to keep it focused):**
- The **GitHub rule-`.md` CTA** via the doc generator — same copy, on the actual peak-value landing page (one-click star, already on GitHub). Highest-converting, just not instrumentable.
- 3 non-plugin README gaps (`eslint-config-interlace`, `eslint-formatter`, `eslint-formatter-sarif`).
- A global docs footer CTA (concept/guide pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)