### PR TITLE
feat(docs): footer star/follow CTA on every non-rule docs page

### DIFF
--- a/apps/docs/src/__tests__/rule-cta-lock.test.ts
+++ b/apps/docs/src/__tests__/rule-cta-lock.test.ts
@@ -39,4 +39,15 @@ describe('rule-page conversion CTA lock', () => {
     const analytics = read('lib/analytics.ts');
     expect(analytics).toMatch(/'rule_page:cta_click':\s*\{[^}]*action:\s*'star'\s*\|\s*'follow'/);
   });
+
+  it('renders DocsFooterCTA on every non-rule docs page, instrumented', () => {
+    const page = read('app/docs/[[...slug]]/page.tsx');
+    expect(page).toMatch(/import\s+\{\s*DocsFooterCTA\s*\}/);
+    expect(page).toMatch(/<DocsFooterCTA\s+slug=/);
+    const cta = read('components/docs/docs-footer-cta.tsx');
+    expect(cta).toContain('https://github.com/ofri-peretz/eslint');
+    expect(cta).toContain('https://dev.to/ofri-peretz');
+    const analytics = read('lib/analytics.ts');
+    expect(analytics).toMatch(/'docs_page:cta_click':\s*\{[^}]*action:\s*'star'\s*\|\s*'follow'/);
+  });
 });

--- a/apps/docs/src/app/docs/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/docs/[[...slug]]/page.tsx
@@ -9,6 +9,7 @@ import {
 import { notFound } from 'next/navigation';
 import { getMDXComponents } from '@/mdx-components';
 import { RuleValueCTA } from '@/components/docs/rule-value-cta';
+import { DocsFooterCTA } from '@/components/docs/docs-footer-cta';
 import type { TableOfContents } from 'fumadocs-core/toc';
 import type { MDXComponents } from 'mdx/types';
 import type { ReactElement } from 'react';
@@ -55,7 +56,9 @@ export default async function Page(props: PageProps<'/docs/[[...slug]]'>) {
         <MDX components={getMDXComponents()} />
         {isRulePage && ruleName ? (
           <RuleValueCTA plugin={rulePlugin} rule={ruleName} />
-        ) : null}
+        ) : (
+          <DocsFooterCTA slug={slug.join('/')} />
+        )}
       </DocsBody>
     </DocsPage>
   );

--- a/apps/docs/src/components/docs/docs-footer-cta.tsx
+++ b/apps/docs/src/components/docs/docs-footer-cta.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+/**
+ * DocsFooterCTA — the conversion ask on non-rule docs pages (getting-started,
+ * concepts, guides). These pages are read by people *evaluating* the project,
+ * which is the highest-intent star/follow audience after a rule actually
+ * firing. Rule pages get the contextual `RuleValueCTA` instead; this is the
+ * generic footer for everything else.
+ *
+ * Per CTA_PHILOSOPHY.md: quiet, reason-first, follow (lower friction) before
+ * star. Each click is a typed `docs_page:cta_click` event (with the page slug)
+ * so we can see which docs convert — the docs side of the download-to-star gap.
+ */
+import Link from 'next/link';
+import { Rss, Star } from 'lucide-react';
+import { Button } from '@interlace/ui/button';
+
+import { track } from '@/lib/analytics';
+
+const REPO_URL = 'https://github.com/ofri-peretz/eslint';
+const DEVTO_URL = 'https://dev.to/ofri-peretz';
+
+export function DocsFooterCTA({ slug }: { slug: string }) {
+  return (
+    <aside className="mt-12 rounded-lg border border-fd-border bg-fd-muted/30 p-5">
+      <p className="text-sm text-fd-muted-foreground">
+        <strong className="font-semibold text-fd-foreground">
+          Building secure JavaScript with Interlace?
+        </strong>{' '}
+        Star the repo to get new rules and CWE coverage as we ship them — or
+        follow the AI-code-security benchmarks behind them.
+      </p>
+      <div className="mt-4 flex flex-wrap gap-3">
+        <Button
+          render={
+            <Link
+              href={DEVTO_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() =>
+                track('docs_page:cta_click', { action: 'follow', slug })
+              }
+            />
+          }
+          variant="default"
+          size="sm"
+        >
+          <Rss />
+          Follow the benchmarks
+        </Button>
+        <Button
+          render={
+            <Link
+              href={REPO_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() =>
+                track('docs_page:cta_click', { action: 'star', slug })
+              }
+            />
+          }
+          variant="outline"
+          size="sm"
+        >
+          <Star className="fill-amber-400 text-amber-500" />
+          Star on GitHub
+        </Button>
+      </div>
+    </aside>
+  );
+}
+
+export default DocsFooterCTA;

--- a/apps/docs/src/lib/analytics.ts
+++ b/apps/docs/src/lib/analytics.ts
@@ -54,6 +54,9 @@ export interface TrackedEventMap {
   // caught something. `follow` (Dev.to) and `star` (GitHub) tracked separately
   // so we can see which conversion the rule-page traffic actually takes.
   'rule_page:cta_click': { action: 'star' | 'follow'; plugin: string; rule: string };
+  // Footer CTA on non-rule docs pages (DocsFooterCTA): getting-started,
+  // concepts, guides — the evaluator audience. `slug` identifies which doc.
+  'docs_page:cta_click': { action: 'star' | 'follow'; slug: string };
   // Stats / scorecard page CTAs (star, install, docs links).
   'stats:cta_click': { action: 'star' | 'plugin_install' | 'plugin_docs'; plugin?: string };
   // Flagship / scorecard page CTAs.


### PR DESCRIPTION
## Summary

Completes the docs-side conversion coverage for the download-to-star gap (~1,815:1). Rule pages got the contextual `RuleValueCTA` (#165); this adds the generic **`DocsFooterCTA`** to every *other* docs page — getting-started, concepts, guides — i.e. the pages read by people **evaluating** the project (the highest-intent star/follow audience after a rule actually firing).

- Quiet, reason-first, **follow-before-star** (CTA_PHILOSOPHY.md).
- Each click is a typed **`docs_page:cta_click`** event with the page slug, so we can see *which* docs convert — more instrumented signal for the PostHog funnel (the docs analytics were dark until yesterday; this widens coverage).
- Rule pages render `RuleValueCTA`; all other docs pages render `DocsFooterCTA` (mutually exclusive, no double-CTA).

After this, the ask appears on: homepage, stats, scorecard, **rule pages**, and **every concept/guide page**.

## Test plan

- [x] `prettier --check` clean on all 4 files.
- [x] `fd-*` tokens + `Button render={<Link/>}` pattern match the existing `RuleValueCTA` / `StarButton`.
- [x] Mutually-exclusive render verified (`isRulePage ? RuleValueCTA : DocsFooterCTA`).
- [x] **Lock extended** — `rule-cta-lock.test.ts` now also pins `DocsFooterCTA` wired into the page renderer + the typed `docs_page:cta_click` event.
- [ ] CI: typecheck / vitest / build / playwright (local lefthook unavailable → CI is the gate).

## After merge

Every docs/concept/guide page carries a quiet star/follow ask, and `docs_page:cta_click` starts flowing into PostHog so we can measure the evaluator-→-advocate conversion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)