### PR TITLE
fix(workspace): unscope recommended config rule ids + barrel-file locks

### DIFF
--- a/.changeset/fix-recommended-config-double-namespace.md
+++ b/.changeset/fix-recommended-config-double-namespace.md
@@ -1,0 +1,33 @@
+---
+"eslint-plugin-maintainability": patch
+"eslint-plugin-operability": patch
+---
+
+fix: republish `recommended` with correctly-namespaced, unscoped rule ids
+
+`eslint-plugin-maintainability@3.0.3` and `eslint-plugin-operability@3.0.5`
+shipped a `recommended` preset whose rule ids carried a doubled, scoped plugin
+segment (`@interlace/maintainability/maintainability/cognitive-complexity`)
+that no registered plugin key matched. Enabling the preset alongside any other
+config made ESLint throw at load:
+
+```text
+Could not find plugin "@interlace/maintainability/maintainability".
+```
+
+(and the equivalent `@interlace/operability/operability` for operability.)
+
+The source was already corrected to the bare, unscoped form
+(`maintainability/cognitive-complexity` under a `maintainability` plugin key)
+but was never republished, so npm still served the broken build. This release
+ships the corrected build. `plugin.meta.name` is also fixed to the unscoped
+`eslint-plugin-maintainability` (was `@interlace/eslint-plugin-maintainability`,
+which drifted from the package name and every other plugin).
+
+Each plugin is configured on its own — there is no unified config. No rule
+behaviour changes.
+
+New regression locks in each plugin's `index.test.ts` reproduce ESLint's rule-id
+resolution, pin the plugin name and key as unscoped, and load each `recommended`
+preset in a real ESLint instance — failing closed if a scoped or doubly
+namespaced config could ship again.

--- a/packages/eslint-plugin-maintainability/src/index.test.ts
+++ b/packages/eslint-plugin-maintainability/src/index.test.ts
@@ -1,12 +1,48 @@
 import { describe, it, expect } from 'vitest';
+import { ESLint } from 'eslint';
 import plugin, { rules, configs } from './index';
 
+// The unscoped published name + bare plugin key. These packages ship WITHOUT
+// the `@interlace` scope (matching `eslint-plugin-*` across the ecosystem and
+// package.json `name`); recommended configs register the bare short key. Pinned
+// so a scoped name/key can never silently ship again.
+const PLUGIN_NAME = 'eslint-plugin-maintainability';
+const PLUGIN_KEY = 'maintainability';
+
+/**
+ * Mirrors ESLint's flat-config rule-id resolution (ESLint 9/10 —
+ * `lib/config/config.js`: `parseRuleId` + `getRuleFromConfig`):
+ *
+ *   - scoped ids (`@scope/...`)  → plugin name is everything up to the LAST `/`
+ *   - unscoped ids               → plugin name is everything up to the FIRST `/`
+ *   - the rule then resolves against `plugins[pluginName].rules[ruleName]`
+ *
+ * This is the exact path that throws `Could not find plugin "<name>"` for a real
+ * consumer (`new ESLint(...)` / the CLI) when a recommended config's rule ids
+ * don't line up with its registered plugin keys. v3.0.3 shipped doubly
+ * namespaced — plugin key `@interlace/maintainability` but rule ids
+ * `@interlace/maintainability/maintainability/cognitive-complexity`, which
+ * resolves to the (unregistered) plugin `@interlace/maintainability/maintainability`.
+ */
+function parseRuleId(ruleId: string): { pluginName: string; ruleName: string } {
+  if (!ruleId.includes('/')) return { pluginName: '@', ruleName: ruleId };
+  const pluginName = ruleId.startsWith('@')
+    ? ruleId.slice(0, ruleId.lastIndexOf('/'))
+    : ruleId.slice(0, ruleId.indexOf('/'));
+  return { pluginName, ruleName: ruleId.slice(pluginName.length + 1) };
+}
+
 describe('eslint-plugin-maintainability plugin interface', () => {
-  it('should export correct meta information', () => {
+  it('should export correct, UNSCOPED meta information (no @interlace scope)', () => {
     expect(plugin.meta).toBeDefined();
-    expect(plugin.meta?.name).toBe('@interlace/eslint-plugin-maintainability');
+    expect(plugin.meta?.name).toBe(PLUGIN_NAME);
+    // Fail closed on ANY scope. Published v3.0.3 carried a scoped
+    // `@interlace/eslint-plugin-maintainability` meta.name that drifted from the
+    // unscoped package.json `name` and the rest of the ecosystem.
+    expect(plugin.meta?.name?.startsWith('@')).toBe(false);
     expect(plugin.meta?.version).toBeDefined();
     expect(typeof plugin.meta?.version).toBe('string');
+    expect(plugin.meta?.version).toBeTruthy();
   });
 
   it('should export all maintainability rules (both flat and categorized)', () => {
@@ -67,9 +103,7 @@ describe('eslint-plugin-maintainability plugin interface', () => {
         expect(ruleName).toMatch(/^maintainability\//);
       });
 
-      expect(
-        recommendedRules['maintainability/cognitive-complexity'],
-      ).toBe('warn');
+      expect(recommendedRules['maintainability/cognitive-complexity']).toBe('warn');
 
       // Verify at least one rule is configured
       expect(Object.keys(recommendedRules).length).toBeGreaterThan(0);
@@ -79,10 +113,93 @@ describe('eslint-plugin-maintainability plugin interface', () => {
       const recommendedRules = Object.keys(configs['recommended'].rules || {});
       const pluginRules = Object.keys(plugin.rules || {});
 
-      recommendedRules.forEach(ruleName => {
+      recommendedRules.forEach((ruleName) => {
         const shortName = ruleName.replace('maintainability/', '');
         expect(pluginRules).toContain(shortName);
       });
+    });
+
+    // Regression lock for the v3.0.3 doubly-namespaced recommended config.
+    // The published build registered `plugins: { '@interlace/maintainability' }`
+    // but keyed rules `@interlace/maintainability/maintainability/<rule>`, so any
+    // consumer enabling this preset alongside another config hit
+    // `Could not find plugin "@interlace/maintainability/maintainability"`.
+    // This reproduces ESLint's own resolution and fails closed on any rule id
+    // whose plugin segment isn't a registered plugin key (or whose rule is
+    // missing from that plugin). It would have caught the bug pre-publish.
+    it('every recommended rule id resolves to a registered plugin + existing rule', () => {
+      const recommended = configs['recommended'];
+      const registeredPlugins = recommended.plugins ?? {};
+      const ruleIds = Object.keys(recommended.rules ?? {});
+
+      expect(ruleIds.length).toBeGreaterThan(0);
+
+      for (const ruleId of ruleIds) {
+        const { pluginName, ruleName } = parseRuleId(ruleId);
+
+        expect(
+          Object.prototype.hasOwnProperty.call(registeredPlugins, pluginName),
+          `rule "${ruleId}" → plugin "${pluginName}" is not registered in ` +
+            `configs.recommended.plugins (keys: ${Object.keys(registeredPlugins).join(', ')})`,
+        ).toBe(true);
+
+        const resolvedRules = (registeredPlugins[pluginName] as { rules?: Record<string, unknown> })
+          ?.rules;
+        expect(
+          resolvedRules?.[ruleName],
+          `rule "${ruleId}" → "${ruleName}" not found in plugin "${pluginName}"`,
+        ).toBeDefined();
+      }
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Barrel-file integrity.
+  //
+  // The barrel (`src/index.ts`) IS the published artifact: a straight tsc of it
+  // becomes `dist/src/index.js`, so locking the barrel's shape locks what ships.
+  // v3.0.3 proved how this breaks silently — a scoped plugin key + a doubled
+  // rule namespace passed in isolation but made every real consumer throw at
+  // config load. These tests fail closed on that whole class.
+  // ─────────────────────────────────────────────────────────────────────────
+  describe('barrel-file integrity', () => {
+    it('exports a well-formed barrel (rules, plugin, configs) with real rule modules', () => {
+      expect(plugin).toBeDefined();
+      expect(rules).toBe(plugin.rules);
+      expect(configs['recommended']).toBeDefined();
+
+      // Every exported rule is a real RuleModule (has a `create` function), so
+      // the barrel can never export a dangling/undefined rule reference.
+      for (const [name, rule] of Object.entries(plugin.rules ?? {})) {
+        expect(typeof (rule as { create?: unknown })?.create, `rule "${name}" has no create()`).toBe(
+          'function',
+        );
+      }
+    });
+
+    it('registers only the UNSCOPED bare plugin key (no @interlace, no eslint-plugin- prefix)', () => {
+      for (const config of Object.values(configs)) {
+        for (const key of Object.keys(config.plugins ?? {})) {
+          expect(key.startsWith('@'), `plugin key "${key}" is @-scoped`).toBe(false);
+          expect(
+            key.startsWith('eslint-plugin-'),
+            `plugin key "${key}" carries the eslint-plugin- prefix`,
+          ).toBe(false);
+        }
+      }
+      expect(Object.keys(configs['recommended'].plugins ?? {})).toEqual([PLUGIN_KEY]);
+    });
+
+    it('recommended config LOADS in real ESLint when enabled alongside another config', async () => {
+      // The exact v3.0.3 failure mode: enabling the preset with a second config
+      // object and running ESLint threw
+      //   Could not find plugin "@interlace/maintainability/maintainability".
+      // Load it for real — plugin/rule resolution errors throw inside lintText.
+      const overrideConfig = [configs['recommended'], { rules: {} }] as never;
+      const eslint = new ESLint({ overrideConfigFile: true, overrideConfig });
+      const results = await eslint.lintText('const x = 1;\n', { filePath: 'smoke.js' });
+      expect(results).toHaveLength(1);
+      expect(results[0]?.messages).toBeDefined();
     });
   });
 });

--- a/packages/eslint-plugin-maintainability/src/index.ts
+++ b/packages/eslint-plugin-maintainability/src/index.ts
@@ -57,7 +57,11 @@ export const rules = {
 
 export const plugin = {
   meta: {
-    name: '@interlace/eslint-plugin-maintainability',
+    // Unscoped, matching package.json `name` and every other plugin in the
+    // ecosystem (`eslint-plugin-*`). These packages are published WITHOUT the
+    // `@interlace` scope; a scoped name here drifts from how consumers install
+    // and reference the plugin. Locked in index.test.ts.
+    name: 'eslint-plugin-maintainability',
     version: '3.0.3',
   },
   rules,

--- a/packages/eslint-plugin-operability/src/index.test.ts
+++ b/packages/eslint-plugin-operability/src/index.test.ts
@@ -1,18 +1,53 @@
 import { describe, it, expect } from 'vitest';
+import { ESLint } from 'eslint';
 import plugin, { rules, configs } from './index';
 
+// The unscoped published name + bare plugin key. These packages ship WITHOUT
+// the `@interlace` scope (matching `eslint-plugin-*` across the ecosystem and
+// package.json `name`); recommended configs register the bare short key. Pinned
+// so a scoped name/key can never silently ship again.
+const PLUGIN_NAME = 'eslint-plugin-operability';
+const PLUGIN_KEY = 'operability';
+
+/**
+ * Mirrors ESLint's flat-config rule-id resolution (ESLint 9/10 —
+ * `lib/config/config.js`: `parseRuleId` + `getRuleFromConfig`):
+ *
+ *   - scoped ids (`@scope/...`)  → plugin name is everything up to the LAST `/`
+ *   - unscoped ids               → plugin name is everything up to the FIRST `/`
+ *   - the rule then resolves against `plugins[pluginName].rules[ruleName]`
+ *
+ * This is the exact path that throws `Could not find plugin "<name>"` for a real
+ * consumer (`new ESLint(...)` / the CLI) when a recommended config's rule ids
+ * don't line up with its registered plugin keys. v3.0.5 shipped doubly
+ * namespaced — plugin key `@interlace/operability` but rule ids
+ * `@interlace/operability/operability/no-console-log`, which resolves to the
+ * (unregistered) plugin `@interlace/operability/operability`.
+ */
+function parseRuleId(ruleId: string): { pluginName: string; ruleName: string } {
+  if (!ruleId.includes('/')) return { pluginName: '@', ruleName: ruleId };
+  const pluginName = ruleId.startsWith('@')
+    ? ruleId.slice(0, ruleId.lastIndexOf('/'))
+    : ruleId.slice(0, ruleId.indexOf('/'));
+  return { pluginName, ruleName: ruleId.slice(pluginName.length + 1) };
+}
+
 describe('eslint-plugin-operability plugin interface', () => {
-  it('should export correct meta information', () => {
+  it('should export correct, UNSCOPED meta information (no @interlace scope)', () => {
     expect(plugin.meta).toBeDefined();
-    expect(plugin.meta?.name).toBe('eslint-plugin-operability');
+    expect(plugin.meta?.name).toBe(PLUGIN_NAME);
+    // Fail closed on ANY scope — keep parity with the unscoped package.json
+    // `name` and the rest of the ecosystem (`eslint-plugin-*`).
+    expect(plugin.meta?.name?.startsWith('@')).toBe(false);
     expect(plugin.meta?.version).toBeDefined();
     expect(typeof plugin.meta?.version).toBe('string');
+    expect(plugin.meta?.version).toBeTruthy();
   });
 
   it('should export all operability rules (both flat and categorized)', () => {
     expect(plugin.rules).toBeDefined();
     const ruleKeys = Object.keys(plugin.rules || {});
-    
+
     // Flat names
     expect(ruleKeys).toContain('no-console-log');
     expect(ruleKeys).toContain('no-process-exit');
@@ -45,7 +80,7 @@ describe('eslint-plugin-operability plugin interface', () => {
       expect(configs['recommended'].plugins?.['operability']).toBeDefined();
 
       const recommendedRules = configs['recommended'].rules || {};
-      Object.keys(recommendedRules).forEach(ruleName => {
+      Object.keys(recommendedRules).forEach((ruleName) => {
         expect(ruleName).toMatch(/^operability\//);
       });
 
@@ -57,10 +92,93 @@ describe('eslint-plugin-operability plugin interface', () => {
       const recommendedRules = Object.keys(configs['recommended'].rules || {});
       const pluginRules = Object.keys(plugin.rules || {});
 
-      recommendedRules.forEach(ruleName => {
+      recommendedRules.forEach((ruleName) => {
         const shortName = ruleName.replace('operability/', '');
         expect(pluginRules).toContain(shortName);
       });
+    });
+
+    // Regression lock for the v3.0.5 doubly-namespaced recommended config.
+    // The published build registered `plugins: { '@interlace/operability' }`
+    // but keyed rules `@interlace/operability/operability/<rule>`, so any
+    // consumer enabling this preset alongside another config hit
+    // `Could not find plugin "@interlace/operability/operability"`.
+    // This reproduces ESLint's own resolution and fails closed on any rule id
+    // whose plugin segment isn't a registered plugin key (or whose rule is
+    // missing from that plugin). It would have caught the bug pre-publish.
+    it('every recommended rule id resolves to a registered plugin + existing rule', () => {
+      const recommended = configs['recommended'];
+      const registeredPlugins = recommended.plugins ?? {};
+      const ruleIds = Object.keys(recommended.rules ?? {});
+
+      expect(ruleIds.length).toBeGreaterThan(0);
+
+      for (const ruleId of ruleIds) {
+        const { pluginName, ruleName } = parseRuleId(ruleId);
+
+        expect(
+          Object.prototype.hasOwnProperty.call(registeredPlugins, pluginName),
+          `rule "${ruleId}" → plugin "${pluginName}" is not registered in ` +
+            `configs.recommended.plugins (keys: ${Object.keys(registeredPlugins).join(', ')})`,
+        ).toBe(true);
+
+        const resolvedRules = (registeredPlugins[pluginName] as { rules?: Record<string, unknown> })
+          ?.rules;
+        expect(
+          resolvedRules?.[ruleName],
+          `rule "${ruleId}" → "${ruleName}" not found in plugin "${pluginName}"`,
+        ).toBeDefined();
+      }
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Barrel-file integrity.
+  //
+  // The barrel (`src/index.ts`) IS the published artifact: a straight tsc of it
+  // becomes `dist/src/index.js`, so locking the barrel's shape locks what ships.
+  // v3.0.5 proved how this breaks silently — a scoped plugin key + a doubled
+  // rule namespace passed in isolation but made every real consumer throw at
+  // config load. These tests fail closed on that whole class.
+  // ─────────────────────────────────────────────────────────────────────────
+  describe('barrel-file integrity', () => {
+    it('exports a well-formed barrel (rules, plugin, configs) with real rule modules', () => {
+      expect(plugin).toBeDefined();
+      expect(rules).toBe(plugin.rules);
+      expect(configs['recommended']).toBeDefined();
+
+      // Every exported rule is a real RuleModule (has a `create` function), so
+      // the barrel can never export a dangling/undefined rule reference.
+      for (const [name, rule] of Object.entries(plugin.rules ?? {})) {
+        expect(typeof (rule as { create?: unknown })?.create, `rule "${name}" has no create()`).toBe(
+          'function',
+        );
+      }
+    });
+
+    it('registers only the UNSCOPED bare plugin key (no @interlace, no eslint-plugin- prefix)', () => {
+      for (const config of Object.values(configs)) {
+        for (const key of Object.keys(config.plugins ?? {})) {
+          expect(key.startsWith('@'), `plugin key "${key}" is @-scoped`).toBe(false);
+          expect(
+            key.startsWith('eslint-plugin-'),
+            `plugin key "${key}" carries the eslint-plugin- prefix`,
+          ).toBe(false);
+        }
+      }
+      expect(Object.keys(configs['recommended'].plugins ?? {})).toEqual([PLUGIN_KEY]);
+    });
+
+    it('recommended config LOADS in real ESLint when enabled alongside another config', async () => {
+      // The exact v3.0.5 failure mode: enabling the preset with a second config
+      // object and running ESLint threw
+      //   Could not find plugin "@interlace/operability/operability".
+      // Load it for real — plugin/rule resolution errors throw inside lintText.
+      const overrideConfig = [configs['recommended'], { rules: {} }] as never;
+      const eslint = new ESLint({ overrideConfigFile: true, overrideConfig });
+      const results = await eslint.lintText('const x = 1;\n', { filePath: 'smoke.js' });
+      expect(results).toHaveLength(1);
+      expect(results[0]?.messages).toBeDefined();
     });
   });
 });


### PR DESCRIPTION
## Summary

Published `eslint-plugin-maintainability@3.0.3` and `eslint-plugin-operability@3.0.5` shipped a `recommended` preset whose rule ids carried a **doubled, scoped** plugin segment that no registered plugin key matched — e.g. `@interlace/maintainability/maintainability/cognitive-complexity` under an `@interlace/maintainability` plugin key. Enabling either preset alongside any other config made ESLint throw at load:

> Could not find plugin "@interlace/maintainability/maintainability" in configuration.

The source was already corrected (bare `maintainability` key, single-segment rule ids) but **never republished**, so npm still serves the broken build. This PR adds the missing regression locks and bumps both plugins (patch) so the corrected build ships.

- **Unscoped `meta.name`** — maintainability's `plugin.meta.name` was `@interlace/eslint-plugin-maintainability`, the only scoped name in the ecosystem; corrected to `eslint-plugin-maintainability` to match package.json and the other 18 plugins. Each plugin is configured **separately** — no unified config.
- **Barrel-file regression locks** (per plugin, `src/index.test.ts`):
  - reproduce ESLint's own rule-id resolution (`parseRuleId` + `getRuleFromConfig`), failing closed on any unresolvable rule id
  - pin the plugin name + key as unscoped (no `@scope`, no `eslint-plugin-` prefix)
  - load each `recommended` preset in a **real ESLint instance** composed with another config — the exact consumer scenario that broke
  - assert the barrel exports real rule modules (every rule has `create()`)
- **Changeset** patches `eslint-plugin-maintainability` + `eslint-plugin-operability`.

## Test plan

- [x] `turbo run test --filter=eslint-plugin-maintainability --filter=eslint-plugin-operability` — green (Node 24)
- [x] New barrel locks pass on the fix (maintainability 9/9, incl. the real-ESLint smoke test)
- [x] **Fail-on-broken proven**: reverting the fix to the scoped/doubled shape fails 6 tests, incl. the real-ESLint smoke with the exact consumer error `Could not find plugin "@interlace/maintainability/maintainability"`
- [x] `turbo run typecheck build` — green; oxlint / markdownlint / changeset:status / shims (maintainability + operability) — green

## After merge

The Changesets bot opens a "Version Packages" PR bumping `eslint-plugin-maintainability` 3.0.3→3.0.4 and `eslint-plugin-operability` 3.0.5→3.0.6. Merging that fires `release.yml` to publish the corrected builds. Verify the published `configs.recommended` has single-segment, unscoped rule ids.

> Note: the repo's heavy (non-required) test gate is currently red on `eslint-plugin-secure-coding` (pre-existing, unrelated — being fixed in `fix/secure-coding-stale-tests`). This PR does not touch secure-coding; the two changed plugins' suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed `recommended` presets in eslint-plugin-maintainability and eslint-plugin-operability that previously caused ESLint to fail with "Could not find plugin" errors.

* **Tests**
  * Added regression tests to ensure rule resolution works correctly and prevent future plugin loading failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->