### PR TITLE
fix(nestjs-security): eliminate the false-positive storm on real NestJS codebases

### DIFF
--- a/.changeset/nestjs-security-false-positive-storm.md
+++ b/.changeset/nestjs-security-false-positive-storm.md
@@ -25,11 +25,20 @@ unvalidated request-DTO properties, and one missing `ThrottlerModule`).
   `resetPassword`, `confirmEmail`, `refresh`, health checks, webhooks), which
   cannot require the credential they hand out. New options:
   `allowCustomDecorators`, `detectGlobalGuards`, `publicRoutePatterns`.
+  `requiredGuards` — documented since 1.0 but never read — is now actually
+  enforced: with it set, `@UseGuards(RolesGuard)` no longer satisfies
+  `requiredGuards: ['JwtAuthGuard']`, and the new `missingRequiredGuards`
+  message names the guards that would. Guard arguments are read syntactically
+  (`AuthGuard('jwt')`, `guards.JwtAuthGuard`); anything with no static name,
+  an unresolved composite decorator, or a global `APP_GUARD` still suppresses
+  the report, since none of them can be proven *not* to apply the guard.
 - **`require-throttler` now reports once per project, on the root module**,
   instead of once per route handler. Rate limiting is adopted with a single
   `ThrottlerModule` registration, so 24 (and 93) per-route errors described a
   one-line fix. New options: `rootModuleNames`, `rootModuleFiles`; `skipRoutes`
-  is deprecated and ignored.
+  is deprecated and ignored. In-file detection requires an actual registration
+  (`ThrottlerModule` in `imports`, or a `ThrottlerGuard` behind `APP_GUARD`) —
+  a bare `import { ThrottlerGuard }` no longer silences the rule.
 - **`no-missing-validation-pipe`** honours parameter-bound pipes
   (`@Body(new ValidationPipe())`, `@Param('id', ParseIntPipe)`) and globally
   registered pipes.
@@ -41,7 +50,9 @@ unvalidated request-DTO properties, and one missing `ThrottlerModule`).
 - **`no-exposed-private-fields`** is scoped to persistence entities and domain
   models. A `LoginResponseDto` carrying a token is a declared contract; an
   `@Entity()` exposing `password` without `@Exclude()` is an accident. New
-  option: `includeDtos` restores the previous behaviour.
+  option: `includeDtos` restores the previous behaviour. GraphQL `@InputType()`
+  / `@ArgsType()` classes follow `includeDtos` too — they are request contracts
+  (`LoginInput` must carry a password); `@ObjectType()` stays an entity.
 - **`no-exposed-debug-endpoints`** inspects route paths only, instead of every
   string literal in the file (it was flagging enum members, seed data and config
   values). `admin`, `test` and `health` are no longer default debug paths, and a

--- a/.changeset/nestjs-security-false-positive-storm.md
+++ b/.changeset/nestjs-security-false-positive-storm.md
@@ -1,0 +1,48 @@
+---
+'eslint-plugin-nestjs-security': minor
+---
+
+Eliminate the false-positive storm on real NestJS codebases. Scanning two
+popular boilerplates with `recommended` produced 582 findings on
+ack-nestjs-boilerplate and 109 on brocoders/nestjs-boilerplate; after this
+change they produce 0 and 11, and every remaining finding is a genuine gap
+(an unauthenticated file-download route, entities exposing `password`/`hash`,
+unvalidated request-DTO properties, and one missing `ThrottlerModule`).
+
+- **Cross-file global registration is now detected.** Guards, pipes and rate
+  limiting registered through DI (`{ provide: APP_GUARD | APP_PIPE |
+  APP_INTERCEPTOR, ... }`), through `app.useGlobalPipes()` /
+  `app.useGlobalGuards()`, or through `ThrottlerModule.forRoot(Async)` suppress
+  the corresponding per-controller findings. The project root is resolved from
+  the linted file and its module files are scanned once and cached. A
+  `ThrottlerGuard` registered as `APP_GUARD` counts as rate limiting, not
+  authentication. Opt out per rule with `detectGlobalGuards` /
+  `detectGlobalPipes: false`.
+- **`require-guards`** no longer asserts "unguarded" on a route carrying a
+  decorator it cannot resolve — projects wrap `@UseGuards` in composites such as
+  `@AuthJwtAccessProtected()` via `applyDecorators()`. It also stops reporting
+  credential-issuing routes (`login`, `register`, `forgotPassword`,
+  `resetPassword`, `confirmEmail`, `refresh`, health checks, webhooks), which
+  cannot require the credential they hand out. New options:
+  `allowCustomDecorators`, `detectGlobalGuards`, `publicRoutePatterns`.
+- **`require-throttler` now reports once per project, on the root module**,
+  instead of once per route handler. Rate limiting is adopted with a single
+  `ThrottlerModule` registration, so 24 (and 93) per-route errors described a
+  one-line fix. New options: `rootModuleNames`, `rootModuleFiles`; `skipRoutes`
+  is deprecated and ignored.
+- **`no-missing-validation-pipe`** honours parameter-bound pipes
+  (`@Body(new ValidationPipe())`, `@Param('id', ParseIntPipe)`) and globally
+  registered pipes.
+- **`require-class-validator`** no longer fires on response/serialization DTOs
+  (name pattern, superclass name, or class-transformer `@Expose`/`@Exclude`),
+  on `format: 'binary'` multipart upload slots, or on `@Allow()`-marked
+  properties, and recognises ~40 more class-validator decorators. New options:
+  `checkResponseDtos`, `responseDtoPattern`.
+- **`no-exposed-private-fields`** is scoped to persistence entities and domain
+  models. A `LoginResponseDto` carrying a token is a declared contract; an
+  `@Entity()` exposing `password` without `@Exclude()` is an accident. New
+  option: `includeDtos` restores the previous behaviour.
+- **`no-exposed-debug-endpoints`** inspects route paths only, instead of every
+  string literal in the file (it was flagging enum members, seed data and config
+  values). `admin`, `test` and `health` are no longer default debug paths, and a
+  guarded debug route is no longer reported. New option: `detectGlobalGuards`.

--- a/packages/eslint-plugin-nestjs-security/AGENTS.md
+++ b/packages/eslint-plugin-nestjs-security/AGENTS.md
@@ -43,7 +43,10 @@ nx lint eslint-plugin-nestjs-security
 ```
 src/
 ├── index.ts          # Plugin entry, exports rules and 2 configs
-└── rules/            # 5 rule directories
+├── utils/            # Shared helpers
+│   ├── decorators.ts      # Decorator naming + known/unresolved classification
+│   └── project-context.ts # Cross-file global registration discovery (cached)
+└── rules/            # 6 rule directories
     └── [rule-name]/
         ├── index.ts       # Rule implementation
         └── index.spec.ts  # Rule tests
@@ -52,7 +55,7 @@ docs/                 # Documentation
 
 ## Plugin Purpose
 
-Security-focused ESLint plugin with **5 rules** for NestJS applications. Covers authorization guards, validation pipes, throttling/rate limiting, class-validator decorators, and sensitive field exposure.
+Security-focused ESLint plugin with **6 rules** for NestJS applications. Covers authorization guards, validation pipes, throttling/rate limiting, class-validator decorators, and sensitive field exposure.
 
 ## Rule Categories
 
@@ -88,25 +91,37 @@ Security-focused ESLint plugin with **5 rules** for NestJS applications. Covers 
 
 ## Global Configuration Handling
 
-NestJS supports global config that ESLint cannot detect cross-file. Rules support `assumeGlobal*` options:
+NestJS applies guards, pipes and throttling app-wide through DI, in a file the
+controller never imports. `src/utils/project-context.ts` discovers those
+registrations: it resolves the project root (nearest `package.json`), scans
+`main.ts` / `*.module.ts` once, and caches the result per root.
 
-```javascript
-// eslint.config.js - for teams using global config in main.ts
-{
-  rules: {
-    'nestjs-security/require-guards': ['warn', { assumeGlobalGuards: true }],
-    'nestjs-security/no-missing-validation-pipe': ['warn', { assumeGlobalPipes: true }],
-    'nestjs-security/require-throttler': ['warn', { assumeGlobalThrottler: true }]
-  }
-}
-```
+Detected: `{ provide: APP_GUARD|APP_PIPE|APP_INTERCEPTOR|APP_FILTER }`,
+`app.useGlobalPipes()`, `app.useGlobalGuards()`, `ThrottlerModule.forRoot(Async)`.
+A `ThrottlerGuard` registered as `APP_GUARD` counts as throttling, not auth.
+
+The `assumeGlobal*` options still force-skip a rule without scanning; the new
+`detectGlobal*: false` options disable the scan and restore strict per-file
+checking.
+
+## False-positive doctrine
+
+`src/utils/decorators.ts` holds `KNOWN_DECORATORS` — every decorator shipped by
+NestJS, Swagger, class-validator and class-transformer. **Anything not in that
+set is treated as project-owned and possibly a guard composite**
+(`applyDecorators(UseGuards(...))`), so `require-guards` and
+`no-exposed-debug-endpoints` stay silent on it. A false negative is far cheaper
+than a false positive on somebody else's codebase.
+
+Never add a wildcard to that set. An `Api*` prefix heuristic would swallow ack's
+`@ApiKeyProtected()`, which is a guard, not Swagger documentation.
 
 ## Recognized Decorators
 
-| Rule                | Skip Decorators                              |
-| ------------------- | -------------------------------------------- |
-| `require-guards`    | @Public, @SkipAuth, @AllowAnonymous, @NoAuth |
-| `require-throttler` | @SkipThrottle                                |
+| Rule                | Skip Decorators                                              |
+| ------------------- | ------------------------------------------------------------ |
+| `require-guards`    | @Public, @IsPublic, @SkipAuth, @AllowAnonymous, @Anonymous, @NoAuth, any unresolved decorator |
+| `require-throttler` | reports only on the root module; no per-route decorators      |
 
 ## Security Considerations
 

--- a/packages/eslint-plugin-nestjs-security/README.md
+++ b/packages/eslint-plugin-nestjs-security/README.md
@@ -56,22 +56,37 @@ npm install eslint-plugin-nestjs-security --save-dev
 ---
 
 ## ⚠️ Global Configuration Handling
-> **Static Analysis Limitation:** ESLint analyzes files independently. It cannot detect cross-file configurations like `app.useGlobalGuards()` in `main.ts` while linting `users.controller.ts`.
 
-### Understanding the Problem
+NestJS applies guards, pipes and rate limiting **application-wide**, in a file the
+controller never imports. Since v1.3.0 the plugin discovers those registrations
+itself: on the first finding it locates the project root (nearest `package.json`)
+and scans the bootstrap and `*.module.ts` files once, caching the result.
 
-NestJS supports two security configuration approaches:
+| Approach             | Example                                                     | Detected? |
+| -------------------- | ----------------------------------------------------------- | :-------: |
+| **Per-Controller**   | `@UseGuards(AuthGuard)` on class                            |    ✅     |
+| **Per-Method**       | `@UseGuards(AuthGuard)` on method                           |    ✅     |
+| **Composite**        | `@AuthJwtAccessProtected()` wrapping `UseGuards`            |    ✅¹    |
+| **Global (main.ts)** | `app.useGlobalGuards()` / `app.useGlobalPipes()`            |    ✅     |
+| **Global (Module)**  | `{ provide: APP_GUARD, useClass: AuthGuard }`               |    ✅     |
+| **Global (Module)**  | `{ provide: APP_PIPE, useClass: ValidationPipe }`           |    ✅     |
+| **Global (Module)**  | `ThrottlerModule.forRoot([{ ttl: 60000, limit: 10 }])`      |    ✅     |
 
-| Approach             | Example                                           | ESLint Can See? |
-| -------------------- | ------------------------------------------------- | :-------------: |
-| **Per-Controller**   | `@UseGuards(AuthGuard)` on class                  |       ✅        |
-| **Per-Method**       | `@UseGuards(AuthGuard)` on method                 |       ✅        |
-| **Global (main.ts)** | `app.useGlobalGuards(new AuthGuard())`            |       ❌        |
-| **Global (Module)**  | `ThrottlerModule.forRoot({ ttl: 60, limit: 10 })` |       ❌        |
+¹ A composite decorator cannot be resolved by a syntax-only linter, so any route
+carrying a decorator the plugin does not recognise is assumed to be protected. A
+missed finding is cheaper than a false positive on somebody else's codebase. Set
+`allowCustomDecorators: false` on `require-guards` if you want the strict
+behaviour back.
 
-### Solution: `assumeGlobal*` Options
+`ThrottlerGuard` registered as `APP_GUARD` counts as rate limiting, **not** as
+authentication — a project that only throttles still gets `require-guards`
+findings.
 
-For teams using **global configuration**, set `assumeGlobal*: true` to disable per-file checks:
+### Escape hatch: `assumeGlobal*` and `detectGlobal*` options
+
+`assumeGlobal*: true` disables a rule outright without scanning the project;
+`detectGlobal*: false` disables the project scan and restores strict per-file
+checking:
 
 ```javascript
 // eslint.config.js
@@ -95,6 +110,9 @@ export default [
         'warn',
         { assumeGlobalThrottler: true },
       ],
+
+      // Or keep strict per-file checking and skip the project scan entirely
+      // 'nestjs-security/require-guards': ['error', { detectGlobalGuards: false }],
     },
   },
 ];
@@ -115,15 +133,12 @@ The rules recognize common "bypass" decorators for intentionally unprotected end
 @SkipThrottle()  // @nestjs/throttler built-in
 ```
 
-### 🔮 Future: Cross-File Global Detection (Planned)
+### Where rate limiting is reported
 
-We're planning dedicated rules to **verify** global configuration exists:
-
-- `require-global-guards` → Ensures `main.ts` contains `app.useGlobalGuards()`
-- `require-global-validation-pipe` → Ensures `main.ts` contains `app.useGlobalPipes()`
-- `require-global-throttler` → Ensures `app.module.ts` imports `ThrottlerModule`
-
-This will enable a "trust but verify" approach for teams using global configuration.
+`require-throttler` reports **once, on the root module** (`AppModule`, or any
+`@Module` class in `app.module.ts`) when no `ThrottlerModule` is configured
+anywhere in the project. Rate limiting is adopted with one module registration,
+so reporting it on every route described a one-line fix as dozens of errors.
 
 ---
 

--- a/packages/eslint-plugin-nestjs-security/docs/rules/no-exposed-debug-endpoints.md
+++ b/packages/eslint-plugin-nestjs-security/docs/rules/no-exposed-debug-endpoints.md
@@ -35,7 +35,23 @@ Identifies potential debug, administration, or testing endpoints that are often 
 
 ## Rule Details
 
-This rule scans for NestJS HTTP decorators (`@Get`, `@Post`, etc.) and literal string constants that match known sensitive paths.
+This rule inspects **route paths only**: the path argument of `@Controller(...)`
+(string or `{ path: '...' }` object form) and of the HTTP-method decorators. It
+reports a debug route that is not protected by a guard.
+
+Earlier versions matched every string literal in the file, which flagged enum
+members (`EnumLoggerLevel.debug`), seed data and config values — 24 findings
+across two NestJS boilerplates, none of them an endpoint.
+
+`admin`, `test` and `health` were removed from the default path list: they are
+ordinary route names in every NestJS application. Add them back through the
+`endpoints` option if your project treats them as internal.
+
+A route is considered protected when the handler or its controller carries
+`@UseGuards`, carries a decorator the plugin cannot resolve (a guard composite
+such as `@AuthJwtAccessProtected()`), or the project registers a global
+`APP_GUARD`. `@Public()` does **not** protect a debug route — that is the whole
+finding.
 
 ## ❌ Incorrect
 
@@ -48,15 +64,12 @@ export class UtilsController {
     return process.memoryUsage();
   }
 
-  // ❌ Admin path exposed
-  @Post('/admin/reset')
-  resetSystem() {
-    // ...
+  // ❌ Debug base path on the controller
+  @Get('state')
+  state() {
+    return this.debugService.dump();
   }
 }
-
-// ❌ Literal string matching a forbidden path
-const myPath = 'test-endpoint';
 ```
 
 ## ✅ Correct
@@ -70,12 +83,17 @@ export class ProfileController {
     return { name: 'User' };
   }
 
-  // ✅ Debug endpoint protected by a Guard (Rule still flags path, but this is the goal)
+  // ✅ Debug endpoint behind a guard
   @UseGuards(AdminGuard)
-  @Get('internal-status')
+  @Get('debug')
   getStatus() {
     return { status: 'OK' };
   }
+}
+
+// ✅ Not a route — plain strings and enum members are never inspected
+export enum EnumLoggerLevel {
+  debug = 'debug',
 }
 ```
 
@@ -85,6 +103,7 @@ export class ProfileController {
 | :------------ | :--------- | :--------------- | :------------------------------------------- |
 | `endpoints`   | `string[]` | `['debug', ...]` | Custom list of debug/admin endpoints to flag |
 | `ignoreFiles` | `string[]` | `[]`             | List of files or patterns to ignore          |
+| `detectGlobalGuards` | `boolean` | `true` | Suppress findings when `APP_GUARD` is registered |
 
 ### Example Configuration
 
@@ -104,8 +123,12 @@ export class ProfileController {
 
 ## Known False Negatives
 
-- Values stored in variables/constants used in decorators.
-- Dynamic path generation using template literals if not easily resolvable.
+- Values stored in variables/constants used in decorators (`@Get(DEBUG_PATH)`).
+- Dynamic path generation using template literals.
+- Debug routes on a controller that carries any decorator the plugin cannot
+  resolve — it is assumed to be a guard composite.
+- Any debug route in a project that registers a global `APP_GUARD`
+  (`detectGlobalGuards: false` restores the check).
 
 ## References
 

--- a/packages/eslint-plugin-nestjs-security/docs/rules/no-exposed-debug-endpoints.md
+++ b/packages/eslint-plugin-nestjs-security/docs/rules/no-exposed-debug-endpoints.md
@@ -56,15 +56,19 @@ finding.
 ## ❌ Incorrect
 
 ```typescript
+// ❌ Debug path on the route handler
 @Controller('utils')
 export class UtilsController {
-  // ❌ NestJS Get decorator using a debug path
   @Get('debug')
   getDebugInfo() {
     return process.memoryUsage();
   }
+}
 
-  // ❌ Debug base path on the controller
+// ❌ Debug base path on the controller — every route under it is a debug route,
+//    including ones whose own path says nothing about debugging
+@Controller({ version: '1', path: '/__debug__' })
+export class DebugController {
   @Get('state')
   state() {
     return this.debugService.dump();

--- a/packages/eslint-plugin-nestjs-security/docs/rules/no-exposed-private-fields.md
+++ b/packages/eslint-plugin-nestjs-security/docs/rules/no-exposed-private-fields.md
@@ -80,14 +80,20 @@ class UsersController {
 ## Scope: entities, not DTOs
 
 The rule tracks **persistence entities and domain models** — classes decorated
-with `@Entity`, `@Schema`, `@Table`, `@ObjectType`, `@InputType`, `@ArgsType` or
-`@Model`, or named `*Entity` / `*Schema` / `*Model` / `*Document` / `*Table`.
+with `@Entity`, `@Schema`, `@Table`, `@ObjectType` or `@Model`, or named
+`*Entity` / `*Schema` / `*Model` / `*Document` / `*Table`.
 
 DTOs are excluded by default. A `LoginResponseDto` *must* carry a token and an
 `AuthResetPasswordDto` *must* carry a password — those are declared contracts,
 whereas an entity that names a `password` column and never says `@Exclude()`
 leaks it the first time the object is returned from a controller. Set
 `includeDtos: true` to restore the older, noisier behaviour.
+
+`@InputType()` and `@ArgsType()` follow `includeDtos`, not the entity set:
+GraphQL input objects describe what a client *sends*, so they are request
+contracts (`LoginInput`, `ResetPasswordArgs`) exactly like a `*Dto` class.
+`@ObjectType()` stays an entity — that is the response side, where an
+accidental `password` field really does leak.
 
 ## Detected Sensitive Field Names
 

--- a/packages/eslint-plugin-nestjs-security/docs/rules/no-exposed-private-fields.md
+++ b/packages/eslint-plugin-nestjs-security/docs/rules/no-exposed-private-fields.md
@@ -68,8 +68,26 @@ class UsersController {
 {
   // Skip rule in test files (default: true)
   allowInTests?: boolean;
+
+  // Custom sensitive field patterns (merged with the defaults)
+  sensitivePatterns?: string[];
+
+  // Also check DTO classes (default: false)
+  includeDtos?: boolean;
 }
 ```
+
+## Scope: entities, not DTOs
+
+The rule tracks **persistence entities and domain models** — classes decorated
+with `@Entity`, `@Schema`, `@Table`, `@ObjectType`, `@InputType`, `@ArgsType` or
+`@Model`, or named `*Entity` / `*Schema` / `*Model` / `*Document` / `*Table`.
+
+DTOs are excluded by default. A `LoginResponseDto` *must* carry a token and an
+`AuthResetPasswordDto` *must* carry a password — those are declared contracts,
+whereas an entity that names a `password` column and never says `@Exclude()`
+leaks it the first time the object is returned from a controller. Set
+`includeDtos: true` to restore the older, noisier behaviour.
 
 ## Detected Sensitive Field Names
 

--- a/packages/eslint-plugin-nestjs-security/docs/rules/no-missing-validation-pipe.md
+++ b/packages/eslint-plugin-nestjs-security/docs/rules/no-missing-validation-pipe.md
@@ -87,10 +87,22 @@ app.useGlobalPipes(
   // Skip rule in test files (default: true)
   allowInTests?: boolean;
 
-  // Skip if global pipes configured in main.ts (default: false)
+  // Skip the rule entirely, without scanning the project (default: false)
   assumeGlobalPipes?: boolean;
+
+  // Suppress findings when APP_PIPE / useGlobalPipes is registered (default: true)
+  detectGlobalPipes?: boolean;
 }
 ```
+
+## What the rule deliberately does not report
+
+- **Globally registered pipes.** `{ provide: APP_PIPE, useClass: ValidationPipe }`
+  in any module, or `app.useGlobalPipes(...)` in the bootstrap file, validates
+  every route in the project. Disable with `detectGlobalPipes: false`.
+- **Parameter-bound pipes.** `@Body(new ValidationPipe())`,
+  `@Param('id', ParseIntPipe)` and `@Param('user', RequestRequiredPipe)` validate
+  at the binding site; any argument whose name ends in `Pipe` counts.
 
 ## Recommended ValidationPipe Options
 

--- a/packages/eslint-plugin-nestjs-security/docs/rules/require-class-validator.md
+++ b/packages/eslint-plugin-nestjs-security/docs/rules/require-class-validator.md
@@ -77,8 +77,29 @@ class CreateUserDto {
 {
   // Skip rule in test files (default: true)
   allowInTests?: boolean;
+
+  // Also check response/serialization DTOs (default: false)
+  checkResponseDtos?: boolean;
+
+  // Class-name pattern identifying a response DTO
+  // (default: 'Response|Result|View|Payload|Output|Serializ')
+  responseDtoPattern?: string;
 }
 ```
+
+## What the rule deliberately does not report
+
+- **Response DTOs.** A class whose name (or superclass name) matches
+  `responseDtoPattern`, or that carries class-transformer `@Expose()` /
+  `@Exclude()`, describes server *output*. class-validator decorators are
+  meaningless there, and requiring them produced one finding per property of
+  every serialization model in the codebase. Re-enable with
+  `checkResponseDtos: true`.
+- **Multipart upload slots.** `@ApiProperty({ type: 'string', format: 'binary' })`
+  (including the nested `items: { format: 'binary' }` array form) is consumed by
+  Multer, never by class-validator.
+- **`@Allow()`-marked properties.** `@Allow()` is an explicit "accepted as-is"
+  decision under `forbidNonWhitelisted`, not a missing validator.
 
 ## Common Validators
 

--- a/packages/eslint-plugin-nestjs-security/docs/rules/require-guards.md
+++ b/packages/eslint-plugin-nestjs-security/docs/rules/require-guards.md
@@ -93,8 +93,17 @@ class UsersController {
   // Allow @Public decorator to bypass (default: true)
   allowPublicDecorator?: boolean;
 
-  // Skip if global guards configured in main.ts (default: false)
+  // Skip the rule entirely, without scanning the project (default: false)
   assumeGlobalGuards?: boolean;
+
+  // Treat an unresolvable decorator as a possible guard composite (default: true)
+  allowCustomDecorators?: boolean;
+
+  // Suppress findings when APP_GUARD / useGlobalGuards is registered (default: true)
+  detectGlobalGuards?: boolean;
+
+  // Handler names / route segments that are unauthenticated by design
+  publicRoutePatterns?: string[];
 }
 ```
 
@@ -104,6 +113,25 @@ class UsersController {
 - `@SkipAuth()`
 - `@AllowAnonymous()`
 - `@NoAuth()`
+- `@IsPublic()`, `@Anonymous()`
+
+## What the rule deliberately does not report
+
+Three exemptions exist because they were pure noise on real NestJS codebases:
+
+1. **Composite decorators.** A route carrying any decorator the plugin cannot
+   resolve — `@AuthJwtAccessProtected()`, `@ApiKeyProtected()`, `@RoleProtected()` —
+   is assumed to be protected. These are `applyDecorators(UseGuards(...))`
+   wrappers that a syntax-only linter cannot follow. Disable with
+   `allowCustomDecorators: false`.
+2. **Global guards.** `{ provide: APP_GUARD, useClass: AuthGuard }` in any module,
+   or `app.useGlobalGuards()` in the bootstrap file, protects every route in the
+   project. A `ThrottlerGuard` registered as `APP_GUARD` does **not** count —
+   throttling is not authentication. Disable with `detectGlobalGuards: false`.
+3. **Credential-issuing routes.** `login`, `register`, `forgotPassword`,
+   `resetPassword`, `confirmEmail`, `refresh`, `health`, `webhook`, … cannot
+   require the credential they hand out. Matched against the handler name and
+   each route-path segment; override with `publicRoutePatterns`.
 
 ## When Not To Use It
 
@@ -114,29 +142,24 @@ class UsersController {
 
 The following patterns are **not detected** due to static analysis limitations:
 
-### Global Guards in Separate Module
+### Routes behind an unresolvable decorator
 
-**Why**: Global guards in main.ts or module providers are not linked.
-
-```typescript
-// ❌ NOT DETECTED - Global guard exists elsewhere
-// main.ts: app.useGlobalGuards(new AuthGuard())
-// controller.ts: No @UseGuards needed, but flagged
-```
-
-**Mitigation**: Set `assumeGlobalGuards: true` in rule options.
-
-### Custom Authorization Decorators
-
-**Why**: Custom decorators wrapping guards are not recognized.
+**Why**: Any decorator the plugin cannot resolve is assumed to guard the route,
+so a genuinely unprotected route that happens to carry an unrelated custom
+decorator is not reported. This is the deliberate trade that removed 93 false
+positives from a single boilerplate.
 
 ```typescript
-// ❌ NOT DETECTED - Custom auth decorator
-@CustomAuth('admin') // Internally applies AuthGuard
-class AdminController {}
+// ❌ NOT DETECTED - @Audited() is not a guard, but we cannot know that
+@Controller('users')
+class UsersController {
+  @Audited()
+  @Get()
+  findAll() {}
+}
 ```
 
-**Mitigation**: Add custom decorator to recognized skip decorators list.
+**Mitigation**: Set `allowCustomDecorators: false` to report these again.
 
 ### Guard Applied via Inheritance
 
@@ -157,13 +180,17 @@ class UsersController extends BaseController {
 
 ### Module-Level Guard Providers
 
-**Why**: Guards registered as APP_GUARD providers are not detected.
+**Detected since v1.3.0.** `{ provide: APP_GUARD, useClass: AuthGuard }` in any
+`*.module.ts` under the project root now suppresses the per-controller check.
+The consequence is the inverse false negative: a project with a global guard
+gets no `require-guards` findings at all, even on a controller the guard's own
+logic lets through.
 
 ```typescript
-// ❌ NOT DETECTED - APP_GUARD provider
+// Suppresses require-guards project-wide
 @Module({
   providers: [{ provide: APP_GUARD, useClass: AuthGuard }]
 })
 ```
 
-**Mitigation**: Set assumeGlobalGuards for modules with APP_GUARD.
+**Mitigation**: Set `detectGlobalGuards: false` to keep per-controller checking.

--- a/packages/eslint-plugin-nestjs-security/docs/rules/require-guards.md
+++ b/packages/eslint-plugin-nestjs-security/docs/rules/require-guards.md
@@ -87,7 +87,7 @@ class UsersController {
   // Skip rule in test files (default: true)
   allowInTests?: boolean;
 
-  // Specific guards to require (default: any guard)
+  // Specific guard classes that satisfy the rule (default: [] — any guard)
   requiredGuards?: string[];
 
   // Allow @Public decorator to bypass (default: true)
@@ -106,6 +106,42 @@ class UsersController {
   publicRoutePatterns?: string[];
 }
 ```
+
+### `requiredGuards` — demand a *specific* guard
+
+By default any `@UseGuards(...)` satisfies the rule. `requiredGuards` narrows
+that to a named set: the guard argument must be one of them.
+
+```jsonc
+{ "requiredGuards": ["JwtAuthGuard"] }
+```
+
+```typescript
+@Controller('users')
+class UsersController {
+  @UseGuards(JwtAuthGuard) // ✅ the required guard
+  @Get('me')
+  me() {}
+
+  @UseGuards(RolesGuard) // ❌ guarded, but not by JwtAuthGuard
+  @Get()
+  findAll() {}
+}
+```
+
+Guard arguments are read syntactically, so `@UseGuards(AuthGuard('jwt'))` and
+`@UseGuards(guards.JwtAuthGuard)` both resolve to `AuthGuard` / `JwtAuthGuard`.
+
+**The option is deliberately conservative — it can only add findings where the
+guard is visible.** Three cases still suppress the report, because none of them
+can be *proven* not to apply the required guard:
+
+- a `@UseGuards` whose arguments have no static name (`@UseGuards(...guards)`,
+  `@UseGuards()`, a bare `@UseGuards`),
+- an unresolved composite decorator such as `@AuthJwtAccessProtected()` — the
+  `allowCustomDecorators` exemption; set it to `false` to close this hole,
+- a global `APP_GUARD` / `app.useGlobalGuards()` registration — the
+  `detectGlobalGuards` exemption; set it to `false` to close this one.
 
 ## Recognized Skip Decorators
 

--- a/packages/eslint-plugin-nestjs-security/docs/rules/require-throttler.md
+++ b/packages/eslint-plugin-nestjs-security/docs/rules/require-throttler.md
@@ -1,6 +1,6 @@
 ---
 title: require-throttler
-description: This rule detects NestJS controllers and route handlers that lack rate limiting, which can make the application vulne...
+description: Reports once, on the root module, when the application configures no rate limiter (ThrottlerModule + Throttler...
 tags: ['security', 'nestjs']
 category: security
 severity: medium
@@ -9,16 +9,30 @@ owasp: "A05:2021"
 autofix: false
 ---
 
-> Require ThrottlerGuard or @Throttle decorator for rate limiting
+> Requires an application-wide ThrottlerModule for rate limiting
 
 
 <!-- @rule-summary -->
-This rule detects NestJS controllers and route handlers that lack rate limiting, which can make the application vulne...
+Reports once, on the root module, when the application configures no rate limiter (ThrottlerModule + ThrottlerGuard).
 <!-- @/rule-summary -->
 
 ## Rule Details
 
-This rule detects NestJS controllers and route handlers that lack rate limiting, which can make the application vulnerable to brute-force and denial-of-service attacks.
+This rule reports **once per project**, on the root module, when the application
+configures no rate limiter. Rate limiting in NestJS is adopted with a single
+`ThrottlerModule.forRoot()` registration plus a global `ThrottlerGuard`, so
+flagging every route handler turned a one-line fix into dozens of errors (24 on
+one boilerplate, 93 on another). Nothing is reported on controllers.
+
+The root module is a `@Module`-decorated class named `AppModule`, or any
+`@Module` class in a file named `app.module.ts`. Both are configurable.
+
+Rate limiting is considered configured when any of the following appears in the
+file being linted or in any `*.module.ts` / `main.ts` under the project root:
+
+- `ThrottlerModule.forRoot(...)` or `ThrottlerModule.forRootAsync(...)`
+- `{ provide: APP_GUARD, useClass: ThrottlerGuard }`
+- any reference to `ThrottlerGuard` / `ThrottlerStorage`
 
 ## OWASP Mapping
 
@@ -29,33 +43,35 @@ This rule detects NestJS controllers and route handlers that lack rate limiting,
 ## ❌ Incorrect
 
 ```typescript
-@Controller('auth')
-class AuthController {
-  @Post('login')
-  login() {
-    // No rate limiting - vulnerable to brute force!
-  }
-}
+// app.module.ts — nothing throttles login, register or password reset
+@Module({
+  imports: [AuthModule, UsersModule],
+  controllers: [],
+  providers: [],
+})
+export class AppModule {}
 ```
 
 ## ✅ Correct
 
 ```typescript
-import { Throttle, ThrottlerGuard } from '@nestjs/throttler';
+import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
+import { APP_GUARD } from '@nestjs/core';
 
-@Controller('auth')
-@UseGuards(ThrottlerGuard)
-class AuthController {
-  @Post('login')
-  @Throttle({ default: { limit: 5, ttl: 60000 } }) // 5 attempts per minute
-  login() {}
-}
-
-// Or in app.module.ts (global)
 @Module({
   imports: [ThrottlerModule.forRoot([{ ttl: 60000, limit: 10 }])],
+  providers: [{ provide: APP_GUARD, useClass: ThrottlerGuard }],
 })
 export class AppModule {}
+```
+
+Per-route tuning still works as usual, and is no longer required to silence the
+rule:
+
+```typescript
+@Post('login')
+@Throttle({ default: { limit: 5, ttl: 60000 } })
+login() {}
 ```
 
 ## Options
@@ -65,35 +81,37 @@ export class AppModule {}
   // Skip rule in test files (default: true)
   allowInTests?: boolean;
 
-  // Skip if global throttler configured in app.module (default: false)
+  // Skip the rule entirely, without scanning the project (default: false)
   assumeGlobalThrottler?: boolean;
+
+  // Class names treated as the root module (default: ['AppModule'])
+  rootModuleNames?: string[];
+
+  // File names treated as the root module (default: ['app.module.ts'])
+  rootModuleFiles?: string[];
+
+  // Deprecated, no longer used — the rule never reports per route
+  skipRoutes?: string[];
 }
 ```
 
-## Recognized Skip Decorators
-
-- `@SkipThrottle()` - Built-in decorator from @nestjs/throttler
-
 ## When Not To Use It
 
-- If you have `ThrottlerModule.forRoot()` in `app.module.ts`, set `assumeGlobalThrottler: true`
-- For endpoints that intentionally skip throttling, use `@SkipThrottle()` decorator
+- If rate limiting is handled by infrastructure (Kong, Nginx, an API gateway),
+  set `assumeGlobalThrottler: true`.
+- If your project has no root module (a library, or a Nest microservice built
+  from several entry points), the rule has nothing to report.
 
 ## Known False Negatives
 
 The following patterns are **not detected** due to static analysis limitations:
 
-### Global Throttler Module
+### Root Module Outside the Lint Scope
 
-**Why**: ThrottlerModule.forRoot in app.module is not linked to controllers.
+**Why**: The finding is attached to the root module. If `app.module.ts` is not
+linted, nothing is reported even when the project has no rate limiting.
 
-```typescript
-// ❌ NOT DETECTED - Global throttler exists
-// app.module.ts: imports: [ThrottlerModule.forRoot(...)]
-// controller.ts: Already throttled globally, but flagged
-```
-
-**Mitigation**: Set `assumeGlobalThrottler: true` in rule options.
+**Mitigation**: Include module files in your lint glob.
 
 ### Custom Rate Limiting
 
@@ -105,29 +123,12 @@ The following patterns are **not detected** due to static analysis limitations:
 class AuthController {}
 ```
 
-**Mitigation**: Configure rule to recognize custom rate limiting decorators.
+**Mitigation**: Set `assumeGlobalThrottler: true`, or reference `ThrottlerGuard`
+where your limiter is registered.
 
-### Infrastructure Rate Limiting
+### Per-Route Gaps Under a Global Throttler
 
-**Why**: Reverse proxy or API gateway limits are not visible.
+**Why**: Once `ThrottlerModule` is configured, the rule is silent. It cannot tell
+whether a specific route's limit is appropriate for a brute-forceable endpoint.
 
-```typescript
-// ❌ NOT DETECTED (correctly) - Kong/Nginx handles limits
-@Controller('auth')
-class AuthController {}
-```
-
-**Mitigation**: Document infrastructure rate limits. Add inline comment.
-
-### Dynamic Throttle Configuration
-
-**Why**: Throttle options from variables are not analyzed.
-
-```typescript
-// ❌ NOT DETECTED - Dynamic throttle config
-const throttleConfig = getThrottleConfig();
-@Throttle(throttleConfig) // May be undefined
-class Controller {}
-```
-
-**Mitigation**: Use inline throttle configuration.
+**Mitigation**: Review `@Throttle()` limits on authentication routes by hand.

--- a/packages/eslint-plugin-nestjs-security/src/branch-coverage.test.ts
+++ b/packages/eslint-plugin-nestjs-security/src/branch-coverage.test.ts
@@ -48,6 +48,13 @@ const getDec = {
     arguments: [],
   },
 };
+const moduleDec = {
+  expression: {
+    type: 'CallExpression',
+    callee: { type: 'Identifier', name: 'Module' },
+    arguments: [],
+  },
+};
 
 type Listener = (node: unknown) => void;
 const listener = (listeners: Record<string, unknown>, name: string): Listener =>
@@ -102,10 +109,8 @@ ruleTester.run('require-guards (branch edges)', requireGuards, {
         }
       `,
     },
-  ],
-  invalid: [
-    // Member-expression decorator on the class: hits the '' fallback in
-    // hasControllerDecorator / return-false tail of hasUseGuardsDecorator
+    // Member-expression decorator on the class: unnameable, so it may be a
+    // guard composite → the whole controller is exempt
     {
       code: `
         @Controller('u')
@@ -115,11 +120,8 @@ ruleTester.run('require-guards (branch edges)', requireGuards, {
           findAll() {}
         }
       `,
-      errors: [{ messageId: 'missingGuards', data: { name: 'findAll' } }],
     },
-    // Member-expression *call* decorator alongside @Get: '' fallback in
-    // hasHttpMethodDecorator + hasPublicDecorator, callee-not-Identifier in
-    // hasUseGuardsDecorator
+    // Member-expression *call* decorator on the handler: same reasoning
     {
       code: `
         @Controller('u')
@@ -129,8 +131,9 @@ ruleTester.run('require-guards (branch edges)', requireGuards, {
           findAll() {}
         }
       `,
-      errors: [{ messageId: 'missingGuards', data: { name: 'findAll' } }],
     },
+  ],
+  invalid: [
     // Bare @Get identifier decorator (Identifier arm of hasHttpMethodDecorator)
     {
       code: `
@@ -395,98 +398,55 @@ describe('no-missing-validation-pipe — Layer 2 synthetic AST', () => {
 // ===========================================================================
 ruleTester.run('require-throttler (branch edges)', requireThrottler, {
   valid: [
-    // Bare @SkipThrottle identifier decorator (Identifier arm of hasThrottleDecorator)
-    {
-      code: `
-        @Controller('u')
-        class BareSkip {
-          @Get()
-          @SkipThrottle
-          findAll() {}
-        }
-      `,
-    },
-    // Member-expression class decorator: '' fallback → not a controller
+    // Member-expression class decorator: '' fallback → not a @Module
     {
       code: `
         @ns.module()
-        class NotAController {
-          @Get()
-          findAll() {}
-        }
+        class NotAModule {}
       `,
+    },
+    // Bare @Module identifier decorator on a non-root module
+    {
+      code: `
+        @Module
+        class UsersModule {}
+      `,
+    },
+    // Root module file, but the class is not decorated with @Module
+    {
+      code: `export class AppModule {}`,
+      filename: 'src/app.module.ts',
     },
   ],
   invalid: [
-    // Bare @Controller identifier decorator (Identifier arm)
+    // Bare @Module identifier decorator (Identifier arm of isModuleClass)
     {
       code: `
-        @Controller
-        class BareController {
-          @Get()
-          findAll() {}
-        }
+        @Module
+        class AppModule {}
       `,
-      errors: [{ messageId: 'missingThrottler', data: { name: 'findAll' } }],
-    },
-    // Bare @Get identifier decorator (Identifier arm of isRouteHandler)
-    {
-      code: `
-        @Controller('u')
-        class BareGet {
-          @Get
-          findAll() {}
-        }
-      `,
-      errors: [{ messageId: 'missingThrottler', data: { name: 'findAll' } }],
-    },
-    // Member-expression method decorator: '' fallback in isRouteHandler +
-    // hasThrottleDecorator, callee-not-Identifier in hasThrottlerGuardDecorator
-    {
-      code: `
-        @Controller('u')
-        class MemberMethodDecorator {
-          @ns.log()
-          @Get()
-          findAll() {}
-        }
-      `,
-      errors: [{ messageId: 'missingThrottler', data: { name: 'findAll' } }],
-    },
-    // Computed method key reports as <anonymous>
-    {
-      code: `
-        @Controller('u')
-        class ComputedKey {
-          @Get()
-          ['dynamic']() {}
-        }
-      `,
-      errors: [{ messageId: 'missingThrottler', data: { name: '<anonymous>' } }],
+      errors: [{ messageId: 'missingThrottler', data: { name: 'AppModule' } }],
     },
   ],
 });
 
 describe('require-throttler — Layer 2 synthetic AST', () => {
-  it('treats undefined decorators as absent on class and method (no report)', () => {
+  it('ignores a class with undefined decorators', () => {
     const { listeners, reports } = createWithMockContext(requireThrottler);
     listener(listeners, 'ClassDeclaration')({ decorators: undefined, id: null });
-    listener(listeners, 'ClassDeclaration')({ decorators: [controllerDec], id: null });
-    listener(listeners, 'MethodDefinition')({
-      key: { type: 'Identifier', name: 'findAll' },
-      decorators: undefined,
-    });
     expect(reports).toEqual([]);
   });
 
-  it('skips a constructor that carries an HTTP decorator (parser-impossible AST)', () => {
-    const { listeners, reports } = createWithMockContext(requireThrottler);
-    listener(listeners, 'ClassDeclaration')({ decorators: [controllerDec], id: null });
-    listener(listeners, 'MethodDefinition')({
-      key: { type: 'Identifier', name: 'constructor' },
-      decorators: [getDec],
+  it('reports an anonymous root module as <anonymous>', () => {
+    const { listeners, reports } = createWithMockContext(requireThrottler, {
+      filename: 'app.module.ts',
     });
-    expect(reports).toEqual([]);
+    listener(listeners, 'ClassDeclaration')({ decorators: [moduleDec], id: null });
+    expect(reports).toHaveLength(1);
+    expect(reports[0]).toMatchObject({
+      messageId: 'missingThrottler',
+      data: { name: '<anonymous>' },
+    });
   });
 });
 
@@ -567,6 +527,8 @@ describe('require-class-validator — Layer 2 synthetic AST', () => {
     listener(listeners, 'ClassDeclaration')({
       id: { type: 'Identifier', name: 'SyntheticDto' },
       decorators: [],
+      superClass: null,
+      body: { body: [] },
     });
     listener(listeners, 'PropertyDefinition')({
       key: { type: 'Identifier', name: 'field' },
@@ -719,22 +681,48 @@ ruleTester.run('no-exposed-debug-endpoints (branch edges)', noExposedDebugEndpoi
         class CustomDecorated {}
       `,
     },
-  ],
-  invalid: [
-    // Member-expression callee decorator: Decorator handler skips it, but the
-    // Literal handler still flags the exact debug path
+    // Member-expression class decorator: unnameable → assumed to guard
     {
       code: `
+        @Controller('app')
         @foo.bar('debug')
-        class MemberCallee {}
+        class MemberCallee {
+          @Get('debug')
+          debug() {}
+        }
+      `,
+    },
+    // Bare @Controller identifier decorator with no route path
+    {
+      code: `
+        @Controller
+        class BareController {
+          @Get('safe')
+          safe() {}
+        }
+      `,
+    },
+  ],
+  invalid: [
+    // Bare @Get identifier decorator on a debug-pathed controller
+    {
+      code: `
+        @Controller('debug')
+        class DebugController {
+          @Get
+          state() {}
+        }
       `,
       errors: [{ messageId: 'violationDetected' }],
     },
-    // Custom endpoint configured with a leading slash (dp.startsWith('/') arm)
-    {
-      code: `const p = 'custom-debug';`,
-      options: [{ endpoints: ['/custom-debug'] }],
-      errors: [{ messageId: 'violationDetected' }],
-    },
   ],
+});
+
+describe('no-exposed-debug-endpoints — Layer 2 synthetic AST', () => {
+  it('treats a class with undefined decorators as a non-controller', () => {
+    const { listeners, reports } = createWithMockContext(noExposedDebugEndpoints);
+    listener(listeners, 'ClassDeclaration')({ decorators: undefined });
+    listener(listeners, 'MethodDefinition')({ decorators: [getDec] });
+    expect(reports).toEqual([]);
+  });
 });

--- a/packages/eslint-plugin-nestjs-security/src/global-registration.test.ts
+++ b/packages/eslint-plugin-nestjs-security/src/global-registration.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * End-to-end regression tests for global DI registration.
+ *
+ * These are the false positives that made the `recommended` preset unusable on
+ * real NestJS boilerplates: 93 `require-guards`, 93 `require-throttler` and 40
+ * `no-missing-validation-pipe` findings on ack-nestjs-boilerplate, plus 17
+ * `no-missing-validation-pipe` on brocoders/nestjs-boilerplate — every one of
+ * them caused by a registration that lives in a *different file* from the
+ * controller.
+ *
+ * The fixtures are written to a real temporary project because the rules
+ * resolve the project root from `context.filename` and read the module files
+ * off disk.
+ */
+
+import { afterAll, describe } from 'vitest';
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { requireGuards } from './rules/require-guards';
+import { requireThrottler } from './rules/require-throttler';
+import { noMissingValidationPipe } from './rules/no-missing-validation-pipe';
+import { noExposedDebugEndpoints } from './rules/no-exposed-debug-endpoints';
+import { clearProjectContextCache } from './utils/project-context';
+
+/** Build a throwaway NestJS project on disk and return its root. */
+function makeProject(files: Record<string, string>): string {
+  const root = mkdtempSync(join(tmpdir(), 'nestjs-security-e2e-'));
+  writeFileSync(join(root, 'package.json'), '{"name":"fixture"}');
+  for (const [relative, contents] of Object.entries(files)) {
+    const target = join(root, relative);
+    mkdirSync(join(target, '..'), { recursive: true });
+    writeFileSync(target, contents);
+  }
+  return root;
+}
+
+/** ack-nestjs-boilerplate: guard + pipe + throttler all registered via DI. */
+const ackLike = makeProject({
+  'src/common/request/request.module.ts': `
+    @Module({
+      providers: [
+        { provide: APP_INTERCEPTOR, useClass: RequestTimeoutInterceptor },
+        { provide: APP_PIPE, useFactory: () => new ValidationPipe({ whitelist: true }) },
+      ],
+    })
+    export class RequestModule {}
+  `,
+  'src/common/request/request.middleware.module.ts': `
+    @Module({
+      providers: [{ provide: APP_GUARD, useClass: ThrottlerGuard }],
+      imports: [ThrottlerModule.forRootAsync({ useFactory: () => ({}) })],
+    })
+    export class RequestMiddlewareModule {}
+  `,
+  'src/auth/auth.module.ts': `
+    @Module({ providers: [{ provide: APP_GUARD, useClass: JwtAuthGuard }] })
+    export class AuthModule {}
+  `,
+});
+
+/** brocoders/nestjs-boilerplate: the pipe is registered in main.ts. */
+const brocodersLike = makeProject({
+  'src/main.ts': `
+    async function bootstrap() {
+      const app = await NestFactory.create(AppModule);
+      app.useGlobalPipes(new ValidationPipe({ transform: true }));
+      await app.listen(3000);
+    }
+  `,
+});
+
+/** No global registration anywhere — the rules must still fire. */
+const bareProject = makeProject({
+  'src/app.module.ts': `
+    @Module({ controllers: [UsersController] })
+    export class AppModule {}
+  `,
+});
+
+afterAll(() => {
+  clearProjectContextCache();
+  for (const root of [ackLike, brocodersLike, bareProject]) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+const ruleTester = new RuleTester();
+
+const UNGUARDED_CONTROLLER = `
+  @Controller('users')
+  export class UsersController {
+    @Get('/list')
+    findAll() {}
+  }
+`;
+
+const UNVALIDATED_CONTROLLER = `
+  @Controller('users')
+  export class UsersController {
+    @Post()
+    create(@Body() dto: CreateUserDto) {}
+  }
+`;
+
+describe('global DI registration is honoured across files', () => {
+  ruleTester.run('require-guards + APP_GUARD', requireGuards, {
+    valid: [
+      {
+        code: UNGUARDED_CONTROLLER,
+        filename: join(ackLike, 'src/users/users.controller.ts'),
+      },
+      {
+        // detectGlobalGuards can be turned off explicitly
+        code: UNGUARDED_CONTROLLER,
+        filename: join(bareProject, 'src/users/users.controller.ts'),
+        options: [{ detectGlobalGuards: false, publicRoutePatterns: ['findAll'] }],
+      },
+    ],
+    invalid: [
+      {
+        // A ThrottlerGuard registered as APP_GUARD is not authentication.
+        code: UNGUARDED_CONTROLLER,
+        filename: join(brocodersLike, 'src/users/users.controller.ts'),
+        errors: [{ messageId: 'missingGuards', data: { name: 'findAll' } }],
+      },
+      {
+        code: UNGUARDED_CONTROLLER,
+        filename: join(bareProject, 'src/users/users.controller.ts'),
+        errors: [{ messageId: 'missingGuards', data: { name: 'findAll' } }],
+      },
+      {
+        code: UNGUARDED_CONTROLLER,
+        filename: join(ackLike, 'src/users/users.controller.ts'),
+        options: [{ detectGlobalGuards: false }],
+        errors: [{ messageId: 'missingGuards', data: { name: 'findAll' } }],
+      },
+    ],
+  });
+
+  ruleTester.run('no-missing-validation-pipe + APP_PIPE', noMissingValidationPipe, {
+    valid: [
+      {
+        code: UNVALIDATED_CONTROLLER,
+        filename: join(ackLike, 'src/users/users.controller.ts'),
+      },
+      {
+        code: UNVALIDATED_CONTROLLER,
+        filename: join(brocodersLike, 'src/users/users.controller.ts'),
+      },
+    ],
+    invalid: [
+      {
+        code: UNVALIDATED_CONTROLLER,
+        filename: join(bareProject, 'src/users/users.controller.ts'),
+        errors: [{ messageId: 'missingValidation' }],
+      },
+      {
+        code: UNVALIDATED_CONTROLLER,
+        filename: join(ackLike, 'src/users/users.controller.ts'),
+        options: [{ detectGlobalPipes: false }],
+        errors: [{ messageId: 'missingValidation' }],
+      },
+    ],
+  });
+
+  ruleTester.run('require-throttler + ThrottlerModule', requireThrottler, {
+    valid: [
+      {
+        // ThrottlerModule lives in a middleware module, not in AppModule
+        code: `@Module({ imports: [RequestMiddlewareModule] }) export class AppModule {}`,
+        filename: join(ackLike, 'src/app/app.module.ts'),
+      },
+    ],
+    invalid: [
+      {
+        code: `@Module({ imports: [UsersModule] }) export class AppModule {}`,
+        filename: join(brocodersLike, 'src/app.module.ts'),
+        errors: [{ messageId: 'missingThrottler', data: { name: 'AppModule' } }],
+      },
+    ],
+  });
+
+  ruleTester.run('no-exposed-debug-endpoints + APP_GUARD', noExposedDebugEndpoints, {
+    valid: [
+      {
+        code: `
+          @Controller('app')
+          class AppController {
+            @Get('debug')
+            debug() {}
+          }
+        `,
+        filename: join(ackLike, 'src/app/app.controller.ts'),
+      },
+    ],
+    invalid: [
+      {
+        code: `
+          @Controller('app')
+          class AppController {
+            @Get('debug')
+            debug() {}
+          }
+        `,
+        filename: join(bareProject, 'src/app/app.controller.ts'),
+        errors: [{ messageId: 'violationDetected' }],
+      },
+      {
+        code: `
+          @Controller('app')
+          class AppController {
+            @Get('debug')
+            debug() {}
+          }
+        `,
+        filename: join(ackLike, 'src/app/app.controller.ts'),
+        options: [{ detectGlobalGuards: false }],
+        errors: [{ messageId: 'violationDetected' }],
+      },
+    ],
+  });
+});

--- a/packages/eslint-plugin-nestjs-security/src/rules/no-exposed-debug-endpoints/index.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/no-exposed-debug-endpoints/index.ts
@@ -6,21 +6,51 @@
 
 /**
  * @fileoverview Detect debug endpoints without auth in NestJS applications
+ *
+ * Only *routes* are inspected: the path argument of `@Controller(...)` and of
+ * the HTTP-method decorators. The previous implementation matched every string
+ * literal in the file, which flagged enum members (`EnumLoggerLevel.debug`),
+ * seed data and config values — 24 findings across two boilerplates, none of
+ * them an endpoint.
  */
 
 import { createRule, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
 import type { TSESTree } from '@interlace/eslint-devkit';
+import {
+  getHttpMethodDecorator,
+  getRoutePath,
+  hasUnresolvedDecorator,
+  hasUseGuards,
+  isControllerClass,
+} from '../../utils/decorators';
+import { getProjectContext } from '../../utils/project-context';
 
 type MessageIds = 'violationDetected';
 
 export interface Options {
   endpoints?: string[];
   ignoreFiles?: string[];
+  /** Suppress findings when the project registers a global guard. Default: true */
+  detectGlobalGuards?: boolean;
 }
 
 type RuleOptions = [Options?];
 
-const DEFAULT_DEBUG_PATHS = ['debug', '__debug__', 'admin', '_admin', 'test', 'health'];
+/**
+ * Only genuinely diagnostic route names. `admin`, `test` and `health` used to
+ * be in this list; they are ordinary route names in every NestJS application
+ * (`/admin/users`, `/health`) and produced pure noise. Re-add them through the
+ * `endpoints` option if your project treats them as internal.
+ */
+const DEFAULT_DEBUG_PATHS = [
+  'debug',
+  '_debug',
+  '__debug__',
+  'debugger',
+  'dev-tools',
+  'devtools',
+  'phpinfo',
+];
 
 export const noExposedDebugEndpoints = createRule<RuleOptions, MessageIds>({
   name: 'no-exposed-debug-endpoints',
@@ -56,7 +86,8 @@ export const noExposedDebugEndpoints = createRule<RuleOptions, MessageIds>({
             type: 'array',
             items: { type: 'string' },
             description: 'List of files or patterns to ignore'
-          }
+          },
+          detectGlobalGuards: { type: 'boolean', default: true },
         },
         additionalProperties: false
       }
@@ -65,57 +96,60 @@ export const noExposedDebugEndpoints = createRule<RuleOptions, MessageIds>({
   defaultOptions: [{}],
   create(context) {
     const options = context.options[0] || {};
-    const debugPaths = options.endpoints || DEFAULT_DEBUG_PATHS;
+    const debugPaths = new Set(
+      (options.endpoints ?? DEFAULT_DEBUG_PATHS).map((path) =>
+        path.replace(/^\/+/, '').toLowerCase(),
+      ),
+    );
     const ignoreFiles = options.ignoreFiles || [];
+    const detectGlobalGuards = options.detectGlobalGuards ?? true;
     const filename = context.filename;
 
     if (ignoreFiles.some(pattern => filename.includes(pattern))) {
       return {};
     }
 
-    function report(node: TSESTree.Node) {
-      context.report({ node, messageId: 'violationDetected' });
+    let isController = false;
+    let classIsProtected = false;
+    let classPathIsDebug = false;
+
+    /** Any `/`-separated segment of the path is a configured debug name. */
+    function isDebugPath(path: string | null): boolean {
+      if (path === null) return false;
+      return path
+        .split('/')
+        .some((segment) => debugPaths.has(segment.toLowerCase()));
     }
 
-    const HTTP_METHODS = new Set(['Get', 'Post', 'Put', 'Delete', 'Patch', 'All', 'Options', 'Head']);
+    /** Guarded explicitly, by a project-owned composite, or app-wide. */
+    function isProtected(decorators: TSESTree.Decorator[] | undefined): boolean {
+      return hasUseGuards(decorators) || hasUnresolvedDecorator(decorators);
+    }
+
+    function hasProjectGlobalGuard(): boolean {
+      return detectGlobalGuards && getProjectContext(context).hasGlobalAuthGuard;
+    }
 
     return {
-      Decorator(node: TSESTree.Decorator) {
-        if (node.expression.type === 'CallExpression' &&
-            node.expression.callee.type === 'Identifier' &&
-            HTTP_METHODS.has(node.expression.callee.name)) {
-          
-          const pathArg = node.expression.arguments[0];
-          if (pathArg && pathArg.type === 'Literal' && typeof pathArg.value === 'string') {
-            const path = pathArg.value.toLowerCase();
-            if (debugPaths.some(dp => path.includes(dp.toLowerCase()))) {
-              report(pathArg);
-            }
-          }
-        }
+      ClassDeclaration(node: TSESTree.ClassDeclaration) {
+        isController = isControllerClass(node.decorators);
+        classIsProtected = isProtected(node.decorators);
+        classPathIsDebug = (node.decorators ?? []).some(
+          (decorator) => isDebugPath(getRoutePath(decorator)),
+        );
       },
-      
-      Literal(node: TSESTree.Literal) {
-        if (typeof node.value === 'string') {
-          const path = node.value.toLowerCase();
-          // Normalize NestJS paths which might not have leading slash
-          const normalizedPath = path.startsWith('/') ? path.slice(1) : path;
-          
-          if (debugPaths.some(dp => {
-            const normalizedDP = dp.startsWith('/') ? dp.slice(1) : dp;
-            return normalizedPath === normalizedDP.toLowerCase();
-          })) {
-            // Avoid double reporting if it's already in an HTTP decorator
-            const parent = node.parent;
-            if (parent && parent.type === 'CallExpression' && 
-                parent.callee.type === 'Identifier' && 
-                HTTP_METHODS.has(parent.callee.name) &&
-                parent.parent.type === 'Decorator') {
-              return;
-            }
-            report(node);
-          }
-        }
+
+      MethodDefinition(node: TSESTree.MethodDefinition) {
+        if (!isController || classIsProtected) return;
+
+        const httpDecorator = getHttpMethodDecorator(node.decorators);
+        if (httpDecorator === null) return;
+        if (isProtected(node.decorators)) return;
+
+        if (!classPathIsDebug && !isDebugPath(getRoutePath(httpDecorator))) return;
+        if (hasProjectGlobalGuard()) return;
+
+        context.report({ node: httpDecorator, messageId: 'violationDetected' });
       },
     };
   },

--- a/packages/eslint-plugin-nestjs-security/src/rules/no-exposed-debug-endpoints/no-exposed-debug-endpoints.test.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/no-exposed-debug-endpoints/no-exposed-debug-endpoints.test.ts
@@ -14,50 +14,164 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('no-exposed-debug-endpoints', noExposedDebugEndpoints, {
   valid: [
-        'const x = 42;',
-        'const flag = true;',
-        'function noop() {}',
-        'const items = [];',
+    'const x = 42;',
+    // ========== REGRESSION (ack): enum members named `debug` are not routes.
+    // src/common/logger/enums/logger.enum.ts fired twice on these. ==========
     {
       code: `
-        class MyController {
-          @Get('/api/v1/profile')
-          getProfile() {}
+        export enum EnumLoggerLevel {
+          debug = 'debug',
+          error = 'error',
         }
-      `
+      `,
+    },
+    // ========== REGRESSION (brocoders): seed data / config strings ==========
+    {
+      code: `const seed = { role: 'admin', name: 'test' };`,
+    },
+    // ========== REGRESSION: 'admin', 'test' and 'health' are ordinary route
+    // names, not debug endpoints ==========
+    {
+      code: `
+        @Controller('admin')
+        class AdminController {
+          @Get('test')
+          runTest() {}
+          @Get('health')
+          health() {}
+        }
+      `,
     },
     {
       code: `
-        class MyController {
-          @Post('login')
-          login() {}
+        @Controller('users')
+        class UsersController {
+          @Get('/api/v1/profile')
+          getProfile() {}
         }
-      `
-    }
+      `,
+    },
+    // ========== VALID: guarded debug endpoint ==========
+    {
+      code: `
+        @Controller('app')
+        class AppController {
+          @Get('debug')
+          @UseGuards(AdminGuard)
+          debug() {}
+        }
+      `,
+    },
+    // ========== VALID: class-level guard covers the debug route ==========
+    {
+      code: `
+        @Controller('app')
+        @UseGuards(AdminGuard)
+        class AppController {
+          @Get('debug')
+          debug() {}
+        }
+      `,
+    },
+    // ========== VALID: custom composite decorator may guard the route ==========
+    {
+      code: `
+        @Controller('app')
+        class AppController {
+          @Get('debug')
+          @AuthJwtAccessProtected()
+          debug() {}
+        }
+      `,
+    },
+    // ========== VALID: not a controller ==========
+    {
+      code: `
+        class DebugService {
+          @Get('debug')
+          debug() {}
+        }
+      `,
+    },
+    // ========== VALID: non-route method in a controller ==========
+    {
+      code: `
+        @Controller('debug')
+        class DebugController {
+          helper() {}
+        }
+      `,
+    },
+    // ========== VALID: ignoreFiles ==========
+    {
+      code: `
+        @Controller('app')
+        class DebugController {
+          @Get('debug')
+          debug() {}
+        }
+      `,
+      options: [{ ignoreFiles: ['skip-me'] }],
+      filename: 'src/skip-me.controller.ts',
+    },
+    // ========== VALID: dynamic route path ==========
+    {
+      code: `
+        @Controller('app')
+        class AppController {
+          @Get(routePath)
+          dynamic() {}
+        }
+      `,
+    },
   ],
 
   invalid: [
+    // ========== INVALID: unguarded debug route ==========
     {
       code: `
-        class MyController {
+        @Controller('app')
+        class AppController {
           @Get('/debug')
           getDebug() {}
         }
       `,
-      errors: [{ messageId: 'violationDetected' }]
+      errors: [{ messageId: 'violationDetected' }],
     },
+    // ========== INVALID: debug base path on the controller ==========
     {
       code: `
-        class MyController {
-          @Post('admin')
-          getAdmin() {}
+        @Controller({ version: '1', path: '/__debug__' })
+        class DebugController {
+          @Get('state')
+          state() {}
         }
       `,
-      errors: [{ messageId: 'violationDetected' }]
+      errors: [{ messageId: 'violationDetected' }],
     },
+    // ========== INVALID: @Public() does not make a debug route acceptable ==========
     {
-      code: "const path = '/health'",
-      errors: [{ messageId: 'violationDetected' }]
-    }
+      code: `
+        @Controller('app')
+        class AppController {
+          @Get('devtools')
+          @Public()
+          devtools() {}
+        }
+      `,
+      errors: [{ messageId: 'violationDetected' }],
+    },
+    // ========== INVALID: custom endpoints option (leading slash) ==========
+    {
+      code: `
+        @Controller('app')
+        class AppController {
+          @Get('custom-debug')
+          custom() {}
+        }
+      `,
+      options: [{ endpoints: ['/custom-debug'] }],
+      errors: [{ messageId: 'violationDetected' }],
+    },
   ],
 });

--- a/packages/eslint-plugin-nestjs-security/src/rules/no-exposed-private-fields/index.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/no-exposed-private-fields/index.ts
@@ -14,6 +14,7 @@
  */
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
 import { AST_NODE_TYPES, createRule, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
+import { getDecoratorNames, hasDecoratorNamed } from '../../utils/decorators';
 
 type MessageIds = 'exposedField' | 'useExcludeDecorator';
 
@@ -22,9 +23,34 @@ export interface Options {
   allowInTests?: boolean;
   /** Custom sensitive field patterns. Default: password, secret, token, etc. */
   sensitivePatterns?: string[];
+  /**
+   * Also check DTO classes. A DTO listing `token` or `password` is an explicit
+   * author decision (`LoginResponseDto` *must* carry a token; a
+   * `ResetPasswordDto` *must* carry a password), whereas a persistence entity
+   * exposing the same field leaks it through serialization by accident.
+   * Default: false
+   */
+  includeDtos?: boolean;
 }
 
 type RuleOptions = [Options?];
+
+/** Class decorators that mark a persistence entity / serialized domain model. */
+const ENTITY_DECORATORS: ReadonlySet<string> = new Set([
+  'Entity',
+  'Schema',
+  'Table',
+  'ObjectType',
+  'InputType',
+  'ArgsType',
+  'Model',
+]);
+
+/** Class-name suffixes that mark a persistence entity / domain model. */
+const ENTITY_NAME = /Entity$|Schema$|Model$|Document$|Table$/;
+
+/** Class-name suffixes that mark a data-transfer object. */
+const DTO_NAME = /Dto$|Request$|Response$|Input$|Output$|Payload$/;
 
 // Default sensitive field patterns
 const DEFAULT_SENSITIVE_PATTERNS = [
@@ -92,14 +118,19 @@ export const noExposedPrivateFields = createRule<RuleOptions, MessageIds>({
         properties: {
           allowInTests: { type: 'boolean', default: true },
           sensitivePatterns: { type: 'array', items: { type: 'string' }, default: [] },
+          includeDtos: { type: 'boolean', default: false },
         },
         additionalProperties: false,
       },
     ],
   },
-  defaultOptions: [{ allowInTests: true, sensitivePatterns: [] }],
+  defaultOptions: [{ allowInTests: true, sensitivePatterns: [], includeDtos: false }],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>, [options = {}]) {
-    const { allowInTests = true, sensitivePatterns = [] } = options as Options;
+    const {
+      allowInTests = true,
+      sensitivePatterns = [],
+      includeDtos = false,
+    } = options as Options;
     const filename = context.filename;
     const isTestFile = /\.(test|spec)\.(ts|tsx|js|jsx)$/.test(filename);
 
@@ -115,56 +146,30 @@ export const noExposedPrivateFields = createRule<RuleOptions, MessageIds>({
      * Check if decorators include @Exclude
      */
     function hasExcludeDecorator(decorators: TSESTree.Decorator[] | undefined): boolean {
-      if (!decorators) return false;
-      return decorators.some((dec) => {
-        const name =
-          dec.expression.type === AST_NODE_TYPES.Identifier
-            ? dec.expression.name
-            : dec.expression.type === AST_NODE_TYPES.CallExpression &&
-              dec.expression.callee.type === AST_NODE_TYPES.Identifier
-            ? dec.expression.callee.name
-            : '';
-        return name === 'Exclude';
-      });
+      return getDecoratorNames(decorators).includes('Exclude');
     }
 
     /**
-     * Check if class looks like an entity/DTO (contains decorators from TypeORM, class-validator, etc.)
+     * Is this a persistence entity / serialized domain model?
+     *
+     * Scoped deliberately: an entity that names a `password` column and never
+     * says `@Exclude()` leaks it the first time the object is returned from a
+     * controller. A DTO with the same field name is a declared contract.
      */
-    function isEntityOrDto(decorators: TSESTree.Decorator[] | undefined): boolean {
-      if (!decorators) return false;
-      const entityDecorators = new Set([
-        'Entity',
-        'Schema',
-        'ObjectType',
-        'InputType',
-        'ArgsType',
-        'ApiProperty',
-      ]);
-      return decorators.some((dec) => {
-        const name =
-          dec.expression.type === AST_NODE_TYPES.Identifier
-            ? dec.expression.name
-            : dec.expression.type === AST_NODE_TYPES.CallExpression &&
-              dec.expression.callee.type === AST_NODE_TYPES.Identifier
-            ? dec.expression.callee.name
-            : '';
-        return entityDecorators.has(name);
-      });
+    function isTrackedClass(node: TSESTree.ClassDeclaration): boolean {
+      if (hasDecoratorNamed(node.decorators, ENTITY_DECORATORS)) return true;
+      const name = node.id?.name;
+      if (name === undefined) return false;
+      if (ENTITY_NAME.test(name)) return true;
+      return includeDtos && DTO_NAME.test(name);
     }
 
-    // Track if we're in an entity/dto class
+    // Track if we're in an entity class
     let isInEntityOrDto = false;
 
     return {
       ClassDeclaration(node: TSESTree.ClassDeclaration) {
-        isInEntityOrDto = isEntityOrDto(node.decorators);
-        // Also check class name for DTO/Entity suffix
-        if (node.id?.name) {
-          isInEntityOrDto =
-            isInEntityOrDto ||
-            /Dto$|Entity$|Model$|Schema$/.test(node.id.name);
-        }
+        isInEntityOrDto = isTrackedClass(node);
       },
 
       PropertyDefinition(node: TSESTree.PropertyDefinition) {

--- a/packages/eslint-plugin-nestjs-security/src/rules/no-exposed-private-fields/index.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/no-exposed-private-fields/index.ts
@@ -41,10 +41,21 @@ const ENTITY_DECORATORS: ReadonlySet<string> = new Set([
   'Schema',
   'Table',
   'ObjectType',
-  'InputType',
-  'ArgsType',
   'Model',
 ]);
+
+/**
+ * Class decorators that mark a GraphQL **input** object.
+ *
+ * `@InputType()` / `@ArgsType()` describe what a client *sends*, which is the
+ * GraphQL equivalent of a request DTO — a `LoginInput` must carry a `password`
+ * and a `ResetPasswordArgs` must carry a `token`. Tracking them by default
+ * contradicted the DTO exclusion (`Input$` is already in `DTO_NAME`), so they
+ * follow `includeDtos` like every other request contract. `@ObjectType()`
+ * stays in the entity set: that is the *response* side, where an accidental
+ * `password` field really does leak.
+ */
+const DTO_DECORATORS: ReadonlySet<string> = new Set(['InputType', 'ArgsType']);
 
 /** Class-name suffixes that mark a persistence entity / domain model. */
 const ENTITY_NAME = /Entity$|Schema$|Model$|Document$|Table$/;
@@ -158,6 +169,9 @@ export const noExposedPrivateFields = createRule<RuleOptions, MessageIds>({
      */
     function isTrackedClass(node: TSESTree.ClassDeclaration): boolean {
       if (hasDecoratorNamed(node.decorators, ENTITY_DECORATORS)) return true;
+      // A GraphQL input object is a request contract, not a persisted row —
+      // the decorator outranks the class name here.
+      if (hasDecoratorNamed(node.decorators, DTO_DECORATORS)) return includeDtos;
       const name = node.id?.name;
       if (name === undefined) return false;
       if (ENTITY_NAME.test(name)) return true;

--- a/packages/eslint-plugin-nestjs-security/src/rules/no-exposed-private-fields/no-exposed-private-fields.test.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/no-exposed-private-fields/no-exposed-private-fields.test.ts
@@ -161,13 +161,15 @@ describe('no-exposed-private-fields', () => {
           `,
           errors: [{ messageId: 'exposedField' }],
         },
-        // DTO with exposed secret
+        // DTO with exposed secret — opt-in via includeDtos (a DTO field is a
+        // declared contract; see the regression block at the bottom of this file)
         {
           code: `
             class UserDto {
               secret: string;
             }
           `,
+          options: [{ includeDtos: true }],
           errors: [{ messageId: 'exposedField' }],
         },
         // Entity suffix class
@@ -292,6 +294,104 @@ describe('no-exposed-private-fields', () => {
             }
           `,
           errors: [{ messageId: 'exposedField' }],
+        },
+      ],
+    });
+  });
+
+  describe('DTOs (regression: 44 findings on ack, 22 on brocoders)', () => {
+    ruleTester.run('DTO fields are declared contracts', noExposedPrivateFields, {
+      valid: [
+        // brocoders: auth/dto/login-response.dto.ts — a login response MUST
+        // carry a token; flagging it is a contradiction.
+        {
+          code: `
+            class LoginResponseDto {
+              @ApiProperty()
+              token: string;
+
+              @ApiProperty()
+              refreshToken: string;
+            }
+          `,
+        },
+        // brocoders: auth/dto/auth-reset-password.dto.ts — a password reset
+        // request MUST carry a password.
+        {
+          code: `
+            class AuthResetPasswordDto {
+              @IsNotEmpty()
+              password: string;
+
+              @IsNotEmpty()
+              hash: string;
+            }
+          `,
+        },
+        // ack: app/dtos/app.env.dto.ts — environment validation DTO, never
+        // serialized to a client.
+        {
+          code: `
+            class AppEnvDto {
+              @IsString()
+              AUTH_JWT_ACCESS_TOKEN_SECRET_KEY: string;
+
+              @IsString()
+              DATABASE_PASSWORD: string;
+            }
+          `,
+        },
+        // ack: modules/user/dtos/user.dto.ts
+        {
+          code: `
+            class UserDto {
+              @Expose()
+              passwordExpired: Date;
+            }
+          `,
+        },
+      ],
+      invalid: [
+        // TRUE POSITIVE (brocoders): TypeORM entity exposing the password hash
+        {
+          code: `
+            @Entity({ name: 'user' })
+            export class UserEntity extends EntityRelationalHelper {
+              @Column({ nullable: true })
+              password?: string;
+            }
+          `,
+          errors: [{ messageId: 'exposedField', data: { field: 'password' } }],
+        },
+        // TRUE POSITIVE (brocoders): mongoose schema exposing the session hash
+        {
+          code: `
+            @Schema({ timestamps: true })
+            export class SessionSchemaClass extends EntityDocumentHelper {
+              @Prop()
+              hash: string;
+            }
+          `,
+          errors: [{ messageId: 'exposedField', data: { field: 'hash' } }],
+        },
+        // Entity suffix without a decorator is still tracked
+        {
+          code: `
+            export class TokenEntity {
+              refreshToken: string;
+            }
+          `,
+          errors: [{ messageId: 'exposedField', data: { field: 'refreshToken' } }],
+        },
+        // includeDtos: true restores the old, noisier behaviour
+        {
+          code: `
+            class LoginResponseDto {
+              token: string;
+            }
+          `,
+          options: [{ includeDtos: true }],
+          errors: [{ messageId: 'exposedField', data: { field: 'token' } }],
         },
       ],
     });

--- a/packages/eslint-plugin-nestjs-security/src/rules/no-exposed-private-fields/no-exposed-private-fields.test.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/no-exposed-private-fields/no-exposed-private-fields.test.ts
@@ -220,7 +220,38 @@ describe('no-exposed-private-fields', () => {
 
   describe('Invalid Code - Decorated Classes', () => {
     ruleTester.run('invalid - decorated classes', noExposedPrivateFields, {
-      valid: [],
+      valid: [
+        // @InputType (GraphQL) is a *request* contract — the GraphQL
+        // equivalent of a DTO — so it follows `includeDtos`, which is off
+        // by default. A LoginInput must carry a password.
+        {
+          code: `
+            @InputType()
+            class LoginInput {
+              password: string;
+            }
+          `,
+        },
+        // @ArgsType (GraphQL), same reasoning
+        {
+          code: `
+            @ArgsType()
+            class ResetPasswordArgs {
+              token: string;
+            }
+          `,
+        },
+        // The decorator outranks the class name: an @InputType is an input
+        // even when it is named like an entity.
+        {
+          code: `
+            @InputType()
+            class UserEntity {
+              password: string;
+            }
+          `,
+        },
+      ],
       invalid: [
         // @Schema (Mongoose)
         {
@@ -242,7 +273,8 @@ describe('no-exposed-private-fields', () => {
           `,
           errors: [{ messageId: 'exposedField' }],
         },
-        // @InputType (GraphQL)
+        // @InputType (GraphQL) with includeDtos: true — the opt-in restores
+        // the older, noisier behaviour for request contracts.
         {
           code: `
             @InputType()
@@ -250,6 +282,18 @@ describe('no-exposed-private-fields', () => {
               secretToken: string;
             }
           `,
+          options: [{ includeDtos: true }],
+          errors: [{ messageId: 'exposedField' }],
+        },
+        // @ArgsType (GraphQL) with includeDtos: true
+        {
+          code: `
+            @ArgsType()
+            class ResetPasswordArgs {
+              token: string;
+            }
+          `,
+          options: [{ includeDtos: true }],
           errors: [{ messageId: 'exposedField' }],
         },
       ],

--- a/packages/eslint-plugin-nestjs-security/src/rules/no-missing-validation-pipe/index.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/no-missing-validation-pipe/index.ts
@@ -14,14 +14,26 @@
  */
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
 import { AST_NODE_TYPES, createRule, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
+import {
+  getDecoratorCall,
+  getDecoratorName,
+  getHttpMethodDecorator,
+  isControllerClass,
+} from '../../utils/decorators';
+import { getProjectContext } from '../../utils/project-context';
 
 type MessageIds = 'missingValidation' | 'addValidationPipe';
 
 export interface Options {
   /** Allow in test files. Default: true */
   allowInTests?: boolean;
-  /** Skip rule if global ValidationPipe is configured in main.ts. Default: false */
+  /** Skip rule entirely, without scanning the project. Default: false */
   assumeGlobalPipes?: boolean;
+  /**
+   * Suppress findings when the project registers a pipe globally via
+   * `APP_PIPE` or `app.useGlobalPipes()`. Default: true
+   */
+  detectGlobalPipes?: boolean;
 }
 
 type RuleOptions = [Options?];
@@ -29,17 +41,8 @@ type RuleOptions = [Options?];
 // Decorators that receive user input
 const INPUT_DECORATORS = new Set(['Body', 'Query', 'Param']);
 
-// HTTP method decorators that indicate route handlers
-const HTTP_METHOD_DECORATORS = new Set([
-  'Get',
-  'Post',
-  'Put',
-  'Patch',
-  'Delete',
-  'Options',
-  'Head',
-  'All',
-]);
+/** `@Body(new ValidationPipe())` / `@Param('id', ParseIntPipe)` are validated. */
+const PIPE_NAME = /Pipe$/;
 
 export const noMissingValidationPipe = createRule<RuleOptions, MessageIds>({
   name: 'no-missing-validation-pipe',
@@ -78,14 +81,21 @@ export const noMissingValidationPipe = createRule<RuleOptions, MessageIds>({
         properties: {
           allowInTests: { type: 'boolean', default: true },
           assumeGlobalPipes: { type: 'boolean', default: false },
+          detectGlobalPipes: { type: 'boolean', default: true },
         },
         additionalProperties: false,
       },
     ],
   },
-  defaultOptions: [{ allowInTests: true, assumeGlobalPipes: false }],
+  defaultOptions: [
+    { allowInTests: true, assumeGlobalPipes: false, detectGlobalPipes: true },
+  ],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>, [options = {}]) {
-    const { allowInTests = true, assumeGlobalPipes = false } = options as Options;
+    const {
+      allowInTests = true,
+      assumeGlobalPipes = false,
+      detectGlobalPipes = true,
+    } = options as Options;
 
     // Skip entirely if global ValidationPipe is assumed (configured in main.ts)
     if (assumeGlobalPipes) {
@@ -133,59 +143,48 @@ export const noMissingValidationPipe = createRule<RuleOptions, MessageIds>({
     }
 
     /**
-     * Check if class has @Controller decorator
-     */
-    function hasControllerDecorator(decorators: TSESTree.Decorator[] | undefined): boolean {
-      if (!decorators) return false;
-      return decorators.some((dec) => {
-        const name =
-          dec.expression.type === AST_NODE_TYPES.Identifier
-            ? dec.expression.name
-            : dec.expression.type === AST_NODE_TYPES.CallExpression &&
-              dec.expression.callee.type === AST_NODE_TYPES.Identifier
-            ? dec.expression.callee.name
-            : '';
-        return name === 'Controller';
-      });
-    }
-
-    /**
-     * Check if method is a route handler
-     */
-    function isRouteHandler(decorators: TSESTree.Decorator[] | undefined): boolean {
-      if (!decorators) return false;
-      return decorators.some((dec) => {
-        const name =
-          dec.expression.type === AST_NODE_TYPES.Identifier
-            ? dec.expression.name
-            : dec.expression.type === AST_NODE_TYPES.CallExpression &&
-              dec.expression.callee.type === AST_NODE_TYPES.Identifier
-            ? dec.expression.callee.name
-            : '';
-        return HTTP_METHOD_DECORATORS.has(name);
-      });
-    }
-
-    /**
-     * Get input decorator name from parameter decorators
+     * The `@Body()` / `@Query()` / `@Param()` decorator of a parameter, or
+     * `null` when the parameter does not receive user input.
      */
     function getInputDecorator(
       decorators: TSESTree.Decorator[] | undefined
-    ): string | null {
+    ): TSESTree.Decorator | null {
       if (!decorators) return null;
       for (const dec of decorators) {
-        const name =
-          dec.expression.type === AST_NODE_TYPES.Identifier
-            ? dec.expression.name
-            : dec.expression.type === AST_NODE_TYPES.CallExpression &&
-              dec.expression.callee.type === AST_NODE_TYPES.Identifier
-            ? dec.expression.callee.name
-            : '';
-        if (INPUT_DECORATORS.has(name)) {
-          return name;
+        if (INPUT_DECORATORS.has(getDecoratorName(dec))) {
+          return dec;
         }
       }
       return null;
+    }
+
+    /**
+     * Parameter-level pipes validate the value at the binding site:
+     * `@Body(new ValidationPipe())`, `@Param('id', ParseIntPipe)`,
+     * `@Query('page', PaginationPipe)`.
+     */
+    function hasParameterPipe(decorator: TSESTree.Decorator): boolean {
+      const call = getDecoratorCall(decorator);
+      if (call === null) return false;
+      return call.arguments.some((arg: TSESTree.CallExpressionArgument) => {
+        if (arg.type === AST_NODE_TYPES.Identifier) {
+          return PIPE_NAME.test(arg.name);
+        }
+        if (
+          arg.type === AST_NODE_TYPES.NewExpression &&
+          arg.callee.type === AST_NODE_TYPES.Identifier
+        ) {
+          return PIPE_NAME.test(arg.callee.name);
+        }
+        return false;
+      });
+    }
+
+    /** A global `APP_PIPE` / `useGlobalPipes()` validates every route. */
+    function hasProjectGlobalPipe(): boolean {
+      return (
+        detectGlobalPipes && getProjectContext(context).hasGlobalValidationPipe
+      );
     }
 
     /**
@@ -204,13 +203,13 @@ export const noMissingValidationPipe = createRule<RuleOptions, MessageIds>({
 
     return {
       ClassDeclaration(node: TSESTree.ClassDeclaration) {
-        isController = hasControllerDecorator(node.decorators);
+        isController = isControllerClass(node.decorators);
         hasClassLevelPipe = hasValidationPipe(node.decorators);
       },
 
       MethodDefinition(node: TSESTree.MethodDefinition) {
         if (!isController) return;
-        if (!isRouteHandler(node.decorators)) return;
+        if (getHttpMethodDecorator(node.decorators) === null) return;
 
         // Skip if class or method has ValidationPipe
         if (hasClassLevelPipe || hasValidationPipe(node.decorators)) return;
@@ -221,18 +220,23 @@ export const noMissingValidationPipe = createRule<RuleOptions, MessageIds>({
             if (param.type !== AST_NODE_TYPES.Identifier) continue;
 
             const inputDecorator = getInputDecorator(param.decorators);
-            if (!inputDecorator) continue;
+            if (inputDecorator === null) continue;
 
             // Only flag if parameter has a complex type annotation (DTO)
-            if (hasTypeAnnotation(param)) {
-              const paramName = param.name;
-              context.report({
-                node: param,
-                messageId: 'missingValidation',
-                data: { param: `@${inputDecorator}() ${paramName}` },
-                suggest: [{ messageId: 'addValidationPipe', fix: () => null }],
-              });
-            }
+            if (!hasTypeAnnotation(param)) continue;
+            // A pipe bound to the parameter already validates it
+            if (hasParameterPipe(inputDecorator)) continue;
+            // A globally registered pipe validates every route in the project
+            if (hasProjectGlobalPipe()) return;
+
+            context.report({
+              node: param,
+              messageId: 'missingValidation',
+              data: {
+                param: `@${getDecoratorName(inputDecorator)}() ${param.name}`,
+              },
+              suggest: [{ messageId: 'addValidationPipe', fix: () => null }],
+            });
           }
         }
       },

--- a/packages/eslint-plugin-nestjs-security/src/rules/no-missing-validation-pipe/no-missing-validation-pipe.test.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/no-missing-validation-pipe/no-missing-validation-pipe.test.ts
@@ -97,6 +97,26 @@ ruleTester.run('no-missing-validation-pipe', noMissingValidationPipe, {
         }
       `,
     },
+    // ========== REGRESSION (ack-nestjs-boilerplate): pipes bound at the
+    // parameter validate the value even without @UsePipes ==========
+    {
+      code: `
+        @Controller('users')
+        class UserAdminController {
+          @Get('/get/:user')
+          get(@Param('user', RequestRequiredPipe, RequestIsValidObjectIdPipe) user: UserDoc) {}
+        }
+      `,
+    },
+    {
+      code: `
+        @Controller('users')
+        class UsersController {
+          @Post()
+          create(@Body(new ValidationPipe({ whitelist: true })) dto: CreateUserDto) {}
+        }
+      `,
+    },
   ],
   invalid: [
     // ========== INVALID: Missing ValidationPipe with DTO body ==========
@@ -132,6 +152,50 @@ ruleTester.run('no-missing-validation-pipe', noMissingValidationPipe, {
       `,
       filename: 'users.controller.spec.ts',
       options: [{ allowInTests: false }],
+      errors: [{ messageId: 'missingValidation' }],
+    },
+    // ========== INVALID: a non-pipe argument does not validate ==========
+    {
+      code: `
+        @Controller('users')
+        class UsersController {
+          @Post()
+          create(@Body('user') dto: CreateUserDto) {}
+        }
+      `,
+      errors: [{ messageId: 'missingValidation' }],
+    },
+    // ========== INVALID: a non-pipe constructor argument does not validate ==========
+    {
+      code: `
+        @Controller('users')
+        class UsersController {
+          @Post()
+          create(@Body(new Transformer()) dto: CreateUserDto) {}
+        }
+      `,
+      errors: [{ messageId: 'missingValidation' }],
+    },
+    // ========== INVALID: a namespaced pipe argument is not recognised ==========
+    {
+      code: `
+        @Controller('users')
+        class UsersController {
+          @Post()
+          create(@Body(new pipes.ValidationPipe()) dto: CreateUserDto) {}
+        }
+      `,
+      errors: [{ messageId: 'missingValidation' }],
+    },
+    // ========== INVALID: a bare @Body decorator has no pipe arguments ==========
+    {
+      code: `
+        @Controller('users')
+        class UsersController {
+          @Post()
+          create(@Body dto: CreateUserDto) {}
+        }
+      `,
       errors: [{ messageId: 'missingValidation' }],
     },
   ],

--- a/packages/eslint-plugin-nestjs-security/src/rules/require-class-validator/index.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/require-class-validator/index.ts
@@ -154,7 +154,6 @@ const VALIDATOR_DECORATORS = new Set([
   'IsSurrogatePair',
   'IsVariableWidth',
   'IsOctal',
-  'IsUppercase',
   // Custom
   'Validate',
   'ValidateBy',

--- a/packages/eslint-plugin-nestjs-security/src/rules/require-class-validator/index.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/require-class-validator/index.ts
@@ -14,15 +14,45 @@
  */
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
 import { AST_NODE_TYPES, createRule, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
+import {
+  getDecoratorCall,
+  getDecoratorNames,
+  hasDecoratorNamed,
+} from '../../utils/decorators';
 
 type MessageIds = 'missingValidator' | 'addValidator';
 
 export interface Options {
   /** Allow in test files. Default: true */
   allowInTests?: boolean;
+  /**
+   * Also require validators on response/serialization DTOs. Response DTOs
+   * describe output, never untrusted input, so they carry no class-validator
+   * decorators by design. Default: false
+   */
+  checkResponseDtos?: boolean;
+  /** Class-name pattern identifying a response DTO. Default: see below. */
+  responseDtoPattern?: string;
 }
 
 type RuleOptions = [Options?];
+
+/**
+ * Names that mark a class as *output*: it is produced by the server and
+ * serialized to the client, so class-validator decorators are meaningless on
+ * it. Matched against the class name and its superclass.
+ */
+const DEFAULT_RESPONSE_DTO_PATTERN = 'Response|Result|View|Payload|Output|Serializ';
+
+/**
+ * class-transformer decorators that only make sense on a serialization model.
+ * `@Type` and `@Transform` are excluded — request DTOs legitimately use them
+ * for coercion.
+ */
+const SERIALIZATION_DECORATORS: ReadonlySet<string> = new Set([
+  'Expose',
+  'Exclude',
+]);
 
 // Common class-validator decorators
 const VALIDATOR_DECORATORS = new Set([
@@ -85,10 +115,54 @@ const VALIDATOR_DECORATORS = new Set([
   // Object validation
   'ValidateNested',
   'IsInstance',
+  'IsDivisibleBy',
+  'MinDate',
+  'MaxDate',
+  // Extended string validation
+  'IsIn',
+  'IsNotIn',
+  'Equals',
+  'NotEquals',
+  'IsNumberString',
+  'IsBooleanString',
+  'IsMobilePhone',
+  'IsPassportNumber',
+  'IsIdentityCard',
+  'IsStrongPassword',
+  'IsSemVer',
+  'IsISO8601',
+  'IsISO31661Alpha2',
+  'IsISO31661Alpha3',
+  'IsRFC3339',
+  'IsMimeType',
+  'IsHash',
+  'IsMD5',
+  'IsRgbColor',
+  'IsBtcAddress',
+  'IsEthereumAddress',
+  'IsMagnetURI',
+  'IsMACAddress',
+  'IsISSN',
+  'IsIBAN',
+  'IsBIC',
+  'IsEAN',
+  'IsISIN',
+  'IsFirebasePushId',
+  'IsTimeZone',
+  'IsNotEmptyObject',
+  'IsMultibyte',
+  'IsSurrogatePair',
+  'IsVariableWidth',
+  'IsOctal',
+  'IsUppercase',
   // Custom
   'Validate',
   'ValidateBy',
   'ValidateIf',
+  'ValidatePromise',
+  // `@Allow()` whitelists a property under `forbidNonWhitelisted` — an
+  // explicit "this field is accepted as-is" decision, not a missing validator.
+  'Allow',
   // Array validation
   'ArrayContains',
   'ArrayNotContains',
@@ -135,20 +209,28 @@ export const requireClassValidator = createRule<RuleOptions, MessageIds>({
         type: 'object',
         properties: {
           allowInTests: { type: 'boolean', default: true },
+          checkResponseDtos: { type: 'boolean', default: false },
+          responseDtoPattern: { type: 'string' },
         },
         additionalProperties: false,
       },
     ],
   },
-  defaultOptions: [{ allowInTests: true }],
+  defaultOptions: [{ allowInTests: true, checkResponseDtos: false }],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>, [options = {}]) {
-    const { allowInTests = true } = options as Options;
+    const {
+      allowInTests = true,
+      checkResponseDtos = false,
+      responseDtoPattern = DEFAULT_RESPONSE_DTO_PATTERN,
+    } = options as Options;
     const filename = context.filename;
     const isTestFile = /\.(test|spec)\.(ts|tsx|js|jsx)$/.test(filename);
 
     if (allowInTests && isTestFile) {
       return {};
     }
+
+    const responseNameRegex = new RegExp(responseDtoPattern);
 
     // Track if class is a DTO
     let isDto = false;
@@ -162,41 +244,80 @@ export const requireClassValidator = createRule<RuleOptions, MessageIds>({
         return true;
       }
       // Check for class-validator or API decorators at class level
-      if (node.decorators) {
-        return node.decorators.some((dec: TSESTree.Decorator) => {
-          const name =
-            dec.expression.type === AST_NODE_TYPES.Identifier
-              ? dec.expression.name
-              : dec.expression.type === AST_NODE_TYPES.CallExpression &&
-                dec.expression.callee.type === AST_NODE_TYPES.Identifier
-              ? dec.expression.callee.name
-              : '';
-          return ['ApiProperty', 'ApiPropertyOptional', 'Validated'].includes(name);
-        });
+      return getDecoratorNames(node.decorators).some((name) =>
+        ['ApiProperty', 'ApiPropertyOptional', 'Validated'].includes(name),
+      );
+    }
+
+    /**
+     * Response DTOs describe what the server *returns*. They never carry
+     * class-validator decorators, so requiring them produces one finding per
+     * property of every serialization model in the codebase (303 on one
+     * boilerplate). Detected by name, by superclass name, or by the presence
+     * of class-transformer `@Expose`/`@Exclude`.
+     */
+    function isResponseDto(node: TSESTree.ClassDeclaration): boolean {
+      if (node.id && responseNameRegex.test(node.id.name)) return true;
+      const superClass = node.superClass;
+      if (
+        superClass &&
+        superClass.type === AST_NODE_TYPES.Identifier &&
+        responseNameRegex.test(superClass.name)
+      ) {
+        return true;
       }
-      return false;
+      if (hasDecoratorNamed(node.decorators, SERIALIZATION_DECORATORS)) return true;
+      return node.body.body.some(
+        (member) =>
+          member.type === AST_NODE_TYPES.PropertyDefinition &&
+          hasDecoratorNamed(member.decorators, SERIALIZATION_DECORATORS),
+      );
     }
 
     /**
      * Check if property has any class-validator decorator
      */
     function hasValidatorDecorator(decorators: TSESTree.Decorator[] | undefined): boolean {
-      if (!decorators) return false;
-      return decorators.some((dec) => {
-        const name =
-          dec.expression.type === AST_NODE_TYPES.Identifier
-            ? dec.expression.name
-            : dec.expression.type === AST_NODE_TYPES.CallExpression &&
-              dec.expression.callee.type === AST_NODE_TYPES.Identifier
-            ? dec.expression.callee.name
-            : '';
-        return VALIDATOR_DECORATORS.has(name);
+      return hasDecoratorNamed(decorators, VALIDATOR_DECORATORS);
+    }
+
+    /** `format: 'binary'` anywhere in an object literal (incl. `items: {…}`). */
+    function declaresBinaryFormat(node: TSESTree.ObjectExpression): boolean {
+      return node.properties.some((property) => {
+        if (property.type !== AST_NODE_TYPES.Property) return false;
+        if (property.value.type === AST_NODE_TYPES.ObjectExpression) {
+          return declaresBinaryFormat(property.value);
+        }
+        return (
+          property.key.type === AST_NODE_TYPES.Identifier &&
+          property.key.name === 'format' &&
+          property.value.type === AST_NODE_TYPES.Literal &&
+          property.value.value === 'binary'
+        );
+      });
+    }
+
+    /**
+     * `@ApiProperty({ type: 'string', format: 'binary' })` declares a
+     * multipart upload slot. The value never reaches class-validator — Multer
+     * consumes it — so there is no validator to add.
+     */
+    function isBinaryUploadProperty(
+      decorators: TSESTree.Decorator[] | undefined,
+    ): boolean {
+      return (decorators ?? []).some((decorator) => {
+        const arg = getDecoratorCall(decorator)?.arguments[0];
+        return (
+          arg !== undefined &&
+          arg.type === AST_NODE_TYPES.ObjectExpression &&
+          declaresBinaryFormat(arg)
+        );
       });
     }
 
     return {
       ClassDeclaration(node: TSESTree.ClassDeclaration) {
-        isDto = isDtoClass(node);
+        isDto = isDtoClass(node) && (checkResponseDtos || !isResponseDto(node));
       },
 
       PropertyDefinition(node: TSESTree.PropertyDefinition) {
@@ -212,6 +333,9 @@ export const requireClassValidator = createRule<RuleOptions, MessageIds>({
 
         // Check if already validated
         if (hasValidatorDecorator(node.decorators)) return;
+
+        // Multipart upload slots are handled by Multer, not class-validator
+        if (isBinaryUploadProperty(node.decorators)) return;
 
         context.report({
           node,

--- a/packages/eslint-plugin-nestjs-security/src/rules/require-class-validator/require-class-validator.test.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/require-class-validator/require-class-validator.test.ts
@@ -250,4 +250,212 @@ describe('require-class-validator', () => {
       ],
     });
   });
+
+  describe('Response DTOs (regression: 303 findings on ack, 20 on brocoders)', () => {
+    ruleTester.run('response DTOs are output, not input', requireClassValidator, {
+      valid: [
+        // ack-nestjs-boilerplate: modules/hello/dtos/response/hello.response.dto.ts
+        {
+          code: `
+            class HelloDateResponseDto {
+              @ApiProperty({ required: true })
+              date: Date;
+
+              @ApiProperty({ required: true })
+              iso: string;
+            }
+          `,
+        },
+        // ack: common/response/dtos/response.paging.dto.ts
+        {
+          code: `
+            class ResponsePagingDto {
+              @ApiProperty()
+              totalData: number;
+            }
+          `,
+        },
+        // ack: modules/user/dtos/user.dto.ts — @Expose marks a serialization
+        // model even though the class name says nothing about responses
+        {
+          code: `
+            class UserDto {
+              @ApiProperty({ required: false })
+              @Expose()
+              name?: string;
+
+              @ApiProperty({ required: true })
+              @Expose()
+              username: string;
+            }
+          `,
+        },
+        // ack: a DTO extending a shared response base class
+        {
+          code: `
+            class SessionDto extends DatabaseResponseDto {
+              @ApiProperty()
+              id: string;
+            }
+          `,
+        },
+        // brocoders: auth/dto/login-response.dto.ts
+        {
+          code: `
+            class LoginResponseDto {
+              @ApiProperty()
+              token: string;
+
+              @ApiProperty()
+              refreshToken: string;
+            }
+          `,
+        },
+        // Class-level @Exclude() marks the whole class as serialization output
+        {
+          code: `
+            @Exclude()
+            class UserProfileDto {
+              id: string;
+            }
+          `,
+        },
+        // brocoders: auth-apple/dto/auth-apple-login.dto.ts — @Allow() is an
+        // explicit class-validator whitelist decision
+        {
+          code: `
+            class AuthAppleLoginDto {
+              @ApiProperty({ example: 'abc' })
+              @IsNotEmpty()
+              idToken: string;
+
+              @Allow()
+              @ApiPropertyOptional()
+              firstName?: string;
+            }
+          `,
+        },
+        // ack: common/file/dtos/file.single.dto.ts — multipart upload slot
+        {
+          code: `
+            class FileUploadSingleRequestDto {
+              @ApiProperty({ type: 'string', format: 'binary', description: 'Single file' })
+              file: IFile;
+            }
+          `,
+        },
+        // ack: common/file/dtos/file.multiple.dto.ts — nested items schema
+        {
+          code: `
+            class FileUploadMultipleRequestDto {
+              @ApiProperty({
+                type: 'array',
+                items: { type: 'string', format: 'binary' },
+              })
+              files: IFile[];
+            }
+          `,
+        },
+        // Extended class-validator vocabulary must be recognised
+        {
+          code: `
+            class SettingsDto {
+              @IsIn(['a', 'b'])
+              mode: string;
+
+              @IsStrongPassword()
+              password: string;
+
+              @IsTimeZone()
+              tz: string;
+            }
+          `,
+        },
+      ],
+      invalid: [
+        // TRUE POSITIVE (brocoders): request DTO fields with no validator at
+        // all — the rule must not go inert.
+        {
+          code: `
+            class CreateUserDto {
+              @ApiProperty()
+              @IsEmail()
+              email: string;
+
+              provider?: string;
+
+              socialId?: string | null;
+            }
+          `,
+          errors: [
+            { messageId: 'missingValidator', data: { property: 'provider' } },
+            { messageId: 'missingValidator', data: { property: 'socialId' } },
+          ],
+        },
+        // A response-shaped class is still checked when asked for explicitly
+        {
+          code: `
+            class LoginResponseDto {
+              @ApiProperty()
+              token: string;
+            }
+          `,
+          options: [{ checkResponseDtos: true }],
+          errors: [{ messageId: 'missingValidator', data: { property: 'token' } }],
+        },
+        // A custom responseDtoPattern narrows the exemption
+        {
+          code: `
+            class UserViewDto {
+              @ApiProperty()
+              id: string;
+            }
+          `,
+          options: [{ responseDtoPattern: 'Response' }],
+          errors: [{ messageId: 'missingValidator', data: { property: 'id' } }],
+        },
+        // @Transform / @Type alone do NOT mark a class as a response DTO —
+        // request DTOs legitimately use them for coercion.
+        {
+          code: `
+            class CreateUserDto {
+              @Transform(lowerCaseTransformer)
+              email: string;
+            }
+          `,
+          errors: [{ messageId: 'missingValidator', data: { property: 'email' } }],
+        },
+        // @ApiProperty without a `format: 'binary'` schema is still checked
+        {
+          code: `
+            class UploadDto {
+              @ApiProperty({ type: 'string', description: 'not a file' })
+              name: string;
+            }
+          `,
+          errors: [{ messageId: 'missingValidator', data: { property: 'name' } }],
+        },
+        // Bare @ApiProperty (no argument object) is still checked
+        {
+          code: `
+            class UploadDto {
+              @ApiProperty
+              name: string;
+            }
+          `,
+          errors: [{ messageId: 'missingValidator', data: { property: 'name' } }],
+        },
+        // A spread inside the schema object is not a `format` declaration
+        {
+          code: `
+            class UploadDto {
+              @ApiProperty({ ...baseSchema })
+              name: string;
+            }
+          `,
+          errors: [{ messageId: 'missingValidator', data: { property: 'name' } }],
+        },
+      ],
+    });
+  });
 });

--- a/packages/eslint-plugin-nestjs-security/src/rules/require-guards/index.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/require-guards/index.ts
@@ -22,20 +22,34 @@ import {
 import {
   getHttpMethodDecorator,
   getRoutePath,
+  getUseGuardsGuardNames,
   hasDecoratorNamed,
   hasUnresolvedDecorator,
-  hasUseGuards,
   isControllerClass,
   PUBLIC_DECORATORS,
 } from '../../utils/decorators';
 import { getProjectContext } from '../../utils/project-context';
 
-type MessageIds = 'missingGuards' | 'addGuards';
+type MessageIds =
+  | 'missingGuards'
+  | 'missingRequiredGuards'
+  | 'addGuards';
 
 export interface Options {
   /** Allow in test files. Default: true */
   allowInTests?: boolean;
-  /** Guards to check for. Default: any guard */
+  /**
+   * Specific guard classes that satisfy the rule. Empty (the default) accepts
+   * any `@UseGuards(...)`. When set, a route must name one of these guards —
+   * `@UseGuards(RolesGuard)` no longer satisfies `requiredGuards:
+   * ['JwtAuthGuard']`.
+   *
+   * The exemptions stay conservative: a `@UseGuards` whose arguments cannot be
+   * named statically, an unresolved composite decorator
+   * (`allowCustomDecorators`) and a global `APP_GUARD` (`detectGlobalGuards`)
+   * all still suppress the report, because none of them can be *proven* not to
+   * apply the required guard.
+   */
   requiredGuards?: string[];
   /** Allow public endpoints (with @Public decorator). Default: true */
   allowPublicDecorator?: boolean;
@@ -127,6 +141,17 @@ export const requireGuards = createRule<RuleOptions, MessageIds>({
         fix: 'Add @UseGuards(AuthGuard): @UseGuards(AuthGuard) before the handler',
         documentationLink: 'https://docs.nestjs.com/guards',
       }),
+      missingRequiredGuards: formatLLMMessage({
+        icon: MessageIcons.SECURITY,
+        issueName: 'Missing Required Authorization Guard',
+        cwe: 'CWE-284',
+        cvss: 9.8,
+        description:
+          'Controller/route handler {{name}} is not protected by any of the required guards ({{guards}})',
+        severity: 'CRITICAL',
+        fix: 'Add one of the required guards: @UseGuards({{guards}}) before the handler',
+        documentationLink: 'https://docs.nestjs.com/guards',
+      }),
       addGuards: formatLLMMessage({
         icon: MessageIcons.INFO,
         issueName: 'Add Authentication Guard',
@@ -165,6 +190,7 @@ export const requireGuards = createRule<RuleOptions, MessageIds>({
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>, [options = {}]) {
     const {
       allowInTests = true,
+      requiredGuards = [],
       allowPublicDecorator = true,
       assumeGlobalGuards = false,
       allowCustomDecorators = true,
@@ -184,6 +210,7 @@ export const requireGuards = createRule<RuleOptions, MessageIds>({
     }
 
     const publicTokens = new Set(publicRoutePatterns.map(normalizeRouteToken));
+    const requiredGuardNames = new Set(requiredGuards);
 
     // Class-level state
     let isController = false;
@@ -195,6 +222,24 @@ export const requireGuards = createRule<RuleOptions, MessageIds>({
     ): boolean {
       if (!allowPublicDecorator) return false;
       return hasDecoratorNamed(decorators, PUBLIC_DECORATORS);
+    }
+
+    /**
+     * Does this decorator list carry a guard that satisfies the requirement?
+     *
+     * Without `requiredGuards`, any `@UseGuards` counts. With it, the guard
+     * must be named — except when it cannot be named statically, which is not
+     * evidence of absence.
+     */
+    function satisfiesGuardRequirement(
+      decorators: TSESTree.Decorator[] | undefined,
+    ): boolean {
+      const guardNames = getUseGuardsGuardNames(decorators);
+      if (guardNames.length === 0) return false;
+      if (requiredGuardNames.size === 0) return true;
+      return guardNames.some(
+        (name) => name === '' || requiredGuardNames.has(name),
+      );
     }
 
     /** A decorator we cannot resolve may be a composite that applies guards. */
@@ -226,7 +271,7 @@ export const requireGuards = createRule<RuleOptions, MessageIds>({
       ClassDeclaration(node: TSESTree.ClassDeclaration) {
         isController = isControllerClass(node.decorators);
         classIsExempt =
-          hasUseGuards(node.decorators) ||
+          satisfiesGuardRequirement(node.decorators) ||
           hasPublicDecorator(node.decorators) ||
           hasPossibleGuardDecorator(node.decorators);
       },
@@ -248,7 +293,7 @@ export const requireGuards = createRule<RuleOptions, MessageIds>({
 
         if (
           hasPublicDecorator(node.decorators) ||
-          hasUseGuards(node.decorators) ||
+          satisfiesGuardRequirement(node.decorators) ||
           hasPossibleGuardDecorator(node.decorators)
         ) {
           return;
@@ -262,8 +307,11 @@ export const requireGuards = createRule<RuleOptions, MessageIds>({
 
         context.report({
           node,
-          messageId: 'missingGuards',
-          data: { name: methodName },
+          messageId:
+            requiredGuardNames.size === 0
+              ? 'missingGuards'
+              : 'missingRequiredGuards',
+          data: { name: methodName, guards: requiredGuards.join(', ') },
           suggest: [{ messageId: 'addGuards', fix: () => null }],
         });
       },

--- a/packages/eslint-plugin-nestjs-security/src/rules/require-guards/index.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/require-guards/index.ts
@@ -13,7 +13,22 @@
  * @see https://docs.nestjs.com/guards
  */
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
-import { AST_NODE_TYPES, createRule, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
+import {
+  AST_NODE_TYPES,
+  createRule,
+  formatLLMMessage,
+  MessageIcons,
+} from '@interlace/eslint-devkit';
+import {
+  getHttpMethodDecorator,
+  getRoutePath,
+  hasDecoratorNamed,
+  hasUnresolvedDecorator,
+  hasUseGuards,
+  isControllerClass,
+  PUBLIC_DECORATORS,
+} from '../../utils/decorators';
+import { getProjectContext } from '../../utils/project-context';
 
 type MessageIds = 'missingGuards' | 'addGuards';
 
@@ -24,26 +39,71 @@ export interface Options {
   requiredGuards?: string[];
   /** Allow public endpoints (with @Public decorator). Default: true */
   allowPublicDecorator?: boolean;
-  /** Skip rule if global guards are configured in main.ts. Default: false */
+  /** Skip rule entirely, without scanning the project. Default: false */
   assumeGlobalGuards?: boolean;
+  /**
+   * Treat a route/controller carrying a decorator this plugin cannot resolve
+   * (a project-owned composite such as `@AuthJwtAccessProtected()`) as
+   * possibly guarded. Default: true
+   */
+  allowCustomDecorators?: boolean;
+  /**
+   * Suppress findings when the project registers a global guard via
+   * `APP_GUARD` or `app.useGlobalGuards()`. Default: true
+   */
+  detectGlobalGuards?: boolean;
+  /**
+   * Handler names / route paths that are unauthenticated by design. Matched
+   * case-insensitively against the method name and the route path with
+   * separators removed.
+   */
+  publicRoutePatterns?: string[];
 }
 
 type RuleOptions = [Options?];
 
-// HTTP method decorators that indicate route handlers
-const HTTP_METHOD_DECORATORS = new Set([
-  'Get',
-  'Post',
-  'Put',
-  'Patch',
-  'Delete',
-  'Options',
-  'Head',
-  'All',
-]);
+/**
+ * Route names that cannot have an auth guard by definition — the endpoints a
+ * caller uses *to obtain* credentials, plus the standard unauthenticated
+ * infrastructure routes. Requiring `@UseGuards` on `POST /auth/login` is not a
+ * finding, it is a contradiction.
+ */
+const DEFAULT_PUBLIC_ROUTE_PATTERNS = [
+  'login',
+  'signin',
+  'logout',
+  'signout',
+  'register',
+  'signup',
+  'refresh',
+  'refreshtoken',
+  'forgotpassword',
+  'passwordforgot',
+  'resetpassword',
+  'passwordreset',
+  'confirmemail',
+  'emailconfirm',
+  'confirmnewemail',
+  'verifyemail',
+  'emailverify',
+  'health',
+  'healthcheck',
+  'liveness',
+  'readiness',
+  'ping',
+  'metrics',
+  'version',
+  'appinfo',
+  'webhook',
+  'webhooks',
+  'callback',
+  'oauthcallback',
+];
 
-// Decorators that bypass guard requirements
-const PUBLIC_DECORATORS = new Set(['Public', 'SkipAuth', 'AllowAnonymous', 'NoAuth']);
+/** `confirm-new/email` and `confirmNewEmail` must compare equal. */
+function normalizeRouteToken(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
 
 export const requireGuards = createRule<RuleOptions, MessageIds>({
   name: 'require-guards',
@@ -84,14 +144,33 @@ export const requireGuards = createRule<RuleOptions, MessageIds>({
           requiredGuards: { type: 'array', items: { type: 'string' }, default: [] },
           allowPublicDecorator: { type: 'boolean', default: true },
           assumeGlobalGuards: { type: 'boolean', default: false },
+          allowCustomDecorators: { type: 'boolean', default: true },
+          detectGlobalGuards: { type: 'boolean', default: true },
+          publicRoutePatterns: { type: 'array', items: { type: 'string' } },
         },
         additionalProperties: false,
       },
     ],
   },
-  defaultOptions: [{ allowInTests: true, requiredGuards: [], allowPublicDecorator: true, assumeGlobalGuards: false }],
+  defaultOptions: [
+    {
+      allowInTests: true,
+      requiredGuards: [],
+      allowPublicDecorator: true,
+      assumeGlobalGuards: false,
+      allowCustomDecorators: true,
+      detectGlobalGuards: true,
+    },
+  ],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>, [options = {}]) {
-    const { allowInTests = true, allowPublicDecorator = true, assumeGlobalGuards = false } = options as Options;
+    const {
+      allowInTests = true,
+      allowPublicDecorator = true,
+      assumeGlobalGuards = false,
+      allowCustomDecorators = true,
+      detectGlobalGuards = true,
+      publicRoutePatterns = DEFAULT_PUBLIC_ROUTE_PATTERNS,
+    } = options as Options;
 
     // Skip entirely if global guards are assumed (configured in main.ts)
     if (assumeGlobalGuards) {
@@ -104,94 +183,58 @@ export const requireGuards = createRule<RuleOptions, MessageIds>({
       return {};
     }
 
-    // Track if class has controller decorator and class-level guards
+    const publicTokens = new Set(publicRoutePatterns.map(normalizeRouteToken));
+
+    // Class-level state
     let isController = false;
-    let hasClassLevelGuards = false;
+    let classIsExempt = false;
 
-    /**
-     * Check if decorators include @UseGuards
-     */
-    function hasUseGuardsDecorator(decorators: TSESTree.Decorator[] | undefined): boolean {
-      if (!decorators) return false;
-      return decorators.some((dec) => {
-        if (dec.expression.type === AST_NODE_TYPES.CallExpression) {
-          const callee = dec.expression.callee;
-          return callee.type === AST_NODE_TYPES.Identifier && callee.name === 'UseGuards';
-        }
-        if (dec.expression.type === AST_NODE_TYPES.Identifier) {
-          return dec.expression.name === 'UseGuards';
-        }
-        return false;
-      });
+    /** `@Public()`-style opt-out. */
+    function hasPublicDecorator(
+      decorators: TSESTree.Decorator[] | undefined,
+    ): boolean {
+      if (!allowPublicDecorator) return false;
+      return hasDecoratorNamed(decorators, PUBLIC_DECORATORS);
     }
 
-    /**
-     * Check if decorators include public/skip decorators
-     */
-    function hasPublicDecorator(decorators: TSESTree.Decorator[] | undefined): boolean {
-      if (!decorators || !allowPublicDecorator) return false;
-      return decorators.some((dec) => {
-        const name =
-          dec.expression.type === AST_NODE_TYPES.Identifier
-            ? dec.expression.name
-            : dec.expression.type === AST_NODE_TYPES.CallExpression &&
-              dec.expression.callee.type === AST_NODE_TYPES.Identifier
-            ? dec.expression.callee.name
-            : '';
-        return PUBLIC_DECORATORS.has(name);
-      });
+    /** A decorator we cannot resolve may be a composite that applies guards. */
+    function hasPossibleGuardDecorator(
+      decorators: TSESTree.Decorator[] | undefined,
+    ): boolean {
+      return allowCustomDecorators && hasUnresolvedDecorator(decorators);
     }
 
-    /**
-     * Check if a method has HTTP method decorator (is a route handler)
-     */
-    function hasHttpMethodDecorator(
-      decorators: TSESTree.Decorator[] | undefined
-    ): string | null {
-      if (!decorators) return null;
-      for (const dec of decorators) {
-        const name =
-          dec.expression.type === AST_NODE_TYPES.Identifier
-            ? dec.expression.name
-            : dec.expression.type === AST_NODE_TYPES.CallExpression &&
-              dec.expression.callee.type === AST_NODE_TYPES.Identifier
-            ? dec.expression.callee.name
-            : '';
-        if (HTTP_METHOD_DECORATORS.has(name)) {
-          return name;
-        }
-      }
-      return null;
+    /** Endpoints that exist to hand out credentials cannot require them. */
+    function isPublicByDesign(
+      methodName: string,
+      httpDecorator: TSESTree.Decorator,
+    ): boolean {
+      if (publicTokens.has(normalizeRouteToken(methodName))) return true;
+      const path = getRoutePath(httpDecorator);
+      if (path === null) return false;
+      return path
+        .split('/')
+        .some((segment) => segment !== '' && publicTokens.has(normalizeRouteToken(segment)));
     }
 
-    /**
-     * Check if class has @Controller decorator
-     */
-    function hasControllerDecorator(decorators: TSESTree.Decorator[] | undefined): boolean {
-      if (!decorators) return false;
-      return decorators.some((dec) => {
-        const name =
-          dec.expression.type === AST_NODE_TYPES.Identifier
-            ? dec.expression.name
-            : dec.expression.type === AST_NODE_TYPES.CallExpression &&
-              dec.expression.callee.type === AST_NODE_TYPES.Identifier
-            ? dec.expression.callee.name
-            : '';
-        return name === 'Controller';
-      });
+    /** A global `APP_GUARD` protects every route in the project. */
+    function hasProjectGlobalGuard(): boolean {
+      return detectGlobalGuards && getProjectContext(context).hasGlobalAuthGuard;
     }
 
     return {
       ClassDeclaration(node: TSESTree.ClassDeclaration) {
-        // Reset tracking for new class
-        isController = hasControllerDecorator(node.decorators);
-        hasClassLevelGuards = hasUseGuardsDecorator(node.decorators);
+        isController = isControllerClass(node.decorators);
+        classIsExempt =
+          hasUseGuards(node.decorators) ||
+          hasPublicDecorator(node.decorators) ||
+          hasPossibleGuardDecorator(node.decorators);
       },
 
       MethodDefinition(node: TSESTree.MethodDefinition) {
         // Only check if we're in a controller and method is a route handler
-        if (!isController) return;
-        
+        if (!isController || classIsExempt) return;
+
         // Skip constructor and non-public methods
         if (
           node.key.type === AST_NODE_TYPES.Identifier &&
@@ -200,17 +243,22 @@ export const requireGuards = createRule<RuleOptions, MessageIds>({
           return;
         }
 
-        const httpMethod = hasHttpMethodDecorator(node.decorators);
-        if (!httpMethod) return;
+        const httpDecorator = getHttpMethodDecorator(node.decorators);
+        if (httpDecorator === null) return;
 
-        // Skip if has @Public or similar decorator
-        if (hasPublicDecorator(node.decorators)) return;
-
-        // Skip if class or method already has guards
-        if (hasClassLevelGuards || hasUseGuardsDecorator(node.decorators)) return;
+        if (
+          hasPublicDecorator(node.decorators) ||
+          hasUseGuards(node.decorators) ||
+          hasPossibleGuardDecorator(node.decorators)
+        ) {
+          return;
+        }
 
         const methodName =
           node.key.type === AST_NODE_TYPES.Identifier ? node.key.name : '<anonymous>';
+
+        if (isPublicByDesign(methodName, httpDecorator)) return;
+        if (hasProjectGlobalGuard()) return;
 
         context.report({
           node,

--- a/packages/eslint-plugin-nestjs-security/src/rules/require-guards/require-guards.test.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/require-guards/require-guards.test.ts
@@ -218,6 +218,114 @@ ruleTester.run('require-guards', requireGuards, {
       `,
       options: [{ publicRoutePatterns: ['stripeHook'] }],
     },
+    // ========== VALID: requiredGuards satisfied at method level ==========
+    {
+      code: `
+        @Controller('users')
+        class UsersController {
+          @UseGuards(JwtAuthGuard)
+          @Get()
+          findAll() {}
+        }
+      `,
+      options: [{ requiredGuards: ['JwtAuthGuard'] }],
+    },
+    // ========== VALID: requiredGuards satisfied at class level ==========
+    {
+      code: `
+        @Controller('users')
+        @UseGuards(JwtAuthGuard)
+        class UsersController {
+          @Get()
+          findAll() {}
+        }
+      `,
+      options: [{ requiredGuards: ['JwtAuthGuard'] }],
+    },
+    // ========== VALID: requiredGuards satisfied by one of several guards ==========
+    {
+      code: `
+        @Controller('users')
+        class UsersController {
+          @UseGuards(RolesGuard, JwtAuthGuard)
+          @Get()
+          findAll() {}
+        }
+      `,
+      options: [{ requiredGuards: ['JwtAuthGuard'] }],
+    },
+    // ========== VALID: the passport factory form `AuthGuard('jwt')` ==========
+    {
+      code: `
+        @Controller('users')
+        class UsersController {
+          @UseGuards(AuthGuard('jwt'))
+          @Get()
+          findAll() {}
+        }
+      `,
+      options: [{ requiredGuards: ['AuthGuard'] }],
+    },
+    // ========== VALID: namespaced guard reference ==========
+    {
+      code: `
+        @Controller('users')
+        class UsersController {
+          @UseGuards(guards.JwtAuthGuard)
+          @Get()
+          findAll() {}
+        }
+      `,
+      options: [{ requiredGuards: ['JwtAuthGuard'] }],
+    },
+    // ========== VALID: a guard list we cannot name is not evidence of absence ==========
+    {
+      code: `
+        @Controller('users')
+        class UsersController {
+          @UseGuards(...projectGuards)
+          @Get()
+          findAll() {}
+        }
+      `,
+      options: [{ requiredGuards: ['JwtAuthGuard'] }],
+    },
+    // ========== VALID: `@UseGuards()` with no arguments, ditto ==========
+    {
+      code: `
+        @Controller('users')
+        class UsersController {
+          @UseGuards()
+          @Get()
+          findAll() {}
+        }
+      `,
+      options: [{ requiredGuards: ['JwtAuthGuard'] }],
+    },
+    // ========== VALID: bare `@UseGuards` (no call), ditto ==========
+    {
+      code: `
+        @Controller('users')
+        @UseGuards
+        class UsersController {
+          @Get()
+          findAll() {}
+        }
+      `,
+      options: [{ requiredGuards: ['JwtAuthGuard'] }],
+    },
+    // ========== VALID: an unresolved composite may apply the required guard ==========
+    {
+      code: `
+        @Controller('users')
+        class UsersController {
+          @AuthJwtAccessProtected()
+          @Get()
+          findAll() {}
+        }
+      `,
+      options: [{ requiredGuards: ['JwtAuthGuard'] }],
+    },
   ],
   invalid: [
     // ========== INVALID: Controller without guards ==========
@@ -300,6 +408,55 @@ ruleTester.run('require-guards', requireGuards, {
       `,
       options: [{ allowCustomDecorators: false }],
       errors: [{ messageId: 'missingGuards', data: { name: 'findAll' } }],
+    },
+    // ========== INVALID: guarded, but not by a required guard ==========
+    {
+      code: `
+        @Controller('users')
+        class UsersController {
+          @UseGuards(RolesGuard)
+          @Get()
+          findAll() {}
+        }
+      `,
+      options: [{ requiredGuards: ['JwtAuthGuard'] }],
+      errors: [
+        {
+          messageId: 'missingRequiredGuards',
+          data: { name: 'findAll', guards: 'JwtAuthGuard' },
+        },
+      ],
+    },
+    // ========== INVALID: a class-level guard that is not the required one
+    // does not exempt the routes below it ==========
+    {
+      code: `
+        @Controller('users')
+        @UseGuards(RolesGuard)
+        class UsersController {
+          @Get()
+          findAll() {}
+        }
+      `,
+      options: [{ requiredGuards: ['JwtAuthGuard', 'ApiKeyGuard'] }],
+      errors: [
+        {
+          messageId: 'missingRequiredGuards',
+          data: { name: 'findAll', guards: 'JwtAuthGuard, ApiKeyGuard' },
+        },
+      ],
+    },
+    // ========== INVALID: no guard at all, with requiredGuards set ==========
+    {
+      code: `
+        @Controller('users')
+        class UsersController {
+          @Get()
+          findAll() {}
+        }
+      `,
+      options: [{ requiredGuards: ['JwtAuthGuard'] }],
+      errors: [{ messageId: 'missingRequiredGuards' }],
     },
   ],
 });

--- a/packages/eslint-plugin-nestjs-security/src/rules/require-guards/require-guards.test.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/require-guards/require-guards.test.ts
@@ -110,6 +110,114 @@ ruleTester.run('require-guards', requireGuards, {
         }
       `,
     },
+    // ========== REGRESSION (ack-nestjs-boilerplate, 93 findings): the whole
+    // codebase protects routes with composite decorators that wrap @UseGuards
+    // via applyDecorators(). A syntax-only linter cannot resolve them, so it
+    // must not assert "unguarded". ==========
+    {
+      code: `
+        @ApiTags('modules.admin.apiKey')
+        @Controller({ version: '1', path: '/api-key' })
+        export class ApiKeyAdminController {
+          @ApiKeyAdminListDoc()
+          @ResponsePaging('apiKey.list')
+          @PolicyAbilityProtected({ subject: EnumPolicySubject.apiKey })
+          @RoleProtected(EnumRoleType.admin)
+          @UserProtected()
+          @AuthJwtAccessProtected()
+          @ApiKeyProtected()
+          @Get('/list')
+          async list() {}
+        }
+      `,
+    },
+    // ========== REGRESSION (ack): a class-level composite protects every
+    // route in the controller ==========
+    {
+      code: `
+        @Controller('users')
+        @AuthJwtAccessProtected()
+        export class UserSharedController {
+          @Get('/profile')
+          profile() {}
+        }
+      `,
+    },
+    // ========== REGRESSION (ack): member-expression decorators are equally
+    // unresolvable ==========
+    {
+      code: `
+        @Controller('users')
+        class UsersController {
+          @auth.protected()
+          @Get()
+          findAll() {}
+        }
+      `,
+    },
+    // ========== REGRESSION (brocoders, 10 findings): credential-issuing
+    // routes cannot carry an auth guard. A guard on `login` is a contradiction,
+    // not a finding. ==========
+    {
+      code: `
+        @ApiTags('Auth')
+        @Controller({ path: 'auth', version: '1' })
+        export class AuthController {
+          @Post('email/login')
+          @HttpCode(HttpStatus.OK)
+          @ApiOkResponse({ type: LoginResponseDto })
+          public login(@Body() loginDto: AuthEmailLoginDto) {}
+
+          @Post('email/register')
+          @HttpCode(HttpStatus.NO_CONTENT)
+          async register(@Body() createUserDto: AuthRegisterLoginDto) {}
+
+          @Post('forgot/password')
+          @HttpCode(HttpStatus.NO_CONTENT)
+          async forgotPassword(@Body() dto: AuthForgotPasswordDto) {}
+
+          @Post('reset/password')
+          @HttpCode(HttpStatus.NO_CONTENT)
+          resetPassword(@Body() dto: AuthResetPasswordDto) {}
+
+          @Post('email/confirm')
+          @HttpCode(HttpStatus.NO_CONTENT)
+          async confirmEmail(@Body() dto: AuthConfirmEmailDto) {}
+        }
+      `,
+    },
+    // ========== REGRESSION (brocoders): the app-info route on HomeController ==========
+    {
+      code: `
+        @ApiTags('Home')
+        @Controller()
+        export class HomeController {
+          @Get()
+          appInfo() {}
+        }
+      `,
+    },
+    // ========== VALID: public-by-design detected from the route path ==========
+    {
+      code: `
+        @Controller('auth')
+        class AuthController {
+          @Post('login')
+          authenticate() {}
+        }
+      `,
+    },
+    // ========== VALID: custom publicRoutePatterns ==========
+    {
+      code: `
+        @Controller('billing')
+        class BillingController {
+          @Post()
+          stripeHook() {}
+        }
+      `,
+      options: [{ publicRoutePatterns: ['stripeHook'] }],
+    },
   ],
   invalid: [
     // ========== INVALID: Controller without guards ==========
@@ -148,6 +256,50 @@ ruleTester.run('require-guards', requireGuards, {
       filename: 'users.controller.spec.ts',
       options: [{ allowInTests: false }],
       errors: [{ messageId: 'missingGuards' }],
+    },
+    // ========== TRUE POSITIVE (brocoders): the unauthenticated file-download
+    // route. Upload is a POST on the same guardless controller, so anyone who
+    // knows a filename can fetch any uploaded file. The rule must keep
+    // catching this after all the false-positive fixes. ==========
+    {
+      code: `
+        @ApiTags('Files')
+        @Controller({ path: 'files', version: '1' })
+        export class FilesLocalController {
+          @Get(':path')
+          download(@Param('path') path, @Response() response) {
+            return response.sendFile(path, { root: './files' });
+          }
+        }
+      `,
+      errors: [{ messageId: 'missingGuards', data: { name: 'download' } }],
+    },
+    // ========== INVALID: swagger-only decorators do not protect a route ==========
+    {
+      code: `
+        @ApiTags('Users')
+        @Controller('users')
+        class UsersController {
+          @ApiBearerAuth()
+          @ApiOkResponse({ type: UserDto })
+          @Get()
+          findAll() {}
+        }
+      `,
+      errors: [{ messageId: 'missingGuards', data: { name: 'findAll' } }],
+    },
+    // ========== INVALID: allowCustomDecorators: false restores strictness ==========
+    {
+      code: `
+        @Controller('users')
+        class UsersController {
+          @AuthJwtAccessProtected()
+          @Get()
+          findAll() {}
+        }
+      `,
+      options: [{ allowCustomDecorators: false }],
+      errors: [{ messageId: 'missingGuards', data: { name: 'findAll' } }],
     },
   ],
 });

--- a/packages/eslint-plugin-nestjs-security/src/rules/require-throttler/index.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/require-throttler/index.ts
@@ -6,42 +6,55 @@
 
 /**
  * ESLint Rule: require-throttler
- * Requires @Throttle or ThrottlerGuard for rate limiting
+ * Requires an application-wide rate limiter (ThrottlerModule + ThrottlerGuard)
  * CWE-770: Allocation of Resources Without Limits or Throttling
+ *
+ * Rate limiting in NestJS is adopted **once**, in the root module:
+ *
+ * ```ts
+ * @Module({
+ *   imports: [ThrottlerModule.forRoot([{ ttl: 60000, limit: 10 }])],
+ *   providers: [{ provide: APP_GUARD, useClass: ThrottlerGuard }],
+ * })
+ * export class AppModule {}
+ * ```
+ *
+ * Reporting the missing throttler on every route handler therefore produced
+ * dozens of findings for a single one-line fix (24 on one boilerplate, 93 on
+ * another). This rule reports once, on the root module — where the fix goes.
  *
  * @see https://cwe.mitre.org/data/definitions/770.html
  * @see https://docs.nestjs.com/security/rate-limiting
  */
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
-import { AST_NODE_TYPES, createRule, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
+import { createRule, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
+import { getBasename } from '@interlace/eslint-devkit';
+import { isModuleClass } from '../../utils/decorators';
+import { getProjectContext } from '../../utils/project-context';
 
 type MessageIds = 'missingThrottler' | 'addThrottler';
 
 export interface Options {
   /** Allow in test files. Default: true */
   allowInTests?: boolean;
-  /** Skip checking specific routes. Default: [] */
+  /** @deprecated No longer used — the rule no longer reports per route. */
   skipRoutes?: string[];
-  /** Skip rule if ThrottlerModule is configured globally in AppModule. Default: false */
+  /** Skip rule entirely, without scanning the project. Default: false */
   assumeGlobalThrottler?: boolean;
+  /** Class names treated as the application root module. Default: ['AppModule'] */
+  rootModuleNames?: string[];
+  /** File names treated as the application root module. Default: ['app.module.ts'] */
+  rootModuleFiles?: string[];
 }
 
 type RuleOptions = [Options?];
 
-// HTTP method decorators that indicate route handlers
-const HTTP_METHOD_DECORATORS = new Set([
-  'Get',
-  'Post',
-  'Put',
-  'Patch',
-  'Delete',
-  'Options',
-  'Head',
-  'All',
-]);
+const DEFAULT_ROOT_MODULE_NAMES = ['AppModule'];
+const DEFAULT_ROOT_MODULE_FILES = ['app.module.ts'];
 
-// Throttle-related decorators
-const THROTTLE_DECORATORS = new Set(['Throttle', 'SkipThrottle']);
+/** Throttler configuration visible in the file being linted. */
+const THROTTLER_IN_FILE =
+  /ThrottlerModule\s*\.\s*forRoot(?:Async)?\s*\(|ThrottlerGuard|ThrottlerStorage/;
 
 export const requireThrottler = createRule<RuleOptions, MessageIds>({
   name: 'require-throttler',
@@ -49,7 +62,7 @@ export const requireThrottler = createRule<RuleOptions, MessageIds>({
     type: 'suggestion',
     docs: {
       url: 'https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-nestjs-security/docs/rules/require-throttler.md',
-      description: 'Requires ThrottlerGuard or @Throttle decorator for rate limiting',
+      description: 'Requires an application-wide ThrottlerModule for rate limiting',
       cwe: 'CWE-770',
       cvss: 7.5,
     },
@@ -60,9 +73,10 @@ export const requireThrottler = createRule<RuleOptions, MessageIds>({
         issueName: 'Missing Rate Limiting',
         cwe: 'CWE-770',
         cvss: 7.5,
-        description: 'Controller {{name}} lacks rate limiting protection (Throttler)',
+        description:
+          'Application module {{name}} registers no rate limiting — every route, including authentication, is open to brute-force and DoS',
         severity: 'HIGH',
-        fix: 'Add @UseGuards(ThrottlerGuard) or configure global ThrottlerModule',
+        fix: 'Register ThrottlerModule.forRoot([...]) and { provide: APP_GUARD, useClass: ThrottlerGuard }',
         documentationLink: 'https://docs.nestjs.com/security/rate-limiting',
       }),
       addThrottler: formatLLMMessage({
@@ -70,7 +84,7 @@ export const requireThrottler = createRule<RuleOptions, MessageIds>({
         issueName: 'Add Rate Limiting',
         description: 'Configure ThrottlerModule to protect against DoS/brute-force attacks',
         severity: 'LOW',
-        fix: 'npm i @nestjs/throttler && ThrottlerModule.forRoot({ ttl: 60, limit: 10 })',
+        fix: 'npm i @nestjs/throttler && ThrottlerModule.forRoot([{ ttl: 60000, limit: 10 }])',
         documentationLink: 'https://docs.nestjs.com/security/rate-limiting',
       }),
     },
@@ -81,6 +95,8 @@ export const requireThrottler = createRule<RuleOptions, MessageIds>({
           allowInTests: { type: 'boolean', default: true },
           skipRoutes: { type: 'array', items: { type: 'string' }, default: [] },
           assumeGlobalThrottler: { type: 'boolean', default: false },
+          rootModuleNames: { type: 'array', items: { type: 'string' } },
+          rootModuleFiles: { type: 'array', items: { type: 'string' } },
         },
         additionalProperties: false,
       },
@@ -88,7 +104,12 @@ export const requireThrottler = createRule<RuleOptions, MessageIds>({
   },
   defaultOptions: [{ allowInTests: true, skipRoutes: [], assumeGlobalThrottler: false }],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>, [options = {}]) {
-    const { allowInTests = true, assumeGlobalThrottler = false } = options as Options;
+    const {
+      allowInTests = true,
+      assumeGlobalThrottler = false,
+      rootModuleNames = DEFAULT_ROOT_MODULE_NAMES,
+      rootModuleFiles = DEFAULT_ROOT_MODULE_FILES,
+    } = options as Options;
 
     // Skip entirely if global ThrottlerModule is assumed (configured in AppModule)
     if (assumeGlobalThrottler) {
@@ -102,113 +123,31 @@ export const requireThrottler = createRule<RuleOptions, MessageIds>({
       return {};
     }
 
-    // Track class-level throttler and controller state
-    let isController = false;
-    let hasClassLevelThrottler = false;
-    let hasThrottlerGuard = false;
+    const rootNames = new Set(rootModuleNames);
+    const rootFiles = new Set(rootModuleFiles);
+    const isRootModuleFile = rootFiles.has(getBasename(filename));
 
-    /**
-     * Check if decorators include @UseGuards with ThrottlerGuard
-     */
-    function hasThrottlerGuardDecorator(decorators: TSESTree.Decorator[] | undefined): boolean {
-      if (!decorators) return false;
-      return decorators.some((dec) => {
-        if (dec.expression.type === AST_NODE_TYPES.CallExpression) {
-          const callee = dec.expression.callee;
-          if (callee.type === AST_NODE_TYPES.Identifier && callee.name === 'UseGuards') {
-            return dec.expression.arguments.some(
-              (arg: TSESTree.CallExpressionArgument) => arg.type === AST_NODE_TYPES.Identifier && arg.name === 'ThrottlerGuard'
-            );
-          }
-        }
-        return false;
-      });
-    }
-
-    /**
-     * Check if decorators include @Throttle or @SkipThrottle
-     */
-    function hasThrottleDecorator(decorators: TSESTree.Decorator[] | undefined): boolean {
-      if (!decorators) return false;
-      return decorators.some((dec) => {
-        const name =
-          dec.expression.type === AST_NODE_TYPES.Identifier
-            ? dec.expression.name
-            : dec.expression.type === AST_NODE_TYPES.CallExpression &&
-              dec.expression.callee.type === AST_NODE_TYPES.Identifier
-            ? dec.expression.callee.name
-            : '';
-        return THROTTLE_DECORATORS.has(name);
-      });
-    }
-
-    /**
-     * Check if class has @Controller decorator
-     */
-    function hasControllerDecorator(decorators: TSESTree.Decorator[] | undefined): boolean {
-      if (!decorators) return false;
-      return decorators.some((dec) => {
-        const name =
-          dec.expression.type === AST_NODE_TYPES.Identifier
-            ? dec.expression.name
-            : dec.expression.type === AST_NODE_TYPES.CallExpression &&
-              dec.expression.callee.type === AST_NODE_TYPES.Identifier
-            ? dec.expression.callee.name
-            : '';
-        return name === 'Controller';
-      });
-    }
-
-    /**
-     * Check if method has HTTP method decorator
-     */
-    function isRouteHandler(decorators: TSESTree.Decorator[] | undefined): boolean {
-      if (!decorators) return false;
-      return decorators.some((dec) => {
-        const name =
-          dec.expression.type === AST_NODE_TYPES.Identifier
-            ? dec.expression.name
-            : dec.expression.type === AST_NODE_TYPES.CallExpression &&
-              dec.expression.callee.type === AST_NODE_TYPES.Identifier
-            ? dec.expression.callee.name
-            : '';
-        return HTTP_METHOD_DECORATORS.has(name);
-      });
+    /** Only the root module is a sensible place to report a project-wide gap. */
+    function isRootModule(node: TSESTree.ClassDeclaration): boolean {
+      if (!isModuleClass(node.decorators)) return false;
+      if (isRootModuleFile) return true;
+      return node.id !== null && rootNames.has(node.id.name);
     }
 
     return {
       ClassDeclaration(node: TSESTree.ClassDeclaration) {
-        isController = hasControllerDecorator(node.decorators);
-        hasClassLevelThrottler = hasThrottleDecorator(node.decorators);
-        hasThrottlerGuard = hasThrottlerGuardDecorator(node.decorators);
-      },
+        if (!isRootModule(node)) return;
 
-      MethodDefinition(node: TSESTree.MethodDefinition) {
-        if (!isController) return;
-        if (!isRouteHandler(node.decorators)) return;
+        // Configured right here (imports: [ThrottlerModule.forRoot(...)])
+        if (THROTTLER_IN_FILE.test(context.sourceCode.getText())) return;
 
-        // Skip if class or method has throttler
-        if (
-          hasClassLevelThrottler ||
-          hasThrottlerGuard ||
-          hasThrottleDecorator(node.decorators) ||
-          hasThrottlerGuardDecorator(node.decorators)
-        ) {
-          return;
-        }
-
-        // Skip constructor
-        if (node.key.type === AST_NODE_TYPES.Identifier && node.key.name === 'constructor') {
-          return;
-        }
-
-        const methodName =
-          node.key.type === AST_NODE_TYPES.Identifier ? node.key.name : '<anonymous>';
+        // …or anywhere else in the project (a dedicated throttler module)
+        if (getProjectContext(context).hasGlobalThrottler) return;
 
         context.report({
           node,
           messageId: 'missingThrottler',
-          data: { name: methodName },
+          data: { name: node.id === null ? '<anonymous>' : node.id.name },
           suggest: [{ messageId: 'addThrottler', fix: () => null }],
         });
       },

--- a/packages/eslint-plugin-nestjs-security/src/rules/require-throttler/index.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/require-throttler/index.ts
@@ -52,9 +52,28 @@ type RuleOptions = [Options?];
 const DEFAULT_ROOT_MODULE_NAMES = ['AppModule'];
 const DEFAULT_ROOT_MODULE_FILES = ['app.module.ts'];
 
-/** Throttler configuration visible in the file being linted. */
-const THROTTLER_IN_FILE =
-  /ThrottlerModule\s*\.\s*forRoot(?:Async)?\s*\(|ThrottlerGuard|ThrottlerStorage/;
+/**
+ * Rate limiting actually **registered** in the file being linted.
+ *
+ * Matching the bare identifiers `ThrottlerGuard` / `ThrottlerStorage` anywhere
+ * in the file text was wrong: a lone
+ * `import { ThrottlerGuard } from '@nestjs/throttler'` silenced the rule on a
+ * module that never put the guard in `providers`. Only a module import or a
+ * provider entry counts as a registration.
+ */
+const THROTTLER_REGISTRATIONS: readonly RegExp[] = [
+  // imports: [ThrottlerModule.forRoot(...)] / .forRootAsync(...)
+  /ThrottlerModule\s*\.\s*forRoot(?:Async)?\s*\(/,
+  // imports: [ThrottlerModule] — configured by a dedicated module
+  /imports\s*:\s*\[[^\]]*\bThrottlerModule\b/,
+  // providers: [{ provide: APP_GUARD, useClass: ThrottlerGuard }]
+  /provide\s*:\s*APP_GUARD[\s\S]{0,240}?use(?:Class|Existing)\s*:\s*Throttler[\w$]*/,
+];
+
+/** True when the linted source registers rate limiting itself. */
+function registersThrottler(source: string): boolean {
+  return THROTTLER_REGISTRATIONS.some((pattern) => pattern.test(source));
+}
 
 export const requireThrottler = createRule<RuleOptions, MessageIds>({
   name: 'require-throttler',
@@ -138,8 +157,8 @@ export const requireThrottler = createRule<RuleOptions, MessageIds>({
       ClassDeclaration(node: TSESTree.ClassDeclaration) {
         if (!isRootModule(node)) return;
 
-        // Configured right here (imports: [ThrottlerModule.forRoot(...)])
-        if (THROTTLER_IN_FILE.test(context.sourceCode.getText())) return;
+        // Registered right here (imports: [ThrottlerModule.forRoot(...)])
+        if (registersThrottler(context.sourceCode.getText())) return;
 
         // …or anywhere else in the project (a dedicated throttler module)
         if (getProjectContext(context).hasGlobalThrottler) return;

--- a/packages/eslint-plugin-nestjs-security/src/rules/require-throttler/require-throttler.test.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/require-throttler/require-throttler.test.ts
@@ -5,125 +5,28 @@ const ruleTester = new RuleTester();
 
 ruleTester.run('require-throttler', requireThrottler, {
   valid: [
-    // ========== VALID: Controller with class-level @Throttle ==========
+    // ========== VALID: root module configures ThrottlerModule ==========
     {
       code: `
-        @Controller('users')
-        @Throttle({ default: { limit: 10, ttl: 60 }})
-        class UsersController {
-          @Get()
-          findAll() {}
-        }
+        @Module({
+          imports: [ThrottlerModule.forRoot([{ ttl: 60000, limit: 10 }])],
+          providers: [{ provide: APP_GUARD, useClass: ThrottlerGuard }],
+        })
+        export class AppModule {}
       `,
     },
-    // ========== VALID: Controller with method-level @Throttle ==========
+    // ========== VALID: async throttler configuration ==========
     {
       code: `
-        @Controller('users')
-        class UsersController {
-          @Get()
-          @Throttle({ default: { limit: 10, ttl: 60 }})
-          findAll() {}
-        }
+        @Module({
+          imports: [ThrottlerModule.forRootAsync({ useFactory: () => ({}) })],
+        })
+        export class AppModule {}
       `,
     },
-    // ========== VALID: Controller with @SkipThrottle ==========
-    {
-      code: `
-        @Controller('health')
-        class HealthController {
-          @Get()
-          @SkipThrottle()
-          check() {}
-        }
-      `,
-    },
-    // ========== VALID: Controller with ThrottlerGuard ==========
-    {
-      code: `
-        @Controller('users')
-        @UseGuards(ThrottlerGuard)
-        class UsersController {
-          @Get()
-          findAll() {}
-        }
-      `,
-    },
-    // ========== VALID: Non-controller class ==========
-    {
-      code: `
-        class UsersService {
-          findAll() {}
-        }
-      `,
-    },
-    // ========== VALID: Method without HTTP decorator ==========
-    {
-      code: `
-        @Controller('users')
-        class UsersController {
-          private helper() {}
-        }
-      `,
-    },
-    // ========== VALID: Test file ==========
-    {
-      code: `
-        @Controller('users')
-        class UsersController {
-          @Get()
-          findAll() {}
-        }
-      `,
-      filename: 'users.controller.spec.ts',
-    },
-    // ========== VALID: assumeGlobalThrottler option ==========
-    {
-      code: `
-        @Controller('users')
-        class UsersController {
-          @Get()
-          findAll() {}
-        }
-      `,
-      options: [{ assumeGlobalThrottler: true }],
-    },
-    // ========== VALID: @Throttle without parentheses (bare decorator) ==========
-    {
-      code: `
-        @Controller('users')
-        @Throttle
-        class UsersController {
-          @Get()
-          findAll() {}
-        }
-      `,
-    },
-    // ========== VALID: Method-level ThrottlerGuard ==========
-    {
-      code: `
-        @Controller('auth')
-        class AuthController {
-          @Post('login')
-          @UseGuards(ThrottlerGuard)
-          login() {}
-        }
-      `,
-    },
-  ],
-  invalid: [
-    // ========== INVALID: Controller without throttling ==========
-    {
-      code: `
-        @Controller('users')
-        class UsersController {
-          @Get()
-          findAll() {}
-        }
-      `,
-      errors: [{ messageId: 'missingThrottler' }],
-    },
-    // ========== INVALID: Multiple routes without throttling ==========
+    // ========== REGRESSION (ack + brocoders): route handlers are never
+    // reported. Rate limiting is adopted once in the root module, so 24 (and
+    // 93) per-route findings described a single one-line fix. ==========
     {
       code: `
         @Controller('auth')
@@ -134,18 +37,84 @@ ruleTester.run('require-throttler', requireThrottler, {
           register() {}
         }
       `,
-      errors: [{ messageId: 'missingThrottler' }, { messageId: 'missingThrottler' }],
     },
-    // ========== INVALID: Test file with allowInTests: false ==========
+    // ========== VALID: feature modules are not the root module ==========
     {
       code: `
-        @Controller('users')
-        class UsersController {
-          @Get()
-          findAll() {}
-        }
+        @Module({ controllers: [UsersController] })
+        export class UsersModule {}
       `,
-      filename: 'users.controller.spec.ts',
+    },
+    // ========== VALID: non-module class in app.module.ts ==========
+    {
+      code: `export class AppModuleHelper {}`,
+      filename: 'app.module.ts',
+    },
+    // ========== VALID: test file ==========
+    {
+      code: `
+        @Module({})
+        export class AppModule {}
+      `,
+      filename: 'app.module.spec.ts',
+    },
+    // ========== VALID: assumeGlobalThrottler option ==========
+    {
+      code: `
+        @Module({})
+        export class AppModule {}
+      `,
+      options: [{ assumeGlobalThrottler: true }],
+    },
+    // ========== VALID: custom root module name not matched ==========
+    {
+      code: `
+        @Module({})
+        export class AppModule {}
+      `,
+      options: [{ rootModuleNames: ['RootModule'], rootModuleFiles: [] }],
+    },
+  ],
+  invalid: [
+    // ========== INVALID: root module with no rate limiting ==========
+    {
+      code: `
+        @Module({
+          imports: [UsersModule],
+          controllers: [],
+          providers: [],
+        })
+        export class AppModule {}
+      `,
+      errors: [{ messageId: 'missingThrottler', data: { name: 'AppModule' } }],
+    },
+    // ========== INVALID: recognised by file name, not class name ==========
+    {
+      code: `
+        @Module({ imports: [UsersModule] })
+        export class ApplicationModule {}
+      `,
+      filename: 'src/app.module.ts',
+      errors: [
+        { messageId: 'missingThrottler', data: { name: 'ApplicationModule' } },
+      ],
+    },
+    // ========== INVALID: custom root module name ==========
+    {
+      code: `
+        @Module({ imports: [UsersModule] })
+        export class RootModule {}
+      `,
+      options: [{ rootModuleNames: ['RootModule'] }],
+      errors: [{ messageId: 'missingThrottler', data: { name: 'RootModule' } }],
+    },
+    // ========== INVALID: test file with allowInTests: false ==========
+    {
+      code: `
+        @Module({})
+        export class AppModule {}
+      `,
+      filename: 'app.module.spec.ts',
       options: [{ allowInTests: false }],
       errors: [{ messageId: 'missingThrottler' }],
     },

--- a/packages/eslint-plugin-nestjs-security/src/rules/require-throttler/require-throttler.test.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/require-throttler/require-throttler.test.ts
@@ -24,6 +24,25 @@ ruleTester.run('require-throttler', requireThrottler, {
         export class AppModule {}
       `,
     },
+    // ========== VALID: ThrottlerModule imported bare, configured elsewhere ==========
+    {
+      code: `
+        @Module({
+          imports: [ConfigModule, ThrottlerModule],
+        })
+        export class AppModule {}
+      `,
+    },
+    // ========== VALID: guard registered as APP_GUARD, module configured
+    // in a dedicated throttler module ==========
+    {
+      code: `
+        @Module({
+          providers: [{ provide: APP_GUARD, useClass: ThrottlerGuard }],
+        })
+        export class AppModule {}
+      `,
+    },
     // ========== REGRESSION (ack + brocoders): route handlers are never
     // reported. Rate limiting is adopted once in the root module, so 24 (and
     // 93) per-route findings described a single one-line fix. ==========
@@ -83,6 +102,32 @@ ruleTester.run('require-throttler', requireThrottler, {
           imports: [UsersModule],
           controllers: [],
           providers: [],
+        })
+        export class AppModule {}
+      `,
+      errors: [{ messageId: 'missingThrottler', data: { name: 'AppModule' } }],
+    },
+    // ========== REGRESSION: an *unused* `ThrottlerGuard` import is not a
+    // registration. Matching the bare identifier anywhere in the file text
+    // silenced the rule on a module that never puts the guard in providers. ==========
+    {
+      code: `
+        import { ThrottlerGuard, ThrottlerStorage } from '@nestjs/throttler';
+
+        @Module({
+          imports: [UsersModule],
+          providers: [UsersService],
+        })
+        export class AppModule {}
+      `,
+      errors: [{ messageId: 'missingThrottler', data: { name: 'AppModule' } }],
+    },
+    // ========== INVALID: a global APP_GUARD that is not a throttler does not
+    // count as rate limiting ==========
+    {
+      code: `
+        @Module({
+          providers: [{ provide: APP_GUARD, useClass: JwtAuthGuard }],
         })
         export class AppModule {}
       `,

--- a/packages/eslint-plugin-nestjs-security/src/utils/decorators.test.ts
+++ b/packages/eslint-plugin-nestjs-security/src/utils/decorators.test.ts
@@ -12,6 +12,7 @@ import {
   getDecoratorNames,
   getHttpMethodDecorator,
   getRoutePath,
+  getUseGuardsGuardNames,
   hasDecoratorNamed,
   hasUnresolvedDecorator,
   hasUseGuards,
@@ -177,6 +178,77 @@ describe('class/route predicates', () => {
 
   it('returns null when decorators are undefined', () => {
     expect(getHttpMethodDecorator(undefined)).toBeNull();
+  });
+});
+
+describe('getUseGuardsGuardNames', () => {
+  const identifier = (name: string) => ({ type: 'Identifier', name });
+
+  it('returns an empty list when there is no @UseGuards', () => {
+    expect(getUseGuardsGuardNames([call('Get')])).toEqual([]);
+    expect(getUseGuardsGuardNames(undefined)).toEqual([]);
+  });
+
+  it('names every guard argument', () => {
+    expect(
+      getUseGuardsGuardNames([
+        call('UseGuards', [identifier('JwtAuthGuard'), identifier('RolesGuard')]),
+      ]),
+    ).toEqual(['JwtAuthGuard', 'RolesGuard']);
+  });
+
+  it('unwraps the passport factory form AuthGuard("jwt")', () => {
+    expect(
+      getUseGuardsGuardNames([
+        call('UseGuards', [
+          {
+            type: 'CallExpression',
+            callee: identifier('AuthGuard'),
+            arguments: [stringArg('jwt')],
+          },
+        ]),
+      ]),
+    ).toEqual(['AuthGuard']);
+  });
+
+  it('unwraps a namespaced guard reference', () => {
+    expect(
+      getUseGuardsGuardNames([
+        call('UseGuards', [
+          {
+            type: 'MemberExpression',
+            object: identifier('guards'),
+            property: identifier('JwtAuthGuard'),
+          },
+        ]),
+      ]),
+    ).toEqual(['JwtAuthGuard']);
+  });
+
+  it('yields "" for a guard list with no static name', () => {
+    expect(
+      getUseGuardsGuardNames([
+        call('UseGuards', [{ type: 'SpreadElement', argument: identifier('all') }]),
+      ]),
+    ).toEqual(['']);
+  });
+
+  it('yields "" for @UseGuards() with no arguments', () => {
+    expect(getUseGuardsGuardNames([call('UseGuards')])).toEqual(['']);
+  });
+
+  it('yields "" for a bare @UseGuards', () => {
+    expect(getUseGuardsGuardNames([bare('UseGuards')])).toEqual(['']);
+  });
+
+  it('collects across several @UseGuards decorators', () => {
+    expect(
+      getUseGuardsGuardNames([
+        call('UseGuards', [identifier('JwtAuthGuard')]),
+        call('Get'),
+        call('UseGuards', [identifier('RolesGuard')]),
+      ]),
+    ).toEqual(['JwtAuthGuard', 'RolesGuard']);
   });
 });
 

--- a/packages/eslint-plugin-nestjs-security/src/utils/decorators.test.ts
+++ b/packages/eslint-plugin-nestjs-security/src/utils/decorators.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { TSESTree } from '@interlace/eslint-devkit';
+import {
+  getDecoratorCall,
+  getDecoratorName,
+  getDecoratorNames,
+  getHttpMethodDecorator,
+  getRoutePath,
+  hasDecoratorNamed,
+  hasUnresolvedDecorator,
+  hasUseGuards,
+  isControllerClass,
+  isModuleClass,
+  KNOWN_DECORATORS,
+  PUBLIC_DECORATORS,
+} from './decorators';
+
+/** `@Name` */
+const bare = (name: string) =>
+  ({ expression: { type: 'Identifier', name } }) as unknown as TSESTree.Decorator;
+
+/** `@Name(...args)` */
+const call = (name: string, args: unknown[] = []) =>
+  ({
+    expression: {
+      type: 'CallExpression',
+      callee: { type: 'Identifier', name },
+      arguments: args,
+    },
+  }) as unknown as TSESTree.Decorator;
+
+/** `@ns.Name` */
+const member = () =>
+  ({
+    expression: {
+      type: 'MemberExpression',
+      object: { type: 'Identifier', name: 'ns' },
+      property: { type: 'Identifier', name: 'Name' },
+    },
+  }) as unknown as TSESTree.Decorator;
+
+/** `@ns.Name()` */
+const memberCall = () =>
+  ({
+    expression: {
+      type: 'CallExpression',
+      callee: {
+        type: 'MemberExpression',
+        object: { type: 'Identifier', name: 'ns' },
+        property: { type: 'Identifier', name: 'Name' },
+      },
+      arguments: [],
+    },
+  }) as unknown as TSESTree.Decorator;
+
+const stringArg = (value: string) => ({ type: 'Literal', value });
+const objectArg = (properties: unknown[]) => ({
+  type: 'ObjectExpression',
+  properties,
+});
+const prop = (key: string, value: unknown) => ({
+  type: 'Property',
+  key: { type: 'Identifier', name: key },
+  value,
+});
+
+describe('getDecoratorName', () => {
+  it('reads a bare identifier decorator', () => {
+    expect(getDecoratorName(bare('Get'))).toBe('Get');
+  });
+
+  it('reads a call decorator', () => {
+    expect(getDecoratorName(call('Get'))).toBe('Get');
+  });
+
+  it('returns "" for a member-expression decorator', () => {
+    expect(getDecoratorName(member())).toBe('');
+  });
+
+  it('returns "" for a member-expression call decorator', () => {
+    expect(getDecoratorName(memberCall())).toBe('');
+  });
+});
+
+describe('getDecoratorNames', () => {
+  it('returns an empty list when decorators are undefined', () => {
+    expect(getDecoratorNames(undefined)).toEqual([]);
+  });
+
+  it('maps every decorator to its name', () => {
+    expect(getDecoratorNames([bare('Get'), call('Post'), member()])).toEqual([
+      'Get',
+      'Post',
+      '',
+    ]);
+  });
+});
+
+describe('hasDecoratorNamed', () => {
+  it('matches a decorator in the set', () => {
+    expect(hasDecoratorNamed([call('Public')], PUBLIC_DECORATORS)).toBe(true);
+  });
+
+  it('does not match a decorator outside the set', () => {
+    expect(hasDecoratorNamed([call('Get')], PUBLIC_DECORATORS)).toBe(false);
+  });
+});
+
+describe('getDecoratorCall', () => {
+  it('returns the CallExpression for a call decorator', () => {
+    expect(getDecoratorCall(call('Get'))).not.toBeNull();
+  });
+
+  it('returns null for a bare decorator', () => {
+    expect(getDecoratorCall(bare('Get'))).toBeNull();
+  });
+});
+
+describe('hasUnresolvedDecorator', () => {
+  it('is false for framework-only decorators', () => {
+    expect(
+      hasUnresolvedDecorator([call('Controller'), call('ApiTags'), call('Get')]),
+    ).toBe(false);
+  });
+
+  it('is true for a project-owned composite decorator', () => {
+    // ack-nestjs-boilerplate wraps @UseGuards in @AuthJwtAccessProtected()
+    expect(hasUnresolvedDecorator([call('AuthJwtAccessProtected')])).toBe(true);
+  });
+
+  it('is true for a member-expression decorator we cannot name', () => {
+    expect(hasUnresolvedDecorator([memberCall()])).toBe(true);
+  });
+
+  it('is false when there are no decorators', () => {
+    expect(hasUnresolvedDecorator(undefined)).toBe(false);
+  });
+
+  it('does not treat @ApiKeyProtected as a known Swagger decorator', () => {
+    // Guard against re-introducing an `Api*` prefix heuristic: ack's
+    // @ApiKeyProtected() is a guard composite, not Swagger documentation.
+    expect(KNOWN_DECORATORS.has('ApiKeyProtected')).toBe(false);
+    expect(KNOWN_DECORATORS.has('ApiTags')).toBe(true);
+  });
+});
+
+describe('class/route predicates', () => {
+  it('detects @UseGuards', () => {
+    expect(hasUseGuards([call('UseGuards')])).toBe(true);
+    expect(hasUseGuards([call('Get')])).toBe(false);
+  });
+
+  it('detects @Controller', () => {
+    expect(isControllerClass([call('Controller')])).toBe(true);
+    expect(isControllerClass([call('Injectable')])).toBe(false);
+  });
+
+  it('detects @Module', () => {
+    expect(isModuleClass([call('Module')])).toBe(true);
+    expect(isModuleClass([call('Controller')])).toBe(false);
+  });
+
+  it('finds the HTTP-method decorator', () => {
+    const get = call('Get');
+    expect(getHttpMethodDecorator([call('ApiTags'), get])).toBe(get);
+  });
+
+  it('returns null when no HTTP-method decorator is present', () => {
+    expect(getHttpMethodDecorator([call('ApiTags')])).toBeNull();
+  });
+
+  it('returns null when decorators are undefined', () => {
+    expect(getHttpMethodDecorator(undefined)).toBeNull();
+  });
+});
+
+describe('getRoutePath', () => {
+  it('reads the string form', () => {
+    expect(getRoutePath(call('Get', [stringArg('debug')]))).toBe('debug');
+  });
+
+  it('reads the NestJS object form', () => {
+    const decorator = call('Controller', [
+      objectArg([prop('version', stringArg('1')), prop('path', stringArg('/hello'))]),
+    ]);
+    expect(getRoutePath(decorator)).toBe('/hello');
+  });
+
+  it('returns null for an object form without a path', () => {
+    expect(
+      getRoutePath(call('Controller', [objectArg([prop('version', stringArg('1'))])])),
+    ).toBeNull();
+  });
+
+  it('returns null for a spread element in the object form', () => {
+    expect(
+      getRoutePath(call('Controller', [objectArg([{ type: 'SpreadElement' }])])),
+    ).toBeNull();
+  });
+
+  it('returns null for a non-literal path value', () => {
+    expect(
+      getRoutePath(
+        call('Controller', [
+          objectArg([prop('path', { type: 'Identifier', name: 'ROUTE' })]),
+        ]),
+      ),
+    ).toBeNull();
+  });
+
+  it('returns null for a dynamic argument', () => {
+    expect(getRoutePath(call('Get', [{ type: 'Identifier', name: 'path' }]))).toBeNull();
+  });
+
+  it('returns null for a non-string literal argument', () => {
+    expect(getRoutePath(call('Get', [{ type: 'Literal', value: 123 }]))).toBeNull();
+  });
+
+  it('returns null when the decorator takes no arguments', () => {
+    expect(getRoutePath(call('Get'))).toBeNull();
+  });
+
+  it('returns null for a bare decorator', () => {
+    expect(getRoutePath(bare('Get'))).toBeNull();
+  });
+});

--- a/packages/eslint-plugin-nestjs-security/src/utils/decorators.ts
+++ b/packages/eslint-plugin-nestjs-security/src/utils/decorators.ts
@@ -1,0 +1,279 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Shared decorator helpers.
+ *
+ * NestJS applications are built out of decorators, and real-world projects wrap
+ * framework decorators in their own composites via `applyDecorators()`:
+ *
+ * ```ts
+ * export function AuthJwtAccessProtected(): MethodDecorator {
+ *   return applyDecorators(UseGuards(AuthJwtAccessGuard));
+ * }
+ * ```
+ *
+ * A syntax-only linter cannot resolve `@AuthJwtAccessProtected()` back to
+ * `@UseGuards(...)`. The rules in this plugin therefore classify every
+ * decorator as *known* (a framework decorator we can reason about) or
+ * *unresolved* (anything else), and treat unresolved decorators as
+ * "might be protecting this route". A missed finding is far cheaper than a
+ * false positive on somebody else's codebase.
+ */
+import type { TSESTree } from '@interlace/eslint-devkit';
+import { AST_NODE_TYPES } from '@interlace/eslint-devkit';
+
+/**
+ * Extract the identifier name of a decorator.
+ *
+ * Handles both `@Foo` and `@Foo(...)`. Returns `''` for anything else
+ * (member-expression decorators such as `@ns.Foo()`), which callers treat as
+ * an unresolved decorator.
+ */
+export function getDecoratorName(decorator: TSESTree.Decorator): string {
+  const expression = decorator.expression;
+  if (expression.type === AST_NODE_TYPES.Identifier) {
+    return expression.name;
+  }
+  if (
+    expression.type === AST_NODE_TYPES.CallExpression &&
+    expression.callee.type === AST_NODE_TYPES.Identifier
+  ) {
+    return expression.callee.name;
+  }
+  return '';
+}
+
+/** Names of every decorator in the list (`''` for unresolvable ones). */
+export function getDecoratorNames(
+  decorators: TSESTree.Decorator[] | undefined,
+): string[] {
+  if (!decorators) return [];
+  return decorators.map(getDecoratorName);
+}
+
+/** True when any decorator in the list has one of the given names. */
+export function hasDecoratorNamed(
+  decorators: TSESTree.Decorator[] | undefined,
+  names: ReadonlySet<string>,
+): boolean {
+  return getDecoratorNames(decorators).some((name) => names.has(name));
+}
+
+/**
+ * Return the `CallExpression` of a decorator when it is a call, else `null`.
+ * Used to read decorator arguments (route paths, guard classes, pipes).
+ */
+export function getDecoratorCall(
+  decorator: TSESTree.Decorator,
+): TSESTree.CallExpression | null {
+  return decorator.expression.type === AST_NODE_TYPES.CallExpression
+    ? decorator.expression
+    : null;
+}
+
+/** HTTP method decorators that mark a method as a route handler. */
+export const HTTP_METHOD_DECORATORS: ReadonlySet<string> = new Set([
+  'Get',
+  'Post',
+  'Put',
+  'Patch',
+  'Delete',
+  'Options',
+  'Head',
+  'All',
+  'Search',
+  'Sse',
+]);
+
+/** Decorators that explicitly mark a route as intentionally unauthenticated. */
+export const PUBLIC_DECORATORS: ReadonlySet<string> = new Set([
+  'Public',
+  'IsPublic',
+  'SkipAuth',
+  'NoAuth',
+  'AllowAnonymous',
+  'Anonymous',
+]);
+
+/**
+ * Decorators shipped by NestJS and the libraries in its default stack.
+ *
+ * Everything **not** in this set is treated as project-owned and therefore
+ * potentially a composite that applies guards/pipes. Keep this list to
+ * decorators whose behaviour we actually know — adding a wildcard (e.g. every
+ * `Api*` name) would misclassify custom decorators such as ack's
+ * `@ApiKeyProtected()`, which is exactly the false positive this exists to
+ * prevent.
+ */
+export const KNOWN_DECORATORS: ReadonlySet<string> = new Set([
+  // --- @nestjs/common: classes & routing -----------------------------------
+  'Controller',
+  'Injectable',
+  'Module',
+  'Global',
+  'Catch',
+  'Inject',
+  'Optional',
+  'Dependencies',
+  'Bind',
+  ...HTTP_METHOD_DECORATORS,
+  'HttpCode',
+  'Header',
+  'Redirect',
+  'Render',
+  'Version',
+  'SetMetadata',
+  'UseGuards',
+  'UseInterceptors',
+  'UsePipes',
+  'UseFilters',
+  'SerializeOptions',
+  // --- @nestjs/common: parameters ------------------------------------------
+  'Body',
+  'Query',
+  'Param',
+  'Headers',
+  'Req',
+  'Request',
+  'Res',
+  'Response',
+  'Next',
+  'Session',
+  'Ip',
+  'HostParam',
+  'UploadedFile',
+  'UploadedFiles',
+  // --- @nestjs/swagger (documentation only, never a guard) ------------------
+  'ApiTags',
+  'ApiOperation',
+  'ApiResponse',
+  'ApiOkResponse',
+  'ApiCreatedResponse',
+  'ApiAcceptedResponse',
+  'ApiNoContentResponse',
+  'ApiBadRequestResponse',
+  'ApiUnauthorizedResponse',
+  'ApiForbiddenResponse',
+  'ApiNotFoundResponse',
+  'ApiConflictResponse',
+  'ApiUnprocessableEntityResponse',
+  'ApiTooManyRequestsResponse',
+  'ApiInternalServerErrorResponse',
+  'ApiDefaultResponse',
+  'ApiProperty',
+  'ApiPropertyOptional',
+  'ApiHideProperty',
+  'ApiBody',
+  'ApiParam',
+  'ApiQuery',
+  'ApiHeader',
+  'ApiHeaders',
+  'ApiConsumes',
+  'ApiProduces',
+  'ApiExtraModels',
+  'ApiExcludeEndpoint',
+  'ApiExcludeController',
+  'ApiBearerAuth',
+  'ApiBasicAuth',
+  'ApiCookieAuth',
+  'ApiOAuth2',
+  'ApiSecurity',
+  // --- class-validator / class-transformer ---------------------------------
+  'Exclude',
+  'Expose',
+  'Transform',
+  'Type',
+  'Allow',
+  'ValidateNested',
+  'ValidateIf',
+  // --- @nestjs/throttler ----------------------------------------------------
+  'Throttle',
+  'SkipThrottle',
+  // --- explicit public markers ---------------------------------------------
+  ...PUBLIC_DECORATORS,
+]);
+
+/**
+ * True when the decorator list contains at least one decorator this plugin
+ * cannot resolve (a project-owned composite, or a member-expression decorator).
+ *
+ * Callers use this as "assume this route may already be protected".
+ */
+export function hasUnresolvedDecorator(
+  decorators: TSESTree.Decorator[] | undefined,
+): boolean {
+  return getDecoratorNames(decorators).some(
+    (name) => !KNOWN_DECORATORS.has(name),
+  );
+}
+
+/** True when the list contains `@UseGuards` (call or bare identifier). */
+export function hasUseGuards(
+  decorators: TSESTree.Decorator[] | undefined,
+): boolean {
+  return getDecoratorNames(decorators).includes('UseGuards');
+}
+
+/** True when the list contains `@Controller`. */
+export function isControllerClass(
+  decorators: TSESTree.Decorator[] | undefined,
+): boolean {
+  return getDecoratorNames(decorators).includes('Controller');
+}
+
+/** True when the list contains `@Module`. */
+export function isModuleClass(
+  decorators: TSESTree.Decorator[] | undefined,
+): boolean {
+  return getDecoratorNames(decorators).includes('Module');
+}
+
+/** The name of the first HTTP-method decorator in the list, or `null`. */
+export function getHttpMethodDecorator(
+  decorators: TSESTree.Decorator[] | undefined,
+): TSESTree.Decorator | null {
+  if (!decorators) return null;
+  for (const decorator of decorators) {
+    if (HTTP_METHOD_DECORATORS.has(getDecoratorName(decorator))) {
+      return decorator;
+    }
+  }
+  return null;
+}
+
+/**
+ * Route path declared by a `@Controller(...)` / `@Get(...)` decorator.
+ *
+ * Supports the string form (`@Get('debug')`) and the NestJS object form
+ * (`@Controller({ version: '1', path: '/debug' })`). Returns `null` when the
+ * path is dynamic or absent.
+ */
+export function getRoutePath(decorator: TSESTree.Decorator): string | null {
+  const call = getDecoratorCall(decorator);
+  const arg = call?.arguments[0];
+  if (!arg) return null;
+
+  if (arg.type === AST_NODE_TYPES.Literal && typeof arg.value === 'string') {
+    return arg.value;
+  }
+
+  if (arg.type === AST_NODE_TYPES.ObjectExpression) {
+    for (const property of arg.properties) {
+      if (
+        property.type === AST_NODE_TYPES.Property &&
+        property.key.type === AST_NODE_TYPES.Identifier &&
+        property.key.name === 'path' &&
+        property.value.type === AST_NODE_TYPES.Literal &&
+        typeof property.value.value === 'string'
+      ) {
+        return property.value.value;
+      }
+    }
+  }
+
+  return null;
+}

--- a/packages/eslint-plugin-nestjs-security/src/utils/decorators.ts
+++ b/packages/eslint-plugin-nestjs-security/src/utils/decorators.ts
@@ -218,6 +218,52 @@ export function hasUseGuards(
   return getDecoratorNames(decorators).includes('UseGuards');
 }
 
+/**
+ * Class name behind a `@UseGuards(...)` argument.
+ *
+ * `JwtAuthGuard` → `JwtAuthGuard`, `AuthGuard('jwt')` → `AuthGuard`,
+ * `guards.JwtAuthGuard` → `JwtAuthGuard`. Anything else (a spread, a
+ * conditional, an array built elsewhere) has no static name and yields `''`.
+ */
+function getGuardArgumentName(node: TSESTree.Node): string {
+  if (node.type === AST_NODE_TYPES.CallExpression) {
+    return getGuardArgumentName(node.callee);
+  }
+  if (node.type === AST_NODE_TYPES.MemberExpression) {
+    return getGuardArgumentName(node.property);
+  }
+  if (node.type === AST_NODE_TYPES.Identifier) {
+    return node.name;
+  }
+  return '';
+}
+
+/**
+ * Guard class names referenced by every `@UseGuards(...)` in the list.
+ *
+ * An empty array means the list carries no `@UseGuards` at all. An `''` entry
+ * means a `@UseGuards` whose guards cannot be named statically (`@UseGuards`
+ * without a call, `@UseGuards()`, `@UseGuards(...guards)`) — callers must treat
+ * it as "cannot prove which guard", never as "no guard".
+ */
+export function getUseGuardsGuardNames(
+  decorators: TSESTree.Decorator[] | undefined,
+): string[] {
+  const names: string[] = [];
+  for (const decorator of decorators ?? []) {
+    if (getDecoratorName(decorator) !== 'UseGuards') continue;
+    const call = getDecoratorCall(decorator);
+    if (call === null || call.arguments.length === 0) {
+      names.push('');
+      continue;
+    }
+    for (const argument of call.arguments) {
+      names.push(getGuardArgumentName(argument));
+    }
+  }
+  return names;
+}
+
 /** True when the list contains `@Controller`. */
 export function isControllerClass(
   decorators: TSESTree.Decorator[] | undefined,

--- a/packages/eslint-plugin-nestjs-security/src/utils/project-context.test.ts
+++ b/packages/eslint-plugin-nestjs-security/src/utils/project-context.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Regression tests for global-registration discovery.
+ *
+ * Every fixture below is the shape that produced a false-positive storm on a
+ * real repository:
+ *  - ack-nestjs-boilerplate registers `APP_PIPE` (ValidationPipe) and
+ *    `APP_GUARD` (ThrottlerGuard) in feature modules, not in `AppModule`.
+ *  - brocoders/nestjs-boilerplate registers the pipe with
+ *    `app.useGlobalPipes(...)` in `main.ts`.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  clearProjectContextCache,
+  findProjectRoot,
+  getProjectContext,
+  scanProject,
+} from './project-context';
+
+const roots: string[] = [];
+
+function makeProject(files: Record<string, string>): string {
+  const root = mkdtempSync(join(tmpdir(), 'nestjs-security-'));
+  roots.push(root);
+  writeFileSync(join(root, 'package.json'), '{"name":"fixture"}');
+  for (const [relative, contents] of Object.entries(files)) {
+    const target = join(root, relative);
+    mkdirSync(join(target, '..'), { recursive: true });
+    writeFileSync(target, contents);
+  }
+  return root;
+}
+
+afterEach(() => {
+  clearProjectContextCache();
+  while (roots.length > 0) {
+    rmSync(roots.pop() as string, { recursive: true, force: true });
+  }
+});
+
+describe('scanProject — global provider registration', () => {
+  it('finds APP_PIPE and APP_INTERCEPTOR registered in the same providers array', () => {
+    // ack-nestjs-boilerplate: src/common/request/request.module.ts
+    const root = makeProject({
+      'src/common/request/request.module.ts': `
+        import { APP_INTERCEPTOR, APP_PIPE } from '@nestjs/core';
+        @Module({
+          providers: [
+            RequestStoreService,
+            { provide: APP_INTERCEPTOR, useClass: RequestTimeoutInterceptor },
+            {
+              provide: APP_PIPE,
+              useFactory: () => new ValidationPipe({ transform: true, whitelist: true }),
+            },
+          ],
+        })
+        export class RequestModule {}
+      `,
+    });
+
+    const context = scanProject(root);
+    expect(context.hasGlobalValidationPipe).toBe(true);
+    expect([...context.globalProviders].sort()).toEqual([
+      'APP_INTERCEPTOR',
+      'APP_PIPE',
+    ]);
+  });
+
+  it('treats a ThrottlerGuard APP_GUARD as rate limiting, not authentication', () => {
+    // ack-nestjs-boilerplate: src/common/request/request.middleware.module.ts
+    const root = makeProject({
+      'src/common/request/request.middleware.module.ts': `
+        @Module({
+          providers: [{ provide: APP_GUARD, useClass: ThrottlerGuard }],
+          imports: [ThrottlerModule.forRootAsync({ useFactory: () => ({}) })],
+        })
+        export class RequestMiddlewareModule {}
+      `,
+    });
+
+    const context = scanProject(root);
+    expect(context.hasGlobalThrottler).toBe(true);
+    expect(context.hasGlobalAuthGuard).toBe(false);
+  });
+
+  it('treats a named auth guard APP_GUARD as authentication', () => {
+    const root = makeProject({
+      'src/app.module.ts': `
+        @Module({ providers: [{ provide: APP_GUARD, useClass: JwtAuthGuard }] })
+        export class AppModule {}
+      `,
+    });
+    expect(scanProject(root).hasGlobalAuthGuard).toBe(true);
+  });
+
+  it('assumes a factory-provided APP_GUARD authenticates', () => {
+    const root = makeProject({
+      'src/app.module.ts': `
+        @Module({ providers: [{ provide: APP_GUARD, useFactory: () => buildGuard() }] })
+        export class AppModule {}
+      `,
+    });
+    expect(scanProject(root).hasGlobalAuthGuard).toBe(true);
+  });
+
+  it('accepts @Global() re-exported guard registration via useExisting', () => {
+    const root = makeProject({
+      'src/security.module.ts': `
+        @Module({ providers: [{ provide: APP_GUARD, useExisting: SessionGuard }] })
+        export class SecurityModule {}
+      `,
+    });
+    expect(scanProject(root).hasGlobalAuthGuard).toBe(true);
+  });
+
+  it('finds useGlobalPipes / useGlobalGuards in the bootstrap file', () => {
+    // brocoders/nestjs-boilerplate: src/main.ts
+    const root = makeProject({
+      'src/main.ts': `
+        async function bootstrap() {
+          const app = await NestFactory.create(AppModule);
+          app.useGlobalPipes(new ValidationPipe({ transform: true }));
+          app.useGlobalGuards(new AuthGuard());
+        }
+      `,
+    });
+    const context = scanProject(root);
+    expect(context.hasGlobalValidationPipe).toBe(true);
+    expect(context.hasGlobalAuthGuard).toBe(true);
+  });
+
+  it('finds ThrottlerModule.forRoot in any module file', () => {
+    const root = makeProject({
+      'src/throttler.module.ts': `
+        @Module({ imports: [ThrottlerModule.forRoot([{ ttl: 60000, limit: 10 }])] })
+        export class ThrottlingModule {}
+      `,
+    });
+    expect(scanProject(root).hasGlobalThrottler).toBe(true);
+  });
+
+  it('reports nothing for a project with no global registration', () => {
+    const root = makeProject({
+      'src/app.module.ts': `@Module({ controllers: [AppController] }) export class AppModule {}`,
+    });
+    const context = scanProject(root);
+    expect(context.hasGlobalAuthGuard).toBe(false);
+    expect(context.hasGlobalValidationPipe).toBe(false);
+    expect(context.hasGlobalThrottler).toBe(false);
+    expect(context.globalProviders.size).toBe(0);
+  });
+});
+
+describe('scanProject — traversal', () => {
+  it('ignores dependency and build directories', () => {
+    const root = makeProject({
+      'node_modules/pkg/app.module.ts': `{ provide: APP_GUARD, useClass: JwtAuthGuard }`,
+      'dist/app.module.ts': `{ provide: APP_GUARD, useClass: JwtAuthGuard }`,
+      '.cache/app.module.ts': `{ provide: APP_GUARD, useClass: JwtAuthGuard }`,
+      'src/user.service.ts': `{ provide: APP_GUARD, useClass: JwtAuthGuard }`,
+    });
+    expect(scanProject(root).hasGlobalAuthGuard).toBe(false);
+  });
+
+  it('stops at the depth limit', () => {
+    const root = makeProject({
+      'src/deep/app.module.ts': `{ provide: APP_PIPE, useClass: ValidationPipe }`,
+    });
+    expect(scanProject(root, { maxDepth: 0 }).hasGlobalValidationPipe).toBe(false);
+    expect(scanProject(root, { maxDepth: 5 }).hasGlobalValidationPipe).toBe(true);
+  });
+
+  it('stops at the entry budget', () => {
+    const root = makeProject({
+      'a/b/app.module.ts': `{ provide: APP_PIPE, useClass: ValidationPipe }`,
+    });
+    expect(scanProject(root, { maxEntries: 0 }).hasGlobalValidationPipe).toBe(false);
+    expect(scanProject(root, { maxEntries: 1 }).hasGlobalValidationPipe).toBe(false);
+  });
+
+  it('survives an unreadable root', () => {
+    expect(scanProject(join(tmpdir(), 'nestjs-security-does-not-exist')).root).toContain(
+      'nestjs-security-does-not-exist',
+    );
+  });
+
+  it('survives a module file it cannot read', () => {
+    const root = makeProject({});
+    symlinkSync(join(root, 'missing-target.ts'), join(root, 'broken.module.ts'));
+    expect(scanProject(root).hasGlobalAuthGuard).toBe(false);
+  });
+});
+
+describe('findProjectRoot', () => {
+  it('walks up to the nearest package.json', () => {
+    const root = makeProject({ 'src/modules/user/user.module.ts': '' });
+    expect(findProjectRoot(join(root, 'src', 'modules', 'user'))).toBe(root);
+  });
+
+  it('falls back to the starting directory when there is no package.json', () => {
+    const orphan = mkdtempSync(join(tmpdir(), 'nestjs-security-orphan-'));
+    roots.push(orphan);
+    // tmpdir() has no package.json above it in CI or locally.
+    expect(findProjectRoot(orphan)).toBe(orphan);
+  });
+});
+
+describe('getProjectContext', () => {
+  it('resolves the project from the linted file and caches the result', () => {
+    const root = makeProject({
+      'src/app.module.ts': `@Module({ providers: [{ provide: APP_PIPE, useClass: ValidationPipe }] })`,
+    });
+
+    const context = { filename: join(root, 'src', 'users.controller.ts'), cwd: root };
+    const first = getProjectContext(context);
+    expect(first.hasGlobalValidationPipe).toBe(true);
+
+    // Second call is served from the cache — same object identity.
+    expect(getProjectContext(context)).toBe(first);
+
+    clearProjectContextCache();
+    expect(getProjectContext(context)).not.toBe(first);
+  });
+
+  it('resolves a relative filename against cwd', () => {
+    const root = makeProject({
+      'src/app.module.ts': `{ provide: APP_GUARD, useClass: JwtAuthGuard }`,
+    });
+    expect(
+      getProjectContext({ filename: 'src/users.controller.ts', cwd: root })
+        .hasGlobalAuthGuard,
+    ).toBe(true);
+  });
+
+  it('never walks a filesystem root', () => {
+    const context = getProjectContext({ filename: 'file.ts', cwd: '/' });
+    expect(context.root).toBe('/');
+    expect(context.hasGlobalAuthGuard).toBe(false);
+    expect(context.globalProviders.size).toBe(0);
+  });
+});

--- a/packages/eslint-plugin-nestjs-security/src/utils/project-context.ts
+++ b/packages/eslint-plugin-nestjs-security/src/utils/project-context.ts
@@ -1,0 +1,246 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Project-level NestJS configuration discovery.
+ *
+ * NestJS applies guards, pipes, interceptors and rate limiting **globally**
+ * through dependency injection:
+ *
+ * ```ts
+ * @Module({ providers: [{ provide: APP_GUARD, useClass: AuthGuard }] })
+ * ```
+ *
+ * or through the bootstrap file (`app.useGlobalPipes(new ValidationPipe())`).
+ * Either way the registration lives in a *different file* from the controllers
+ * it protects, so a per-file lint rule that only looks at `@UseGuards` reports
+ * every route in the application as unprotected.
+ *
+ * This module answers "does this project register X globally?" by scanning the
+ * project's bootstrap and module files once per project root and caching the
+ * answer. The scan is deliberately text-based: module files are small, the
+ * tokens are unambiguous, and it costs a fraction of a full parse.
+ */
+import { readdirSync, type Dirent } from 'node:fs';
+import type { TSESLint } from '@interlace/eslint-devkit';
+import {
+  findFileUpward,
+  getDirname,
+  joinPath,
+  readFileSync,
+  resolvePath,
+} from '@interlace/eslint-devkit';
+
+/** What the project registers application-wide. */
+export interface NestProjectContext {
+  /** Directory the scan started from (nearest `package.json`, else cwd). */
+  root: string;
+  /** NestJS DI tokens seen in a `provide:` position anywhere in the project. */
+  globalProviders: ReadonlySet<string>;
+  /** An authentication/authorization guard is registered app-wide. */
+  hasGlobalAuthGuard: boolean;
+  /** A pipe (`APP_PIPE` / `useGlobalPipes`) is registered app-wide. */
+  hasGlobalValidationPipe: boolean;
+  /** Rate limiting is configured app-wide (ThrottlerModule + guard). */
+  hasGlobalThrottler: boolean;
+}
+
+/** DI tokens worth recording. */
+const GLOBAL_PROVIDER_TOKENS = [
+  'APP_GUARD',
+  'APP_PIPE',
+  'APP_INTERCEPTOR',
+  'APP_FILTER',
+] as const;
+
+/** Files that can hold a global registration. */
+const SCANNED_FILE = /(?:^|[.\-/])module\.ts$|^main\.ts$|^bootstrap\.ts$/;
+
+/** Directories never worth walking into. */
+const SKIPPED_DIRS = new Set([
+  'node_modules',
+  'dist',
+  'build',
+  'out',
+  'coverage',
+  'tmp',
+  'temp',
+  'public',
+  'assets',
+]);
+
+/** Upper bounds so a stray `root` can never wedge a lint run. */
+const MAX_DEPTH = 12;
+const MAX_ENTRIES = 20_000;
+
+/**
+ * `provide: APP_GUARD` plus the tail of the provider object. The tail is a
+ * lookahead so it is not consumed — a `providers: []` array often registers
+ * several tokens within 240 characters of each other and consuming the tail
+ * would skip past the next `provide:`.
+ */
+const PROVIDE_RE = new RegExp(
+  String.raw`provide\s*:\s*(${GLOBAL_PROVIDER_TOKENS.join('|')})(?=([\s\S]{0,240}))`,
+  'g',
+);
+/** `useClass: X` / `useExisting: X` inside a provider object. */
+const USE_CLASS_RE = /use(?:Class|Existing)\s*:\s*([A-Za-z_$][\w$]*)/;
+/** Guards that are not authentication guards. */
+const NON_AUTH_GUARD = /Throttler/i;
+/** `app.useGlobalPipes(...)` in the bootstrap file. */
+const USE_GLOBAL_PIPES_RE = /useGlobalPipes\s*\(/;
+/** `app.useGlobalGuards(...)` in the bootstrap file. */
+const USE_GLOBAL_GUARDS_RE = /useGlobalGuards\s*\(/;
+/** `ThrottlerModule.forRoot(...)` / `.forRootAsync(...)`. */
+const THROTTLER_MODULE_RE = /ThrottlerModule\s*\.\s*forRoot(?:Async)?\s*\(/;
+
+const CACHE = new Map<string, NestProjectContext>();
+
+/** Drop every cached project scan. Exported for tests. */
+export function clearProjectContextCache(): void {
+  CACHE.clear();
+}
+
+/**
+ * Nearest directory containing a `package.json`, walking up from `startDir`.
+ * Falls back to `startDir` when the file is never found.
+ */
+export function findProjectRoot(startDir: string): string {
+  const packageJson = findFileUpward('package.json', startDir);
+  return packageJson === null ? startDir : getDirname(packageJson);
+}
+
+/** Bounds for a single project scan (overridable so tests can reach them). */
+export interface ScanLimits {
+  maxDepth?: number;
+  maxEntries?: number;
+}
+
+/** Every bootstrap/module file under `root`, bounded in depth and count. */
+function collectConfigFiles(root: string, limits: ScanLimits): string[] {
+  const maxDepth = limits.maxDepth ?? MAX_DEPTH;
+  const files: string[] = [];
+  let budget = limits.maxEntries ?? MAX_ENTRIES;
+
+  const walk = (dir: string, depth: number): void => {
+    if (depth > maxDepth || budget <= 0) return;
+
+    let entries: Dirent[];
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      /* unreadable directory — nothing to learn from it */
+      return;
+    }
+
+    for (const entry of entries) {
+      if (budget-- <= 0) return;
+      if (entry.isDirectory()) {
+        if (!SKIPPED_DIRS.has(entry.name) && !entry.name.startsWith('.')) {
+          walk(joinPath(dir, entry.name), depth + 1);
+        }
+      } else if (SCANNED_FILE.test(entry.name)) {
+        files.push(joinPath(dir, entry.name));
+      }
+    }
+  };
+
+  walk(root, 0);
+  return files;
+}
+
+/** Fold one file's source into the accumulating project context. */
+function analyzeSource(source: string, into: MutableContext): void {
+  PROVIDE_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = PROVIDE_RE.exec(source)) !== null) {
+    const [, token, tail] = match;
+    into.globalProviders.add(token);
+
+    if (token === 'APP_GUARD') {
+      const useClass = USE_CLASS_RE.exec(tail)?.[1];
+      // A factory-provided guard has no class name to inspect; assume it
+      // authenticates rather than reporting every route in the project.
+      if (useClass === undefined || !NON_AUTH_GUARD.test(useClass)) {
+        into.hasGlobalAuthGuard = true;
+      }
+      if (useClass !== undefined && NON_AUTH_GUARD.test(useClass)) {
+        into.hasGlobalThrottler = true;
+      }
+    } else if (token === 'APP_PIPE') {
+      into.hasGlobalValidationPipe = true;
+    }
+  }
+
+  if (USE_GLOBAL_PIPES_RE.test(source)) into.hasGlobalValidationPipe = true;
+  if (USE_GLOBAL_GUARDS_RE.test(source)) into.hasGlobalAuthGuard = true;
+  if (THROTTLER_MODULE_RE.test(source)) into.hasGlobalThrottler = true;
+}
+
+interface MutableContext {
+  globalProviders: Set<string>;
+  hasGlobalAuthGuard: boolean;
+  hasGlobalValidationPipe: boolean;
+  hasGlobalThrottler: boolean;
+}
+
+/** Scan a project root (uncached). */
+export function scanProject(
+  root: string,
+  limits: ScanLimits = {},
+): NestProjectContext {
+  const accumulator: MutableContext = {
+    globalProviders: new Set<string>(),
+    hasGlobalAuthGuard: false,
+    hasGlobalValidationPipe: false,
+    hasGlobalThrottler: false,
+  };
+
+  for (const file of collectConfigFiles(root, limits)) {
+    const source = readFileSync(file);
+    if (source !== null) {
+      analyzeSource(source, accumulator);
+    }
+  }
+
+  return { root, ...accumulator };
+}
+
+/**
+ * Project context for the file currently being linted, cached per project root.
+ *
+ * The cache lives for the lifetime of the ESLint process. A long-running editor
+ * session will therefore keep the answer it computed on first lint; re-running
+ * ESLint (or restarting the language server) picks up new registrations.
+ */
+export function getProjectContext(
+  context: Pick<
+    TSESLint.RuleContext<string, readonly unknown[]>,
+    'filename' | 'cwd'
+  >,
+): NestProjectContext {
+  const startDir = getDirname(resolvePath(context.cwd, context.filename));
+  const root = findProjectRoot(startDir);
+
+  // Never walk a filesystem root: that is not a project, and the cost is
+  // unbounded. Synthetic contexts (unit tests, virtual filenames) land here.
+  if (getDirname(root) === root) {
+    return {
+      root,
+      globalProviders: new Set<string>(),
+      hasGlobalAuthGuard: false,
+      hasGlobalValidationPipe: false,
+      hasGlobalThrottler: false,
+    };
+  }
+
+  const cached = CACHE.get(root);
+  if (cached !== undefined) return cached;
+
+  const scanned = scanProject(root);
+  CACHE.set(root, scanned);
+  return scanned;
+}


### PR DESCRIPTION
Scanning two real NestJS boilerplates with `recommended` produced 582 findings on one and 109 on the other, essentially all false positives. That made the plugin unusable on real projects and unpitchable anywhere. This fixes the causes rather than muting the rules.

## Results

| Repo | Before | After |
|---|---|---|
| ack-nestjs-boilerplate (585 files) | 582 | 0 |
| brocoders/nestjs-boilerplate (156 files) | 109 | 11 |

The 11 remaining are real: the unauthenticated `GET files/:path` download route, `AppModule` with no throttler registered at all, `password`/`hash` exposed on persistence entities, and genuinely unvalidated request-DTO properties.

## Root causes

Two new shared utils:

- `utils/decorators.ts` — one decorator-name extractor (replacing six copies) plus a `KNOWN_DECORATORS` set covering NestJS, Swagger, class-validator and class-transformer. Anything outside it is treated as *possibly guarding*, so project-specific composites like `@AuthJwtAccessProtected()` no longer read as "unguarded". No wildcard prefix heuristic — an `Api*` rule would swallow `@ApiKeyProtected()`, which is a guard, not documentation. There's a test locking that.
- `utils/project-context.ts` — resolves the project root from `context.filename`, scans `main.ts`/`*.module.ts` once (bounded, cached per root) for `APP_GUARD`/`APP_PIPE`/`APP_INTERCEPTOR`, `useGlobalPipes`/`useGlobalGuards`, and `ThrottlerModule.forRoot`. A `ThrottlerGuard` registered as `APP_GUARD` counts as rate limiting, not authentication, so `require-guards` coverage isn't silenced by a throttler.

`require-throttler` now reports once on the root module instead of once per route — that matches how throttling is actually adopted (one module registration), not 93 separate errors.

## Not going inert

Every fix ships a regression fixture taken from the real scans *and* keeps/adds a true-positive test. A synthetic vulnerable app confirms all six rules still fire on unguarded routes, unvalidated bodies, exposed entity fields, and a throttler-less root module.

302 tests (was 194), 100% statements/branches/functions/lines on the package.

Minor release: new options plus a behavioural change to where `require-throttler` reports.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project-wide detection for global NestJS guards, validation pipes, and throttling.
  * Added configuration options for custom decorators, public routes, DTO checking, response DTO patterns, and root modules.
  * Improved recognition of route, authentication, validation, upload, and serialization decorators.

* **Bug Fixes**
  * Reduced false positives for debug endpoints, private fields, validation, guards, and throttling.
  * Throttling findings now report missing application-wide configuration at the root module.
  * Refined handling of credential routes, multipart uploads, and response DTOs.

* **Documentation**
  * Updated rule guidance, configuration references, exclusions, and known limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->