### PR TITLE
fix(docs): make CTA callouts labeled regions, not nested complementary landmarks

### DIFF
--- a/apps/docs/src/components/docs/docs-footer-cta.tsx
+++ b/apps/docs/src/components/docs/docs-footer-cta.tsx
@@ -22,7 +22,15 @@ const DEVTO_URL = 'https://dev.to/ofri-peretz';
 
 export function DocsFooterCTA({ slug }: { slug: string }) {
   return (
-    <aside className="mt-12 rounded-lg border border-fd-border bg-fd-muted/30 p-5">
+    // A labeled <section> (role=region), not <aside>: this callout renders
+    // inside the page's <main> landmark, and axe's strict
+    // `landmark-complementary-is-top-level` rule (correctly) requires
+    // complementary landmarks to be top-level. A named region is valid nested
+    // and keeps the callout discoverable in the AT landmark list.
+    <section
+      aria-label="Support this project"
+      className="mt-12 rounded-lg border border-fd-border bg-fd-muted/30 p-5"
+    >
       <p className="text-sm text-fd-muted-foreground">
         <strong className="font-semibold text-fd-foreground">
           Building secure JavaScript with Interlace?
@@ -66,7 +74,7 @@ export function DocsFooterCTA({ slug }: { slug: string }) {
           Star on GitHub
         </Button>
       </div>
-    </aside>
+    </section>
   );
 }
 

--- a/apps/docs/src/components/docs/rule-value-cta.tsx
+++ b/apps/docs/src/components/docs/rule-value-cta.tsx
@@ -25,7 +25,15 @@ const DEVTO_URL = 'https://dev.to/ofri-peretz';
 
 export function RuleValueCTA({ plugin, rule }: { plugin: string; rule: string }) {
   return (
-    <aside className="mt-10 rounded-lg border border-fd-border bg-fd-muted/30 p-5">
+    // A labeled <section> (role=region), not <aside>: this callout renders
+    // inside the page's <main> landmark, and axe's strict
+    // `landmark-complementary-is-top-level` rule (correctly) requires
+    // complementary landmarks to be top-level. A named region is valid nested
+    // and keeps the callout discoverable in the AT landmark list.
+    <section
+      aria-label="Support this project"
+      className="mt-10 rounded-lg border border-fd-border bg-fd-muted/30 p-5"
+    >
       <p className="text-sm text-fd-muted-foreground">
         <strong className="font-semibold text-fd-foreground">
           Did this rule catch something?
@@ -69,7 +77,7 @@ export function RuleValueCTA({ plugin, rule }: { plugin: string; rule: string })
           Star on GitHub
         </Button>
       </div>
-    </aside>
+    </section>
   );
 }
 


### PR DESCRIPTION
## What

Fixes the pre-existing red **axe-core strict scan** (Accessibility workflow) that has been failing on `main` and turning every PR red.

## Root cause

axe rule **`landmark-complementary-is-top-level`** (moderate, `best-practice` tag) fired on `/docs/getting-started` and every rule page (e.g. `/docs/security/plugin-node-security/rules/no-sha1-hash`), in both light and dark schemes:

- `DocsFooterCTA` (`apps/docs/src/components/docs/docs-footer-cta.tsx`) and
- `RuleValueCTA` (`apps/docs/src/components/docs/rule-value-cta.tsx`)

both rendered an `<aside>` (implicit `role=complementary`) **inside the page's `<main>` landmark**. axe (correctly) requires complementary landmarks to be top-level.

## Fix

These callouts are in-content conversion asks, not complementary page content — so they're now `<section aria-label="Support this project">` (`role=region`), which is valid nested inside `main` and keeps the callout discoverable in the AT landmark list. Styling, copy, and the `*_page:cta_click` analytics wiring are unchanged (`rule-cta-lock` test still passes — it pins URLs/events, not the tag).

## What about the Web Vitals Budget failures?

The `Lighthouse (Web Vitals Budget)` failures on `main` (scheduled runs 2026-06-24 / 2026-07-01) were **not** a vitals regression and no budget was adjusted: the job died in **Build docs site** because `sync-tweet-cache.ts` hard-failed when a tweet's upstream `pbs.twimg.com` card image started returning 404. That was already fixed on `main` by #221 (tweet-cache HEAD-check made advisory) — the latest Web Vitals runs pass. This PR intentionally carries no budget changes.

## Verification

- Ran the exact CI job locally (`npm run build --workspace=docs` + `npm run test:a11y`, Playwright + axe, strict WCAG 2.2 AA + best-practice + ACT tags): all routes × both schemes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the semantic structure of documentation support callouts by updating them to labeled sections.
  * Enhanced accessibility and landmark behavior for these callouts, making them easier to navigate with assistive technologies.
  * Preserved the existing call-to-action content and tracking behavior without changing what users see.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->