### PR TITLE
fix(workspace): unwedge CI — advisory tweet-cache HEAD-check + react-features plugin dedupe

### DIFF
--- a/.github/workflows/component-api-lint.yml
+++ b/.github/workflows/component-api-lint.yml
@@ -20,6 +20,12 @@ on:
     paths:
       - 'packages/ui/**/*.tsx'
       - 'packages/eslint-plugin-react-features/**'
+      # The lint step resolves plugins through the root flat config and
+      # the @interlace/eslint-config preset — a bad edit to either can
+      # crash every lint run (e.g. the duplicate react-features plugin
+      # registration, 2026-07-04), so config changes must run this gate.
+      - 'eslint.config.mjs'
+      - 'packages/eslint-config-interlace/**'
       - '.github/workflows/component-api-lint.yml'
   push:
     branches: [main]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,8 +62,12 @@ making concurrent changes.
   referenced in source.
 - **Tweet cache HEAD-check** — `scripts/sync-tweet-cache.ts` HEADs
   every cached `card.binding_values.photo_image_full_size_large` URL
-  after sync and exits 1 on non-2xx. Twitter rotates these URLs
-  faster than our 7-day TTL, so a "fresh" cache can still hold a 404.
+  after sync and warns on non-2xx (advisory: Twitter rotates/deletes
+  these URLs faster than our 7-day TTL and upstream 404s can't be
+  fixed by re-running the build, so they must never wedge a deploy —
+  see `shouldFailSync` + its lock in `social-embeds-integrity.test.ts`).
+  The script still exits 1 when a tweet can't be fetched AND has no
+  cached fallback (the "Tweet not found in production" case).
 
 If you add a new homepage section, a new external-data dependency, or
 a new visual primitive, add a matching lock in the same PR.

--- a/apps/docs/scripts/sync-tweet-cache.ts
+++ b/apps/docs/scripts/sync-tweet-cache.ts
@@ -202,6 +202,22 @@ async function headStatus(url: string) {
 }
 
 /**
+ * Exit-code policy for the sync run.
+ *
+ * Only hard-fail when a tweet could not be fetched at all AND has no
+ * cached fallback (`failedWithoutFallback`) — that's the case that
+ * renders "Tweet not found" in production. An unreachable card *image*
+ * on an already-cached tweet is advisory: Twitter deletes/rotates
+ * `pbs.twimg.com/card_img/*` assets upstream and no amount of
+ * re-running the build can bring them back, so failing the build just
+ * wedges every deploy behind an upstream 404 we cannot fix
+ * (regression: 2026-07-04, tweet 2006790779537121585).
+ */
+function shouldFailSync(failedWithoutFallback: number, _unreachableCardImages: number) {
+  return failedWithoutFallback > 0;
+}
+
+/**
  * Main sync function
  */
 async function main() {
@@ -235,6 +251,7 @@ async function main() {
   let fetched = 0;
   let cached = 0;
   let failed = 0;
+  let failedWithoutFallback = 0;
   
   for (const id of Array.from(allTweetIds)) {
     // Check if we can use cached version
@@ -268,19 +285,23 @@ async function main() {
       } else {
         console.error(`  ✗ ${id}: Tweet not found (deleted or private?)`);
         failed++;
-        
+
         // Keep old cached version if available
         if (cache.tweets[id]) {
           console.log(`     ↳ Keeping stale cache as fallback`);
+        } else {
+          failedWithoutFallback++;
         }
       }
     } catch (error) {
       console.error(`  ✗ ${id}: API error - ${(error as Error).message}`);
       failed++;
-      
+
       // Keep old cached version if available
       if (cache.tweets[id]) {
         console.log(`     ↳ Keeping stale cache as fallback`);
+      } else {
+        failedWithoutFallback++;
       }
     }
     
@@ -293,10 +314,12 @@ async function main() {
 
   // Verify every cached preview image URL is live. Twitter rotates
   // `pbs.twimg.com/card_img/*` IDs faster than our 7-day TTL, so a "fresh"
-  // cache can still hold a 404 URL. Fail loudly so the issue surfaces
-  // pre-deploy instead of after prod renders an empty card. The lock test
-  // catches the structural case (URL missing from JSON) at PR time;
-  // this HEAD check catches the dynamic case (URL present but 404).
+  // cache can still hold a 404 URL. This check is ADVISORY: when Twitter
+  // deletes a card image upstream, re-running the build can never fix it,
+  // so a hard failure here just wedges every deploy (2026-07-04). We warn
+  // loudly and keep the stale entry — the card renders text-only until a
+  // human swaps the embed. The lock test still catches the structural
+  // case (URL missing from JSON) at PR time.
   console.log(`\n🔎 Verifying cached preview image URLs are live…`);
   let unreachable = 0;
   for (const [id, t] of Object.entries(cache.tweets)) {
@@ -309,7 +332,8 @@ async function main() {
     if (status >= 200 && status < 300) {
       console.log(`  ✓ ${id}: card image OK (${status})`);
     } else {
-      console.error(`  ✗ ${id}: card image unreachable (HTTP ${status}) — ${url}`);
+      console.warn(`  ⚠ ${id}: card image unreachable (HTTP ${status}) — ${url}`);
+      console.warn(`     ↳ Keeping stale cache entry; the card renders without a preview image until the embed is replaced.`);
       unreachable++;
     }
   }
@@ -320,14 +344,16 @@ async function main() {
   console.log(`   Failed: ${failed}`);
   console.log(`   Unreachable card images: ${unreachable}`);
 
-  if (failed > 0 || unreachable > 0) {
-    if (failed > 0) {
-      console.log(`\n⚠️  ${failed} tweet(s) could not be fetched.`);
-    }
-    if (unreachable > 0) {
-      console.log(`\n⚠️  ${unreachable} cached card image URL(s) returned non-2xx.`);
-      console.log(`   Re-run with --force; if the failure repeats, the tweet's preview image was removed upstream.`);
-    }
+  if (failed > 0) {
+    console.log(`\n⚠️  ${failed} tweet(s) could not be fetched.`);
+  }
+  if (unreachable > 0) {
+    console.log(`\n⚠️  ${unreachable} cached card image URL(s) returned non-2xx (upstream deleted/rotated).`);
+    console.log(`   Advisory only — the build proceeds with the stale cache entry.`);
+  }
+
+  if (shouldFailSync(failedWithoutFallback, unreachable)) {
+    console.error(`\n❌ ${failedWithoutFallback} tweet(s) failed to fetch with NO cached fallback — these would render "Tweet not found" in production.`);
     process.exit(1);
   }
 }
@@ -340,4 +366,4 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
   });
 }
 
-export { extractTweetIds, loadCache, saveCache, getCardImageUrl, mergePreservedCardImages };
+export { extractTweetIds, loadCache, saveCache, getCardImageUrl, mergePreservedCardImages, shouldFailSync };

--- a/apps/docs/src/__tests__/social-embeds-integrity.test.ts
+++ b/apps/docs/src/__tests__/social-embeds-integrity.test.ts
@@ -17,6 +17,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { readFileSync, readdirSync, statSync, existsSync } from 'fs';
 import { join, resolve } from 'path';
 import { getTweet } from 'react-tweet/api';
+import { shouldFailSync } from '../../scripts/sync-tweet-cache';
 
 // ============================================================================
 // Configuration
@@ -467,6 +468,33 @@ describe('Social Embeds - Cache Validation', () => {
       missing,
       `${missing.length} cached tweet(s) have a \`card\` field but no preview image URL — this renders an empty box where the article preview should be.`,
     ).toHaveLength(0);
+  });
+});
+
+// ============================================================================
+// Tests: Sync-script exit policy (regression lock: 2026-07-04)
+// ============================================================================
+
+describe('sync-tweet-cache exit policy', () => {
+  // Regression lock — a cached tweet's upstream card image 404ing
+  // (Twitter deleted/rotated the pbs.twimg.com/card_img asset) used to
+  // hard-fail the docs build via `process.exit(1)`. That failure is
+  // unfixable by re-running the build, so it wedged every deploy. The
+  // policy is: unreachable card images on already-cached tweets are
+  // advisory (warn + keep the stale entry); only a fetch failure with
+  // NO cached fallback — i.e. "Tweet not found" would ship — fails.
+  it('does NOT fail the build for unreachable card images on cached tweets', () => {
+    expect(shouldFailSync(0, 1)).toBe(false);
+    expect(shouldFailSync(0, 5)).toBe(false);
+  });
+
+  it('does NOT fail the build when nothing went wrong', () => {
+    expect(shouldFailSync(0, 0)).toBe(false);
+  });
+
+  it('DOES fail the build when a tweet cannot be fetched and has no cached fallback', () => {
+    expect(shouldFailSync(1, 0)).toBe(true);
+    expect(shouldFailSync(2, 3)).toBe(true);
   });
 });
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -161,7 +161,22 @@ export default [
     rules: {
       ...reactA11y.configs.recommended.rules,
       ...reactFeatures.configs.recommended.rules,
-      // Component-API rules for the DS surface only
+      // Known false positives on the DS surface — keep as guidance
+      // (warn), not gate, matching the componentApi severity model
+      // (only `no-default-test-id` is a hard error). These surfaced on
+      // 2026-07-04 when the duplicate-plugin crash was fixed and the
+      // rules actually ran for the first time since #180:
+      // - no-unknown-property fires on custom-component props
+      //   (<Box surface radius border>, <Stack direction gap>) — it
+      //   should only check lowercase DOM tags. Rule fix tracked in
+      //   eslint-plugin-react-features.
+      // - jsx-key flags index keys on static decorative arrays
+      //   (meteors.tsx) that never reorder.
+      // - anchor-has-content can't see children forwarded via a
+      //   {...props} spread (pagination-link).
+      'react-features/no-unknown-property': 'warn',
+      'react-features/jsx-key': 'warn',
+      'react-a11y/anchor-has-content': 'warn',
     },
   },
   {
@@ -178,10 +193,22 @@ export default [
   // Scoped to UI primitives via `files` (the preset binds globally by
   // default; that's correct for consumer apps but too broad for an
   // ecosystem repo where most code isn't shared components).
-  ...componentApiPreset.map((c) => ({
-    ...c,
-    files: ['packages/ui/src/primitives/**/*.tsx'],
-  })),
+  //
+  // IMPORTANT: strip the preset's `plugins` key. The preset carries its
+  // own `react-features` plugin object (resolved through the
+  // meta-package's built dist), which is a DIFFERENT module instance
+  // than the `eslint-plugin-react-features` imported directly above.
+  // Flat config only allows re-registering a plugin name when it's the
+  // identical object — two instances under one namespace for the same
+  // files throws `ConfigError: Cannot redefine plugin "react-features"`
+  // and crashes every lint run (component-api-lint CI, 2026-07-04).
+  // The rules still resolve fine: the `react-features` namespace is
+  // already registered for these files by the blocks above.
+  ...componentApiPreset.map((c) => {
+    const scoped = { ...c, files: ['packages/ui/src/primitives/**/*.tsx'] };
+    delete scoped.plugins;
+    return scoped;
+  }),
 
   // ── oxlint integration ──────────────────────────────────────────────────
   // Disable ESLint rules that oxlint handles natively in Rust (50-100× faster).


### PR DESCRIPTION
## Summary

Fixes the two pre-existing CI breakages on `main`.

### 1. Docs build failed in `sync-tweet-cache.ts` (upstream 404)

**Root cause:** Twitter deleted the card preview image behind cached tweet `2006790779537121585` (`pbs.twimg.com/card_img/2068683856237170689/NqfhkhRF` now HEADs 404). The post-sync HEAD-check treated any non-2xx as fatal and `process.exit(1)`'d, failing `apps/docs` `npm run build` (and with it the lefthook pre-push build and every docs deploy). An upstream-deleted asset can never be fixed by re-running the build, so the gate wedged CI on a failure nobody can act on from inside the repo.

**Fix:** the HEAD-check is now advisory — a 404 on an already-cached asset warns and keeps the stale entry (the card renders text-only until the embed is replaced). The build still hard-fails for the one case that genuinely ships breakage: a tweet that cannot be fetched AND has no cached fallback ("Tweet not found" in production). The policy is encoded in the exported `shouldFailSync()` and locked by three new vitest cases in `social-embeds-integrity.test.ts`; the structural preview-image lock is unchanged. `CLAUDE.md`'s lock inventory updated to match.

### 2. `component-api lint` crashed: `ConfigError: Cannot redefine plugin "react-features"`

**Root cause:** PR #180 wired `eslint-plugin-react-features` directly into the root flat config (recommended + componentApi blocks) on top of the `componentApi` preset spread from `@interlace/eslint-config` (PR #100). The preset carries its own `react-features` plugin object resolved through the meta-package's built dist — a *different module instance* than the direct import — and ESLint flat config only allows re-registering a plugin name with the identical object. Every workflow run since #180 crashed before linting a single file.

**Fix:** strip the preset's `plugins` key when scoping it to `packages/ui/src/primitives/**` — the `react-features` namespace is already registered for those files by the direct blocks, so rule resolution is unchanged.

**Follow-ups in the same change:**
- With the crash gone, the recommended rules ran for the first time since #180 and surfaced 14 errors — all false positives or benign (`no-unknown-property` fires on custom-component props like `<Box surface radius>`, `jsx-key` on a static decorative array, `anchor-has-content` on `{...props}`-spread children). Downgraded those three to `warn` on the DS surface, matching the workflow's documented severity model (only `no-default-test-id` is the hard gate).
- `component-api-lint.yml` now also triggers on `eslint.config.mjs` + `packages/eslint-config-interlace/**`, so a config edit that crashes the lint is caught on the PR that introduces it instead of on `main`.

## Test plan

- [x] Reproduced both failures locally on `origin/main` before fixing (build exit 1 on the 404; `ConfigError` from the workflow's exact eslint invocation)
- [x] `npx eslint --format json 'packages/ui/src/primitives/**/*.tsx'` → exit 0, 35 warnings / 0 errors
- [x] `npx eslint --max-warnings 0 packages/ui/src/primitives/dialog.tsx` → exit 0 (reference-primitive self-test)
- [x] `tsx scripts/sync-tweet-cache.ts` → exit 0, warns on the 404, keeps the stale entry, no cache churn
- [x] `apps/docs` full `npm run build` → exit 0
- [x] `vitest run src/__tests__/social-embeds-integrity.test.ts` → 16/16 (incl. 3 new `shouldFailSync` locks)
- [x] Full lefthook pre-push battery green (typecheck, build, tests, markdown, portability, lockfile, workflows, changeset, shims)

## After merge

Docs builds and the component-api lint gate are unwedged. The tweet card for `2006790779537121585` renders without a preview image until the embed is replaced — consider swapping the embed or fixing the `no-unknown-property` custom-component FP in `eslint-plugin-react-features` as follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)