### PR TITLE
fix(workspace): gate the closing footer, correct UTM comment

### DIFF
--- a/tools/scripts/check-readme-structure.ts
+++ b/tools/scripts/check-readme-structure.ts
@@ -75,6 +75,15 @@ function checkPlugin(pkg: string): Violation | null {
   if (!hasDualLogo && !hasLegacyLockup) {
     reasons.push('missing Interlace + ESLint logos in prelude');
   }
+
+  // 2b. Closing footer: the dual-logo header format additionally requires a
+  // standalone Interlace mark (icon-light.svg, height=70) as the very last
+  // element (item 15 in readme-structure.md) — distinct from the header's
+  // icon-light.svg (height=90). Legacy-lockup READMEs predate this footer
+  // and are exempt, same as the header check above.
+  if (hasDualLogo && !content.includes('icon-light.svg" alt="Interlace" height="70"')) {
+    reasons.push('missing closing Interlace mark footer (item 15 in readme-structure.md)');
+  }
   if (
     !content.includes('img.shields.io/npm/v/') ||
     !content.includes('img.shields.io/badge/License-MIT')

--- a/tools/scripts/fix-readmes.ts
+++ b/tools/scripts/fix-readmes.ts
@@ -496,7 +496,9 @@ MIT © [Ofri Peretz](https://github.com/ofri-peretz)
 
     // Closing footer — Interlace mark only (no ESLint mark here; that pairing
     // lives in the header). Same light-pair asset as the header, smaller
-    // (~70px), linking back with the same UTM campaign as the package.
+    // (~70px). The link below is bare; `scripts/stamp-utm-links.ts` stamps
+    // the per-package UTM campaign onto it in a later pass (same as the
+    // header link above).
     output.push(`<p align="center">`);
     output.push(`  <a href="https://eslint.interlace.tools" target="blank"><img src="https://eslint.interlace.tools/icon-light.svg" alt="Interlace" height="70" /></a>`);
     output.push(`</p>`);


### PR DESCRIPTION
## Summary

Follow-up to #269 (dual-logo README header + closing Interlace mark footer), addressing two non-blocking notes left by the Claude Code Review bot on that PR:

- `tools/scripts/check-readme-structure.ts`: the drift gate asserted the dual-logo **header** (`icon-light.svg` + `eslint-logo.svg`) but had no check for the closing Interlace-mark **footer** (item 15 in `.agent/rules/readme-structure.md`). A regeneration that dropped the footer would have passed the gate silently. Added an assertion for the `icon-light.svg" alt="Interlace" height="70"` footer marker, exempt for not-yet-migrated legacy-lockup READMEs (same exemption pattern as the header check).
- `tools/scripts/fix-readmes.ts`: the footer's generator comment claimed it links back "with the same UTM campaign as the package," but the generated URL is bare — UTM stamping is a separate `scripts/stamp-utm-links.ts` pass, same as the header. Corrected the comment to say so explicitly (matching the header comment's phrasing).

## Test plan

- [x] `npx tsx tools/scripts/check-readme-structure.ts` — all 19 READMEs pass.
- [x] Sanity-checked the new assertion actually fires: temporarily stripped the footer from one README, re-ran the gate, confirmed it failed with `missing closing Interlace mark footer (item 15 in readme-structure.md)`, then restored the file (confirmed clean diff).
- [x] Local pre-push hook suite green (tests, build, shim-verify, typecheck, lockfile, changelog, portability, workflows, markdown-full).

## After merge

No runtime or published-README changes — this only tightens the drift gate and a code comment. No changeset needed (doesn't touch package source or README content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)