### PR TITLE
ci: gate coverage with ratchet floors en route to 100% policy

### DIFF
--- a/.changeset/coverage-ratchet-gate.md
+++ b/.changeset/coverage-ratchet-gate.md
@@ -1,0 +1,4 @@
+---
+---
+
+CI-only: coverage ratchet gate (no package behavior changes, no release needed).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,7 +176,7 @@ All ESLint rules must meet these criteria before release:
 | Criterion          | Requirement                                |
 | ------------------ | ------------------------------------------ |
 | **Conceptual Fit** | Rule belongs in the correct plugin         |
-| **Test Coverage**  | ≥90% line coverage                         |
+| **Test Coverage**  | 100% target, ratchet-enforced (QUALITY_STANDARDS.md §2) |
 | **Performance**    | O(n) complexity, single-pass AST traversal |
 | **Documentation**  | Rule docs with examples, OWASP mapping     |
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,12 +8,10 @@ coverage:
   status:
     project:
       default:
-        target: auto
-        threshold: 5%
+        target: 100%
     patch:
       default:
-        target: auto
-        threshold: 5%
+        target: 100%
 
 comment:
   layout: 'header, diff, flags, components'
@@ -35,7 +33,7 @@ component_management:
   default_rules:
     statuses:
       - type: project
-        target: auto
+        target: 100%
         branches:
           - '!main'
   individual_components:
@@ -48,9 +46,9 @@ component_management:
         - packages/eslint-plugin-secure-coding/**
       statuses:
         - type: project
-          target: 85%
+          target: 100%
         - type: patch
-          target: 80%
+          target: 100%
 
     - component_id: eslint-plugin-crypto
       name: 'eslint-plugin-crypto'
@@ -58,9 +56,9 @@ component_management:
         - packages/eslint-plugin-crypto/**
       statuses:
         - type: project
-          target: 85%
+          target: 100%
         - type: patch
-          target: 80%
+          target: 100%
 
     - component_id: eslint-plugin-jwt
       name: 'eslint-plugin-jwt'
@@ -68,9 +66,9 @@ component_management:
         - packages/eslint-plugin-jwt/**
       statuses:
         - type: project
-          target: 85%
+          target: 100%
         - type: patch
-          target: 80%
+          target: 100%
 
     - component_id: eslint-plugin-pg
       name: 'eslint-plugin-pg'
@@ -78,9 +76,9 @@ component_management:
         - packages/eslint-plugin-pg/**
       statuses:
         - type: project
-          target: 80%
+          target: 100%
         - type: patch
-          target: 75%
+          target: 100%
 
     - component_id: eslint-plugin-mongodb-security
       name: 'eslint-plugin-mongodb-security'
@@ -88,9 +86,9 @@ component_management:
         - packages/eslint-plugin-mongodb-security/**
       statuses:
         - type: project
-          target: 85%
+          target: 100%
         - type: patch
-          target: 80%
+          target: 100%
 
     - component_id: eslint-plugin-node-security
       name: 'eslint-plugin-node-security'
@@ -98,9 +96,9 @@ component_management:
         - packages/eslint-plugin-node-security/**
       statuses:
         - type: project
-          target: 85%
+          target: 100%
         - type: patch
-          target: 80%
+          target: 100%
 
     # ─────────────────────────────────────────────────────────────────────────
     # Framework Security Plugins
@@ -111,7 +109,7 @@ component_management:
         - packages/eslint-plugin-express-security/**
       statuses:
         - type: project
-          target: 80%
+          target: 100%
 
     - component_id: eslint-plugin-nestjs-security
       name: 'eslint-plugin-nestjs-security'
@@ -119,7 +117,7 @@ component_management:
         - packages/eslint-plugin-nestjs-security/**
       statuses:
         - type: project
-          target: 80%
+          target: 100%
 
     - component_id: eslint-plugin-lambda-security
       name: 'eslint-plugin-lambda-security'
@@ -127,7 +125,7 @@ component_management:
         - packages/eslint-plugin-lambda-security/**
       statuses:
         - type: project
-          target: 80%
+          target: 100%
 
     - component_id: eslint-plugin-browser-security
       name: 'eslint-plugin-browser-security'
@@ -135,7 +133,7 @@ component_management:
         - packages/eslint-plugin-browser-security/**
       statuses:
         - type: project
-          target: 80%
+          target: 100%
 
     # ─────────────────────────────────────────────────────────────────────────
     # AI Security Plugins
@@ -146,7 +144,7 @@ component_management:
         - packages/eslint-plugin-vercel-ai-security/**
       statuses:
         - type: project
-          target: 90%
+          target: 100%
 
     # ─────────────────────────────────────────────────────────────────────────
     # Governance & Quality Plugins
@@ -157,7 +155,7 @@ component_management:
         - packages/eslint-plugin-conventions/**
       statuses:
         - type: project
-          target: 80%
+          target: 100%
 
     - component_id: eslint-plugin-maintainability
       name: 'eslint-plugin-maintainability'
@@ -165,7 +163,7 @@ component_management:
         - packages/eslint-plugin-maintainability/**
       statuses:
         - type: project
-          target: 80%
+          target: 100%
 
     - component_id: eslint-plugin-modernization
       name: 'eslint-plugin-modernization'
@@ -173,7 +171,7 @@ component_management:
         - packages/eslint-plugin-modernization/**
       statuses:
         - type: project
-          target: 80%
+          target: 100%
 
     - component_id: eslint-plugin-modularity
       name: 'eslint-plugin-modularity'
@@ -181,7 +179,7 @@ component_management:
         - packages/eslint-plugin-modularity/**
       statuses:
         - type: project
-          target: 80%
+          target: 100%
 
     - component_id: eslint-plugin-operability
       name: 'eslint-plugin-operability'
@@ -189,7 +187,7 @@ component_management:
         - packages/eslint-plugin-operability/**
       statuses:
         - type: project
-          target: 80%
+          target: 100%
 
     - component_id: eslint-plugin-reliability
       name: 'eslint-plugin-reliability'
@@ -197,7 +195,7 @@ component_management:
         - packages/eslint-plugin-reliability/**
       statuses:
         - type: project
-          target: 80%
+          target: 100%
 
     # ─────────────────────────────────────────────────────────────────────────
     # Core Packages
@@ -208,7 +206,7 @@ component_management:
         - packages/eslint-devkit/**
       statuses:
         - type: project
-          target: 70%
+          target: 100%
 
     # ─────────────────────────────────────────────────────────────────────────
     # Utility & Feature Plugins
@@ -219,7 +217,7 @@ component_management:
         - packages/eslint-plugin-import-next/**
       statuses:
         - type: project
-          target: 75%
+          target: 100%
 
     - component_id: eslint-plugin-react-features
       name: 'eslint-plugin-react-features'

--- a/docs/QUALITY_STANDARDS.md
+++ b/docs/QUALITY_STANDARDS.md
@@ -100,14 +100,25 @@ if (node.value.includes('password') || node.value.includes('secret')) {
 
 ## 2. Test Coverage Requirements
 
-### Minimum Thresholds
+### Coverage Policy: 100% (ratchet-enforced)
 
-| Metric     | Minimum | Target | Blocking? |
-| ---------- | ------- | ------ | :-------: |
-| Lines      | 90%     | 95%+   |    ✅     |
-| Branches   | 75%     | 85%+   |    ⚠️     |
-| Functions  | 95%     | 100%   |    ✅     |
-| Statements | 90%     | 95%+   |    ✅     |
+| Metric     | Policy Target | Enforced Today | Blocking? |
+| ---------- | :-----------: | -------------- | :-------: |
+| Lines      |     100%      | Ratchet floor  |    ✅     |
+| Branches   |     100%      | Ratchet floor  |    ✅     |
+| Functions  |     100%      | Ratchet floor  |    ✅     |
+| Statements |     100%      | Ratchet floor  |    ✅     |
+
+**The target is 100% on all four metrics for every published package.**
+
+**Ratchet mechanism (never-regress en route to 100):** each package pins
+`coverage.thresholds` in its vitest/vite config at its measured coverage,
+floored to the whole percent (snapshot: 2026-07-04). Coverage is always
+collected (`coverage.enabled: true`), so the required Quality gate fails on
+any regression below a package's floor. Floors may only be raised — never
+lowered. When a package reaches 100 on a metric, its floor becomes 100 and
+stays there. The gap between each floor and 100 is tracked as the work queue
+for the test-writing wave.
 
 ### Verification Command
 
@@ -145,19 +156,25 @@ Every rule MUST have tests covering:
    - Functions < 90%
    - Large blocks of uncovered code
 
-2. **Acceptable gaps** (document with `c8 ignore`):
-   - Safety checker early returns (see §6)
-   - File system operations
-   - Runtime-only conditions
+2. **Annotation debt** (legacy only — see below):
+   - Existing `c8 ignore` blocks are tracked as annotation debt and will be
+     reproduced-or-deleted during the 100% test wave
 
 3. **NOT acceptable** (must fix):
    - Main rule logic uncovered
    - Error reporting paths uncovered
    - Option handling uncovered
 
-### c8/v8 Ignore Best Practices
+### c8/v8 Ignore Comments: BANNED
 
-Use coverage ignore comments **only** for structurally untestable code:
+Coverage-ignore annotations (`/* v8 ignore */`, `/* istanbul ignore */`,
+`/* c8 ignore */`) are **banned going forward** — do not add new ones.
+They hide real coverage gaps behind the reported percentages. Existing
+annotations are inventoried as annotation debt and will be
+reproduced-or-deleted during the 100% test wave: either the guarded code
+gets a real test, or the code is removed.
+
+Legacy guidance (kept for context while the debt is worked off):
 
 ```typescript
 // ✅ CORRECT: Safety checker that requires JSDoc context
@@ -191,11 +208,9 @@ Is the code covered?
 ├── YES → No action needed
 └── NO → Can the code be tested via RuleTester?
     ├── YES → Add missing test cases
-    └── NO → Why not?
-        ├── JSDoc/annotation requirement → ✅ Use c8 ignore with explanation
-        ├── File system access → ✅ Use c8 ignore with explanation
-        ├── Runtime-only condition → ✅ Use c8 ignore with explanation
-        └── Dead code / unreachable → ❌ REMOVE the code
+    └── NO → Can it be tested another way (unit test, mock, harness)?
+        ├── YES → Add the test — new c8 ignore comments are banned
+        └── NO → Dead code / unreachable → ❌ REMOVE the code
 ```
 
 > **Reference**: See RULETESTER-COVERAGE-LIMITATIONS.md (planned) for detailed patterns.

--- a/packages/eslint-config-interlace/vitest.config.mts
+++ b/packages/eslint-config-interlace/vitest.config.mts
@@ -75,19 +75,17 @@ export default defineConfig({
     name: { label: 'eslint-config', color: 'magenta' },
     pool: 'vmThreads',
     coverage: {
+      enabled: true,
       provider: 'v8',
+      // Coverage ratchet — policy target is 100/100/100/100 (docs/QUALITY_STANDARDS.md §2).
+      // Floors = measured coverage on 2026-07-04, floored to whole %. Never lower — only raise toward 100.
+      thresholds: { lines: 100, statements: 100, functions: 100, branches: 100 },
       reportOnFailure: true,
       reportsDirectory: './coverage',
       include: ['src/**/*.ts'],
       exclude: ['node_modules/', 'dist/', '**/*.test.ts', '**/*.spec.ts'],
       clean: true,
       reporter: ['text', 'text-summary', 'html', 'lcov'],
-      thresholds: {
-        lines: 80,
-        branches: 70,
-        functions: 80,
-        statements: 80,
-      },
     },
     reporters: ['default', 'junit'],
     outputFile: {

--- a/packages/eslint-devkit/vitest.config.mts
+++ b/packages/eslint-devkit/vitest.config.mts
@@ -36,7 +36,11 @@ export default defineConfig({
       NODE_PATH: './test-mocks/node_modules',
     },
     coverage: {
+      enabled: true,
       provider: 'v8',
+      // Coverage ratchet — policy target is 100/100/100/100 (docs/QUALITY_STANDARDS.md §2).
+      // Floors = measured coverage on 2026-07-04, floored to whole %. Never lower — only raise toward 100.
+      thresholds: { lines: 88, statements: 87, functions: 81, branches: 88 },
       // json for Codecov, text for console, html for local dev
       reporter: ['json', 'text', 'lcov'],
       reportOnFailure: true,

--- a/packages/eslint-formatter/package.json
+++ b/packages/eslint-formatter/package.json
@@ -57,5 +57,9 @@
   },
   "devDependencies": {
     "eslint": "^10.4.1"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   }
 }

--- a/packages/eslint-formatter/vitest.config.mts
+++ b/packages/eslint-formatter/vitest.config.mts
@@ -10,7 +10,11 @@ export default defineConfig({
     passWithNoTests: true,
     pool: 'vmThreads',
     coverage: {
+      enabled: true,
       provider: 'v8',
+      // Coverage ratchet — policy target is 100/100/100/100 (docs/QUALITY_STANDARDS.md §2).
+      // Floors = measured coverage on 2026-07-04, floored to whole %. Never lower — only raise toward 100.
+      thresholds: { lines: 66, statements: 67, functions: 67, branches: 69 },
       reportsDirectory: './coverage',
       include: ['src/**/*.ts'],
       exclude: ['node_modules/', 'dist/', '**/*.test.ts', '**/*.spec.ts'],

--- a/packages/eslint-plugin-browser-security/vitest.config.mts
+++ b/packages/eslint-plugin-browser-security/vitest.config.mts
@@ -10,7 +10,11 @@ export default defineConfig({
     passWithNoTests: true,
     pool: 'vmThreads',
     coverage: {
+      enabled: true,
       provider: 'v8',
+      // Coverage ratchet — policy target is 100/100/100/100 (docs/QUALITY_STANDARDS.md §2).
+      // Floors = measured coverage on 2026-07-04, floored to whole %. Never lower — only raise toward 100.
+      thresholds: { lines: 94, statements: 93, functions: 97, branches: 86 },
       reportsDirectory: './coverage',
       include: ['src/**/*.ts'],
       exclude: ['node_modules/', 'dist/', '**/*.test.ts', '**/*.spec.ts'],

--- a/packages/eslint-plugin-conventions/vite.config.ts
+++ b/packages/eslint-plugin-conventions/vite.config.ts
@@ -14,8 +14,12 @@ export default defineConfig(() => ({
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     reporters: ['default'],
     coverage: {
+      enabled: true,
       reportsDirectory: '../../coverage/packages/eslint-plugin-conventions',
       provider: 'v8' as const,
+      // Coverage ratchet — policy target is 100/100/100/100 (docs/QUALITY_STANDARDS.md §2).
+      // Floors = measured coverage on 2026-07-04, floored to whole %. Never lower — only raise toward 100.
+      thresholds: { lines: 90, statements: 86, functions: 97, branches: 77 },
     },
   },
 }));

--- a/packages/eslint-plugin-express-security/vitest.config.mts
+++ b/packages/eslint-plugin-express-security/vitest.config.mts
@@ -10,7 +10,11 @@ export default defineConfig({
     passWithNoTests: true,
     pool: 'vmThreads',
     coverage: {
+      enabled: true,
       provider: 'v8',
+      // Coverage ratchet — policy target is 100/100/100/100 (docs/QUALITY_STANDARDS.md §2).
+      // Floors = measured coverage on 2026-07-04, floored to whole %. Never lower — only raise toward 100.
+      thresholds: { lines: 93, statements: 93, functions: 98, branches: 86 },
       reportsDirectory: './coverage',
       include: ['src/**/*.ts'],
       exclude: ['node_modules/', 'dist/', '**/*.test.ts', '**/*.spec.ts'],

--- a/packages/eslint-plugin-import-next/vitest.config.mts
+++ b/packages/eslint-plugin-import-next/vitest.config.mts
@@ -21,7 +21,11 @@ export default defineConfig({
     testTimeout: 30000, // Increase timeout for tests that require file system resolution
     globalSetup: ['../../vitest.global-setup.ts'],
     coverage: {
+      enabled: true,
       provider: 'v8',
+      // Coverage ratchet — policy target is 100/100/100/100 (docs/QUALITY_STANDARDS.md §2).
+      // Floors = measured coverage on 2026-07-04, floored to whole %. Never lower — only raise toward 100.
+      thresholds: { lines: 88, statements: 86, functions: 94, branches: 78 },
       reporter: ['json', 'text', 'lcov'],
       reportOnFailure: true,
       reportsDirectory: './coverage',

--- a/packages/eslint-plugin-jwt/vitest.config.mts
+++ b/packages/eslint-plugin-jwt/vitest.config.mts
@@ -10,7 +10,11 @@ export default defineConfig({
     passWithNoTests: true,
     pool: 'vmThreads',
     coverage: {
+      enabled: true,
       provider: 'v8',
+      // Coverage ratchet — policy target is 100/100/100/100 (docs/QUALITY_STANDARDS.md §2).
+      // Floors = measured coverage on 2026-07-04, floored to whole %. Never lower — only raise toward 100.
+      thresholds: { lines: 96, statements: 94, functions: 100, branches: 90 },
       reportsDirectory: './coverage',
       include: ['src/**/*.ts'],
       exclude: ['node_modules/', 'dist/', '**/*.test.ts', '**/*.spec.ts'],

--- a/packages/eslint-plugin-lambda-security/vitest.config.mts
+++ b/packages/eslint-plugin-lambda-security/vitest.config.mts
@@ -10,7 +10,11 @@ export default defineConfig({
     passWithNoTests: true,
     pool: 'vmThreads',
     coverage: {
+      enabled: true,
       provider: 'v8',
+      // Coverage ratchet — policy target is 100/100/100/100 (docs/QUALITY_STANDARDS.md §2).
+      // Floors = measured coverage on 2026-07-04, floored to whole %. Never lower — only raise toward 100.
+      thresholds: { lines: 97, statements: 95, functions: 99, branches: 88 },
       reportsDirectory: './coverage',
       include: ['src/**/*.ts'],
       exclude: ['node_modules/', 'dist/', '**/*.test.ts', '**/*.spec.ts'],

--- a/packages/eslint-plugin-maintainability/vitest.config.mts
+++ b/packages/eslint-plugin-maintainability/vitest.config.mts
@@ -14,7 +14,11 @@ export default defineConfig({
     passWithNoTests: true,
     globalSetup: ['../../vitest.global-setup.ts'],
     coverage: {
+      enabled: true,
       provider: 'v8',
+      // Coverage ratchet — policy target is 100/100/100/100 (docs/QUALITY_STANDARDS.md §2).
+      // Floors = measured coverage on 2026-07-04, floored to whole %. Never lower — only raise toward 100.
+      thresholds: { lines: 92, statements: 91, functions: 97, branches: 81 },
       reporter: ['json', 'text', 'lcov'],
       reportOnFailure: true,
       reportsDirectory: './coverage',

--- a/packages/eslint-plugin-modernization/vite.config.ts
+++ b/packages/eslint-plugin-modernization/vite.config.ts
@@ -11,8 +11,12 @@ export default defineConfig(() => ({
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     reporters: ['default'],
     coverage: {
+      enabled: true,
       reportsDirectory: '../../coverage/packages/eslint-plugin-modernization',
       provider: 'v8' as const,
+      // Coverage ratchet — policy target is 100/100/100/100 (docs/QUALITY_STANDARDS.md §2).
+      // Floors = measured coverage on 2026-07-04, floored to whole %. Never lower — only raise toward 100.
+      thresholds: { lines: 94, statements: 92, functions: 100, branches: 92 },
     },
   },
 }));

--- a/packages/eslint-plugin-modularity/vite.config.ts
+++ b/packages/eslint-plugin-modularity/vite.config.ts
@@ -11,8 +11,12 @@ export default defineConfig(() => ({
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     reporters: ['default'],
     coverage: {
+      enabled: true,
       reportsDirectory: '../../coverage/packages/eslint-plugin-modularity',
       provider: 'v8' as const,
+      // Coverage ratchet — policy target is 100/100/100/100 (docs/QUALITY_STANDARDS.md §2).
+      // Floors = measured coverage on 2026-07-04, floored to whole %. Never lower — only raise toward 100.
+      thresholds: { lines: 95, statements: 93, functions: 97, branches: 79 },
     },
   },
 }));

--- a/packages/eslint-plugin-mongodb-security/vitest.config.mts
+++ b/packages/eslint-plugin-mongodb-security/vitest.config.mts
@@ -7,7 +7,11 @@ export default defineConfig({
     environment: 'node',
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
     coverage: {
+      enabled: true,
       provider: 'v8',
+      // Coverage ratchet — policy target is 100/100/100/100 (docs/QUALITY_STANDARDS.md §2).
+      // Floors = measured coverage on 2026-07-04, floored to whole %. Never lower — only raise toward 100.
+      thresholds: { lines: 91, statements: 88, functions: 94, branches: 78 },
       reporter: ['text', 'lcov', 'html'],
       reportsDirectory: './coverage',
       include: ['src/**/*.ts'],

--- a/packages/eslint-plugin-nestjs-security/vitest.config.mts
+++ b/packages/eslint-plugin-nestjs-security/vitest.config.mts
@@ -10,7 +10,11 @@ export default defineConfig({
     passWithNoTests: true,
     pool: 'vmThreads',
     coverage: {
+      enabled: true,
       provider: 'v8',
+      // Coverage ratchet — policy target is 100/100/100/100 (docs/QUALITY_STANDARDS.md §2).
+      // Floors = measured coverage on 2026-07-04, floored to whole %. Never lower — only raise toward 100.
+      thresholds: { lines: 95, statements: 88, functions: 98, branches: 78 },
       reportsDirectory: './coverage',
       include: ['src/**/*.ts'],
       exclude: ['node_modules/', 'dist/', '**/*.test.ts', '**/*.spec.ts'],

--- a/packages/eslint-plugin-node-security/vitest.config.mts
+++ b/packages/eslint-plugin-node-security/vitest.config.mts
@@ -10,8 +10,12 @@ export default defineConfig({
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     reporters: ['default'],
     coverage: {
+      enabled: true,
       reportsDirectory: '../../coverage/packages/eslint-plugin-node-security',
       provider: 'v8',
+      // Coverage ratchet — policy target is 100/100/100/100 (docs/QUALITY_STANDARDS.md §2).
+      // Floors = measured coverage on 2026-07-04, floored to whole %. Never lower — only raise toward 100.
+      thresholds: { lines: 90, statements: 89, functions: 96, branches: 80 },
     },
   },
 });

--- a/packages/eslint-plugin-operability/vite.config.ts
+++ b/packages/eslint-plugin-operability/vite.config.ts
@@ -14,8 +14,12 @@ export default defineConfig(() => ({
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     reporters: ['default'],
     coverage: {
+      enabled: true,
       reportsDirectory: '../../coverage/packages/eslint-plugin-operability',
       provider: 'v8' as const,
+      // Coverage ratchet — policy target is 100/100/100/100 (docs/QUALITY_STANDARDS.md §2).
+      // Floors = measured coverage on 2026-07-04, floored to whole %. Never lower — only raise toward 100.
+      thresholds: { lines: 98, statements: 95, functions: 100, branches: 92 },
     },
   },
 }));

--- a/packages/eslint-plugin-pg/vitest.config.mts
+++ b/packages/eslint-plugin-pg/vitest.config.mts
@@ -37,7 +37,11 @@ export default defineConfig({
     // Use vmThreads for better performance
     pool: 'vmThreads',
     coverage: {
+      enabled: true,
       provider: 'v8',
+      // Coverage ratchet — policy target is 100/100/100/100 (docs/QUALITY_STANDARDS.md §2).
+      // Floors = measured coverage on 2026-07-04, floored to whole %. Never lower — only raise toward 100.
+      thresholds: { lines: 96, statements: 95, functions: 98, branches: 90 },
       reportOnFailure: true,
       reportsDirectory: './coverage',
       include: ['src/**/*.ts'],
@@ -51,12 +55,6 @@ export default defineConfig({
         functions: [80, 90],
         statements: [80, 90],
       },
-      thresholds: {
-        lines: 80,
-        branches: 70,
-        functions: 80,
-        statements: 80
-      }
     },
     reporters: ['default', 'junit'],
     outputFile: {

--- a/packages/eslint-plugin-react-a11y/vitest.config.mts
+++ b/packages/eslint-plugin-react-a11y/vitest.config.mts
@@ -20,7 +20,11 @@ export default defineConfig({
     passWithNoTests: true,
     globalSetup: ['../../vitest.global-setup.ts'],
     coverage: {
+      enabled: true,
       provider: 'v8',
+      // Coverage ratchet — policy target is 100/100/100/100 (docs/QUALITY_STANDARDS.md §2).
+      // Floors = measured coverage on 2026-07-04, floored to whole %. Never lower — only raise toward 100.
+      thresholds: { lines: 92, statements: 87, functions: 95, branches: 81 },
       reporter: ['json', 'text', 'lcov'],
       reportOnFailure: true,
       reportsDirectory: './coverage',

--- a/packages/eslint-plugin-react-features/package.json
+++ b/packages/eslint-plugin-react-features/package.json
@@ -70,7 +70,7 @@
   },
   "scripts": {
     "build": "tsx ../../scripts/build-package.ts",
-    "test": "vitest run",
+    "test": "vitest run --coverage",
     "test:coverage": "vitest run --coverage",
     "typecheck": "tsc -p tsconfig.lib.json --noEmit"
   },

--- a/packages/eslint-plugin-react-features/vitest.config.mts
+++ b/packages/eslint-plugin-react-features/vitest.config.mts
@@ -14,7 +14,12 @@ export default defineConfig({
     passWithNoTests: true,
     globalSetup: ['../../vitest.global-setup.ts'],
     coverage: {
-      enabled: true,
+      // NOTE: `enabled: true` is deliberately NOT set here (unlike sibling
+      // packages): component-api-lint.yml runs a filtered subset
+      // (`npx vitest run src/tests/component-api/`) from this package dir,
+      // and always-on coverage would fail the ratchet thresholds on any
+      // partial run. Coverage is enforced via the `--coverage` flag in this
+      // package's `test` script instead, so `turbo run test` still gates.
       provider: 'v8',
       // Coverage ratchet — policy target is 100/100/100/100 (docs/QUALITY_STANDARDS.md §2).
       // Floors = measured coverage on 2026-07-04, floored to whole %. Never lower — only raise toward 100.

--- a/packages/eslint-plugin-react-features/vitest.config.mts
+++ b/packages/eslint-plugin-react-features/vitest.config.mts
@@ -14,7 +14,11 @@ export default defineConfig({
     passWithNoTests: true,
     globalSetup: ['../../vitest.global-setup.ts'],
     coverage: {
+      enabled: true,
       provider: 'v8',
+      // Coverage ratchet — policy target is 100/100/100/100 (docs/QUALITY_STANDARDS.md §2).
+      // Floors = measured coverage on 2026-07-04, floored to whole %. Never lower — only raise toward 100.
+      thresholds: { lines: 88, statements: 86, functions: 96, branches: 78 },
       reporter: ['json', 'text', 'lcov'],
       reportOnFailure: true,
       reportsDirectory: './coverage',

--- a/packages/eslint-plugin-reliability/vite.config.ts
+++ b/packages/eslint-plugin-reliability/vite.config.ts
@@ -14,8 +14,12 @@ export default defineConfig(() => ({
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     reporters: ['default'],
     coverage: {
+      enabled: true,
       reportsDirectory: '../../coverage/packages/eslint-plugin-reliability',
       provider: 'v8' as const,
+      // Coverage ratchet — policy target is 100/100/100/100 (docs/QUALITY_STANDARDS.md §2).
+      // Floors = measured coverage on 2026-07-04, floored to whole %. Never lower — only raise toward 100.
+      thresholds: { lines: 82, statements: 80, functions: 96, branches: 72 },
     },
   },
 }));

--- a/packages/eslint-plugin-secure-coding/vitest.config.mts
+++ b/packages/eslint-plugin-secure-coding/vitest.config.mts
@@ -39,7 +39,11 @@ export default defineConfig({
     // pool: 'forks',
     pool: 'vmThreads',
     coverage: {
+      enabled: true,
       provider: 'v8',
+      // Coverage ratchet — policy target is 100/100/100/100 (docs/QUALITY_STANDARDS.md §2).
+      // Floors = measured coverage on 2026-07-04, floored to whole %. Never lower — only raise toward 100.
+      thresholds: { lines: 89, statements: 88, functions: 97, branches: 78 },
       reportOnFailure: true,
       reportsDirectory: './coverage',
       include: ['src/**/*.ts'],
@@ -47,12 +51,6 @@ export default defineConfig({
       ignoreClassMethods: ['context.report'],
       clean: true,
       reporter: ['text', 'text-summary', 'html', 'lcov'],
-      thresholds: {
-        lines: 80,
-        branches: 70,
-        functions: 80,
-        statements: 80
-      }
     },
     reporters: ['default', 'verbose'],
     // outputFile: {

--- a/packages/eslint-plugin-vercel-ai-security/vitest.config.mts
+++ b/packages/eslint-plugin-vercel-ai-security/vitest.config.mts
@@ -37,7 +37,11 @@ export default defineConfig({
     name: { label: 'vercel-ai-security', color: 'cyan' },
     pool: 'vmThreads',
     coverage: {
+      enabled: true,
       provider: 'v8',
+      // Coverage ratchet — policy target is 100/100/100/100 (docs/QUALITY_STANDARDS.md §2).
+      // Floors = measured coverage on 2026-07-04, floored to whole %. Never lower — only raise toward 100.
+      thresholds: { lines: 90, statements: 85, functions: 83, branches: 81 },
       reportOnFailure: true,
       reportsDirectory: './coverage',
       include: ['src/**/*.ts'],
@@ -45,12 +49,6 @@ export default defineConfig({
       ignoreClassMethods: ['context.report'],
       clean: true,
       reporter: ['text', 'text-summary', 'html', 'lcov'],
-      thresholds: {
-        lines: 95,
-        branches: 75,
-        functions: 95,
-        statements: 90
-      }
     },
     reporters: ['default', 'junit'],
     outputFile: {

--- a/turbo.json
+++ b/turbo.json
@@ -35,6 +35,7 @@
         "tsconfig.spec.json",
         "vitest.config.mts",
         "vitest.config.ts",
+        "vite.config.ts",
         "package.json"
       ],
       "outputs": ["coverage/**", "test-report.junit.xml", "test-results/**"]
@@ -48,6 +49,7 @@
         "tsconfig.spec.json",
         "vitest.config.mts",
         "vitest.config.ts",
+        "vite.config.ts",
         "package.json"
       ],
       "outputs": ["coverage/**"]


### PR DESCRIPTION
## What this does

Enforces test coverage in the required Quality gate, vitest-natively — **no workflow changes**:

- **`coverage.enabled: true`** in every package's vitest/vite config, so plain `vitest run` (what turbo's existing `test` task calls) always collects coverage. A threshold miss fails the test run itself → fails the required **Quality Full Gate**.
  - Exception: `eslint-plugin-react-features` enforces via `--coverage` in its `test` script instead, because `component-api-lint.yml` runs a filtered subset (`vitest run src/tests/component-api/`) from the package dir and always-on coverage would fail thresholds on any partial run. `turbo run test` gates identically.
- **`coverage.thresholds`** set explicitly on all four metrics (lines, statements, functions, branches) in all 22 packages — pinned as **ratchet floors** at each package's measured coverage (floored to whole %, snapshot 2026-07-04). Never lower, only raise.
- **Policy target is 100/100/100/100** (per Ofri's updated policy): `docs/QUALITY_STANDARDS.md` §2 and the `CONTRIBUTING.md` coverage line now state 100% as the policy, with the ratchet floors as the never-regress mechanism en route to 100. A follow-up stacked draft PR (`ci/coverage-100`) pins every threshold at 100 — it is the definition of done for the test wave and merges last.
- **`codecov.yml`: all targets → 100%** (project default, patch, component defaults, and every individual component). Codecov is not a required check, so this is safe immediately.
- **`@interlace/eslint-formatter` newly wired**: it had 50 passing tests but no `test`/`test:coverage` scripts, so its suite never ran in CI. Scripts added; ratcheted at its actual ~67%.
- **turbo caching kept intact**: `test`/`test:coverage` outputs already include `coverage/**`; added `vite.config.ts` to their inputs (5 packages use `vite.config.ts`, which was missing from cache inputs).

## Threshold matrix (ratchet floors vs the 100% target)

Every package below 100 is **ratcheted at current actual coverage** — this table is the work queue for the test-writing wave.

| Package | Floors L/B/F/S | Actual L / B / F / S | Gap to 100 L / B / F / S | Status |
| --- | --- | --- | --- | --- |
| `eslint-config-interlace` | 100/100/100/100 | 100.00 / 100.00 / 100.00 / 100.00 | — / — / — / — | ✅ at 100 |
| `eslint-devkit` | 88/88/81/87 | 88.52 / 88.29 / 81.67 / 87.27 | 11.48 / 11.71 / 18.33 / 12.73 | 🔧 ratcheted |
| `eslint-formatter` | 66/69/67/67 | 66.95 / 69.01 / 67.85 / 67.64 | 33.05 / 30.99 / 32.15 / 32.36 | 🔧 ratcheted |
| `eslint-plugin-browser-security` | 94/86/97/93 | 94.68 / 86.15 / 97.91 / 93.55 | 5.32 / 13.85 / 2.09 / 6.45 | 🔧 ratcheted |
| `eslint-plugin-conventions` | 90/77/97/86 | 90.21 / 77.20 / 97.65 / 86.91 | 9.79 / 22.80 / 2.35 / 13.09 | 🔧 ratcheted |
| `eslint-plugin-express-security` | 93/86/98/93 | 93.86 / 86.91 / 98.11 / 93.34 | 6.14 / 13.09 / 1.89 / 6.66 | 🔧 ratcheted |
| `eslint-plugin-import-next` | 88/78/94/86 | 88.23 / 78.31 / 94.13 / 86.63 | 11.77 / 21.69 / 5.87 / 13.37 | 🔧 ratcheted |
| `eslint-plugin-jwt` | 96/90/100/94 | 96.02 / 90.18 / 100.00 / 94.95 | 3.98 / 9.82 / — / 5.05 | 🔧 ratcheted |
| `eslint-plugin-lambda-security` | 97/88/99/95 | 97.72 / 88.57 / 99.30 / 95.90 | 2.28 / 11.43 / 0.70 / 4.10 | 🔧 ratcheted |
| `eslint-plugin-maintainability` | 92/81/97/91 | 92.43 / 81.67 / 97.61 / 91.97 | 7.57 / 18.33 / 2.39 / 8.03 | 🔧 ratcheted |
| `eslint-plugin-modernization` | 94/92/100/92 | 94.69 / 92.40 / 100.00 / 92.50 | 5.31 / 7.60 / — / 7.50 | 🔧 ratcheted |
| `eslint-plugin-modularity` | 95/79/97/93 | 95.29 / 79.78 / 97.95 / 93.03 | 4.71 / 20.22 / 2.05 / 6.97 | 🔧 ratcheted |
| `eslint-plugin-mongodb-security` | 91/78/94/88 | 91.51 / 78.20 / 94.91 / 88.58 | 8.49 / 21.80 / 5.09 / 11.42 | 🔧 ratcheted |
| `eslint-plugin-nestjs-security` | 95/78/98/88 | 95.79 / 78.87 / 98.36 / 88.68 | 4.21 / 21.13 / 1.64 / 11.32 | 🔧 ratcheted |
| `eslint-plugin-node-security` | 90/80/96/89 | 90.79 / 80.11 / 96.61 / 89.60 | 9.21 / 19.89 / 3.39 / 10.40 | 🔧 ratcheted |
| `eslint-plugin-operability` | 98/92/100/95 | 98.31 / 92.18 / 100.00 / 95.96 | 1.69 / 7.82 / — / 4.04 | 🔧 ratcheted |
| `eslint-plugin-pg` | 96/90/98/95 | 96.63 / 90.11 / 98.68 / 95.04 | 3.37 / 9.89 / 1.32 / 4.96 | 🔧 ratcheted |
| `eslint-plugin-react-a11y` | 92/81/95/87 | 92.19 / 81.34 / 95.55 / 87.20 | 7.81 / 18.66 / 4.45 / 12.80 | 🔧 ratcheted |
| `eslint-plugin-react-features` | 88/78/96/86 | 88.57 / 78.53 / 96.53 / 86.41 | 11.43 / 21.47 / 3.47 / 13.59 | 🔧 ratcheted |
| `eslint-plugin-reliability` | 82/72/96/80 | 82.96 / 72.75 / 96.05 / 80.27 | 17.04 / 27.25 / 3.95 / 19.73 | 🔧 ratcheted |
| `eslint-plugin-secure-coding` | 89/78/97/88 | 89.99 / 78.34 / 97.15 / 88.52 | 10.01 / 21.66 / 2.85 / 11.48 | 🔧 ratcheted |
| `eslint-plugin-vercel-ai-security` | 90/81/83/85 | 90.07 / 81.03 / 83.08 / 85.67 | 9.93 / 18.97 / 16.92 / 14.33 | 🔧 ratcheted |

Notes:
- `eslint-plugin-vercel-ai-security` previously had aspirational thresholds 95/75/95/90 that were **never run in CI and currently fail** (actual 90.07/81.03/83.08/85.67). Ratcheted to actual: lines 95→90, functions 95→83, statements 90→85 (branches raised 75→81). The gap is top of the test-wave queue.
- `eslint-config-interlace` is already at 100/100/100/100 — pinned at 100.
- `@interlace/eslint-formatter-sarif` is **excluded**: a stub package with no tests at all (0%) — first target for the test wave.
- Prior 80/70/80/80 thresholds (`eslint-config-interlace`, `eslint-plugin-pg`, `eslint-plugin-secure-coding`) were all raised, never lowered.

## Annotation debt — to be removed in the 100% test wave

Coverage-ignore annotations are **banned going forward** (`docs/QUALITY_STANDARDS.md` updated). Existing ones are NOT removed in this PR (that would shift the ratchet floors mid-flight). The test wave must reproduce-or-delete each one.

**149 coverage-ignore annotations across 11 packages** (each = a hidden gap the percentages above do not show):

<details><summary><b>eslint-plugin-secure-coding</b> — 75 annotations</summary>

- `packages/eslint-plugin-secure-coding/src/rules/no-electron-security-issues/index.ts:363` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-electron-security-issues/index.ts:442` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-electron-security-issues/index.ts:478` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-unsafe-deserialization/index.ts:475` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-format-string-injection/index.ts:445` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-format-string-injection/index.ts:469` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-format-string-injection/index.ts:491` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-format-string-injection/index.ts:549` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-format-string-injection/index.ts:654` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-format-string-injection/index.ts:713` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-format-string-injection/index.ts:769` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-format-string-injection/index.ts:794` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-weak-password-recovery/index.ts:408` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-weak-password-recovery/index.ts:426` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-weak-password-recovery/index.ts:498` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-unlimited-resource-allocation/index.ts:360` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-unlimited-resource-allocation/index.ts:380` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-unlimited-resource-allocation/index.ts:401` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-unlimited-resource-allocation/index.ts:448` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-unlimited-resource-allocation/index.ts:499` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-unlimited-resource-allocation/index.ts:523` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-unlimited-resource-allocation/index.ts:542` — _defensive detectors for rare patterns_ — `// ZIP bomb detection - unlimited decompression`
- `packages/eslint-plugin-secure-coding/src/rules/no-unlimited-resource-allocation/index.ts:626` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-unlimited-resource-allocation/index.ts:672` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-unlimited-resource-allocation/index.ts:692` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-unlimited-resource-allocation/index.ts:713` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-unlimited-resource-allocation/index.ts:737` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-unlimited-resource-allocation/index.ts:763` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-ldap-injection/index.ts:346` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(filterArg, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-ldap-injection/index.ts:371` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(filterArg, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-ldap-injection/index.ts:420` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node.init, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-ldap-injection/index.ts:447` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node.init, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-ldap-injection/index.ts:472` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node.init, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-ldap-injection/index.ts:505` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node.init, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-ldap-injection/index.ts:530` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node.init, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/detect-object-injection/index.ts:338` — _TypeScript parser services often unavailable in RuleTester_ — `if (parserServices && propertyNode.type === AST_NODE_TYPES.Identifier) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-redos-vulnerable-regex/index.ts:377` — `return;`
- `packages/eslint-plugin-secure-coding/src/rules/no-redos-vulnerable-regex/index.ts:384` — `return;`
- `packages/eslint-plugin-secure-coding/src/rules/no-redos-vulnerable-regex/index.ts:390` — `return;`
- `packages/eslint-plugin-secure-coding/src/rules/no-redos-vulnerable-regex/index.ts:434` — `return;`
- `packages/eslint-plugin-secure-coding/src/rules/no-redos-vulnerable-regex/index.ts:442` — `return;`
- `packages/eslint-plugin-secure-coding/src/rules/no-redos-vulnerable-regex/index.ts:449` — `return;`
- `packages/eslint-plugin-secure-coding/src/rules/no-redos-vulnerable-regex/index.ts:455` — `return;`
- `packages/eslint-plugin-secure-coding/src/rules/no-improper-sanitization/index.ts:338` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-improper-sanitization/index.ts:381` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-improper-sanitization/index.ts:427` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-improper-sanitization/index.ts:521` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-xpath-injection/index.ts:611` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node.init, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-improper-type-validation/index.ts:376` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-improper-type-validation/index.ts:427` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-improper-type-validation/index.ts:470` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-improper-type-validation/index.ts:530` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-improper-type-validation/index.ts:560` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-graphql-injection/index.ts:663` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-graphql-injection/index.ts:711` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-unchecked-loop-condition/index.ts:492` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-unchecked-loop-condition/index.ts:547` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-unchecked-loop-condition/index.ts:566` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-unchecked-loop-condition/index.ts:592` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-unchecked-loop-condition/index.ts:615` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-unchecked-loop-condition/index.ts:634` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-unchecked-loop-condition/index.ts:653` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-unchecked-loop-condition/index.ts:672` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-unchecked-loop-condition/index.ts:692` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-unchecked-loop-condition/index.ts:715` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-unchecked-loop-condition/index.ts:739` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-unchecked-loop-condition/index.ts:769` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-directive-injection/index.ts:292` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-directive-injection/index.ts:323` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-directive-injection/index.ts:353` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-directive-injection/index.ts:386` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-directive-injection/index.ts:429` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-directive-injection/index.ts:454` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-directive-injection/index.ts:480` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-secure-coding/src/rules/no-directive-injection/index.ts:539` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`

</details>

<details><summary><b>eslint-plugin-browser-security</b> — 25 annotations</summary>

- `packages/eslint-plugin-browser-security/src/rules/no-jwt-in-storage/index.ts:219` — _Guard clause for non-storage objects_ — `return;`
- `packages/eslint-plugin-browser-security/src/rules/no-jwt-in-storage/index.ts:237` — _Value-based JWT detection for assignment expressions_ — `if (`
- `packages/eslint-plugin-browser-security/src/rules/no-worker-message-innerhtml/index.ts:190` — _Recursive call for deeply nested expressions_ — `return referencesEventData(node.object, eventName);`
- `packages/eslint-plugin-browser-security/src/rules/no-sensitive-cookie-js/index.ts:170` — _3 - Guard for non-cookie property_ — `if (`
- `packages/eslint-plugin-browser-security/src/rules/require-blob-url-revocation/index.ts:135` — `});`
- `packages/eslint-plugin-browser-security/src/rules/no-sensitive-localstorage/index.ts:169` — _3 - Guard for missing key argument_ — `if (!keyArg) {`
- `packages/eslint-plugin-browser-security/src/rules/no-sensitive-localstorage/index.ts:209` — _3 - Guard for non-storage objects_ — `if (obj.type !== AST_NODE_TYPES.Identifier || !storageObjects.includes(obj.name)) {`
- `packages/eslint-plugin-browser-security/src/rules/no-clickjacking/index.ts:330` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-browser-security/src/rules/no-clickjacking/index.ts:387` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-browser-security/src/rules/no-clickjacking/index.ts:415` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-browser-security/src/rules/no-clickjacking/index.ts:439` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-browser-security/src/rules/no-unencrypted-transmission/index.ts:97` — _ignore-pattern matching is defensive_ — `function matchesIgnorePattern(text: string, patterns: string[]): boolean {`
- `packages/eslint-plugin-browser-security/src/rules/no-filereader-innerhtml/index.ts:190` — _Recursive call for deeply nested expressions_ — `return referencesFileReaderResult(node.object, eventName);`
- `packages/eslint-plugin-browser-security/src/rules/no-filereader-innerhtml/index.ts:231` — _Exit handler cleanup, not testable with RuleTester_ — `'AssignmentExpression:exit'(node: TSESTree.AssignmentExpression) {`
- `packages/eslint-plugin-browser-security/src/rules/no-filereader-innerhtml/index.ts:278` — _Exit handler cleanup, not testable with RuleTester_ — `'CallExpression:exit'(node: TSESTree.CallExpression) {`
- `packages/eslint-plugin-browser-security/src/rules/no-websocket-eval/index.ts:174` — _Recursive call for nested event.data.property_ — `return referencesEventData(node.object, eventName);`
- `packages/eslint-plugin-browser-security/src/rules/no-websocket-eval/index.ts:177` — _3 - Direct event identifier reference edge case_ — `if (node.type === AST_NODE_TYPES.Identifier && node.name === eventName) {`
- `packages/eslint-plugin-browser-security/src/rules/no-websocket-eval/index.ts:195` — _Duplicate Function check for call expression pattern_ — `if (`
- `packages/eslint-plugin-browser-security/src/rules/no-postmessage-innerhtml/index.ts:150` — _Recursive call for nested event.data.property_ — `return referencesEventData(node.object, eventName);`
- `packages/eslint-plugin-browser-security/src/rules/no-postmessage-innerhtml/index.ts:153` — _3 - Direct event identifier reference edge case_ — `if (node.type === AST_NODE_TYPES.Identifier && node.name === eventName) {`
- `packages/eslint-plugin-browser-security/src/rules/no-cookie-auth-tokens/index.ts:152` — `});`
- `packages/eslint-plugin-browser-security/src/rules/no-sensitive-sessionstorage/index.ts:62` — _Additional patterns are optional config_ — `...additionalPatterns.map((p) => new RegExp(p, 'i')),`
- `packages/eslint-plugin-browser-security/src/rules/no-sensitive-sessionstorage/index.ts:173` — _Guard for non-sessionStorage objects_ — `return;`
- `packages/eslint-plugin-browser-security/src/rules/no-innerhtml/index.ts:196` — _3 - Guard for non-identifier property access_ — `if (property.type !== 'Identifier') {`
- `packages/eslint-plugin-browser-security/src/rules/no-insecure-redirects/index.ts:115` — _Guard clause: loc is always present in RuleTester_ — `if (!nodeStart || !nodeEnd || !program) {`

</details>

<details><summary><b>eslint-plugin-express-security</b> — 19 annotations</summary>

- `packages/eslint-plugin-express-security/src/rules/require-csrf-protection/index.ts:104` — `return false;`
- `packages/eslint-plugin-express-security/src/rules/require-csrf-protection/index.ts:131` — `return false;`
- `packages/eslint-plugin-express-security/src/rules/require-csrf-protection/index.ts:135` — `return false;`
- `packages/eslint-plugin-express-security/src/rules/require-csrf-protection/index.ts:234` — `return route.includes(pattern);`
- `packages/eslint-plugin-express-security/src/rules/require-express-body-parser-limits/index.ts:191` — _2_ — `if (object.type !== 'Identifier') {`
- `packages/eslint-plugin-express-security/src/rules/require-express-body-parser-limits/index.ts:200` — _2_ — `if (property.type !== 'Identifier') {`
- `packages/eslint-plugin-express-security/src/rules/require-express-body-parser-limits/index.ts:258` — `return null;`
- `packages/eslint-plugin-express-security/src/rules/no-cors-credentials-wildcard/index.ts:198` — `},`
- `packages/eslint-plugin-express-security/src/rules/no-graphql-introspection-production/index.ts:167` — _2_ — `if (!configArg || configArg.type !== 'ObjectExpression') {`
- `packages/eslint-plugin-express-security/src/rules/no-graphql-introspection-production/index.ts:173` — _2_ — `if (hasProductionGuard(configArg, sourceCode)) {`
- `packages/eslint-plugin-express-security/src/rules/no-graphql-introspection-production/index.ts:197` — _2_ — `if (`
- `packages/eslint-plugin-express-security/src/rules/no-graphql-introspection-production/index.ts:206` — _2_ — `if (!configArg || configArg.type !== 'ObjectExpression') {`
- `packages/eslint-plugin-express-security/src/rules/no-permissive-cors/index.ts:67` — _7_ — `if (/\borigin\s*:\s*true\b/.test(text)) {`
- `packages/eslint-plugin-express-security/src/rules/no-express-unsafe-regex-route/index.ts:151` — _2_ — `if (callee.type !== 'MemberExpression') {`
- `packages/eslint-plugin-express-security/src/rules/no-express-unsafe-regex-route/index.ts:157` — _2_ — `if (property.type !== 'Identifier') {`
- `packages/eslint-plugin-express-security/src/rules/no-express-unsafe-regex-route/index.ts:168` — _2_ — `if (!routeArg) {`
- `packages/eslint-plugin-express-security/src/rules/require-helmet/index.ts:77` — _3_ — `if (arg.type === 'Identifier' && arg.name === 'helmet') {`
- `packages/eslint-plugin-express-security/src/rules/require-helmet/index.ts:99` — _3_ — `if (arg.type === 'Identifier' && alternatives.includes(arg.name)) {`
- `packages/eslint-plugin-express-security/src/rules/require-helmet/index.ts:209` — _15_ — `if (`

</details>

<details><summary><b>eslint-plugin-node-security</b> — 15 annotations</summary>

- `packages/eslint-plugin-node-security/src/rules/no-dynamic-require/index.ts:105` — _allowPatterns check is unreachable: static literals return early before this check_ — `function isAllowedPattern(requirePath: string): boolean {`
- `packages/eslint-plugin-node-security/src/rules/no-dynamic-require/index.ts:142` — _unreachable: static literals already returned above_ — `// Check allow patterns`
- `packages/eslint-plugin-node-security/src/rules/no-timing-unsafe-compare/index.ts:125` — _11 -- suggestions with fix: () => null cannot be tested with RuleTester_ — `context.report({`
- `packages/eslint-plugin-node-security/src/rules/no-ecb-mode/index.ts:115` — _18 -- suggestions require output assertions which are impractical for dynamic fixes_ — `context.report({`
- `packages/eslint-plugin-node-security/src/rules/prefer-native-crypto/index.ts:106` — _15 -- suggestions with fix: () => null cannot be tested with RuleTester_ — `context.report({`
- `packages/eslint-plugin-node-security/src/rules/no-math-random-crypto/index.ts:162` — _6 -- FunctionDeclaration with id.name matching pattern requires specific context_ — `if (current.type === AST_NODE_TYPES.FunctionDeclaration && current.id) {`
- `packages/eslint-plugin-node-security/src/rules/no-math-random-crypto/index.ts:231` — _unreachable when called from valid AST context_ — `return null;`
- `packages/eslint-plugin-node-security/src/rules/no-self-signed-certs/index.ts:129` — _10 -- process.env.NODE_TLS_REJECT_UNAUTHORIZED pattern requires complex AST_ — `context.report({`
- `packages/eslint-plugin-node-security/src/rules/no-buffer-overread/index.ts:636` — _safetyChecker.isSafe requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-node-security/src/rules/no-buffer-overread/index.ts:656` — _safetyChecker.isSafe requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-node-security/src/rules/no-buffer-overread/index.ts:700` — _safetyChecker.isSafe requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-node-security/src/rules/no-buffer-overread/index.ts:730` — _safetyChecker.isSafe requires JSDoc annotations not testable via RuleTester_ — `if (safetyChecker.isSafe(node, context)) {`
- `packages/eslint-plugin-node-security/src/rules/no-static-iv/index.ts:111` — _4 -- standalone randomBytes call requires specific import pattern_ — `if (`
- `packages/eslint-plugin-node-security/src/rules/no-static-iv/index.ts:160` — _7 -- ArrayExpression with all numeric literals is rare pattern_ — `// Check for new Uint8Array([...])`
- `packages/eslint-plugin-node-security/src/rules/no-sha1-hash/index.ts:144` — _12 -- sha1() call pattern requires specific import tracking_ — `context.report({`

</details>

<details><summary><b>eslint-plugin-reliability</b> — 5 annotations</summary>

- `packages/eslint-plugin-reliability/src/rules/error-handling/no-silent-errors.ts:39` — _3 -- defensive: catch clause body is always BlockStatement in valid JS_ — `if (!body || body.type !== 'BlockStatement') {`
- `packages/eslint-plugin-reliability/src/rules/error-handling/no-silent-errors.ts:70` — _3 -- defensive: catch clause always has location, and no comments = no match_ — `if (!catchStart || !comments.length) {`
- `packages/eslint-plugin-reliability/src/rules/reliability/no-missing-null-checks.ts:536` — _4 -- defensive error handling, hard to trigger in tests_ — `} catch {`
- `packages/eslint-plugin-reliability/src/rules/reliability/no-missing-null-checks.ts:549` — _4 -- defensive type check, always true when called by ESLint visitor_ — `// Ensure this is actually a CallExpression (not just a MemberExpression)`
- `packages/eslint-plugin-reliability/src/rules/reliability/no-missing-null-checks.ts:627` — _4 -- defensive error handling, hard to trigger in tests_ — `} catch {`

</details>

<details><summary><b>eslint-plugin-react-features</b> — 3 annotations</summary>

- `packages/eslint-plugin-react-features/src/rules/react/static-property-placement.ts:141` — `if (isStaticProperty(member)) {`
- `packages/eslint-plugin-react-features/src/rules/react/static-property-placement.ts:175` — _only used in unreachable code path above_ — `// oxlint-disable-next-line consistent-function-scoping`
- `packages/eslint-plugin-react-features/src/rules/react/static-property-placement.ts:192` — _only used in unreachable code path above_ — `// oxlint-disable-next-line consistent-function-scoping`

</details>

<details><summary><b>eslint-plugin-jwt</b> — 2 annotations</summary>

- `packages/eslint-plugin-jwt/src/rules/no-decode-without-verify/index.ts:133` — _hasSafeAnnotation requires ESLint comment simulation in tests_ — `// Check for safe annotations`
- `packages/eslint-plugin-jwt/src/rules/no-decode-without-verify/index.ts:149` — _hasSafeAnnotation requires ESLint comment simulation in tests_ — `// Check for safe annotations`

</details>

<details><summary><b>eslint-plugin-maintainability</b> — 2 annotations</summary>

- `packages/eslint-plugin-maintainability/src/rules/error-handling/no-silent-errors.ts:39` — _3 -- defensive: catch clause body is always BlockStatement in valid JS_ — `if (!body || body.type !== 'BlockStatement') {`
- `packages/eslint-plugin-maintainability/src/rules/error-handling/no-silent-errors.ts:70` — _3 -- defensive: catch clause always has location, and no comments = no match_ — `if (!catchStart || !comments.length) {`

</details>

<details><summary><b>eslint-devkit</b> — 1 annotations</summary>

- `packages/eslint-devkit/src/security/security-utils.ts:802` — _safetyChecker requires JSDoc annotations not testable via RuleTester_ — `export function shouldSkipForSafety(`

</details>

<details><summary><b>eslint-plugin-modularity</b> — 1 annotations</summary>

- `packages/eslint-plugin-modularity/src/rules/ddd-value-object-immutability.ts:58` — _TSPropertySignature is for interfaces, rule only processes classes_ — `if (node.type === 'TSPropertySignature') {`

</details>

<details><summary><b>eslint-plugin-import-next</b> — 1 annotations</summary>

- `packages/eslint-plugin-import-next/src/rules/no-amd.ts:86` — _defensive check, filename always provided by ESLint_ — `if (!filename) return false;`

</details>


## Verification

- `turbo run test` locally (Node 24): **46/46 tasks green** with coverage enabled and floors enforced.
- `turbo run typecheck`: green. (`docs#lint` / `registry#lint` fail identically on main — pre-existing, untouched by this diff.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
