### PR TITLE
fix(repo): green main — untrack node_modules self-symlink + express-security lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
 # Dependencies
+# Match BOTH the directory and a stray `node_modules` symlink — a
+# self-referential symlink was committed once (node_modules -> itself, ELOOP),
+# which broke binary resolution in CI + every fresh worktree. The no-slash form
+# also ignores a symlink so `git add -A` can never re-introduce it.
+node_modules
 node_modules/
 .pnp
 .pnp.js

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/ofri/repos/ofriperetz.dev/eslint/node_modules

--- a/packages/eslint-plugin-express-security/src/index.test.ts
+++ b/packages/eslint-plugin-express-security/src/index.test.ts
@@ -23,8 +23,14 @@ describe('eslint-plugin-express-security plugin interface', () => {
       'require-express-body-parser-limits',
       'no-express-unsafe-regex-route',
       'no-exposed-debug-endpoints',
+      // Migrated from browser-security by the plugin-scope reorg — these are
+      // server-side Express checks (correct environment per the scope audit).
+      'no-missing-cors-check',
+      'no-missing-csrf-protection',
+      'no-missing-security-headers',
+      'no-user-controlled-redirect',
     ]);
-    expect(ruleKeys.length).toBe(10);
+    expect(ruleKeys.length).toBe(14);
   });
 
   describe('configurations', () => {


### PR DESCRIPTION
## Summary

Consolidation toward the new plugin-scope structure. The scope reorg itself is **complete and clean** — `plugin-scope-audit` reports **0 placement findings** — but it left two lagging gaps that turned `main` red. This greens both.

### 1. Untrack the `node_modules` self-symlink (the root gap all session)
`node_modules` was tracked on `main` as a **symlink pointing to its own absolute path** (`node_modules -> /…/eslint/node_modules` = ELOOP). Every fresh checkout, every worktree, and the **Changesets CI "version" job** restored it, breaking binary resolution:

```
> changeset version && npm install --package-lock-only
sh: 1: changeset: not found            # exit 127 → Changesets job FAILED
```

It's also why local `eslint` / `vitest` / `playwright` have been ELOOP-broken. Fix: `git rm --cached node_modules` (it's already in `.gitignore`) + harden `.gitignore` so the **no-slash form also ignores a stray symlink** — `git add -A` can never reintroduce it.

### 2. Sync the express-security rule-count lock
The scope reorg migrated 3 server-side checks **into** express-security from browser-security (`no-missing-cors-check`, `no-missing-csrf-protection`, `no-missing-security-headers`) plus `no-user-controlled-redirect`, so the plugin now exports **14** rules. Its `index.test.ts` `toEqual([...])` still listed **10** — the single failing unit test in **Quality (Full)**:

```
× should export all express-security rules
AssertionError: expected [ 'require-helmet', …(13) ] to deeply equal [ 'require-helmet', …(9) ]
```

Synced the lock to the 14 actual rules (browser-security's count was already decremented — its test passes).

## Test plan

- [x] Verified against ground truth, not heuristics: pulled the failed `Quality (Full)` Turbo log — `eslint-plugin-express-security#test` was the **only** failing package (243/244 passed). Every other plugin's count assertion already matches.
- [x] `plugin-scope-audit.json`: `{ findings: [], total: 0 }` — placement is correct; these are lock/infra gaps only.
- [ ] CI: `Quality (Full)` should now pass (express test fixed). The Changesets **version** job only runs on push-to-main, so it's verified post-merge — but the `changeset: not found` cause (the committed symlink) is removed here.

## After merge

- `main` green on Quality (Full); next push-to-main re-runs Changesets cleanly (binary now resolves).
- Fresh worktrees/checkouts stop getting the ELOOP symlink — unblocks local tooling for every agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)