### PR TITLE
feat(docs): Interlace mark+wordmark in top nav, ESLint logo to hero

### DIFF
--- a/apps/docs/src/__tests__/hero-section-render.test.tsx
+++ b/apps/docs/src/__tests__/hero-section-render.test.tsx
@@ -104,4 +104,20 @@ describe('HeroSection — DOM render lock', () => {
       expect(btn.className).toMatch(/\bpy-3\b/);
     }
   });
+
+  // The "Built for ESLint" badge rides HeroCosmic's `footer` slot — a
+  // refactor of the preset that silently drops `footer` would pass the
+  // source-text lock in nav-brand-lock.test.tsx, so pin the rendered
+  // outcome here too: badge text AND the inlined ESLint hexagon (token
+  // fills) must reach the DOM.
+  it('renders the "Built for ESLint" badge with the ESLint mark in the DOM', () => {
+    const { container, getByText } = render(<HeroSection />);
+    const label = getByText(/Built for ESLint/i);
+    expect(label).toBeTruthy();
+    const badge = label.closest('span');
+    expect(badge, 'badge pill must wrap the label').not.toBeNull();
+    const mark = badge!.querySelector('path[fill="var(--eslint-mark-outer)"]');
+    expect(mark, 'ESLint hexagon must render inside the badge').not.toBeNull();
+    expect(container).toBeTruthy();
+  });
 });

--- a/apps/docs/src/__tests__/nav-brand-lock.test.tsx
+++ b/apps/docs/src/__tests__/nav-brand-lock.test.tsx
@@ -1,0 +1,97 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, it, expect, beforeAll } from 'vitest';
+
+/**
+ * Brand-placement lock — top nav vs hero.
+ *
+ * Contract (see layout.shared.tsx header comment):
+ *  - The top nav carries the Interlace identity ONLY: the two-bar mark
+ *    (canonical geometry, theme-paired AA-safe fills via the
+ *    `--brand-mark-bar-*` tokens in global.css, keyed to `.dark`) plus
+ *    the lowercase monospace wordmark "interlace".
+ *  - The ESLint hexagon does NOT live in the nav; it lives in the homepage
+ *    hero as the "Built for ESLint" badge (official colors untouched, via
+ *    the `--eslint-mark-*` tokens).
+ *  - `public/eslint-interlace-logo*.svg` must NOT be re-introduced as the
+ *    nav image (they remain in public/ solely because npm READMEs
+ *    hot-link them).
+ */
+const APP_ROOT = process.cwd();
+
+describe('Top nav — Interlace mark + wordmark', () => {
+  const navPath = join(APP_ROOT, 'src/lib/layout.shared.tsx');
+  let navSource: string;
+
+  beforeAll(() => {
+    navSource = readFileSync(navPath, 'utf-8');
+  });
+
+  it('renders the canonical Interlace two-bar mark geometry', () => {
+    expect(navSource).toContain('rotate(-30 50 50)');
+    expect(navSource).toContain('rx="14"');
+    expect(navSource).toContain('viewBox="0 0 100 100"');
+  });
+
+  it('bar fills read the theme-paired tokens (never raw hex in JSX)', () => {
+    expect(navSource).toContain('fill="var(--brand-mark-bar-o)"');
+    expect(navSource).toContain('fill="var(--brand-mark-bar-g)"');
+  });
+
+  it('wordmark is lowercase "interlace" in the mono stack', () => {
+    expect(navSource).toMatch(/className="[^"]*font-mono[^"]*"/);
+    expect(navSource).toContain('interlace');
+    // Never the old co-branded uppercase nav label.
+    expect(navSource).not.toContain('>ESLint Interlace</span>');
+  });
+
+  it('does not render the co-branded eslint-interlace lockup image in the nav', () => {
+    expect(navSource).not.toMatch(/src=["']\/eslint-interlace-logo/);
+  });
+});
+
+describe('Brand mark tokens — global.css theme pairs', () => {
+  const cssPath = join(APP_ROOT, 'src/app/global.css');
+  let css: string;
+
+  beforeAll(() => {
+    css = readFileSync(cssPath, 'utf-8');
+  });
+
+  it('Interlace bar tokens carry the AA-safe theme-paired values', () => {
+    // Light (deep pair) in :root…
+    expect(css).toMatch(/--brand-mark-bar-o:\s*#a84c17/);
+    expect(css).toMatch(/--brand-mark-bar-g:\s*#0a6b47/);
+    // …bright pair under .dark.
+    expect(css).toMatch(/--brand-mark-bar-o:\s*#f4794a/);
+    expect(css).toMatch(/--brand-mark-bar-g:\s*#0d9460/);
+  });
+
+  it('ESLint mark tokens carry the official untouched fills', () => {
+    expect(css).toMatch(/--eslint-mark-outer:\s*#4b32c3/i);
+    expect(css).toMatch(/--eslint-mark-inner:\s*#8080f2/i);
+    // Dark variant = ESLint's own white/grey pair.
+    expect(css).toMatch(/--eslint-mark-outer:\s*#ffffff/i);
+    expect(css).toMatch(/--eslint-mark-inner:\s*#999999/);
+  });
+});
+
+describe('Homepage hero — ESLint hexagon badge', () => {
+  const heroPath = join(APP_ROOT, 'src/components/home/hero-section.tsx');
+  let heroSource: string;
+
+  beforeAll(() => {
+    heroSource = readFileSync(heroPath, 'utf-8');
+  });
+
+  it('renders the official ESLint mark via tokens in the hero footer slot', () => {
+    expect(heroSource).toContain('fill="var(--eslint-mark-outer)"');
+    expect(heroSource).toContain('fill="var(--eslint-mark-inner)"');
+    expect(heroSource).toContain('<EslintMark');
+    expect(heroSource).toContain('footer={');
+  });
+
+  it('badge copy positions ESLint as the platform, not the brand', () => {
+    expect(heroSource).toContain('Built for ESLint');
+  });
+});

--- a/apps/docs/src/__tests__/nav-brand-lock.test.tsx
+++ b/apps/docs/src/__tests__/nav-brand-lock.test.tsx
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { describe, it, expect, beforeAll } from 'vitest';
 
 /**
@@ -17,7 +17,10 @@ import { describe, it, expect, beforeAll } from 'vitest';
  *    nav image (they remain in public/ solely because npm READMEs
  *    hot-link them).
  */
-const APP_ROOT = process.cwd();
+// Use __dirname so this works regardless of whether vitest is invoked from
+// the repo root (`npx vitest run apps/docs/…`) or from `apps/docs`
+// (`turbo run test`) — same trap documented in homepage-lock.test.tsx.
+const APP_ROOT = resolve(__dirname, '../..');
 
 describe('Top nav — Interlace mark + wordmark', () => {
   const navPath = join(APP_ROOT, 'src/lib/layout.shared.tsx');

--- a/apps/docs/src/app/global.css
+++ b/apps/docs/src/app/global.css
@@ -165,4 +165,33 @@
      light-theme flash during hydration (~12% white keeps the boundary
      legible on either surface). */
   --cta-secondary-bg: rgba(255, 255, 255, 0.12);
+
+  /* =========================================
+     BRAND MARK TOKENS
+     --------------------------------------------------------
+     Fills for the two inline brand marks, defined here so their JSX
+     call sites read `var(--*)` instead of raw hex literals (R19 /
+     `no-raw-color-literal` doctrine — same reasoning as --cta-*).
+
+     - --brand-mark-bar-*: the Interlace two-bar mark in the top nav
+       (`src/lib/layout.shared.tsx`). Theme-paired AA-safe set: light
+       surfaces get the deep pair, dark surfaces the bright pair.
+     - --eslint-mark-*: the official ESLint hexagon in the homepage
+       hero badge (`src/components/home/hero-section.tsx`). Colors are
+       ESLint's own — light theme keeps the purple pair, dark theme
+       uses their white/grey dark-variant fills (mirrors the
+       `prefers-color-scheme` block ESLint ships inside
+       `public/eslint-logo.svg`, but keyed to the site's `.dark`
+       class so the mark follows the THEME, not the OS). */
+  --brand-mark-bar-o: #a84c17;
+  --brand-mark-bar-g: #0a6b47;
+  --eslint-mark-outer: #4b32c3;
+  --eslint-mark-inner: #8080f2;
+}
+
+.dark {
+  --brand-mark-bar-o: #f4794a;
+  --brand-mark-bar-g: #0d9460;
+  --eslint-mark-outer: #ffffff;
+  --eslint-mark-inner: #999999;
 }

--- a/apps/docs/src/components/home/hero-section.tsx
+++ b/apps/docs/src/components/home/hero-section.tsx
@@ -27,6 +27,32 @@ import { track } from '../../lib/analytics';
  *  - Secondary passes `shimmer={false} highlight={false}` — same pill
  *    geometry, no decoration.
  */
+/**
+ * Official ESLint hexagon mark — paths verbatim from
+ * `public/eslint-logo.svg`, colors untouched. The only change is theme
+ * keying: the source SVG swaps to its white/grey dark variant via
+ * `prefers-color-scheme`, but the site themes via the `.dark` class
+ * (fumadocs), so we inline the paths and read the same official fills
+ * from the `--eslint-mark-*` tokens in `global.css` (light:
+ * purple pair, dark: ESLint's white/grey dark variant) — no raw color
+ * literals in JSX attributes (R19). Rendered `aria-hidden` — the
+ * adjacent text names it.
+ */
+function EslintMark({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 294.825 258.982" aria-hidden className={className}>
+      <path
+        fill="var(--eslint-mark-inner)"
+        d="m97.021 99.016 48.432-27.962c1.212-.7 2.706-.7 3.918 0l48.433 27.962a3.92 3.92 0 0 1 1.959 3.393v55.924a3.924 3.924 0 0 1-1.959 3.394l-48.433 27.962c-1.212.7-2.706.7-3.918 0l-48.432-27.962a3.92 3.92 0 0 1-1.959-3.394v-55.924a3.922 3.922 0 0 1 1.959-3.393"
+      />
+      <path
+        fill="var(--eslint-mark-outer)"
+        d="M273.336 124.488 215.469 23.816c-2.102-3.64-5.985-6.325-10.188-6.325H89.545c-4.204 0-8.088 2.685-10.19 6.325l-57.867 100.45c-2.102 3.641-2.102 8.236 0 11.877l57.867 99.847c2.102 3.64 5.986 5.501 10.19 5.501H205.28c4.203 0 8.087-1.805 10.188-5.446l57.867-100.01c2.104-3.639 2.104-7.907.001-11.547m-47.917 48.41c0 1.48-.891 2.849-2.174 3.59l-73.71 42.527a4.194 4.194 0 0 1-4.17 0l-73.767-42.527c-1.282-.741-2.179-2.109-2.179-3.59V87.843c0-1.481.884-2.849 2.167-3.59l73.707-42.527a4.185 4.185 0 0 1 4.168 0l73.772 42.527c1.283.741 2.186 2.109 2.186 3.59v85.055z"
+      />
+    </svg>
+  );
+}
+
 function formatStars(n: number): string {
   return new Intl.NumberFormat('en-US', {
     notation: 'compact',
@@ -145,6 +171,17 @@ export function HeroSection({ githubStars }: { githubStars?: number | null }) {
           />
         ),
       }}
+      // "Built for ESLint" trust badge — the ESLint hexagon's home now that
+      // the top nav carries the Interlace identity alone. Subordinate to the
+      // hero copy (small pill, below the CTAs), official ESLint colors via
+      // <EslintMark>. Pill chrome is theme-aware: translucent light pill on
+      // the daylight surface, translucent white on the cosmic surface.
+      footer={
+        <span className="inline-flex items-center gap-2 rounded-full border border-slate-700/20 bg-white/40 px-3 py-1.5 text-xs font-medium text-slate-700 backdrop-blur-sm dark:border-white/20 dark:bg-white/5 dark:text-white/90">
+          <EslintMark className="size-4 shrink-0" />
+          Built for ESLint — 8, 9, and forward
+        </span>
+      }
     />
   );
 }

--- a/apps/docs/src/lib/layout.shared.tsx
+++ b/apps/docs/src/lib/layout.shared.tsx
@@ -1,13 +1,25 @@
 import type { BaseLayoutProps } from 'fumadocs-ui/layouts/shared';
-import Image from 'next/image';
 
 /**
  * Shared layout options for ESLint Interlace documentation
  * Used by both docs and homepage layouts.
  *
+ * Brand contract (nav slot):
+ * - The nav carries the Interlace identity only: the two-bar mark +
+ *   lowercase monospace wordmark "interlace". The ESLint hexagon lives in
+ *   the homepage hero (see `components/home/hero-section.tsx`), NOT here —
+ *   the old co-branded `eslint-interlace-logo*.svg` lockups stay in
+ *   `public/` because the npm READMEs hot-link them.
+ * - Mark geometry is the canonical Interlace mark (viewBox 0 0 100 100,
+ *   two rx-14 bars rotated -30° about the center). Bar fills read the
+ *   `--brand-mark-bar-*` tokens from `global.css` — theme-paired AA-safe
+ *   values keyed to the site's `.dark` class (fumadocs theme), not
+ *   `prefers-color-scheme`.
+ * - Wordmark is ALWAYS lowercase "interlace" in the site's mono stack.
+ *
  * a11y notes:
- * - Logo `<Image>` uses `alt=""` because the adjacent `<span>` already names
- *   the brand. Otherwise axe `image-redundant-alt` flags duplicate text.
+ * - Mark `<svg>` is `aria-hidden` because the adjacent `<span>` already
+ *   names the brand (same reasoning as the previous `alt=""` logo image).
  * - We deliberately do NOT use `githubUrl` from BaseLayoutProps — fumadocs
  *   renders that as an inline `<svg role="img">` without `<title>` /
  *   `aria-label`, tripping axe `svg-img-alt`. We instead push our own GitHub
@@ -19,23 +31,35 @@ export function baseOptions(): BaseLayoutProps {
     nav: {
       title: (
         <>
-          <Image
-            src="/eslint-interlace-logo.svg"
-            alt=""
-            width={24}
-            height={24}
-            className="dark:hidden"
-            priority
-          />
-          <Image
-            src="/eslint-interlace-logo-white.svg"
-            alt=""
-            width={24}
-            height={24}
-            className="hidden dark:block"
-            priority
-          />
-          <span className="font-semibold">ESLint Interlace</span>
+          <svg
+            viewBox="0 0 100 100"
+            width={22}
+            height={22}
+            aria-hidden="true"
+            className="shrink-0"
+          >
+            <g transform="rotate(-30 50 50)">
+              <rect
+                x="10"
+                y="18"
+                width="62"
+                height="28"
+                rx="14"
+                fill="var(--brand-mark-bar-o)"
+              />
+              <rect
+                x="28"
+                y="54"
+                width="62"
+                height="28"
+                rx="14"
+                fill="var(--brand-mark-bar-g)"
+              />
+            </g>
+          </svg>
+          <span className="font-mono font-semibold lowercase tracking-tight">
+            interlace
+          </span>
         </>
       ),
       transparentMode: 'top',


### PR DESCRIPTION
## What

Rework the logo placement on eslint.interlace.tools per the brand doctrine: the nav carries the Interlace identity alone, ESLint's mark moves to the hero as a platform badge.

- **Top nav**: replaced the co-branded `eslint-interlace-logo*.svg` lockup with the Interlace identity — the canonical two-bar mark (viewBox 0 0 100 100, rx-14 bars rotated -30°) + lowercase monospace wordmark `interlace`. Fills read new `--brand-mark-bar-*` tokens (light `#a84c17`/`#0a6b47`, dark `#f4794a`/`#0d9460`) keyed to the site's `.dark` class, so the mark follows the fumadocs theme toggle rather than `prefers-color-scheme`.
- **Hero**: the official ESLint hexagon (paths verbatim from `public/eslint-logo.svg`, colors untouched) now renders as a "Built for ESLint — 8, 9, and forward" trust badge in the HeroCosmic `footer` slot below the CTAs. Light theme keeps ESLint's purple pair; dark theme uses ESLint's own white/grey dark-variant fills via `--eslint-mark-*` tokens.
- **R19 compliance**: every fill is a `var(--*)` token — no raw color literals in JSX attributes (homepage-lock passes unchanged, and the hero CTA locks are untouched).
- **New lock**: `nav-brand-lock.test.tsx` pins the nav geometry/tokens, the lowercase mono wordmark, the token theme pairs in `global.css`, and the hero badge — and forbids re-introducing the co-branded lockup image in the nav.
- `public/eslint-interlace-logo*.svg` intentionally untouched — 25 npm READMEs hot-link them.

## Verification

- `npx vitest run` in `apps/docs`: 68/68 files green (includes the new lock).
- `npx turbo run build --filter=docs`: green.
- `next start` + Playwright screenshots of the homepage top in both themes: nav mark/wordmark and hero badge render correctly on the daylight and cosmic surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)