### PR TITLE
feat(docs): rebrand Interlace side of co-branded lockups to two-bar mark

### DIFF
--- a/apps/docs/public/eslint-interlace-logo-light.svg
+++ b/apps/docs/public/eslint-interlace-logo-light.svg
@@ -6,15 +6,13 @@
     }
     .outer-shape { fill: var(--eslint-purple); }
     .inner-shape { fill: var(--eslint-light-purple); }
-    .interlace-bar { fill: var(--eslint-purple); }
+    .interlace-bar-o { fill: #a84c17; }
+    .interlace-bar-g { fill: #0a6b47; }
 </style>
 <path class="inner-shape" d="m97.021 99.016 48.432-27.962c1.212-.7 2.706-.7 3.918 0l48.433 27.962a3.92 3.92 0 0 1 1.959 3.393v55.924a3.924 3.924 0 0 1-1.959 3.394l-48.433 27.962c-1.212.7-2.706.7-3.918 0l-48.432-27.962a3.92 3.92 0 0 1-1.959-3.394v-55.924a3.922 3.922 0 0 1 1.959-3.393"/>
 <path class="outer-shape" d="M273.336 124.488 215.469 23.816c-2.102-3.64-5.985-6.325-10.188-6.325H89.545c-4.204 0-8.088 2.685-10.19 6.325l-57.867 100.45c-2.102 3.641-2.102 8.236 0 11.877l57.867 99.847c2.102 3.64 5.986 5.501 10.19 5.501H205.28c4.203 0 8.087-1.805 10.188-5.446l57.867-100.01c2.104-3.639 2.104-7.907.001-11.547m-47.917 48.41c0 1.48-.891 2.849-2.174 3.59l-73.71 42.527a4.194 4.194 0 0 1-4.17 0l-73.767-42.527c-1.282-.741-2.179-2.109-2.179-3.59V87.843c0-1.481.884-2.849 2.167-3.59l73.707-42.527a4.185 4.185 0 0 1 4.168 0l73.772 42.527c1.283.741 2.186 2.109 2.186 3.59v85.055z"/>
-<g id="interlace-i">
-    <rect class="interlace-bar" x="136.4" y="88" width="22" height="12" rx="2" />
-    <rect class="interlace-bar" x="136.4" y="104" width="22" height="12" rx="2" />
-    <rect class="interlace-bar" x="136.4" y="120" width="22" height="12" rx="2" />
-    <rect class="interlace-bar" x="136.4" y="136" width="22" height="12" rx="2" />
-    <rect class="interlace-bar" x="136.4" y="152" width="22" height="12" rx="2" />
+<g id="interlace-mark" transform="translate(104.9 83.5) scale(0.85) rotate(-30 50 50)">
+    <rect class="interlace-bar-o" x="10" y="18" width="62" height="28" rx="14" />
+    <rect class="interlace-bar-g" x="28" y="54" width="62" height="28" rx="14" />
 </g>
 </svg>

--- a/apps/docs/public/eslint-interlace-logo-white.svg
+++ b/apps/docs/public/eslint-interlace-logo-white.svg
@@ -2,15 +2,13 @@
 <style>
     .outer-shape { fill: #FFFFFF; }
     .inner-shape { fill: #999999; }
-    .interlace-bar { fill: #FFFFFF; }
+    .interlace-bar-o { fill: #f4794a; }
+    .interlace-bar-g { fill: #0d9460; }
 </style>
 <path class="inner-shape" d="m97.021 99.016 48.432-27.962c1.212-.7 2.706-.7 3.918 0l48.433 27.962a3.92 3.92 0 0 1 1.959 3.393v55.924a3.924 3.924 0 0 1-1.959 3.394l-48.433 27.962c-1.212.7-2.706.7-3.918 0l-48.432-27.962a3.92 3.92 0 0 1-1.959-3.394v-55.924a3.922 3.922 0 0 1 1.959-3.393"/>
 <path class="outer-shape" d="M273.336 124.488 215.469 23.816c-2.102-3.64-5.985-6.325-10.188-6.325H89.545c-4.204 0-8.088 2.685-10.19 6.325l-57.867 100.45c-2.102 3.641-2.102 8.236 0 11.877l57.867 99.847c2.102 3.64 5.986 5.501 10.19 5.501H205.28c4.203 0 8.087-1.805 10.188-5.446l57.867-100.01c2.104-3.639 2.104-7.907.001-11.547m-47.917 48.41c0 1.48-.891 2.849-2.174 3.59l-73.71 42.527a4.194 4.194 0 0 1-4.17 0l-73.767-42.527c-1.282-.741-2.179-2.109-2.179-3.59V87.843c0-1.481.884-2.849 2.167-3.59l73.707-42.527a4.185 4.185 0 0 1 4.168 0l73.772 42.527c1.283.741 2.186 2.109 2.186 3.59v85.055z"/>
-<g id="interlace-i">
-    <rect class="interlace-bar" x="136.4" y="88" width="22" height="12" rx="2" />
-    <rect class="interlace-bar" x="136.4" y="104" width="22" height="12" rx="2" />
-    <rect class="interlace-bar" x="136.4" y="120" width="22" height="12" rx="2" />
-    <rect class="interlace-bar" x="136.4" y="136" width="22" height="12" rx="2" />
-    <rect class="interlace-bar" x="136.4" y="152" width="22" height="12" rx="2" />
+<g id="interlace-mark" transform="translate(104.9 83.5) scale(0.85) rotate(-30 50 50)">
+    <rect class="interlace-bar-o" x="10" y="18" width="62" height="28" rx="14" />
+    <rect class="interlace-bar-g" x="28" y="54" width="62" height="28" rx="14" />
 </g>
 </svg>

--- a/apps/docs/public/eslint-interlace-logo.svg
+++ b/apps/docs/public/eslint-interlace-logo.svg
@@ -9,22 +9,21 @@
     /* Default (Light Mode) */
     .outer-shape { fill: var(--eslint-purple); }
     .inner-shape { fill: var(--eslint-light-purple); }
-    .interlace-bar { fill: var(--eslint-purple); }
+    .interlace-bar-o { fill: #a84c17; }
+    .interlace-bar-g { fill: #0a6b47; }
 
     /* Dark Mode Preference */
     @media (prefers-color-scheme: dark) {
         .outer-shape { fill: var(--eslint-white); }
         .inner-shape { fill: var(--eslint-grey); }
-        .interlace-bar { fill: var(--eslint-white); }
+        .interlace-bar-o { fill: #f4794a; }
+        .interlace-bar-g { fill: #0d9460; }
     }
 </style>
 <path class="inner-shape" d="m97.021 99.016 48.432-27.962c1.212-.7 2.706-.7 3.918 0l48.433 27.962a3.92 3.92 0 0 1 1.959 3.393v55.924a3.924 3.924 0 0 1-1.959 3.394l-48.433 27.962c-1.212.7-2.706.7-3.918 0l-48.432-27.962a3.92 3.92 0 0 1-1.959-3.394v-55.924a3.922 3.922 0 0 1 1.959-3.393"/>
 <path class="outer-shape" d="M273.336 124.488 215.469 23.816c-2.102-3.64-5.985-6.325-10.188-6.325H89.545c-4.204 0-8.088 2.685-10.19 6.325l-57.867 100.45c-2.102 3.641-2.102 8.236 0 11.877l57.867 99.847c2.102 3.64 5.986 5.501 10.19 5.501H205.28c4.203 0 8.087-1.805 10.188-5.446l57.867-100.01c2.104-3.639 2.104-7.907.001-11.547m-47.917 48.41c0 1.48-.891 2.849-2.174 3.59l-73.71 42.527a4.194 4.194 0 0 1-4.17 0l-73.767-42.527c-1.282-.741-2.179-2.109-2.179-3.59V87.843c0-1.481.884-2.849 2.167-3.59l73.707-42.527a4.185 4.185 0 0 1 4.168 0l73.772 42.527c1.283.741 2.186 2.109 2.186 3.59v85.055z"/>
-<g id="interlace-i">
-    <rect class="interlace-bar" x="136.4" y="88" width="22" height="12" rx="2" />
-    <rect class="interlace-bar" x="136.4" y="104" width="22" height="12" rx="2" />
-    <rect class="interlace-bar" x="136.4" y="120" width="22" height="12" rx="2" />
-    <rect class="interlace-bar" x="136.4" y="136" width="22" height="12" rx="2" />
-    <rect class="interlace-bar" x="136.4" y="152" width="22" height="12" rx="2" />
+<g id="interlace-mark" transform="translate(104.9 83.5) scale(0.85) rotate(-30 50 50)">
+    <rect class="interlace-bar-o" x="10" y="18" width="62" height="28" rx="14" />
+    <rect class="interlace-bar-g" x="28" y="54" width="62" height="28" rx="14" />
 </g>
 </svg>


### PR DESCRIPTION
## Summary

- `eslint-interlace-logo{,-light,-white}.svg` in `apps/docs/public/` are hot-linked by all 25 published npm package READMEs (`https://eslint.interlace.tools/eslint-interlace-logo-light.svg`), so updating them rebrands every npm page instantly.
- Replaces the five-bar "i" glyph (the Interlace side of the lockup) with the locked two-bar mark (−30° pill pair, geometry from the canonical blog icon), centered in the inner hexagon.
- ESLint's own hexagon + official purple palette (`#4B32C3`/`#8080F2`) are untouched — that half is their brand.
- Canvas viewBox (294.825 × 258.982) and overall aspect unchanged, so README layouts don't shift.
- Colors: theme-aware `logo.svg` uses the light pair `#a84c17`/`#0a6b47` by default and the dark pair `#f4794a`/`#0d9460` under `prefers-color-scheme: dark`; `-light` uses the light pair; `-white` uses the dark pair.

## Test plan

- [x] Rendered each variant to PNG (sharp) and visually verified the mark is centered inside the inner hexagon at correct proportion.
- [x] No source/test references to the removed `interlace-i` group or `.interlace-bar` class.
- [x] Follow-up to #263 (main rebrand PR, merged).

## After merge

Auto-deploy publishes the new SVGs at the hot-linked URLs; npm READMEs pick them up immediately (subject to camo cache). Note the docs Vercel deploy pipeline has been failing since Jul 17 (prebuilt-artifact ENOENT, pre-existing) — the new assets go live once that is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)