### PR TITLE
test(docs): fast deterministic horizontal-overflow guard at mobile width

### DIFF
--- a/apps/docs/e2e/layout.spec.ts
+++ b/apps/docs/e2e/layout.spec.ts
@@ -301,4 +301,71 @@ test.describe('Visual Regression Tests', () => {
       });
     });
   });
+
+  test.describe('Horizontal overflow guard', () => {
+    // Fast, deterministic layout lock — NO screenshots, so it is cheap and
+    // never flaky (unlike pixel-diff VRT). Fails if a page scrolls horizontally
+    // at mobile width, i.e. the "text/tables went off the screen" regression
+    // class. The failure message names the worst leaking element so it is
+    // debuggable in one read. Each case is a single page load + one eval.
+    const PAGES = [
+      '/',
+      '/stats',
+      '/scorecard',
+      '/docs/getting-started',
+      '/docs/security/plugin-jwt/rules/no-algorithm-none',
+    ];
+
+    for (const path of PAGES) {
+      test(`no horizontal overflow at ${BREAKPOINTS.mobile.width}px — ${path}`, async ({
+        page,
+      }) => {
+        await page.setViewportSize(BREAKPOINTS.mobile);
+        await page.goto(path);
+        await page.waitForLoadState('networkidle');
+
+        const result = await page.evaluate(() => {
+          const inner = window.innerWidth;
+          const docScroll = document.documentElement.scrollWidth;
+          // Worst element whose content overflows its box AND is not
+          // scroll-clipped (overflow-x: visible) — the real leak. Scrollable
+          // containers (overflow-x: auto/scroll, e.g. wide tables, code blocks)
+          // are intended and excluded.
+          let worst: {
+            over: number;
+            tag: string;
+            cls: string;
+            text: string;
+          } | null = null;
+          for (const el of Array.from(
+            document.querySelectorAll<HTMLElement>('*'),
+          )) {
+            if (
+              el.clientWidth > 30 &&
+              el.scrollWidth > el.clientWidth + 3 &&
+              getComputedStyle(el).overflowX === 'visible'
+            ) {
+              const over = el.scrollWidth - el.clientWidth;
+              if (!worst || over > worst.over) {
+                worst = {
+                  over,
+                  tag: el.tagName,
+                  cls: String(el.className).slice(0, 60),
+                  text: (el.textContent || '').trim().slice(0, 50),
+                };
+              }
+            }
+          }
+          return { inner, docScroll, worst };
+        });
+
+        expect(
+          result.docScroll,
+          `Page scrolls horizontally at mobile width — worst leaking element: ${JSON.stringify(
+            result.worst,
+          )}`,
+        ).toBeLessThanOrEqual(result.inner + 2);
+      });
+    }
+  });
 });


### PR DESCRIPTION
## Summary

You asked for a layout-confidence check that's **optimized (no long CI gates)** and **raises confidence/predictability**. This is the sweet spot.

`layout.spec.ts` already does pixel-diff VRT (`toHaveScreenshot`, threshold 0.15) for responsive layouts — which is the *slow + flaky* approach. This adds the **opposite**: a `Horizontal overflow guard` describe block that is **a single page load + one `scrollWidth` assertion per page, with NO screenshots**.

- **Fast:** no image capture/diff, no baselines to maintain. Pure DOM measurement.
- **Never flaky:** deterministic — a page either scrolls horizontally at 375px or it doesn't.
- **High-confidence:** catches the exact regression class you flagged — "text/tables went off the screen" — across the homepage, `/stats`, `/scorecard`, getting-started, and a rule page.
- **Debuggable:** on failure it names the worst leaking element (`tag`/`class`/`text`/overflow px). Scrollable containers (`overflow-x: auto/scroll` — wide tables, code blocks) are intended and **excluded**, so no false alarms.

## Test plan

- [x] Probed the live site manually with the same logic (console): no *page-level* horizontal overflow on `/stats` or rule pages at the tested width; wide tables/code use `overflow-x: auto` (handled). This guard locks that invariant.
- [ ] CI runs it in the Playwright e2e gate (fresh install — local `node_modules` is in an ELOOP state from parallel branch work, so I rely on CI).
- [ ] If it fails on a page, that page genuinely overflows at 375px — i.e. it caught a real bug (which is the point).

## Note

Pairs with the manual finding to flag separately: a `/stats` chart-header container sized to 48px with ~322px content overflow (cosmetic, not page-level) — worth a fix but not blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)