### PR TITLE
ci(review): add Claude Code Review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -32,6 +32,7 @@ jobs:
     # Skip draft PRs -- review once a PR is opened or marked ready for review.
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Check for Claude token
         id: token

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,91 @@
+name: Claude Code Review
+
+# AI code review on pull requests, powered by anthropics/claude-code-action.
+#
+# Activation: the job no-ops (green) until the CLAUDE_CODE_OAUTH_TOKEN secret
+# exists, so this file is safe to merge before the secret + Claude GitHub App
+# are wired. To enable:
+#   1. Install the Claude GitHub App: https://github.com/apps/claude
+#   2. Generate a token locally: `claude setup-token`
+#   3. Add it as the repo secret CLAUDE_CODE_OAUTH_TOKEN
+#
+# Billing: draws on the owner's Claude subscription monthly programmatic credit.
+# With "extra usage" disabled (the default, Settings -> Usage), runs simply stop
+# when the monthly credit is exhausted -- no overage is ever charged.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  # One review per PR; cancel an in-flight review when a newer commit lands.
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+jobs:
+  review:
+    # Skip draft PRs -- review once a PR is opened or marked ready for review.
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for Claude token
+        id: token
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Claude review skipped::CLAUDE_CODE_OAUTH_TOKEN is not set. Add the secret and install the Claude GitHub App to enable automated reviews."
+          fi
+
+      - name: Checkout repository
+        if: steps.token.outputs.present == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 1
+
+      - name: Claude Code Review
+        if: steps.token.outputs.present == 'true'
+        uses: anthropics/claude-code-action@2fee15510437d71399d9139ed60433470484a8fb # v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            You are reviewing a pull request in a published security &
+            code-quality ESLint plugin ecosystem. Read the repository's
+            CLAUDE.md / AGENTS.md for project conventions and honour them.
+
+            Prioritise, in order:
+
+            1. Correctness & security -- real bugs, broken edge cases,
+               regressions, and security issues (injection, unsafe AST
+               handling, secret leakage, ReDoS, prototype pollution). Map
+               security findings to a CWE when you can.
+            2. Regression locks -- this repo's contract is "lock everything you
+               fix". If a change fixes a bug but adds no test that would fail on
+               the unfixed code, flag it.
+            3. Public-API & docs drift -- exported rule changes that don't
+               update the rule's README, schema, or meta, and CLAUDE.md
+               statements made stale by the change.
+
+            Be precise and low-noise: only post a finding when you can cite the
+            specific file:line and explain why it is wrong. Cap nits -- prefer a
+            single summary line over many inline style comments. If you find no
+            blocking issues, say so plainly.
+
+            Post specific issues as inline comments; use one top-level comment
+            for the summary.
+          claude_args: |
+            --model claude-sonnet-4-6
+            --max-turns 20
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/claude-code-review.yml` — automated AI code review on pull requests via [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action), pinned to commit SHA `2fee155` (v1) per this repo's pinned-dependencies convention.
- Triggers on **non-draft** PRs (`opened`/`synchronize`/`reopened`/`ready_for_review`); `concurrency` cancels a superseded review when a newer commit lands.
- Reviews the diff with a **security-and-correctness-first** prompt (CWE mapping, the repo's "lock everything you fix" regression contract, public-API/docs drift) on **`claude-sonnet-4-6`** to stretch the subscription's monthly programmatic credit.
- A **guard step no-ops the job (green)** until the `CLAUDE_CODE_OAUTH_TOKEN` secret exists — safe to merge before the secret + GitHub App are wired.

## Activation (manual, repo-admin)

1. Install the Claude GitHub App: https://github.com/apps/claude (grant this repo).
2. `claude setup-token` → add the output as repo secret **`CLAUDE_CODE_OAUTH_TOKEN`**.
3. Keep **Settings → Usage → extra usage disabled** so runs *stop* at the monthly limit rather than incur overage.

## Test plan

- [x] `ruby -ryaml` parses the workflow — valid YAML.
- [x] Actions SHA-pinned (`actions/checkout@de0fac2…` v6, `claude-code-action@2fee155…` v1), matching the repo's pinned-dependencies / OSSF Scorecard convention.
- [x] Guard step ⇒ before the secret is added this workflow runs green as a no-op (posts a `::notice::`), so it won't add a red check to existing PRs.

## After merge

Inactive until the secret + app are added. Once active, every non-draft PR gets a Claude review posted as inline comments + a summary. No production deploy impact (workflow-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)