### PR TITLE
fix(scripts): close two CodeQL findings in dev tooling

### DIFF
--- a/scripts/devto-fix-all.ts
+++ b/scripts/devto-fix-all.ts
@@ -325,7 +325,7 @@ async function fixTitles() {
     if (hasFrontmatter(body)) {
       // Escape YAML: wrap in single-quotes if title contains colons or special chars
       const safeTitle = fix.newTitle.includes(':') || fix.newTitle.includes("'")
-        ? `"${fix.newTitle.replace(/"/g, '\\"')}"`
+        ? `"${fix.newTitle.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
         : fix.newTitle;
       const newBody = patchFrontmatter(body, 'title', safeTitle);
       await patchArticle(fix.id, { body_markdown: newBody, title: fix.newTitle });

--- a/scripts/ilb-plugin-scope-audit.ts
+++ b/scripts/ilb-plugin-scope-audit.ts
@@ -387,9 +387,10 @@ function generateManifest(): Record<string, Record<string, {
       // Primary environment: if the rule only uses one env signal, use it.
       // If it uses multiple, pick the most specific one (non-universal wins).
       const allowedEnvs = PLUGIN_ALLOWED_ENVIRONMENTS[pluginDir] ?? ['universal'];
-      const pluginPrimaryEnv = allowedEnvs[allowedEnvs.length - 1]; // most specific
 
-      let environment = pluginPrimaryEnv;
+      // Every branch below assigns `environment`, so no seed value is needed
+      // (the old `= pluginPrimaryEnv` seed was always overwritten — dead store).
+      let environment: string;
       if (envs.length === 0) environment = allowedEnvs[0]; // default to plugin's first
       else if (envs.length === 1) environment = envs[0];
       else {


### PR DESCRIPTION
## Summary
Closes the two CodeQL alerts surfaced on the post-sweep rescan — both in dev/CI scripts (not shipped):
- **`scripts/devto-fix-all.ts`** (`js/incomplete-sanitization`, CWE-116): escape `\` before `"` when YAML-quoting a title, so a backslash can't corrupt a published article's frontmatter.
- **`scripts/ilb-plugin-scope-audit.ts`** (`js/useless-assignment-to-local`): remove the dead `environment` seed — every branch reassigns it. Behavior-identical.

The four original shipped-code findings from #155 (analytics, ExamplePicker, mdx-compiler, eslint-devkit path) all closed on the rescan; these two are newer, from main racing ahead.

## Test plan
- [x] `npm run typecheck:scripts` passes with both edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)