### PR TITLE
docs(eslint-devkit): add closing Interlace brand mark to README

### DIFF
--- a/packages/eslint-devkit/README.md
+++ b/packages/eslint-devkit/README.md
@@ -538,3 +538,7 @@ If the devkit saved you time, **[star the repo](https://github.com/ofri-peretz/e
 ## Changelog
 
 See [CHANGELOG.md](./CHANGELOG.md) for a list of changes and version history.
+
+<p align="center">
+  <a href="https://eslint.interlace.tools/?utm_source=github&utm_medium=referral&utm_campaign=eslint-devkit" target="blank"><img src="https://eslint.interlace.tools/icon-light.svg" alt="Interlace" height="70" /></a>
+</p>


### PR DESCRIPTION
Audit of all published package READMEs against the brand pattern (og banner + closing Interlace mark, per the node-security reference): all 19 `eslint-plugin-*` packages are already consistent on both the repo and live npm. The only published package missing the closing mark was `@interlace/eslint-devkit` — this adds it (footer h=70, `utm_campaign=eslint-devkit`, matching the plugin footers).

The devkit gets no og banner since those are plugin-specific docs-site assets.

Note: the live npm README updates on the next devkit publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)