### PR TITLE
fix(ui): widen docs hero tagline copy to max-w-3xl

### DIFF
--- a/apps/docs/src/__tests__/homepage-lock.test.tsx
+++ b/apps/docs/src/__tests__/homepage-lock.test.tsx
@@ -444,6 +444,14 @@ describe('HeroSection: Structure Lock', () => {
       // Negative lock — the previous value must not return.
       expect(heroSource).not.toMatch(/<p[^>]*\bmb-10\b[^>]*>/);
     });
+
+    it('tagline uses `max-w-3xl` (NOT `max-w-2xl`) — wide daylight sky regressed the narrow version', () => {
+      // The daylight surface (added in #118) made max-w-2xl look pinched
+      // against the open sky. max-w-3xl (48rem) reads proportional on both
+      // the light sky and the dark cosmic background.
+      expect(heroSource).toMatch(/<p[^>]*\bmax-w-3xl\b[^>]*>/);
+      expect(heroSource).not.toMatch(/<p[^>]*\bmax-w-2xl\b[^>]*>/);
+    });
   });
 });
 

--- a/packages/ui/src/patterns/hero-cosmic.tsx
+++ b/packages/ui/src/patterns/hero-cosmic.tsx
@@ -183,7 +183,7 @@ export function HeroCosmic({
           </h1>
 
           {tagline ? (
-            <p className="mx-auto mb-16 max-w-2xl text-lg leading-relaxed text-slate-700 drop-shadow dark:text-purple-100/90 md:text-xl">
+            <p className="mx-auto mb-16 max-w-3xl text-lg leading-relaxed text-slate-700 drop-shadow dark:text-purple-100/90 md:text-xl">
               {tagline}
             </p>
           ) : null}


### PR DESCRIPTION
Ships the June-21 docs landing-page copy-width regression fix: the hero tagline was constrained to `max-w-2xl`, causing premature wrapping. Restores `max-w-3xl`.

One-line change in `packages/ui/src/patterns/hero-cosmic.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Expanded the tagline width in the hero section for a roomier, more readable layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->