### PR TITLE
fix(workspace): unblock Changesets release bot — disable lefthook on its push

### DIFF
--- a/.github/workflows/changesets-pr.yml
+++ b/.github/workflows/changesets-pr.yml
@@ -65,6 +65,14 @@ jobs:
           # No `publish:` — release.yml does that on merge.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # changesets/action runs `git commit` + `git push origin
+          # HEAD:changeset-release/main` to open the Version PR. CI installs
+          # lefthook git hooks (npm ci → prepare), and the pre-push `changelog`
+          # gate then fails the bot's push — the version-bump commit has package
+          # changes but the changesets were just consumed by `changeset version`
+          # (and `shim-verify` flags dist it can't see). Disable lefthook for this
+          # automated push; the real gates run on the resulting Version PR.
+          LEFTHOOK: "0"
 
       # Closes the loop for solo-maintainer continuous delivery: once CI is
       # green, GitHub auto-squash-merges the Version PR. release.yml then fires


### PR DESCRIPTION
## Summary

The **Changesets** workflow has been red on `main` — this is the releases blocker. It's a side-effect that #178 *exposed*: now that the `node_modules` ELOOP is gone, CI resolves the `changeset` binary and the Version-PR job runs `changeset version` successfully (it had been dying at `changeset: not found`). But it now fails one step later:

```
git push origin HEAD:changeset-release/main --force
🦋 error Some packages have been changed but no changesets were found.
✗ 2 failure(s)   # changelog + shim-verify
error: failed to push some refs
```

CI installs lefthook git hooks (`npm ci` → prepare), so the **bot's own push** trips the repo's **pre-push `changelog`** gate — the version-bump commit has package changes but the changesets were just consumed by `changeset version` — plus `shim-verify`. The release bot is blocked by the repo's dev hooks.

**Fix:** `LEFTHOOK: "0"` on the `changesets/action` step so the automated commit+push skips dev hooks. The real quality gates still run on the resulting Version PR (and on every normal contributor PR). This is the standard pattern for release bots.

## Test plan

- [x] Workflow-only change; no package source touched (no changeset needed).
- [ ] After merge: the next push-to-main fires `changesets-pr.yml`; the Version PR should open cleanly (binary resolves + hooks skipped). Verifying post-merge since the version job only runs on push-to-main.

## Context

`main`'s **Quality (Full)** is already green as of #181 — this is the last red workflow. Merging it unblocks the release pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)