### PR TITLE
chore(release): sync plugin meta.version during changeset version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lint:workflows:actionlint": "actionlint",
     "changeset": "changeset",
     "changeset:status": "changeset status --since=origin/main",
-    "changeset:version": "changeset version && npm install --package-lock-only",
+    "changeset:version": "changeset version && tsx scripts/sync-source-versions.ts && npm install --package-lock-only",
     "release:status": "tsx scripts/release-status.ts",
     "release:reconcile": "tsx scripts/reconcile-tags.ts",
     "release:reconcile:backfill": "tsx scripts/reconcile-tags.ts --backfill-missing",


### PR DESCRIPTION
## Summary

Wires `tsx scripts/sync-source-versions.ts` into the `changeset:version` script — the step the Changesets bot runs to open the Version PR — so every release keeps each plugin's hardcoded `plugin.meta.version` in lockstep with its `package.json`.

```diff
- "changeset:version": "changeset version && npm install --package-lock-only",
+ "changeset:version": "changeset version && tsx scripts/sync-source-versions.ts && npm install --package-lock-only",
```

## Why

This guards the exact drift that helped hide the recommended-config namespace bug ([#197](https://github.com/ofri-peretz/eslint/pull/197)): the broken `eslint-plugin-maintainability@3.0.3` shipped with `plugin.meta.version: '1.0.0'` while its `package.json` said `3.0.3`. `check-source-versions` already *detects* this; now `sync-source-versions` *prevents* it on every bump, so the published artifact's `meta.version` always matches the package version.

The follow-up was deferred until the heavy gate was green again (#198 fixed the stale secure-coding tests); it now lands with **no hook bypasses**.

## Test plan

- [x] `check-source-versions` — all in sync (no-op today; matters on the next bump)
- [x] Full pre-push gate green on fresh `main`: tests (45/45), typecheck, build, shim-verify, changelog, lockfile — no bypasses
- [x] No changeset needed — root `package.json` tooling change, not a published package

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release process to ensure version synchronization during package updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->