### PR TITLE
fix(secure-coding): demote naming-heuristic rules from error to warn

### DIFF
--- a/benchmark-results/plugin-scope-audit.json
+++ b/benchmark-results/plugin-scope-audit.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-31T02:46:55.562Z",
+  "generatedAt": "2026-05-31T03:33:20.668Z",
   "findings": [],
   "summary": {
     "total": 0,

--- a/packages/eslint-plugin-secure-coding/src/index.ts
+++ b/packages/eslint-plugin-secure-coding/src/index.ts
@@ -235,7 +235,9 @@ export const configs: Record<string, TSESLint.FlatConfig.Config> = {
       
       // A02:2021 – Cryptographic Failures
       'secure-coding/no-hardcoded-credentials': 'error',
-      'secure-coding/no-sensitive-data-exposure': 'error',
+      // Demoted from 'error': naming-heuristic detection (fires on variable names
+      // that sound sensitive). Cannot be enforcement-grade per I3 invariant.
+      'secure-coding/no-sensitive-data-exposure': 'warn',
       
       // A03:2021 – Injection
       'secure-coding/no-graphql-injection': 'error',

--- a/packages/eslint-plugin-secure-coding/src/rules/detect-weak-password-validation/index.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/detect-weak-password-validation/index.ts
@@ -21,7 +21,7 @@ type RuleOptions = [Options?];
 export const detectWeakPasswordValidation = createRule<RuleOptions, MessageIds>({
   name: 'detect-weak-password-validation',
   meta: {
-    type: 'problem',
+    type: 'suggestion',
     docs: {
       url: 'https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-secure-coding/docs/rules/detect-weak-password-validation.md',
       description: 'Identify weak password requirements',

--- a/packages/eslint-plugin-secure-coding/src/rules/no-pii-in-logs/index.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/no-pii-in-logs/index.ts
@@ -23,7 +23,7 @@ type RuleOptions = [Options?];
 export const noPiiInLogs = createRule<RuleOptions, MessageIds>({
   name: 'no-pii-in-logs',
   meta: {
-    type: 'problem',
+    type: 'suggestion',
     docs: {
       url: 'https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-secure-coding/docs/rules/no-pii-in-logs.md',
       description: 'Prevent PII (email, SSN, credit cards) in console logs',

--- a/packages/eslint-plugin-secure-coding/src/rules/no-sensitive-data-exposure/index.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/no-sensitive-data-exposure/index.ts
@@ -66,7 +66,7 @@ function containsSensitiveData(
 export const noSensitiveDataExposure = createRule<RuleOptions, MessageIds>({
   name: 'no-sensitive-data-exposure',
   meta: {
-    type: 'problem',
+    type: 'suggestion',
     docs: {
       url: 'https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-secure-coding/docs/rules/no-sensitive-data-exposure.md',
       description: 'Detects PII/credentials in logs, responses, or error messages',


### PR DESCRIPTION
## Summary

- **`no-sensitive-data-exposure`**: demoted from `'error'` to `'warn'` in the `owasp-top-10` config (was already `'warn'` in `recommended`); rule `type` changed from `problem` to `suggestion`
- **`detect-weak-password-validation`**: rule `type` changed from `problem` to `suggestion` (fires only when variable name contains "password" — pure naming heuristic)
- **`no-pii-in-logs`**: rule `type` changed from `problem` to `suggestion` (detects property names like `.email`, `.ssn` — naming heuristic)
- All three rules already carried `"confidence": "review-prompt"` in `.agent/plugin-rule-manifest.json` — no manifest changes needed

These rules fire on variable/property names as a proxy for data flow, not on actual data flow analysis. Per the I3 invariant (naming-heuristic detection cannot be enforcement-grade), `type: 'problem'` and `'error'` severity are incorrect for this detection class.

## Test plan

- [x] `tsx scripts/ilb-plugin-scope-audit.ts` → `✅ benchmark-results/plugin-scope-audit.json` (EXIT 0, zero I3 violations)
- [x] All three rule files verified: `type: 'suggestion'` replaces `type: 'problem'`
- [x] `owasp-top-10` config: `no-sensitive-data-exposure` now `'warn'` (was `'error'`)
- [x] Manifest already correct (`"confidence": "review-prompt"`) — no changes needed

## After merge

No breaking changes — demoting from `error` → `warn` and `problem` → `suggestion` is a non-breaking severity reduction. Users on `strict` config (which sets all rules to `error`) are unaffected by the `type` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Demoted `no-sensitive-data-exposure` rule severity from error to warning.

* **Chores**
  * Updated rule classifications for weak password validation, PII detection, and sensitive data exposure rules from "problem" to "suggestion" type.
  * Updated benchmark timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->