### PR TITLE
chore(docs): close the 3 README CTA gaps (config + formatters)

### DIFF
--- a/packages/eslint-config-interlace/README.md
+++ b/packages/eslint-config-interlace/README.md
@@ -141,6 +141,16 @@ directly, this preset will work there unchanged. See
 
 ---
 
+<!-- INTERLACE:STAR_CTA:START -->
+
+## ⭐ Support & follow
+
+If the Interlace ESLint ecosystem is useful to you, **[star the repo](https://github.com/ofri-peretz/eslint)** — stars are the signal that keeps it maintained — and **[follow the writeups on Dev.to](https://dev.to/ofri-peretz)** for the benchmarks and security research behind these rules.
+
+[![GitHub stars](https://img.shields.io/github/stars/ofri-peretz/eslint?style=social)](https://github.com/ofri-peretz/eslint)
+
+<!-- INTERLACE:STAR_CTA:END -->
+
 ## License
 
 [MIT](./LICENSE) © Ofri Peretz.

--- a/packages/eslint-formatter-sarif/README.md
+++ b/packages/eslint-formatter-sarif/README.md
@@ -63,3 +63,13 @@ For one-line CI integration that handles install + run + upload in one step, use
 
 See the [ESLint Version Support Policy](../../docs/ESLINT_VERSION_SUPPORT.md) — current ecosystem share data, the 20% gate, and the forward-looking exception that covers v10.
 
+<!-- INTERLACE:STAR_CTA:START -->
+
+## ⭐ Support & follow
+
+If the Interlace ESLint ecosystem is useful to you, **[star the repo](https://github.com/ofri-peretz/eslint)** — stars are the signal that keeps it maintained — and **[follow the writeups on Dev.to](https://dev.to/ofri-peretz)** for the benchmarks and security research behind these rules.
+
+[![GitHub stars](https://img.shields.io/github/stars/ofri-peretz/eslint?style=social)](https://github.com/ofri-peretz/eslint)
+
+<!-- INTERLACE:STAR_CTA:END -->
+

--- a/packages/eslint-formatter/README.md
+++ b/packages/eslint-formatter/README.md
@@ -173,6 +173,16 @@ Three contracts gate every release:
 - **Latency contract** — `interlace-*` P50 ≤ {tiny:5, small:10, medium:25, large:50, extreme:250} ms per fixture scale.
 - **Per-cell regression check** — every cell within +5 % tokens / max(+50 %, +0.5 ms) latency / signal score ≥ baseline vs the snapshotted `baseline.json`.
 
+<!-- INTERLACE:STAR_CTA:START -->
+
+## ⭐ Support & follow
+
+If the Interlace ESLint ecosystem is useful to you, **[star the repo](https://github.com/ofri-peretz/eslint)** — stars are the signal that keeps it maintained — and **[follow the writeups on Dev.to](https://dev.to/ofri-peretz)** for the benchmarks and security research behind these rules.
+
+[![GitHub stars](https://img.shields.io/github/stars/ofri-peretz/eslint?style=social)](https://github.com/ofri-peretz/eslint)
+
+<!-- INTERLACE:STAR_CTA:END -->
+
 ## License
 
 MIT © [Ofri Peretz](https://ofriperetz.dev/?utm_source=github&utm_medium=referral&utm_campaign=eslint-formatter)


### PR DESCRIPTION
## Summary

The only 3 published packages missing the star/follow CTA — `eslint-config-interlace`, `eslint-formatter`, `eslint-formatter-sarif` — now carry it (21/24 → **24/24**). Marker-guarded `INTERLACE:STAR_CTA` block, generic copy (these aren't plugins), inserted before the License section. Every package a developer installs now has the conversion ask.

Pairs with today's repo-metadata polish (description rewritten + 15 topics added, was empty) and the docs-site CTAs (rule pages #165, footer #173).

## Test plan

- [x] All 3 READMEs now contain the `INTERLACE:STAR_CTA:START/END` markers (verified).
- [x] Block uses markdown links + bold (no bare URLs / underscore-emphasis) → markdownlint-clean.
- [ ] CI: Markdown Lint / Prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)