### PR TITLE
ci(docs): pin Vercel CLI to 54.20.1 — fix prebuilt deploy ENOENT

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -58,6 +58,19 @@ jobs:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      # ─── Pinned Vercel CLI ─────────────────────────────────────────────
+      # `npx vercel` (unpinned) broke this deploy on 2026-07-17+: newer CLIs
+      # (observed on 58.4.4) build functions with `experimentalAllowBundling:
+      # true` + a `filePathMap` whose entries point at repo-root
+      # `node_modules/**` — files that live OUTSIDE `.vercel/output`. With
+      # `--archive=tgz` only the output dir is uploaded, so Vercel's remote
+      # side fails with `ENOENT: lstat '/vercel/path0/node_modules/…'`
+      # during "Deploying outputs". Dropping `--archive=tgz` is not an
+      # option (the artifact is >15k files, over the per-deploy limit).
+      # 54.20.1 is the last empirically-green version (build sets
+      # experimentalAllowBundling: false; deploy succeeds). When bumping,
+      # verify a `target=preview` dispatch end-to-end first.
+      VERCEL_CLI_VERSION: 54.20.1
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
         with:
@@ -70,7 +83,7 @@ jobs:
       - name: Pull Vercel environment metadata
         run: |
           set -euo pipefail
-          npx vercel pull \
+          npx "vercel@$VERCEL_CLI_VERSION" pull \
             --yes \
             --environment=${{ inputs.environment }} \
             --token="$VERCEL_TOKEN"
@@ -112,9 +125,9 @@ jobs:
           # Production gets `--prod`; preview omits it. Vercel CLI uses the
           # build settings from vercel.json (cd apps/docs && next build).
           if [ "${{ inputs.environment }}" = "production" ]; then
-            npx vercel build --prod --token="$VERCEL_TOKEN"
+            npx "vercel@$VERCEL_CLI_VERSION" build --prod --token="$VERCEL_TOKEN"
           else
-            npx vercel build --token="$VERCEL_TOKEN"
+            npx "vercel@$VERCEL_CLI_VERSION" build --token="$VERCEL_TOKEN"
           fi
 
       # ─── Analytics regression lock (built bundle) ──────────────────────
@@ -172,9 +185,9 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${{ inputs.environment }}" = "production" ]; then
-            url=$(npx vercel deploy --prebuilt --prod --archive=tgz --token="$VERCEL_TOKEN")
+            url=$(npx "vercel@$VERCEL_CLI_VERSION" deploy --prebuilt --prod --archive=tgz --token="$VERCEL_TOKEN")
           else
-            url=$(npx vercel deploy --prebuilt --archive=tgz --token="$VERCEL_TOKEN")
+            url=$(npx "vercel@$VERCEL_CLI_VERSION" deploy --prebuilt --archive=tgz --token="$VERCEL_TOKEN")
           fi
           echo "url=$url" >> "$GITHUB_OUTPUT"
           echo "Deployed to: $url"


### PR DESCRIPTION
## Summary

- Every `deploy-docs.yml` run has failed since 2026-07-17; eslint.interlace.tools is serving a pre-Jul-17 build and the rebrand (#263/#264) is blocked on it.
- Root cause of the current failures: the workflow ran **unpinned `npx vercel`**, which now resolves to 58.4.4. That CLI's bundled `@vercel/next` builder emits functions with `experimentalAllowBundling: true` + a `filePathMap` referencing repo-root `node_modules/**` — files *outside* `.vercel/output`. Because the deploy uses `--archive=tgz` (only the output dir is packed), Vercel's remote side fails with `ENOENT: lstat '/vercel/path0/node_modules/client-only/index.js'` during "Deploying outputs".
- Dropping `--archive=tgz` is not viable: the artifact is 18,316 files, over Vercel's 15,000 per-deploy limit (verified empirically).
- Fix: pin every `vercel` invocation (pull/build/deploy) to `VERCEL_CLI_VERSION: 54.20.1` — the CLI version of the last green run (2026-07-06). Its builder sets `experimentalAllowBundling: false` and the archive deploy succeeds.
- Note: the Jul-17→19 failures were a *different* cause (smoke-test broken image URLs, since resolved); tonight's runs pass smoke and die only at the deploy step.

## Test plan

- [x] Reproduced the ENOENT locally: `vercel@58.4.4 build` + `deploy --prebuilt --archive=tgz` → same `ENOENT: lstat '/vercel/path0/node_modules/client-only/index.js'`.
- [x] Verified `deploy --prebuilt` *without* archive fails on the 15k file limit (18,316 files) — archive must stay.
- [x] Verified the fix locally: `vercel@54.20.1 build` + `deploy --prebuilt --archive=tgz` → deployment **Ready**.
- [ ] After merge: `workflow_dispatch environment=production` must go green end-to-end (this change only touches `.github/workflows/**`, so auto-deploy will correctly compute no affected app — manual dispatch required).

## After merge

- Dispatch `deploy-docs.yml` with `environment=production` and verify https://eslint.interlace.tools serves the two-bar rebrand (logo SVG + no violet palette on the homepage).
- Follow-up (not this PR): when bumping the pin, test a `target=preview` dispatch first; the in-file comment documents the failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)