### PR TITLE
fix(workspace): drop deleted eslint-plugin-crypto from benchmark config

### DIFF
--- a/eslint.benchmark.config.mjs
+++ b/eslint.benchmark.config.mjs
@@ -10,7 +10,6 @@
 const secureCodingModule = await import('./packages/eslint-plugin-secure-coding/src/index.ts');
 const nodeSecurityModule = await import('./packages/eslint-plugin-node-security/src/index.ts');
 const pgModule = await import('./packages/eslint-plugin-pg/src/index.ts');
-const cryptoModule = await import('./packages/eslint-plugin-crypto/src/index.ts');
 const expressModule = await import('./packages/eslint-plugin-express-security/src/index.ts');
 const browserModule = await import('./packages/eslint-plugin-browser-security/src/index.ts');
 const jwtModule = await import('./packages/eslint-plugin-jwt/src/index.ts');
@@ -24,7 +23,6 @@ const normalize = (m) => m.default || m;
 const secureCoding = normalize(secureCodingModule);
 const nodeSecurity = normalize(nodeSecurityModule);
 const pg = normalize(pgModule);
-const crypto = normalize(cryptoModule);
 const expressSecurity = normalize(expressModule);
 const browserSecurity = normalize(browserModule);
 const jwt = normalize(jwtModule);
@@ -49,7 +47,6 @@ export default [
       'secure-coding': secureCoding,
       'node-security': nodeSecurity,
       pg,
-      crypto,
       'express-security': expressSecurity,
       'browser-security': browserSecurity,
       jwt,
@@ -62,7 +59,6 @@ export default [
       ...allRulesError('secure-coding', secureCoding),
       ...allRulesError('node-security', nodeSecurity),
       ...allRulesError('pg', pg),
-      ...allRulesError('crypto', crypto),
       ...allRulesError('express-security', expressSecurity),
       ...allRulesError('browser-security', browserSecurity),
       ...allRulesError('jwt', jwt),


### PR DESCRIPTION
## Summary

`Oxlint Parity Gate › Runtime smoke + parity › Finding-level parity bench` has been crashing on a **cache miss** with:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '…/packages/eslint-plugin-crypto/src/index.ts'
  imported from …/eslint.benchmark.config.mjs
```

`eslint-plugin-crypto` was consolidated into `eslint-plugin-node-security` (2026-05-10) and deleted, but `eslint.benchmark.config.mjs` still `await import`ed it, so ESLint failed to load the benchmark config and the parity bench died on startup. The failure was masked while the bench cache stayed warm.

Removed the four stale `crypto` references (import / normalize / plugin entry / `allRulesError` spread). `node-security` already carries the migrated rules.

## Test plan

- [x] `tsx` loads `eslint.benchmark.config.mjs`: 10 plugins, no `crypto` entry, no `MODULE_NOT_FOUND`.
- [x] CI re-runs the parity bench (this PR) — was crashing at config-load, now reaches the bench.

🤖 Generated with [Claude Code](https://claude.com/claude-code)