### PR TITLE
fix(release): use FlatESLint under ESLint 8 in dist-integrity gate

### DIFF
--- a/scripts/verify-dist-integrity.ts
+++ b/scripts/verify-dist-integrity.ts
@@ -87,8 +87,17 @@ const requireBuilt = process.argv.includes('--require-built');
 async function main(): Promise<void> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const eslintMod: any = repoRequire('eslint');
-  const ESLint = eslintMod.ESLint;
   const eslintVersion: string = repoRequire('eslint/package.json').version;
+  // ESLint 9/10 made flat config the default `ESLint` export. ESLint 8's
+  // `ESLint` is still the eslintrc-based class — it rejects the flat-config
+  // shaped options used below (e.g. `overrideConfigFile: true`) with
+  // "Invalid Options". Under 8, use the dedicated flat-config class instead.
+  const eslintMajor = Number.parseInt(eslintVersion, 10);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const ESLint: any =
+    eslintMajor >= 9
+      ? eslintMod.ESLint
+      : repoRequire('eslint/use-at-your-own-risk').FlatESLint;
   if (!ESLint) {
     console.error(
       'verify-dist-integrity: could not load ESLint from the repo root.',


### PR DESCRIPTION
## Summary
- The pre-publish dist-integrity gate (#200) always resolved `ESLint` from the classic eslintrc-based export. Under ESLint 9/10 that export is flat-config by default, but under ESLint 8 it's still eslintrc-based, so the flat-config-shaped options (`overrideConfigFile: true`) it's called with throw `Invalid Options` for every plugin/preset.
- This has failed the `eslint-8` leg of the `integrity` job on every release run since the gate landed, which blocks the `publish` job (`needs: [detect, build, integrity]`) — the root cause of every red `production` deployment today, independent of the already-fixed `@interlace/eslint-config` 404.
- Fix: pick `FlatESLint` from `eslint/use-at-your-own-risk` when the installed major is 8, keep the existing `ESLint` export for 9/10.

## Verification
Reproduced and fixed locally in an isolated worktree against the actual built `dist/` artifacts (not just a synthetic repro):
- `eslint@8.57.1` — was `Invalid Options: 'overrideConfigFile' must be a non-empty string or null`; now passes: `69 preset(s) + 497 rule(s) across 19 built plugin(s)`.
- `eslint@9.39.4` — passes (no regression).
- `eslint@10.6.0` — passes (no regression).

## Test plan
- [x] `npm run verify:dist-integrity:release` under eslint@8, @9, @10 in a real build of all 19 published packages
- [ ] CI green on this PR (installs eslint 8/9/10 via the same matrix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with multiple ESLint major versions, allowing the verification script to run successfully in environments using either ESLint 8 or 9.
  * Updated the script to choose the appropriate linting engine automatically based on the installed version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->