### PR TITLE
chore(changeset): add missed lambda-security eslint9-crash changeset

### DIFF
--- a/.changeset/lambda-security-eslint9-crash.md
+++ b/.changeset/lambda-security-eslint9-crash.md
@@ -1,0 +1,22 @@
+---
+'eslint-plugin-lambda-security': patch
+---
+
+Fix runtime crashes when linting realistic AWS Lambda handlers under ESLint 9.
+
+The published `1.2.3` tarball was a **stale build**: its rules still threw on the
+generated lambda-ai-corpus handlers, even though source had already been fixed.
+This republishes the corrected build and locks it with a regression test.
+
+- **`no-error-swallowing`** no longer throws `RangeError: Maximum call stack size
+exceeded`. The old build walked the catch-block AST by hand and recursed through
+  the cyclic `node.parent` reference; source now uses `sourceCode.getText()` + a
+  regex.
+- **`require-timeout-handling`**, **`no-missing-authorization-check`**, and
+  **`no-unbounded-batch-processing`** no longer throw `Error: Unknown class name:
+exit`. They used a grouped `:exit` selector (`'A:exit, B:exit, C:exit'`); ESLint
+  only strips the trailing `:exit`, so esquery received a bare `:exit`. Source now
+  uses one listener key per node type.
+- `plugin.meta.version` is now read from `package.json` instead of a hardcoded
+  string, so a build can no longer mislabel its own version (1.2.3 embedded
+  `1.1.0`).


### PR DESCRIPTION
PR #211 shipped the eslint-plugin-lambda-security ESLint 9 crash fixes (55d5c0ab / 56768300) but its changeset never landed on main — the open Version Packages PR (#214) already bumps lambda-security to 1.2.5 without documenting those fixes.

This adds `.changeset/lambda-security-eslint9-crash.md` (patch bump for eslint-plugin-lambda-security) so the 1.2.5 changelog includes the crash-fix notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)