### PR TITLE
ci(workflows): full gate on main push + pin reproducible tool installs

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -100,7 +100,7 @@ jobs:
           PORT: "3000"
 
       - name: Install Lighthouse CI
-        run: npm install -g @lhci/cli@0.14.x
+        run: npm install -g @lhci/cli@0.14.0
 
       - name: Run Lighthouse CI
         id: lhci

--- a/.github/workflows/quality-full.yml
+++ b/.github/workflows/quality-full.yml
@@ -21,6 +21,13 @@ run-name: >-
 # ─────────────────────────────────────────────────────────────────────────────
 
 on:
+  # Post-merge verification: the heavy gate is PR-gated for cost, so a merge
+  # (incl. an --admin / draft-merged PR that skipped it) could land broken on
+  # main and sit red only until the weekly cron. Running on push to main turns
+  # that into immediate detection. Non-PR events run the full battery via the
+  # gate job (event != pull_request → run=true).
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
     types: [ready_for_review, labeled, synchronize]

--- a/.github/workflows/storybook-a11y.yml
+++ b/.github/workflows/storybook-a11y.yml
@@ -9,6 +9,16 @@ name: Storybook a11y gate
 # weekly Sunday cron for drift. See AGENTS.md "Promotion gate".
 
 on:
+  # Post-merge verification on main (e.g. a lockfile change that re-hoists
+  # storybook's vite breaks the build) — same path filter as the PR trigger.
+  push:
+    branches: [main]
+    paths:
+      - 'apps/storybook/**'
+      - 'packages/ui/**'
+      - 'apps/docs/src/**'
+      - '.github/workflows/storybook-a11y.yml'
+      - 'package-lock.json'
   pull_request:
     branches: [main]
     types: [ready_for_review, labeled, synchronize]

--- a/.github/workflows/supply-chain-attestation.yml
+++ b/.github/workflows/supply-chain-attestation.yml
@@ -91,7 +91,7 @@ jobs:
       # ───────── SBOM (CycloneDX + SPDX) ─────────────────────────────────
       - name: Generate SBOM (CycloneDX) per package
         run: |
-          npm install -g @cyclonedx/cyclonedx-npm
+          npm install -g @cyclonedx/cyclonedx-npm@4.2.1
           mkdir -p artifacts/sbom
           for PKG in ${{ steps.targets.outputs.list }}; do
             DIR="packages/$PKG"


### PR DESCRIPTION
## Summary

Best-practice CI/supply-chain hardening from the security-scanning sweep — closing the root-cause gap and pinning what's safely pinnable, **without breaking needed functionality**.

- **Close the CI gap (root cause of the recent broken-main detours).** The heavy gate — `Build (Turbo)`, `Unit Tests (Turbo)`, `axe a11y check`, `Quality (Full) Gate` — is PR-gated for cost, so a merge that skipped it (draft-merge / `--admin` / unlabeled) could land broken on `main` and sit red only until the weekly cron. Added `push: [main]` to `quality-full.yml` + `storybook-a11y.yml`; their `gate` jobs already run the full battery for non-PR events. This is exactly the gap that let #157/#158's docs regressions and the storybook vite-hoisting break surface late.
- **Pin reproducible tool installs** (Scorecard Pinned-Dependencies / npmCommand): `@cyclonedx/cyclonedx-npm@4.2.1`, `@lhci/cli@0.14.0`.

### Deliberately NOT changed (functionality > scanner score)
- `eslint-version-matrix.yml` (`eslint@^8`/`^9`) and `sdk-compatibility.yml` (`${{ matrix.packages }}`) install floating versions **on purpose** — they're compat-matrix tests of latest-of-major. Pinning defeats the test.
- `vercel@latest` / `npm@latest` are intentionally current for deploy/publish.

These keep their Scorecard npmCommand note at score 8 by design — the right risk-informed posture, not a regression.

## Test plan
- [x] `gate` job in both workflows already branches `event != pull_request → run=true`, so `push:main` runs the full battery (verified by reading the gate logic).
- [x] CI "Workflow Conventions" + the new gate runs validate the YAML on this PR.

## After merge
Every merge to `main` now runs the full battery post-hoc → a broken main is caught in minutes, not up to a week. Pairs with the existing weekly cron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)