### PR TITLE
fix(node-security): align no-dynamic-algorithm-selection docs.cvss to emitted CVSS

### DIFF
--- a/.changeset/no-dynamic-algorithm-selection-cvss.md
+++ b/.changeset/no-dynamic-algorithm-selection-cvss.md
@@ -1,0 +1,11 @@
+---
+'eslint-plugin-node-security': patch
+---
+
+Align `no-dynamic-algorithm-selection`'s `meta.docs.cvss` (7.4) to the CVSS its
+finding actually emits. The rule's message carries `CWE-327` and sets no
+per-message `cvss`, so it inherits `CWE_MAPPING['CWE-327']` = 7.5 via
+`enrichFromCWE` — docs now match the emitted value. Surfaced by the
+cross-plugin `security-cvss-docs-consistency.lock.test.ts` lock (added in #213),
+which turned main red when this rule landed concurrently with the CVSS sweep.
+Documentation-metadata only; no emitted finding changes.

--- a/packages/eslint-plugin-node-security/src/rules/no-dynamic-algorithm-selection/index.ts
+++ b/packages/eslint-plugin-node-security/src/rules/no-dynamic-algorithm-selection/index.ts
@@ -53,7 +53,10 @@ export const noDynamicAlgorithmSelection = createRule<[], MessageIds>({
       description:
         'Disallow dynamic algorithm names in Node.js crypto functions (CWE-327)',
       cwe: 'CWE-327',
-      cvss: 7.4,
+      // Match the CVSS the finding emits: the message sets no per-message
+      // cvss, so it inherits CWE_MAPPING['CWE-327'] (7.5) via enrichFromCWE.
+      // Locked by security-cvss-docs-consistency.lock.test.ts.
+      cvss: 7.5,
     },
     messages: {
       dynamicAlgorithm: formatLLMMessage({


### PR DESCRIPTION
## Summary

- `no-dynamic-algorithm-selection` documented `meta.docs.cvss: 7.4`, but its message carries `CWE-327` and sets no per-message `cvss`, so the emitted finding reads `CVSS:7.5` (the `CWE_MAPPING['CWE-327']` value, via `enrichFromCWE`). Aligns docs → **7.5** to match the emitted value.
- **Why now:** the cross-plugin `security-cvss-docs-consistency.lock.test.ts` lock (added in #213) turned `main` red — this rule landed concurrently with the CVSS sweep, so it wasn't in that PR's scope, and the lock correctly caught the docs/message drift. This greens main.
- Documentation-metadata only — **no emitted finding changes**.

## Test plan

- [x] `security-cvss-docs-consistency.lock.test.ts` — was failing (`Array(1)` mismatch) on main, **passes** with this fix (0 mismatches).
- [x] Pre-push gates green: `build`, `shim-verify`, `tests`, `typecheck`, `lockfile`.

## After merge

- Greens `main` (the lock stops failing). Patch release for `eslint-plugin-node-security` via the changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected CVSS security score documentation for the no-dynamic-algorithm-selection rule from 7.4 to 7.5 to align with the actual value emitted by the rule.

* **Documentation**
  * Updated rule metadata documentation with CVSS/message mapping references for improved transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->