### PR TITLE
test(workspace): A-lite corpus expansion (candidate-research fixtures)

### DIFF
--- a/benchmarks/corpus/CVE/CVE-2025-27152-axios-absolute-url-override/manifest.json
+++ b/benchmarks/corpus/CVE/CVE-2025-27152-axios-absolute-url-override/manifest.json
@@ -1,0 +1,34 @@
+{
+  "cve": "CVE-2025-27152",
+  "ghsa": null,
+  "cwe": "CWE-918",
+  "owasp": "A10:2021",
+  "package": "axios",
+  "vulnerableVersions": "<1.8.2",
+  "fixedVersion": "1.8.2",
+  "summary": "An absolute URL passed to an axios instance ignores baseURL entirely — the request goes to the attacker-chosen origin while the instance still attaches its default Authorization header (SSRF plus credential leak).",
+  "publishedAt": "2025-03-07",
+  "fixCommit": "https://nvd.nist.gov/vuln/detail/CVE-2025-27152",
+  "expectedPlugins": [
+    "eslint-plugin-node-security"
+  ],
+  "expectedRules": [
+    "node-security/no-ssrf"
+  ],
+  "fixtures": {
+    "vulnerable": [
+      {
+        "file": "proxy-fetch.js",
+        "description": "Instance with baseURL and a default Authorization header, called with a user-supplied path that may be absolute"
+      }
+    ],
+    "safe": [
+      {
+        "file": "proxy-fetch-relative-only.js",
+        "description": "User input rejected unless it is a relative path, then joined against the trusted base"
+      }
+    ]
+  },
+  "fixtureMetadataRequired": true,
+  "notes": "The dangerous shape is a configured client (baseURL + default auth header) whose request target comes from the request. allowAbsoluteUrls: false is the library-side control; validating the input is the user-code control."
+}

--- a/benchmarks/corpus/CVE/CVE-2025-27152-axios-absolute-url-override/safe/proxy-fetch-relative-only.js
+++ b/benchmarks/corpus/CVE/CVE-2025-27152-axios-absolute-url-override/safe/proxy-fetch-relative-only.js
@@ -1,0 +1,40 @@
+// CVE-2025-27152 — safe pattern: only relative paths reach the configured client
+// @author        claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// @cwe           CWE-918
+// @expected      safe
+// This must NOT be flagged
+// The path is validated against a strict relative-path shape and resolved
+// against the trusted base before the request is made, so baseURL can never
+// be overridden.
+const express = require('express');
+const axios = require('axios');
+
+const app = express();
+
+const BASE_URL = 'https://internal-api.example.com/v1/';
+const RELATIVE_PATH = /^[a-z0-9][a-z0-9/_-]{0,120}$/i;
+
+const internalApi = axios.create({
+  baseURL: BASE_URL,
+  allowAbsoluteUrls: false,
+  headers: { Authorization: 'Bearer ' + process.env.INTERNAL_API_TOKEN },
+});
+
+app.get('/proxy', async (req, res) => {
+  const requestedPath = req.query.path;
+  if (typeof requestedPath !== 'string' || !RELATIVE_PATH.test(requestedPath)) {
+    return res.status(400).json({ error: 'path must be a relative API path' });
+  }
+
+  const target = new URL(requestedPath, BASE_URL);
+  if (target.origin !== new URL(BASE_URL).origin) {
+    return res.status(400).json({ error: 'path escapes the API base' });
+  }
+
+  const response = await internalApi.get(requestedPath);
+  res.json(response.data);
+});
+
+module.exports = app;

--- a/benchmarks/corpus/CVE/CVE-2025-27152-axios-absolute-url-override/vulnerable/proxy-fetch.js
+++ b/benchmarks/corpus/CVE/CVE-2025-27152-axios-absolute-url-override/vulnerable/proxy-fetch.js
@@ -1,0 +1,25 @@
+// CVE-2025-27152: absolute URL overrides baseURL, Authorization header follows
+// @author        claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// @cwe           CWE-918
+// @expected      vulnerable
+// This MUST be detected
+// If req.query.path is 'https://attacker.example/collect', axios ignores
+// baseURL and sends the internal API token to the attacker's host.
+const express = require('express');
+const axios = require('axios');
+
+const app = express();
+
+const internalApi = axios.create({
+  baseURL: 'https://internal-api.example.com/v1/',
+  headers: { Authorization: 'Bearer ' + process.env.INTERNAL_API_TOKEN },
+});
+
+app.get('/proxy', async (req, res) => {
+  const response = await internalApi.get(req.query.path);
+  res.json(response.data);
+});
+
+module.exports = app;

--- a/benchmarks/corpus/CVE/CVE-2025-29927-nextjs-middleware-only-auth/manifest.json
+++ b/benchmarks/corpus/CVE/CVE-2025-29927-nextjs-middleware-only-auth/manifest.json
@@ -1,0 +1,35 @@
+{
+  "cve": "CVE-2025-29927",
+  "ghsa": null,
+  "cwe": "CWE-306",
+  "owasp": "A01:2021",
+  "package": "next",
+  "vulnerableVersions": "<14.2.25 || >=15.0.0 <15.2.3",
+  "fixedVersion": "14.2.25 / 15.2.3",
+  "summary": "The x-middleware-subrequest header let a request skip middleware execution entirely. Any application whose only authorization check lived in middleware served protected handlers unauthenticated.",
+  "publishedAt": "2025-03-21",
+  "fixCommit": "https://nvd.nist.gov/vuln/detail/CVE-2025-29927",
+  "expectedPlugins": [
+    "eslint-plugin-secure-coding"
+  ],
+  "expectedRules": [
+    "secure-coding/no-missing-authentication",
+    "secure-coding/require-backend-authorization"
+  ],
+  "fixtures": {
+    "vulnerable": [
+      {
+        "file": "middleware-only-auth.js",
+        "description": "Auth gate implemented once in a middleware-style module; the handler trusts a header the middleware set"
+      }
+    ],
+    "safe": [
+      {
+        "file": "per-route-auth-recheck.js",
+        "description": "Handler re-derives the session and re-checks the role itself, independent of middleware"
+      }
+    ]
+  },
+  "fixtureMetadataRequired": true,
+  "notes": "The library fix restores middleware execution; the durable user-code lesson is that middleware is a convenience layer, never the sole authorization boundary. Expressed here in Express terms for corpus consistency."
+}

--- a/benchmarks/corpus/CVE/CVE-2025-29927-nextjs-middleware-only-auth/safe/per-route-auth-recheck.js
+++ b/benchmarks/corpus/CVE/CVE-2025-29927-nextjs-middleware-only-auth/safe/per-route-auth-recheck.js
@@ -1,0 +1,31 @@
+// CVE-2025-29927 — safe pattern: every protected route re-checks authorization
+// @author        claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// @cwe           CWE-306
+// @expected      safe
+// This must NOT be flagged
+// Middleware stays as a fast-path redirect, but the handler independently
+// resolves the session and asserts the role, so skipping middleware changes
+// nothing about who can read the data.
+const express = require('express');
+
+const app = express();
+
+function middleware(req, res, next) {
+  const session = readSession(req);
+  if (!session) return res.redirect('/login');
+  next();
+}
+
+app.use('/admin', middleware);
+
+app.get('/admin/users', async (req, res) => {
+  const session = await getServerSession(req);
+  if (!session || session.role !== 'admin') {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+  res.json(await listAllUsers());
+});
+
+module.exports = app;

--- a/benchmarks/corpus/CVE/CVE-2025-29927-nextjs-middleware-only-auth/vulnerable/middleware-only-auth.js
+++ b/benchmarks/corpus/CVE/CVE-2025-29927-nextjs-middleware-only-auth/vulnerable/middleware-only-auth.js
@@ -1,0 +1,35 @@
+// CVE-2025-29927: authorization exists only in the middleware layer
+// @author        claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// @cwe           CWE-306
+// @expected      vulnerable
+// This MUST be detected
+// The handler performs no check of its own — it trusts a header the gate is
+// supposed to have set. If the middleware is skipped (CVE-2025-29927) or the
+// header is spoofed, /admin/users serves data to anyone.
+const express = require('express');
+
+const app = express();
+
+// middleware.js-style single gate
+function middleware(req, res, next) {
+  const session = readSession(req);
+  if (!session || session.role !== 'admin') {
+    return res.status(302).set('location', '/login').end();
+  }
+  req.headers['x-middleware-authorized'] = 'true';
+  next();
+}
+
+app.use('/admin', middleware);
+
+app.get('/admin/users', async (req, res) => {
+  // Trusts the middleware entirely; no session lookup, no role check.
+  if (req.headers['x-middleware-authorized'] === 'true') {
+    return res.json(await listAllUsers());
+  }
+  res.sendStatus(403);
+});
+
+module.exports = app;

--- a/benchmarks/corpus/CVE/CVE-2025-30208-vite-dev-server-exposure/manifest.json
+++ b/benchmarks/corpus/CVE/CVE-2025-30208-vite-dev-server-exposure/manifest.json
@@ -1,0 +1,33 @@
+{
+  "cve": "CVE-2025-30208",
+  "ghsa": null,
+  "cwe": "CWE-668",
+  "owasp": "A01:2021",
+  "package": "vite",
+  "vulnerableVersions": "<4.5.10 || >=5.0.0 <5.4.15 || >=6.0.0 <6.2.3",
+  "fixedVersion": "6.2.3 (and 5.4.15 / 4.5.10 backports)",
+  "summary": "A crafted ?raw?? / ?import&raw?? suffix bypassed the dev server fs.deny allow-list and returned arbitrary files. Exposure only matters because the dev server is routinely bound to every interface.",
+  "publishedAt": "2025-03-24",
+  "fixCommit": "https://nvd.nist.gov/vuln/detail/CVE-2025-30208",
+  "expectedPlugins": [
+    "eslint-plugin-node-security"
+  ],
+  "expectedRules": [],
+  "coverageGap": "No rule yet inspects bundler dev-server configuration for an all-interfaces bind or a weakened fs.deny list. Candidate: node-security/no-exposed-dev-server.",
+  "fixtures": {
+    "vulnerable": [
+      {
+        "file": "vite.config.exposed.js",
+        "description": "server.host '0.0.0.0', fs.strict disabled and fs.deny emptied — the dev server answers the LAN and serves outside the project root"
+      }
+    ],
+    "safe": [
+      {
+        "file": "vite.config.default.js",
+        "description": "Default localhost bind with fs.strict on and the sensitive-file deny list intact"
+      }
+    ]
+  },
+  "fixtureMetadataRequired": true,
+  "notes": "Config fixture rather than an Express route: the CVE is only reachable when the developer opened the dev server to the network, which is a user-code (config) decision."
+}

--- a/benchmarks/corpus/CVE/CVE-2025-30208-vite-dev-server-exposure/safe/vite.config.default.js
+++ b/benchmarks/corpus/CVE/CVE-2025-30208-vite-dev-server-exposure/safe/vite.config.default.js
@@ -1,0 +1,19 @@
+// CVE-2025-30208 — safe pattern: loopback-only dev server, deny list intact
+// @author        claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// @cwe           CWE-668
+// @expected      safe
+// This must NOT be flagged
+// The dev server listens on localhost only, file serving stays inside the
+// project root, and secrets remain denied.
+module.exports = {
+  server: {
+    host: 'localhost',
+    port: 5173,
+    fs: {
+      strict: true,
+      deny: ['.env', '.env.*', '*.{crt,pem}', '.git/**'],
+    },
+  },
+};

--- a/benchmarks/corpus/CVE/CVE-2025-30208-vite-dev-server-exposure/vulnerable/vite.config.exposed.js
+++ b/benchmarks/corpus/CVE/CVE-2025-30208-vite-dev-server-exposure/vulnerable/vite.config.exposed.js
@@ -1,0 +1,22 @@
+// CVE-2025-30208: dev server bound to every interface with a weakened fs.deny
+// @author        claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// @cwe           CWE-668
+// @expected      vulnerable
+// This MUST be detected
+// host '0.0.0.0' publishes the dev server to the whole network, fs.strict
+// false lets requests escape the project root, and the empty deny list
+// removes the last guard over .env and private keys.
+module.exports = {
+  server: {
+    host: '0.0.0.0',
+    port: 5173,
+    cors: true,
+    fs: {
+      strict: false,
+      allow: ['/'],
+      deny: [],
+    },
+  },
+};

--- a/benchmarks/corpus/CVE/CVE-2025-48757-supabase-service-role-client/manifest.json
+++ b/benchmarks/corpus/CVE/CVE-2025-48757-supabase-service-role-client/manifest.json
@@ -1,0 +1,38 @@
+{
+  "cve": "CVE-2025-48757",
+  "ghsa": null,
+  "cwe": "CWE-522",
+  "owasp": "A02:2021",
+  "package": "@supabase/supabase-js",
+  "vulnerableVersions": "n/a — configuration/usage flaw, not a library version",
+  "fixedVersion": "n/a — remediate by keeping the service-role key server-side and enabling RLS",
+  "summary": "Supabase projects exposed privileged data because client-reachable code held a key that bypasses Row Level Security. A service-role key shipped in a browser bundle is readable by every visitor and grants full table access.",
+  "publishedAt": "2025-05-23",
+  "fixCommit": "https://nvd.nist.gov/vuln/detail/CVE-2025-48757",
+  "expectedPlugins": [
+    "eslint-plugin-browser-security",
+    "eslint-plugin-secure-coding"
+  ],
+  "expectedRules": [],
+  "coverageGap": "No rule yet correlates a client-marked module with a service-role / admin key reference. Candidate: browser-security/no-service-role-key-in-client.",
+  "fixtures": {
+    "vulnerable": [
+      {
+        "file": "client-service-role.js",
+        "description": "'use client' module creating a Supabase client with the SERVICE_ROLE key — the key ships in the browser bundle"
+      }
+    ],
+    "safe": [
+      {
+        "file": "client-anon-key.js",
+        "description": "'use client' module using only the anon key, relying on RLS"
+      },
+      {
+        "file": "server-admin-client.js",
+        "description": "'use server' module holding the service-role key, never imported by client code"
+      }
+    ]
+  },
+  "fixtureMetadataRequired": true,
+  "notes": "The service-role key bypasses RLS by design, so its blast radius equals the whole database. The rule signal is the pairing of a client boundary marker with a privileged key identifier."
+}

--- a/benchmarks/corpus/CVE/CVE-2025-48757-supabase-service-role-client/safe/client-anon-key.js
+++ b/benchmarks/corpus/CVE/CVE-2025-48757-supabase-service-role-client/safe/client-anon-key.js
@@ -1,0 +1,24 @@
+// CVE-2025-48757 — safe pattern: client code uses the anon key only
+// @author        claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// @cwe           CWE-522
+// @expected      safe
+// This must NOT be flagged
+// The anon key is intended to be public; Row Level Security decides what the
+// signed-in user may read, so shipping it in the bundle is expected.
+'use client';
+
+const { createClient } = require('@supabase/supabase-js');
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+);
+
+async function loadMyOrders() {
+  const { data } = await supabase.from('orders').select('id, total_cents, status');
+  return data;
+}
+
+module.exports = { supabase, loadMyOrders };

--- a/benchmarks/corpus/CVE/CVE-2025-48757-supabase-service-role-client/safe/server-admin-client.js
+++ b/benchmarks/corpus/CVE/CVE-2025-48757-supabase-service-role-client/safe/server-admin-client.js
@@ -1,0 +1,25 @@
+// CVE-2025-48757 — safe pattern: service-role key confined to server-only code
+// @author        claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// @cwe           CWE-522
+// @expected      safe
+// This must NOT be flagged
+// This module never reaches the browser bundle: no client marker, and the key
+// is read from a non-public environment variable.
+'use server';
+
+const { createClient } = require('@supabase/supabase-js');
+
+const admin = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY,
+  { auth: { persistSession: false, autoRefreshToken: false } },
+);
+
+async function reconcileOrders() {
+  const { data } = await admin.from('orders').select('*').eq('status', 'pending');
+  return data;
+}
+
+module.exports = { reconcileOrders };

--- a/benchmarks/corpus/CVE/CVE-2025-48757-supabase-service-role-client/vulnerable/client-service-role.js
+++ b/benchmarks/corpus/CVE/CVE-2025-48757-supabase-service-role-client/vulnerable/client-service-role.js
@@ -1,0 +1,25 @@
+// CVE-2025-48757: Supabase service-role key used in client-side code
+// @author        claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// @cwe           CWE-522
+// @expected      vulnerable
+// This MUST be detected
+// Anything in a "use client" module is bundled and shipped to the browser.
+// The service-role key bypasses Row Level Security, so every visitor gets
+// unrestricted read/write on every table.
+'use client';
+
+const { createClient } = require('@supabase/supabase-js');
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.NEXT_PUBLIC_SUPABASE_SERVICE_ROLE_KEY,
+);
+
+async function loadAllOrders() {
+  const { data } = await supabase.from('orders').select('*');
+  return data;
+}
+
+module.exports = { supabase, loadAllOrders };

--- a/benchmarks/corpus/CVE/CVE-2025-7338-multer-unhandled-busboy-error/manifest.json
+++ b/benchmarks/corpus/CVE/CVE-2025-7338-multer-unhandled-busboy-error/manifest.json
@@ -1,0 +1,33 @@
+{
+  "cve": "CVE-2025-7338",
+  "ghsa": null,
+  "cwe": "CWE-248",
+  "owasp": "A05:2021",
+  "package": "multer",
+  "vulnerableVersions": "<2.0.2",
+  "fixedVersion": "2.0.2",
+  "summary": "A malformed multipart request makes the underlying busboy stream emit an error that nothing handles; the uncaught exception takes the whole Node process down (remote DoS).",
+  "publishedAt": "2025-07-14",
+  "fixCommit": "https://nvd.nist.gov/vuln/detail/CVE-2025-7338",
+  "expectedPlugins": [
+    "eslint-plugin-reliability"
+  ],
+  "expectedRules": [],
+  "coverageGap": "No rule yet detects a request stream piped to a sink without an 'error' listener (or an equivalent pipeline() call). Candidate: reliability/require-stream-error-handler.",
+  "fixtures": {
+    "vulnerable": [
+      {
+        "file": "upload-pipe-no-handler.js",
+        "description": "Upload request piped straight into a write stream with no error listener on either end"
+      }
+    ],
+    "safe": [
+      {
+        "file": "upload-pipe-with-handler.js",
+        "description": "stream.pipeline with a callback, plus an explicit error path that answers the request"
+      }
+    ]
+  },
+  "fixtureMetadataRequired": true,
+  "notes": "Authored as the user-code pattern the CVE implies: an unhandled stream error on an upload path is process-fatal, whatever multer version is pinned."
+}

--- a/benchmarks/corpus/CVE/CVE-2025-7338-multer-unhandled-busboy-error/safe/upload-pipe-with-handler.js
+++ b/benchmarks/corpus/CVE/CVE-2025-7338-multer-unhandled-busboy-error/safe/upload-pipe-with-handler.js
@@ -1,0 +1,35 @@
+// CVE-2025-7338 — safe pattern: errors on the upload stream are handled
+// @author        claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// @cwe           CWE-248
+// @expected      safe
+// This must NOT be flagged
+// pipeline() forwards errors from every stage into one callback, and the
+// multer error path answers the request instead of crashing the process.
+const express = require('express');
+const fs = require('fs');
+const { pipeline } = require('stream');
+const multer = require('multer');
+
+const app = express();
+const upload = multer({ dest: '/tmp/uploads', limits: { fileSize: 10 * 1024 * 1024 } });
+
+app.post('/upload', (req, res) => {
+  upload.single('file')(req, res, (uploadErr) => {
+    if (uploadErr) {
+      return res.status(400).json({ error: 'Invalid upload' });
+    }
+
+    const out = fs.createWriteStream('/srv/data/' + req.file.filename);
+    pipeline(req, out, (err) => {
+      if (err) {
+        logger.error({ err }, 'upload stream failed');
+        return res.status(400).json({ error: 'Upload aborted' });
+      }
+      res.json({ stored: req.file.filename });
+    });
+  });
+});
+
+module.exports = app;

--- a/benchmarks/corpus/CVE/CVE-2025-7338-multer-unhandled-busboy-error/vulnerable/upload-pipe-no-handler.js
+++ b/benchmarks/corpus/CVE/CVE-2025-7338-multer-unhandled-busboy-error/vulnerable/upload-pipe-no-handler.js
@@ -1,0 +1,24 @@
+// CVE-2025-7338: upload stream piped with no error handler
+// @author        claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// @cwe           CWE-248
+// @expected      vulnerable
+// This MUST be detected
+// Neither the request stream nor the write stream has an 'error' listener.
+// A truncated or malformed multipart body emits an error with no handler,
+// which Node escalates to an uncaughtException and the process exits.
+const express = require('express');
+const fs = require('fs');
+const multer = require('multer');
+
+const app = express();
+const upload = multer({ dest: '/tmp/uploads' });
+
+app.post('/upload', upload.single('file'), (req, res) => {
+  const out = fs.createWriteStream('/srv/data/' + req.file.filename);
+  req.pipe(out);
+  out.on('finish', () => res.json({ stored: req.file.filename }));
+});
+
+module.exports = app;

--- a/benchmarks/corpus/CVE/CVE-2025-7783-form-data-math-random-boundary/manifest.json
+++ b/benchmarks/corpus/CVE/CVE-2025-7783-form-data-math-random-boundary/manifest.json
@@ -1,0 +1,34 @@
+{
+  "cve": "CVE-2025-7783",
+  "ghsa": null,
+  "cwe": "CWE-338",
+  "owasp": "A02:2021",
+  "package": "form-data",
+  "vulnerableVersions": "<4.0.4",
+  "fixedVersion": "4.0.4",
+  "summary": "Multipart boundary generated with Math.random() — the boundary is predictable, letting an attacker who controls part of the body forge additional multipart parts (parameter injection).",
+  "publishedAt": "2025-07-18",
+  "fixCommit": "https://nvd.nist.gov/vuln/detail/CVE-2025-7783",
+  "expectedPlugins": [
+    "eslint-plugin-node-security"
+  ],
+  "expectedRules": [
+    "node-security/no-math-random-crypto"
+  ],
+  "fixtures": {
+    "vulnerable": [
+      {
+        "file": "boundary-token.js",
+        "description": "Application-side multipart boundary and upload token derived from Math.random()"
+      }
+    ],
+    "safe": [
+      {
+        "file": "boundary-token-fixed.js",
+        "description": "Same boundary and token derived from crypto.randomBytes"
+      }
+    ]
+  },
+  "fixtureMetadataRequired": true,
+  "notes": "The advisory is against the library, but the exploitable shape in user code is identical: a security-relevant separator or token produced by Math.random(). This entry captures the user-code pattern the rule must catch, not form-data internals."
+}

--- a/benchmarks/corpus/CVE/CVE-2025-7783-form-data-math-random-boundary/safe/boundary-token-fixed.js
+++ b/benchmarks/corpus/CVE/CVE-2025-7783-form-data-math-random-boundary/safe/boundary-token-fixed.js
@@ -1,0 +1,31 @@
+// CVE-2025-7783 — post-fix safe pattern: CSPRNG boundary and token
+// @author        claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// @cwe           CWE-338
+// @expected      safe
+// This must NOT be flagged
+// crypto.randomBytes is a CSPRNG: the boundary and the upload token are not
+// predictable from prior values.
+const express = require('express');
+const crypto = require('crypto');
+const FormData = require('form-data');
+
+const app = express();
+
+function generateBoundary() {
+  return '----Boundary' + crypto.randomBytes(16).toString('hex');
+}
+
+app.post('/relay', async (req, res) => {
+  const boundary = generateBoundary();
+  const uploadToken = crypto.randomBytes(32).toString('base64url');
+
+  const form = new FormData({ boundary });
+  form.append('token', uploadToken);
+  form.append('file', req.body.content, { filename: req.body.filename });
+
+  res.json(await forwardToStorage(form, boundary));
+});
+
+module.exports = app;

--- a/benchmarks/corpus/CVE/CVE-2025-7783-form-data-math-random-boundary/vulnerable/boundary-token.js
+++ b/benchmarks/corpus/CVE/CVE-2025-7783-form-data-math-random-boundary/vulnerable/boundary-token.js
@@ -1,0 +1,31 @@
+// CVE-2025-7783: predictable multipart boundary / upload token from Math.random()
+// @author        claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// @cwe           CWE-338
+// @expected      vulnerable
+// This MUST be detected
+// Math.random() is a non-cryptographic PRNG. An attacker who can observe or
+// influence a few outputs can predict the boundary and inject extra parts
+// into a request that a trusted service will parse.
+const express = require('express');
+const FormData = require('form-data');
+
+const app = express();
+
+function generateBoundary() {
+  return '----Boundary' + Math.random().toString(36).slice(2);
+}
+
+app.post('/relay', async (req, res) => {
+  const boundary = generateBoundary();
+  const uploadToken = Math.random().toString(16).slice(2);
+
+  const form = new FormData({ boundary });
+  form.append('token', uploadToken);
+  form.append('file', req.body.content, { filename: req.body.filename });
+
+  res.json(await forwardToStorage(form, boundary));
+});
+
+module.exports = app;

--- a/benchmarks/corpus/CVE/CVE-2026-24120-vm2-sandbox/manifest.json
+++ b/benchmarks/corpus/CVE/CVE-2026-24120-vm2-sandbox/manifest.json
@@ -1,0 +1,33 @@
+{
+  "cve": "CVE-2026-24120",
+  "ghsa": null,
+  "cwe": "CWE-094",
+  "owasp": "A03:2021",
+  "package": "vm2",
+  "vulnerableVersions": "all published versions",
+  "fixedVersion": "none — vm2 is discontinued; migrate to isolated-vm or an out-of-process runner",
+  "summary": "vm2 sandbox escape: host objects reachable from the sandbox let untrusted code obtain the real require and run arbitrary commands on the host. The library has a long history of escapes and is no longer maintained.",
+  "publishedAt": "2026-01-15",
+  "fixCommit": "https://nvd.nist.gov/vuln/detail/CVE-2026-24120",
+  "expectedPlugins": [
+    "eslint-plugin-node-security"
+  ],
+  "expectedRules": [],
+  "coverageGap": "No rule yet flags require('vm2') or NodeVM/VM .run() on request-derived source. Candidate: node-security/no-vm2-sandbox.",
+  "fixtures": {
+    "vulnerable": [
+      {
+        "file": "run-user-script.js",
+        "description": "Express route that evaluates request-supplied source inside a vm2 NodeVM"
+      }
+    ],
+    "safe": [
+      {
+        "file": "run-user-script-isolated.js",
+        "description": "Untrusted source evaluated in an out-of-process isolate with a memory and time budget, no host modules"
+      }
+    ]
+  },
+  "fixtureMetadataRequired": true,
+  "notes": "The correct user-code response to a vm2 CVE is not an upgrade — there is no fixed version. Treat any vm2 usage on an untrusted-input path as the finding."
+}

--- a/benchmarks/corpus/CVE/CVE-2026-24120-vm2-sandbox/safe/run-user-script-isolated.js
+++ b/benchmarks/corpus/CVE/CVE-2026-24120-vm2-sandbox/safe/run-user-script-isolated.js
@@ -1,0 +1,31 @@
+// CVE-2026-24120 — safe pattern: untrusted code runs in a real isolate, no host modules
+// @author        claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// @cwe           CWE-094
+// @expected      safe
+// This must NOT be flagged
+// isolated-vm gives the script its own V8 isolate with no reference to the
+// host realm, plus hard memory and wall-clock budgets.
+const express = require('express');
+const ivm = require('isolated-vm');
+
+const app = express();
+app.use(express.json({ limit: '32kb' }));
+
+app.post('/run', async (req, res) => {
+  const isolate = new ivm.Isolate({ memoryLimit: 16 });
+  try {
+    const context = await isolate.createContext();
+    const script = await isolate.compileScript(String(req.body.script));
+    const result = await script.run(context, { timeout: 250, copy: true });
+    res.json({ result });
+  } catch (err) {
+    logger.warn({ err }, 'user script rejected');
+    res.status(400).json({ error: 'Script failed to run' });
+  } finally {
+    isolate.dispose();
+  }
+});
+
+module.exports = app;

--- a/benchmarks/corpus/CVE/CVE-2026-24120-vm2-sandbox/vulnerable/run-user-script.js
+++ b/benchmarks/corpus/CVE/CVE-2026-24120-vm2-sandbox/vulnerable/run-user-script.js
@@ -1,0 +1,27 @@
+// CVE-2026-24120: untrusted code executed inside a vm2 sandbox
+// @author        claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// @cwe           CWE-094
+// @expected      vulnerable
+// This MUST be detected
+// vm2 is discontinued and has repeated escapes; a sandbox escape here is a
+// direct remote code execution on the application host.
+const express = require('express');
+const { NodeVM } = require('vm2');
+
+const app = express();
+app.use(express.json());
+
+app.post('/run', (req, res) => {
+  const vm = new NodeVM({
+    console: 'redirect',
+    sandbox: {},
+    require: { external: true, builtin: ['fs', 'path'] },
+  });
+
+  const result = vm.run(req.body.script, 'user-script.js');
+  res.json({ result });
+});
+
+module.exports = app;

--- a/benchmarks/corpus/CVE/GHSA-gpj5-g38j-94v9-drizzle-sql-identifier/manifest.json
+++ b/benchmarks/corpus/CVE/GHSA-gpj5-g38j-94v9-drizzle-sql-identifier/manifest.json
@@ -1,0 +1,34 @@
+{
+  "cve": null,
+  "ghsa": "GHSA-gpj5-g38j-94v9",
+  "cwe": "CWE-089",
+  "owasp": "A03:2021",
+  "package": "drizzle-orm",
+  "vulnerableVersions": "see advisory GHSA-gpj5-g38j-94v9",
+  "fixedVersion": "see advisory GHSA-gpj5-g38j-94v9",
+  "summary": "sql.identifier() interpolates its argument into the statement as a quoted identifier without escaping embedded quotes — user-controlled column or table names break out of the identifier and become SQL.",
+  "publishedAt": "2025-01-01",
+  "fixCommit": "https://github.com/advisories/GHSA-gpj5-g38j-94v9",
+  "expectedPlugins": [
+    "eslint-plugin-secure-coding",
+    "eslint-plugin-pg"
+  ],
+  "expectedRules": [],
+  "coverageGap": "No rule yet models drizzle's sql`` template tag or sql.identifier(); parameter-binding rules only cover values, not identifiers. Candidate: secure-coding/no-user-controlled-sql-identifier.",
+  "fixtures": {
+    "vulnerable": [
+      {
+        "file": "order-by-identifier.js",
+        "description": "Sort column taken from req.query and passed to sql.identifier()"
+      }
+    ],
+    "safe": [
+      {
+        "file": "order-by-allowlist.js",
+        "description": "Sort column resolved through a literal allow-list before it reaches sql.identifier()"
+      }
+    ]
+  },
+  "fixtureMetadataRequired": true,
+  "notes": "Identifiers cannot be parameter-bound, so the only user-code defence is an allow-list. This entry exists to make that distinction testable."
+}

--- a/benchmarks/corpus/CVE/GHSA-gpj5-g38j-94v9-drizzle-sql-identifier/safe/order-by-allowlist.js
+++ b/benchmarks/corpus/CVE/GHSA-gpj5-g38j-94v9-drizzle-sql-identifier/safe/order-by-allowlist.js
@@ -1,0 +1,33 @@
+// GHSA-gpj5-g38j-94v9 — safe pattern: identifier resolved from a literal allow-list
+// @author        claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// @cwe           CWE-089
+// @expected      safe
+// This must NOT be flagged
+// The value reaching sql.identifier() is always one of three string literals
+// written in this file, so no request content can influence the statement.
+const express = require('express');
+const { sql } = require('drizzle-orm');
+const { db } = require('./db');
+
+const app = express();
+
+const SORTABLE_COLUMNS = {
+  created: 'created_at',
+  total: 'total_cents',
+  status: 'status',
+};
+
+app.get('/orders', async (req, res) => {
+  const column = SORTABLE_COLUMNS[req.query.sort] || SORTABLE_COLUMNS.created;
+  const direction = req.query.dir === 'desc' ? sql`desc` : sql`asc`;
+
+  const rows = await db.execute(
+    sql`select * from orders order by ${sql.identifier(column)} ${direction} limit 50`,
+  );
+
+  res.json(rows);
+});
+
+module.exports = app;

--- a/benchmarks/corpus/CVE/GHSA-gpj5-g38j-94v9-drizzle-sql-identifier/vulnerable/order-by-identifier.js
+++ b/benchmarks/corpus/CVE/GHSA-gpj5-g38j-94v9-drizzle-sql-identifier/vulnerable/order-by-identifier.js
@@ -1,0 +1,27 @@
+// GHSA-gpj5-g38j-94v9: user input passed to drizzle sql.identifier()
+// @author        claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// @cwe           CWE-089
+// @expected      vulnerable
+// This MUST be detected
+// Identifiers are not parameter-bound. A sort value containing a quote breaks
+// out of the quoted identifier and appends attacker SQL to the statement.
+const express = require('express');
+const { sql } = require('drizzle-orm');
+const { db } = require('./db');
+
+const app = express();
+
+app.get('/orders', async (req, res) => {
+  const sortColumn = req.query.sort;
+  const direction = req.query.dir === 'desc' ? sql`desc` : sql`asc`;
+
+  const rows = await db.execute(
+    sql`select * from orders order by ${sql.identifier(sortColumn)} ${direction} limit 50`,
+  );
+
+  res.json(rows);
+});
+
+module.exports = app;

--- a/benchmarks/corpus/CWE-020/manifest.json
+++ b/benchmarks/corpus/CWE-020/manifest.json
@@ -1,0 +1,53 @@
+{
+  "cwe": "CWE-020",
+  "name": "Improper Input Validation (validation-bypass cluster)",
+  "owasp": "A03:2021",
+  "severity": "HIGH",
+  "expectedPlugins": ["eslint-plugin-secure-coding"],
+  "fixtures": {
+    "vulnerable": [
+      {
+        "file": "incomplete-hostname-regexp.js",
+        "description": "Unescaped '.' in a hostname regexp used as a redirect allowlist"
+      },
+      {
+        "file": "missing-regexp-anchor.js",
+        "description": "postMessage origin check with an unanchored regular expression"
+      },
+      {
+        "file": "url-substring-sanitization.js",
+        "description": "includes()/indexOf() substring match on a URL as an authorization decision"
+      },
+      {
+        "file": "incomplete-url-scheme-check.js",
+        "description": "Scheme denylist blocking only 'javascript:', leaving data:/vbscript:/blob:"
+      },
+      {
+        "file": "incorrect-suffix-check.js",
+        "description": "indexOf-emulated endsWith with no tail boundary (.trusted.com.evil.io passes)"
+      }
+    ],
+    "safe": [
+      {
+        "file": "escaped-anchored-hostname.js",
+        "description": "Hostname regexp with escaped dots and ^…$ anchoring"
+      },
+      {
+        "file": "anchored-origin-regexp.js",
+        "description": "Fully anchored origin regexp for postMessage validation"
+      },
+      {
+        "file": "url-parse-hostname.js",
+        "description": "new URL(url).hostname equality check with fail-closed parse handling"
+      },
+      {
+        "file": "scheme-allowlist.js",
+        "description": "Protocol allowlist permitting only http:/https:"
+      },
+      {
+        "file": "endswith-boundary.js",
+        "description": "String.prototype.endsWith suffix check with explicit dot boundary"
+      }
+    ]
+  }
+}

--- a/benchmarks/corpus/CWE-020/safe/anchored-origin-regexp.js
+++ b/benchmarks/corpus/CWE-020/safe/anchored-origin-regexp.js
@@ -1,0 +1,13 @@
+// CWE-020: Safe — fully anchored origin regexp
+// @author      claude-fable-5
+// @reviewedBy  benchmark-validator
+// @lastReviewed 2026-07-31
+// This MUST NOT be flagged — ^…$ pins the whole origin, so no suffix or prefix trick matches
+const ALLOWED_ORIGIN = /^https:\/\/app\.example\.com$/;
+
+window.addEventListener('message', (event) => {
+  if (!ALLOWED_ORIGIN.test(event.origin)) {
+    return;
+  }
+  applySettings(event.data);
+});

--- a/benchmarks/corpus/CWE-020/safe/endswith-boundary.js
+++ b/benchmarks/corpus/CWE-020/safe/endswith-boundary.js
@@ -1,0 +1,18 @@
+// CWE-020: Safe — suffix check with an explicit dot boundary
+// @author      claude-fable-5
+// @reviewedBy  benchmark-validator
+// @lastReviewed 2026-07-31
+// This MUST NOT be flagged — endsWith pins the tail, and the apex host is matched exactly
+function isTrustedSubdomain(hostname) {
+  const host = String(hostname).toLowerCase().split(':')[0];
+  return host === 'trusted.com' || host.endsWith('.trusted.com');
+}
+
+function issueSessionCookie(req, res) {
+  const host = req.headers.host;
+  if (!isTrustedSubdomain(host)) {
+    res.status(403).end();
+    return;
+  }
+  res.setHeader('Set-Cookie', `sid=${req.session.id}; Domain=${host}; HttpOnly`);
+}

--- a/benchmarks/corpus/CWE-020/safe/escaped-anchored-hostname.js
+++ b/benchmarks/corpus/CWE-020/safe/escaped-anchored-hostname.js
@@ -1,0 +1,15 @@
+// CWE-020: Safe — hostname regexp with escaped dots and full anchoring
+// @author      claude-fable-5
+// @reviewedBy  benchmark-validator
+// @lastReviewed 2026-07-31
+// This MUST NOT be flagged — every metacharacter is escaped and the pattern is anchored at both ends
+const TRUSTED_HOST = /^https:\/\/example\.com(\/[^\s]*)?$/;
+
+function isTrustedRedirect(target) {
+  return TRUSTED_HOST.test(target);
+}
+
+function handleRedirect(req, res) {
+  const target = req.query.next;
+  res.redirect(isTrustedRedirect(target) ? target : '/');
+}

--- a/benchmarks/corpus/CWE-020/safe/scheme-allowlist.js
+++ b/benchmarks/corpus/CWE-020/safe/scheme-allowlist.js
@@ -1,0 +1,20 @@
+// CWE-020: Safe — URL scheme allowlist (http/https only)
+// @author      claude-fable-5
+// @reviewedBy  benchmark-validator
+// @lastReviewed 2026-07-31
+// This MUST NOT be flagged — an allowlist denies javascript:, data:, vbscript: and everything else by default
+const ALLOWED_PROTOCOLS = ['http:', 'https:'];
+
+function sanitizeHref(raw) {
+  try {
+    const parsed = new URL(raw, window.location.origin);
+    return ALLOWED_PROTOCOLS.includes(parsed.protocol) ? parsed.href : '#';
+  } catch (err) {
+    return '#';
+  }
+}
+
+function renderProfileLink(anchor, profile) {
+  anchor.setAttribute('href', sanitizeHref(profile.website));
+  anchor.textContent = profile.websiteLabel;
+}

--- a/benchmarks/corpus/CWE-020/safe/url-parse-hostname.js
+++ b/benchmarks/corpus/CWE-020/safe/url-parse-hostname.js
@@ -1,0 +1,22 @@
+// CWE-020: Safe — host decision made on a parsed URL, not a substring
+// @author      claude-fable-5
+// @reviewedBy  benchmark-validator
+// @lastReviewed 2026-07-31
+// This MUST NOT be flagged — the WHATWG parser gives the real hostname, and a parse failure denies
+function isTrustedApi(url) {
+  try {
+    return new URL(url).hostname === 'trusted.com';
+  } catch (err) {
+    return false;
+  }
+}
+
+async function proxy(req, res) {
+  const target = req.query.url;
+  if (!isTrustedApi(target)) {
+    res.status(400).json({ error: 'untrusted host' });
+    return;
+  }
+  const upstream = await fetch(target);
+  res.json(await upstream.json());
+}

--- a/benchmarks/corpus/CWE-020/vulnerable/incomplete-hostname-regexp.js
+++ b/benchmarks/corpus/CWE-020/vulnerable/incomplete-hostname-regexp.js
@@ -1,0 +1,19 @@
+// CWE-020: Incomplete hostname regexp used as a security decision
+// @author      claude-fable-5
+// @reviewedBy  benchmark-validator
+// @lastReviewed 2026-07-31
+// This MUST be detected — the unescaped '.' matches any character, so "https://exampleXcom.evil.io" passes
+const TRUSTED_HOST = /https?:\/\/example.com/;
+
+function isTrustedRedirect(target) {
+  return TRUSTED_HOST.test(target);
+}
+
+function handleRedirect(req, res) {
+  const target = req.query.next;
+  if (isTrustedRedirect(target)) {
+    res.redirect(target);
+    return;
+  }
+  res.redirect('/');
+}

--- a/benchmarks/corpus/CWE-020/vulnerable/incomplete-url-scheme-check.js
+++ b/benchmarks/corpus/CWE-020/vulnerable/incomplete-url-scheme-check.js
@@ -1,0 +1,17 @@
+// CWE-020: Incomplete URL scheme denylist
+// @author      claude-fable-5
+// @reviewedBy  benchmark-validator
+// @lastReviewed 2026-07-31
+// This MUST be detected — only 'javascript:' is blocked; 'data:', 'vbscript:' and 'blob:' still execute
+function sanitizeHref(raw) {
+  const value = String(raw).trim().toLowerCase();
+  if (value.startsWith('javascript:')) {
+    return '#';
+  }
+  return raw;
+}
+
+function renderProfileLink(anchor, profile) {
+  anchor.setAttribute('href', sanitizeHref(profile.website));
+  anchor.textContent = profile.websiteLabel;
+}

--- a/benchmarks/corpus/CWE-020/vulnerable/incorrect-suffix-check.js
+++ b/benchmarks/corpus/CWE-020/vulnerable/incorrect-suffix-check.js
@@ -1,0 +1,17 @@
+// CWE-020: indexOf-emulated suffix check with no boundary
+// @author      claude-fable-5
+// @reviewedBy  benchmark-validator
+// @lastReviewed 2026-07-31
+// This MUST be detected — the intent is "ends with .trusted.com", but ".trusted.com.evil.io" also matches
+function isTrustedSubdomain(hostname) {
+  return hostname.lastIndexOf('.trusted.com') !== -1;
+}
+
+function issueSessionCookie(req, res) {
+  const host = req.headers.host;
+  if (isTrustedSubdomain(host)) {
+    res.setHeader('Set-Cookie', `sid=${req.session.id}; Domain=${host}; HttpOnly`);
+    return;
+  }
+  res.status(403).end();
+}

--- a/benchmarks/corpus/CWE-020/vulnerable/missing-regexp-anchor.js
+++ b/benchmarks/corpus/CWE-020/vulnerable/missing-regexp-anchor.js
@@ -1,0 +1,13 @@
+// CWE-020: Origin check with an unanchored regular expression
+// @author      claude-fable-5
+// @reviewedBy  benchmark-validator
+// @lastReviewed 2026-07-31
+// This MUST be detected — without ^…$ the pattern matches anywhere, so "https://app.example.com.evil.io" is accepted
+const ALLOWED_ORIGIN = /https:\/\/app\.example\.com/;
+
+window.addEventListener('message', (event) => {
+  if (!ALLOWED_ORIGIN.test(event.origin)) {
+    return;
+  }
+  applySettings(event.data);
+});

--- a/benchmarks/corpus/CWE-020/vulnerable/url-substring-sanitization.js
+++ b/benchmarks/corpus/CWE-020/vulnerable/url-substring-sanitization.js
@@ -1,0 +1,18 @@
+// CWE-020: URL substring check used as an authorization decision
+// @author      claude-fable-5
+// @reviewedBy  benchmark-validator
+// @lastReviewed 2026-07-31
+// This MUST be detected — "https://trusted.com.evil.io/x" and "https://evil.io/?r=trusted.com" both contain the substring
+function isTrustedApi(url) {
+  return url.includes('trusted.com') || url.indexOf('trusted.com') !== -1;
+}
+
+async function proxy(req, res) {
+  const target = req.query.url;
+  if (!isTrustedApi(target)) {
+    res.status(400).json({ error: 'untrusted host' });
+    return;
+  }
+  const upstream = await fetch(target);
+  res.json(await upstream.json());
+}

--- a/benchmarks/corpus/CWE-073/manifest.json
+++ b/benchmarks/corpus/CWE-073/manifest.json
@@ -1,0 +1,28 @@
+{
+  "cwe": "CWE-073",
+  "name": "External Control of File Name or Path (template object injection via res.render)",
+  "owasp": "A03:2021",
+  "severity": "HIGH",
+  "expectedPlugins": [
+    "eslint-plugin-express-security"
+  ],
+  "coverageGap": "No rule yet detects req.body / req.query flowing into the res.render locals object. Candidate: express-security/no-user-controlled-render-locals. Today only generic hardening rules fire on these fixtures.",
+  "fixtures": {
+    "vulnerable": [
+      {
+        "file": "render-body-spread.js",
+        "description": "res.render(view, req.body) — the whole request body becomes the template locals object"
+      },
+      {
+        "file": "render-query-spread.js",
+        "description": "Query string spread into the locals, overriding engine-reserved keys"
+      }
+    ],
+    "safe": [
+      {
+        "file": "render-explicit-locals.js",
+        "description": "Locals built by explicitly picking known fields"
+      }
+    ]
+  }
+}

--- a/benchmarks/corpus/CWE-073/safe/render-explicit-locals.js
+++ b/benchmarks/corpus/CWE-073/safe/render-explicit-locals.js
@@ -1,0 +1,27 @@
+// CWE-073: safe — locals assembled by explicit field picking
+// @author        claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This must NOT be flagged
+// Only the three fields the template actually reads are forwarded, so no
+// request key can reach a view-engine option.
+const express = require('express');
+const helmet = require('helmet');
+const rateLimit = require('express-rate-limit');
+const csrf = require('csurf');
+
+const app = express();
+app.use(helmet());
+app.use(rateLimit({ windowMs: 60000, max: 100 }));
+app.use(express.json({ limit: '10kb' }));
+const csrfProtection = csrf();
+
+app.post('/preview', csrfProtection, (req, res) => {
+  res.render('preview', {
+    title: String(req.body.title || ''),
+    body: String(req.body.body || ''),
+    authorName: String(req.body.authorName || 'anonymous'),
+  });
+});
+
+module.exports = app;

--- a/benchmarks/corpus/CWE-073/vulnerable/render-body-spread.js
+++ b/benchmarks/corpus/CWE-073/vulnerable/render-body-spread.js
@@ -1,0 +1,19 @@
+// CWE-073: template object injection — req.body used as the render locals
+// @author        claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This MUST be detected
+// Express merges the locals object into the view engine options, so a body
+// key such as "layout", "settings" or "cache" reconfigures the engine and can
+// point it at an attacker-chosen file.
+const express = require('express');
+
+const app = express();
+app.use(express.json());
+app.set('view engine', 'pug');
+
+app.post('/preview', (req, res) => {
+  res.render('preview', req.body);
+});
+
+module.exports = app;

--- a/benchmarks/corpus/CWE-073/vulnerable/render-query-spread.js
+++ b/benchmarks/corpus/CWE-073/vulnerable/render-query-spread.js
@@ -1,0 +1,15 @@
+// CWE-073: template object injection — query string spread into render locals
+// @author        claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This MUST be detected
+const express = require('express');
+
+const app = express();
+app.set('view engine', 'ejs');
+
+app.get('/newsletter', (req, res) => {
+  res.render('newsletter', { ...req.query, generatedAt: Date.now() });
+});
+
+module.exports = app;

--- a/benchmarks/corpus/CWE-088/manifest.json
+++ b/benchmarks/corpus/CWE-088/manifest.json
@@ -1,0 +1,17 @@
+{
+  "cwe": "CWE-088",
+  "name": "Argument Injection",
+  "owasp": "A03:2021",
+  "severity": "HIGH",
+  "expectedPlugins": ["eslint-plugin-node-security"],
+  "fixtures": {
+    "vulnerable": [
+      { "file": "git-ls-remote-arg-injection.js", "description": "execFile('git', ['ls-remote', userInput]) — value can become a --upload-pack= flag" },
+      { "file": "tar-user-args.js", "description": "execFile('tar', [...userTokens]) — user options spread into argv enable flag injection" }
+    ],
+    "safe": [
+      { "file": "separator-guard.js", "description": "User value placed after a literal '--' separator" },
+      { "file": "literal-argv.js", "description": "Fully literal argument vector, no user input" }
+    ]
+  }
+}

--- a/benchmarks/corpus/CWE-088/safe/literal-argv.js
+++ b/benchmarks/corpus/CWE-088/safe/literal-argv.js
@@ -1,0 +1,15 @@
+// CWE-088: Safe — fully literal argument vector
+// @author       claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This must NOT be flagged — no user input reaches argv; every token is a
+// hard-coded string constant.
+const { execFile } = require('child_process');
+
+function currentBranch(cb) {
+  execFile('git', ['rev-parse', '--abbrev-ref', 'HEAD'], (err, stdout) => {
+    cb(err, stdout && stdout.trim());
+  });
+}
+
+module.exports = { currentBranch };

--- a/benchmarks/corpus/CWE-088/safe/separator-guard.js
+++ b/benchmarks/corpus/CWE-088/safe/separator-guard.js
@@ -1,0 +1,17 @@
+// CWE-088: Safe — literal "--" separator ends git option parsing
+// @author       claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This must NOT be flagged — everything after "--" is treated as a positional
+// operand, so a leading-dash value can never be parsed as a flag.
+const { execFile } = require('child_process');
+
+function listRemoteRefs(req, res) {
+  const remote = req.query.remote;
+  execFile('git', ['ls-remote', '--', remote], (err, stdout) => {
+    if (err) return res.status(500).end();
+    res.type('text/plain').send(stdout);
+  });
+}
+
+module.exports = { listRemoteRefs };

--- a/benchmarks/corpus/CWE-088/vulnerable/git-ls-remote-arg-injection.js
+++ b/benchmarks/corpus/CWE-088/vulnerable/git-ls-remote-arg-injection.js
@@ -1,0 +1,17 @@
+// CWE-088: Argument Injection — user input becomes a git CLI flag
+// @author       claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This MUST be detected — a value like "--upload-pack=touch /tmp/pwned" is
+// interpreted by git as an option, not a repo URL, giving arbitrary command exec.
+const { execFile } = require('child_process');
+
+function listRemoteRefs(req, res) {
+  const remote = req.query.remote; // attacker-controlled, may start with "--"
+  execFile('git', ['ls-remote', remote], (err, stdout) => {
+    if (err) return res.status(500).end();
+    res.type('text/plain').send(stdout);
+  });
+}
+
+module.exports = { listRemoteRefs };

--- a/benchmarks/corpus/CWE-088/vulnerable/tar-user-args.js
+++ b/benchmarks/corpus/CWE-088/vulnerable/tar-user-args.js
@@ -1,0 +1,16 @@
+// CWE-088: Argument Injection — user-controlled tar arguments spread into argv
+// @author       claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This MUST be detected — splitting user text straight into argv lets an
+// attacker inject flags like "--to-command=sh" and run arbitrary programs.
+const { execFile } = require('child_process');
+
+function extractArchive(req, res) {
+  const opts = req.body.options.split(' '); // e.g. ["-xf", "backup.tar"]
+  execFile('tar', [...opts, req.body.file], (err) => {
+    res.status(err ? 500 : 200).end();
+  });
+}
+
+module.exports = { extractArchive };

--- a/benchmarks/corpus/CWE-094/manifest.json
+++ b/benchmarks/corpus/CWE-094/manifest.json
@@ -1,0 +1,17 @@
+{
+  "cwe": "CWE-094",
+  "name": "Improper Control of Generation of Code (Code Injection)",
+  "owasp": "A03:2021",
+  "severity": "CRITICAL",
+  "expectedPlugins": ["eslint-plugin-node-security"],
+  "fixtures": {
+    "vulnerable": [
+      { "file": "vm2-run-user-code.js", "description": "require('vm2') NodeVM running request-supplied code" },
+      { "file": "vm-run-user-string.js", "description": "vm.runInNewContext on a user-supplied string" }
+    ],
+    "safe": [
+      { "file": "vm-literal-script.js", "description": "vm.runInNewContext with a fully literal script string" },
+      { "file": "worker-isolation.js", "description": "worker_threads isolation running a fixed module, no eval on input" }
+    ]
+  }
+}

--- a/benchmarks/corpus/CWE-094/safe/vm-literal-script.js
+++ b/benchmarks/corpus/CWE-094/safe/vm-literal-script.js
@@ -1,0 +1,17 @@
+// CWE-094: Safe — vm.runInNewContext with a fully literal script
+// @author       claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This must NOT be flagged — the script is a hard-coded string constant and no
+// user input is evaluated; only numeric inputs cross the boundary as data.
+const vm = require('vm');
+
+const SCRIPT = 'total = price * quantity * (1 - discount)';
+
+function computeTotal(price, quantity, discount) {
+  const sandbox = { price, quantity, discount, total: 0 };
+  vm.runInNewContext(SCRIPT, sandbox, { timeout: 50 });
+  return sandbox.total;
+}
+
+module.exports = { computeTotal };

--- a/benchmarks/corpus/CWE-094/safe/worker-isolation.js
+++ b/benchmarks/corpus/CWE-094/safe/worker-isolation.js
@@ -1,0 +1,20 @@
+// CWE-094: Safe — untrusted work delegated to an isolated worker thread
+// @author       claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This must NOT be flagged — no eval/vm on user input; the worker runs a fixed
+// module file and only structured data crosses the thread boundary.
+const { Worker } = require('worker_threads');
+const path = require('path');
+
+function transform(payload) {
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(path.join(__dirname, 'transform.worker.js'), {
+      workerData: payload,
+    });
+    worker.on('message', resolve);
+    worker.on('error', reject);
+  });
+}
+
+module.exports = { transform };

--- a/benchmarks/corpus/CWE-094/vulnerable/vm-run-user-string.js
+++ b/benchmarks/corpus/CWE-094/vulnerable/vm-run-user-string.js
@@ -1,0 +1,15 @@
+// CWE-094: Code Injection — vm.runInNewContext on a user-supplied string
+// @author       claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This MUST be detected — vm is NOT a security sandbox; evaluating attacker
+// text can reach the constructor chain and escape to arbitrary execution.
+const vm = require('vm');
+
+function evaluate(req, res) {
+  const expr = req.query.expr; // attacker-controlled
+  const value = vm.runInNewContext(expr, { Math });
+  res.json({ value });
+}
+
+module.exports = { evaluate };

--- a/benchmarks/corpus/CWE-094/vulnerable/vm2-run-user-code.js
+++ b/benchmarks/corpus/CWE-094/vulnerable/vm2-run-user-code.js
@@ -1,0 +1,15 @@
+// CWE-094: Code Injection — running user code in vm2 (deprecated/broken sandbox)
+// @author       claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This MUST be detected — vm2 is abandoned with known sandbox escapes; running
+// request-supplied source in it is equivalent to arbitrary code execution.
+const { NodeVM } = require('vm2');
+
+function runPlugin(req, res) {
+  const vm = new NodeVM({ console: 'inherit' });
+  const result = vm.run(req.body.code, 'plugin.js'); // untrusted source
+  res.json({ result });
+}
+
+module.exports = { runPlugin };

--- a/benchmarks/corpus/CWE-099/manifest.json
+++ b/benchmarks/corpus/CWE-099/manifest.json
@@ -1,0 +1,15 @@
+{
+  "cwe": "CWE-099",
+  "name": "Improper Control of Resource Identifiers (Environment Injection)",
+  "owasp": "A03:2021",
+  "severity": "HIGH",
+  "expectedPlugins": ["eslint-plugin-node-security"],
+  "fixtures": {
+    "vulnerable": [
+      { "file": "env-key-from-user.js", "description": "process.env[req.body.key] = req.body.value" }
+    ],
+    "safe": [
+      { "file": "env-allowlisted-key.js", "description": "Assignment to a literal env key resolved from a closed allowlist" }
+    ]
+  }
+}

--- a/benchmarks/corpus/CWE-099/safe/env-allowlisted-key.js
+++ b/benchmarks/corpus/CWE-099/safe/env-allowlisted-key.js
@@ -1,0 +1,16 @@
+// CWE-099: Safe — assignment to a fixed allowlisted env key
+// @author       claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This must NOT be flagged — the target key is a literal from a closed
+// allowlist, so user input can never choose which env variable is written.
+const ALLOWED = { locale: 'APP_LOCALE', theme: 'APP_THEME' };
+
+function setConfig(req, res) {
+  const target = ALLOWED[req.body.setting];
+  if (!target) return res.status(400).end();
+  process.env[target] = String(req.body.value);
+  res.status(204).end();
+}
+
+module.exports = { setConfig };

--- a/benchmarks/corpus/CWE-099/vulnerable/env-key-from-user.js
+++ b/benchmarks/corpus/CWE-099/vulnerable/env-key-from-user.js
@@ -1,0 +1,13 @@
+// CWE-099: Resource Injection — process.env key and value from the request
+// @author       claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This MUST be detected — writing an attacker-named env var can overwrite PATH,
+// NODE_OPTIONS, or LD_PRELOAD and alter how later processes execute.
+function setConfig(req, res) {
+  const { key, value } = req.body;
+  process.env[key] = value; // both key and value attacker-controlled
+  res.status(204).end();
+}
+
+module.exports = { setConfig };

--- a/benchmarks/corpus/CWE-1007/manifest.json
+++ b/benchmarks/corpus/CWE-1007/manifest.json
@@ -1,0 +1,29 @@
+{
+  "cwe": "CWE-1007",
+  "name": "Insufficient Visual Distinction of Homoglyphs Presented to User",
+  "owasp": "A07:2021",
+  "severity": "MEDIUM",
+  "expectedPlugins": ["eslint-plugin-secure-coding"],
+  "fixtures": {
+    "vulnerable": [
+      {
+        "file": "cyrillic-homoglyph-identifier.js",
+        "description": "Identifier pair visually identical via Cyrillic 'а' (U+0430); auth check reads the impostor"
+      },
+      {
+        "file": "zero-width-in-auth-string.js",
+        "description": "Zero-width space (U+200B) inside a group literal used in an equality auth check"
+      }
+    ],
+    "safe": [
+      {
+        "file": "ascii-identifiers.js",
+        "description": "Plain ASCII identifiers with a single canonical role constant"
+      },
+      {
+        "file": "i18n-ui-copy.js",
+        "description": "Legitimate Hebrew/Russian/Japanese translation strings in UI copy (FP lock)"
+      }
+    ]
+  }
+}

--- a/benchmarks/corpus/CWE-1007/safe/ascii-identifiers.js
+++ b/benchmarks/corpus/CWE-1007/safe/ascii-identifiers.js
@@ -1,0 +1,15 @@
+// CWE-1007: Safe — plain ASCII identifiers, one canonical role constant
+// @author      claude-fable-5
+// @reviewedBy  benchmark-validator
+// @lastReviewed 2026-07-31
+// This MUST NOT be flagged — every identifier is ASCII and the comparison uses the single source of truth
+const ADMIN_ROLE = 'admin';
+const GUEST_ROLE = 'guest';
+
+function grantAccess(user) {
+  return user.role === ADMIN_ROLE ? 'full-access' : 'read-only';
+}
+
+function describe(user) {
+  return `${user.name} (${grantAccess(user)})`;
+}

--- a/benchmarks/corpus/CWE-1007/safe/i18n-ui-copy.js
+++ b/benchmarks/corpus/CWE-1007/safe/i18n-ui-copy.js
@@ -1,0 +1,15 @@
+// CWE-1007: Safe — legitimate non-ASCII text in translated UI copy
+// @author      claude-fable-5
+// @reviewedBy  benchmark-validator
+// @lastReviewed 2026-07-31
+// This MUST NOT be flagged — non-Latin script here is user-facing translation data, not an identifier or a security comparison
+const MESSAGES = {
+  en: { signIn: 'Sign in', adminBadge: 'Administrator' },
+  he: { signIn: 'התחברות', adminBadge: 'מנהל מערכת' },
+  ru: { signIn: 'Войти', adminBadge: 'Администратор' },
+  ja: { signIn: 'ログイン', adminBadge: '管理者' },
+};
+
+function renderSignInButton(button, locale) {
+  button.textContent = (MESSAGES[locale] || MESSAGES.en).signIn;
+}

--- a/benchmarks/corpus/CWE-1007/vulnerable/cyrillic-homoglyph-identifier.js
+++ b/benchmarks/corpus/CWE-1007/vulnerable/cyrillic-homoglyph-identifier.js
@@ -1,0 +1,15 @@
+// CWE-1007: Homoglyph — two identifiers that render identically
+// @author      claude-fable-5
+// @reviewedBy  benchmark-validator
+// @lastReviewed 2026-07-31
+// This MUST be detected — the second declaration uses Cyrillic 'а' (U+0430); the auth check reads the impostor
+const adminRole = 'admin';
+const аdminRole = 'guest';
+
+function grantAccess(user) {
+  return user.role === аdminRole ? 'full-access' : 'read-only';
+}
+
+function describe(user) {
+  return `${user.name} (${grantAccess(user)})`;
+}

--- a/benchmarks/corpus/CWE-1007/vulnerable/zero-width-in-auth-string.js
+++ b/benchmarks/corpus/CWE-1007/vulnerable/zero-width-in-auth-string.js
@@ -1,0 +1,14 @@
+// CWE-1007: Invisible Format character inside an auth comparison value
+// @author      claude-fable-5
+// @reviewedBy  benchmark-validator
+// @lastReviewed 2026-07-31
+// This MUST be detected — the group literal carries a zero-width space (U+200B), so the equality check silently never matches
+const ADMIN_GROUP = 'admin​';
+
+function isAdmin(user) {
+  return user.group === ADMIN_GROUP;
+}
+
+function renderDeleteButton(button, user) {
+  button.hidden = !isAdmin(user);
+}

--- a/benchmarks/corpus/CWE-116/manifest.json
+++ b/benchmarks/corpus/CWE-116/manifest.json
@@ -1,0 +1,29 @@
+{
+  "cwe": "CWE-116",
+  "name": "Improper Encoding or Escaping of Output (broken sanitizers)",
+  "owasp": "A03:2021",
+  "severity": "HIGH",
+  "expectedPlugins": ["eslint-plugin-secure-coding"],
+  "fixtures": {
+    "vulnerable": [
+      {
+        "file": "single-pass-replace.js",
+        "description": "Non-global replace('<script>', '') removes only the first match"
+      },
+      {
+        "file": "tag-filter-regexp.js",
+        "description": "Regexp tag filter /<script.*?>.*?<\\/script>/ used as HTML sanitization"
+      }
+    ],
+    "safe": [
+      {
+        "file": "dompurify-sanitize.js",
+        "description": "DOMPurify.sanitize with an explicit tag/attribute allowlist"
+      },
+      {
+        "file": "replace-until-stable.js",
+        "description": "Global replace looped until the output stops changing, then written as text"
+      }
+    ]
+  }
+}

--- a/benchmarks/corpus/CWE-116/safe/dompurify-sanitize.js
+++ b/benchmarks/corpus/CWE-116/safe/dompurify-sanitize.js
@@ -1,0 +1,11 @@
+// CWE-116: Safe — dedicated HTML sanitizer with an explicit allowlist
+// @author      claude-fable-5
+// @reviewedBy  benchmark-validator
+// @lastReviewed 2026-07-31
+// This MUST NOT be flagged — DOMPurify parses the markup and drops anything outside the allowlist
+function renderComment(node, comment) {
+  node.innerHTML = DOMPurify.sanitize(comment.bodyHtml, {
+    ALLOWED_TAGS: ['b', 'i', 'em', 'strong', 'a', 'p', 'br'],
+    ALLOWED_ATTR: ['href', 'title'],
+  });
+}

--- a/benchmarks/corpus/CWE-116/safe/replace-until-stable.js
+++ b/benchmarks/corpus/CWE-116/safe/replace-until-stable.js
@@ -1,0 +1,20 @@
+// CWE-116: Safe — global replace applied until the output is stable
+// @author      claude-fable-5
+// @reviewedBy  benchmark-validator
+// @lastReviewed 2026-07-31
+// This MUST NOT be flagged — the loop removes nested/overlapping tags, and the result is written as text
+const HTML_TAG = /<[^>]*>/g;
+
+function stripTags(input) {
+  let current = String(input);
+  let previous;
+  do {
+    previous = current;
+    current = current.replace(HTML_TAG, '');
+  } while (current !== previous);
+  return current;
+}
+
+function renderBio(container, req) {
+  container.textContent = stripTags(req.body.bio);
+}

--- a/benchmarks/corpus/CWE-116/vulnerable/single-pass-replace.js
+++ b/benchmarks/corpus/CWE-116/vulnerable/single-pass-replace.js
@@ -1,0 +1,12 @@
+// CWE-116: Broken sanitizer — single-pass, non-global replace()
+// @author      claude-fable-5
+// @reviewedBy  benchmark-validator
+// @lastReviewed 2026-07-31
+// This MUST be detected — a string-argument replace() removes only the FIRST match, so "<scr<script>ipt>" survives
+function stripScripts(input) {
+  return input.replace('<script>', '').replace('</script>', '');
+}
+
+function renderBio(container, req) {
+  container.innerHTML = stripScripts(req.body.bio);
+}

--- a/benchmarks/corpus/CWE-116/vulnerable/tag-filter-regexp.js
+++ b/benchmarks/corpus/CWE-116/vulnerable/tag-filter-regexp.js
@@ -1,0 +1,14 @@
+// CWE-116: Broken sanitizer — regexp tag filter as HTML sanitization
+// @author      claude-fable-5
+// @reviewedBy  benchmark-validator
+// @lastReviewed 2026-07-31
+// This MUST be detected — '.' skips newlines and only <script> is targeted, so <img onerror=…> and <script\n> pass
+const SCRIPT_TAG = /<script.*?>.*?<\/script>/gi;
+
+function sanitizeHtml(html) {
+  return html.replace(SCRIPT_TAG, '');
+}
+
+function renderComment(node, comment) {
+  node.innerHTML = sanitizeHtml(comment.bodyHtml);
+}

--- a/benchmarks/corpus/CWE-117/manifest.json
+++ b/benchmarks/corpus/CWE-117/manifest.json
@@ -1,0 +1,29 @@
+{
+  "cwe": "CWE-117",
+  "name": "Improper Output Neutralization for Logs (log injection)",
+  "owasp": "A09:2021",
+  "severity": "MEDIUM",
+  "expectedPlugins": ["eslint-plugin-secure-coding"],
+  "fixtures": {
+    "vulnerable": [
+      {
+        "file": "newline-in-log-message.js",
+        "description": "req.body.username concatenated into a log message (CR/LF forges records)"
+      },
+      {
+        "file": "template-literal-log.js",
+        "description": "Untrusted header/query values interpolated into a log template literal"
+      }
+    ],
+    "safe": [
+      {
+        "file": "stripped-newlines.js",
+        "description": "CR/LF and control characters stripped before logging"
+      },
+      {
+        "file": "structured-logging.js",
+        "description": "Constant message plus JSON-encoded fields for untrusted values"
+      }
+    ]
+  }
+}

--- a/benchmarks/corpus/CWE-117/safe/stripped-newlines.js
+++ b/benchmarks/corpus/CWE-117/safe/stripped-newlines.js
@@ -1,0 +1,14 @@
+// CWE-117: Safe — CR/LF stripped before the value reaches the log line
+// @author      claude-fable-5
+// @reviewedBy  benchmark-validator
+// @lastReviewed 2026-07-31
+// This MUST NOT be flagged — record boundaries cannot be forged once newlines and tabs are removed
+function sanitizeForLog(value) {
+  return String(value)
+    .replace(/[\r\n\t]+/g, ' ')
+    .slice(0, 256);
+}
+
+function onLoginAttempt(req) {
+  logger.info('login attempt: ' + sanitizeForLog(req.body.username));
+}

--- a/benchmarks/corpus/CWE-117/safe/structured-logging.js
+++ b/benchmarks/corpus/CWE-117/safe/structured-logging.js
@@ -1,0 +1,20 @@
+// CWE-117: Safe — structured logging keeps untrusted input in an encoded field
+// @author      claude-fable-5
+// @reviewedBy  benchmark-validator
+// @lastReviewed 2026-07-31
+// This MUST NOT be flagged — the message is a constant and user data is a JSON-encoded field, not a line fragment
+function onLoginAttempt(req) {
+  logger.info({ event: 'login_attempt', username: req.body.username }, 'login attempt');
+}
+
+function auditRequest(req) {
+  logger.info(
+    {
+      event: 'request',
+      username: req.query.user,
+      ip: req.headers['x-forwarded-for'],
+      path: req.path,
+    },
+    'request handled',
+  );
+}

--- a/benchmarks/corpus/CWE-117/vulnerable/newline-in-log-message.js
+++ b/benchmarks/corpus/CWE-117/vulnerable/newline-in-log-message.js
@@ -1,0 +1,12 @@
+// CWE-117: Log injection — request field concatenated into a log line
+// @author      claude-fable-5
+// @reviewedBy  benchmark-validator
+// @lastReviewed 2026-07-31
+// This MUST be detected — a username containing \r\n forges an extra log record ("admin\n[INFO] login ok")
+function onLoginAttempt(req) {
+  logger.info('login attempt: ' + req.body.username);
+}
+
+function onLoginFailure(req, reason) {
+  logger.warn('login failed for ' + req.body.username + ' reason=' + reason);
+}

--- a/benchmarks/corpus/CWE-117/vulnerable/template-literal-log.js
+++ b/benchmarks/corpus/CWE-117/vulnerable/template-literal-log.js
@@ -1,0 +1,13 @@
+// CWE-117: Log injection — untrusted header interpolated into a log template
+// @author      claude-fable-5
+// @reviewedBy  benchmark-validator
+// @lastReviewed 2026-07-31
+// This MUST be detected — headers and query params are attacker-controlled and may carry CR/LF
+function auditRequest(req) {
+  const forwardedFor = req.headers['x-forwarded-for'];
+  logger.info(`request user=${req.query.user} ip=${forwardedFor} path=${req.path}`);
+}
+
+function auditExport(req, rows) {
+  console.log(`export by ${req.query.user}: ${rows.length} rows`);
+}

--- a/benchmarks/corpus/CWE-178/manifest.json
+++ b/benchmarks/corpus/CWE-178/manifest.json
@@ -1,0 +1,24 @@
+{
+  "cwe": "CWE-178",
+  "name": "Improper Handling of Case Sensitivity (auth-guard path bypass)",
+  "owasp": "A01:2021",
+  "severity": "HIGH",
+  "expectedPlugins": [
+    "eslint-plugin-express-security"
+  ],
+  "coverageGap": "No rule yet compares a case-sensitive path guard against a case-insensitive route matcher. Candidate: express-security/require-case-insensitive-path-guard. no-exposed-debug-endpoints fires on the /admin literal, but for an unrelated reason.",
+  "fixtures": {
+    "vulnerable": [
+      {
+        "file": "case-sensitive-admin-guard.js",
+        "description": "Guard compares req.path with a case-sensitive prefix while the route matches case-insensitively"
+      }
+    ],
+    "safe": [
+      {
+        "file": "normalized-path-guard.js",
+        "description": "Guard lowercases the path before comparing, matching the routers case-insensitive semantics"
+      }
+    ]
+  }
+}

--- a/benchmarks/corpus/CWE-178/safe/normalized-path-guard.js
+++ b/benchmarks/corpus/CWE-178/safe/normalized-path-guard.js
@@ -1,0 +1,32 @@
+// CWE-178: safe — path normalized to lower case before the prefix check
+// @author        claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This must NOT be flagged
+// Guard and router now agree on case, so '/Admin/users' is gated exactly the
+// same way the lower-case spelling is.
+const express = require('express');
+const helmet = require('helmet');
+const rateLimit = require('express-rate-limit');
+
+const ADMIN_PREFIX = '/admin/';
+
+const app = express();
+app.use(helmet());
+app.use(rateLimit({ windowMs: 60000, max: 100 }));
+
+app.use((req, res, next) => {
+  const normalizedPath = req.path.toLowerCase();
+  if (normalizedPath.startsWith(ADMIN_PREFIX)) {
+    if (!req.user || req.user.role !== 'admin') {
+      return res.sendStatus(403);
+    }
+  }
+  next();
+});
+
+app.get(/^\/admin\/users$/i, async (req, res) => {
+  res.json(await listAllUsers());
+});
+
+module.exports = app;

--- a/benchmarks/corpus/CWE-178/vulnerable/case-sensitive-admin-guard.js
+++ b/benchmarks/corpus/CWE-178/vulnerable/case-sensitive-admin-guard.js
@@ -1,0 +1,25 @@
+// CWE-178: case-sensitive guard in front of a case-insensitive route
+// @author        claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This MUST be detected
+// The guard only sees '/admin', but the route regex has the 'i' flag, so
+// GET /Admin/users reaches the handler with no authorization check at all.
+const express = require('express');
+
+const app = express();
+
+app.use((req, res, next) => {
+  if (req.path.startsWith('/admin')) {
+    if (!req.user || req.user.role !== 'admin') {
+      return res.sendStatus(403);
+    }
+  }
+  next();
+});
+
+app.get(/^\/admin\/users$/i, async (req, res) => {
+  res.json(await listAllUsers());
+});
+
+module.exports = app;

--- a/benchmarks/corpus/CWE-209/manifest.json
+++ b/benchmarks/corpus/CWE-209/manifest.json
@@ -1,0 +1,28 @@
+{
+  "cwe": "CWE-209",
+  "name": "Generation of Error Message Containing Sensitive Information (stack-trace exposure)",
+  "owasp": "A05:2021",
+  "severity": "MEDIUM",
+  "expectedPlugins": [
+    "eslint-plugin-express-security"
+  ],
+  "coverageGap": "No rule yet detects err.stack / a raw error object reaching res.send / res.json. Candidate: express-security/no-error-details-in-response. Today only generic hardening rules fire on these fixtures.",
+  "fixtures": {
+    "vulnerable": [
+      {
+        "file": "stack-in-response.js",
+        "description": "Error handler sends err.stack straight to the client"
+      },
+      {
+        "file": "error-object-in-json.js",
+        "description": "Route serialises the caught error object into the JSON response"
+      }
+    ],
+    "safe": [
+      {
+        "file": "generic-error-response.js",
+        "description": "Generic client message plus a server-side log of the real error"
+      }
+    ]
+  }
+}

--- a/benchmarks/corpus/CWE-209/safe/generic-error-response.js
+++ b/benchmarks/corpus/CWE-209/safe/generic-error-response.js
@@ -1,0 +1,31 @@
+// CWE-209: safe — generic client message, real error logged server-side
+// @author        claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This must NOT be flagged
+// The client gets a correlation id and nothing else; the detail stays in the
+// server log where only operators can read it.
+const express = require('express');
+const helmet = require('helmet');
+const rateLimit = require('express-rate-limit');
+const crypto = require('crypto');
+
+const app = express();
+app.use(helmet());
+app.use(rateLimit({ windowMs: 60000, max: 100 }));
+
+app.use((err, req, res, next) => {
+  const incidentId = crypto.randomUUID();
+  logger.error({ incidentId, err, path: req.path }, 'unhandled request error');
+  res.status(500).json({ error: 'Internal Server Error', incidentId });
+});
+
+app.get('/reports/:id', async (req, res, next) => {
+  try {
+    res.json(await loadReport(req.params.id));
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = app;

--- a/benchmarks/corpus/CWE-209/vulnerable/error-object-in-json.js
+++ b/benchmarks/corpus/CWE-209/vulnerable/error-object-in-json.js
@@ -1,0 +1,21 @@
+// CWE-209: stack-trace exposure — the caught error is serialised into JSON
+// @author        claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This MUST be detected
+// Driver errors carry query text, connection strings and hostnames; echoing
+// the error object hands all of it to the caller.
+const express = require('express');
+
+const app = express();
+
+app.post('/invoices', async (req, res) => {
+  try {
+    const invoice = await db.insertInvoice(req.body);
+    res.status(201).json(invoice);
+  } catch (err) {
+    res.status(500).json({ error: err, message: err.message, stack: err.stack });
+  }
+});
+
+module.exports = app;

--- a/benchmarks/corpus/CWE-209/vulnerable/stack-in-response.js
+++ b/benchmarks/corpus/CWE-209/vulnerable/stack-in-response.js
@@ -1,0 +1,24 @@
+// CWE-209: stack-trace exposure — err.stack written to the HTTP response
+// @author        claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This MUST be detected
+// The stack reveals absolute paths, dependency versions and internal module
+// layout — a free reconnaissance channel for an attacker.
+const express = require('express');
+
+const app = express();
+
+app.use((err, req, res, next) => {
+  res.status(500).send(err.stack);
+});
+
+app.get('/reports/:id', async (req, res, next) => {
+  try {
+    res.json(await loadReport(req.params.id));
+  } catch (err) {
+    res.status(500).send(err.stack);
+  }
+});
+
+module.exports = app;

--- a/benchmarks/corpus/CWE-248/manifest.json
+++ b/benchmarks/corpus/CWE-248/manifest.json
@@ -1,0 +1,17 @@
+{
+  "cwe": "CWE-248",
+  "name": "Uncaught Exception (Unhandled Stream Error)",
+  "owasp": "A04:2021",
+  "severity": "MEDIUM",
+  "expectedPlugins": ["eslint-plugin-node-security"],
+  "fixtures": {
+    "vulnerable": [
+      { "file": "pipe-no-error-listener.js", "description": "fs.createReadStream(p).pipe(res) with no 'error' listener" },
+      { "file": "multipart-pipe-no-handler.js", "description": "busboy file stream piped without an error handler" }
+    ],
+    "safe": [
+      { "file": "pipe-with-error-listener.js", "description": ".on('error', handler) attached before piping" },
+      { "file": "pipeline-promises.js", "description": "pipeline() from stream/promises centralizes error handling" }
+    ]
+  }
+}

--- a/benchmarks/corpus/CWE-248/safe/pipe-with-error-listener.js
+++ b/benchmarks/corpus/CWE-248/safe/pipe-with-error-listener.js
@@ -1,0 +1,17 @@
+// CWE-248: Safe — error listener attached before piping
+// @author       claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This must NOT be flagged — the 'error' event is handled, so a failed read
+// responds with 404 instead of throwing an uncaught exception.
+const fs = require('fs');
+
+function download(req, res) {
+  const stream = fs.createReadStream(`./uploads/${req.params.id}`);
+  stream.on('error', () => {
+    if (!res.headersSent) res.status(404).end();
+  });
+  stream.pipe(res);
+}
+
+module.exports = { download };

--- a/benchmarks/corpus/CWE-248/safe/pipeline-promises.js
+++ b/benchmarks/corpus/CWE-248/safe/pipeline-promises.js
@@ -1,0 +1,18 @@
+// CWE-248: Safe — stream/promises pipeline centralizes error handling
+// @author       claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This must NOT be flagged — pipeline() forwards and awaits errors, cleans up
+// every stream, and surfaces failures via the rejected promise.
+const fs = require('fs');
+const { pipeline } = require('stream/promises');
+
+async function download(req, res) {
+  try {
+    await pipeline(fs.createReadStream(`./uploads/${req.params.id}`), res);
+  } catch {
+    if (!res.headersSent) res.status(404).end();
+  }
+}
+
+module.exports = { download };

--- a/benchmarks/corpus/CWE-248/vulnerable/multipart-pipe-no-handler.js
+++ b/benchmarks/corpus/CWE-248/vulnerable/multipart-pipe-no-handler.js
@@ -1,0 +1,18 @@
+// CWE-248: Uncaught Exception — multipart stream piped without error handling
+// @author       claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This MUST be detected — a truncated upload makes busboy's file stream emit
+// 'error'; with no handler on either stream the exception takes down the server.
+const Busboy = require('busboy');
+const fs = require('fs');
+
+function upload(req, res) {
+  const busboy = Busboy({ headers: req.headers });
+  busboy.on('file', (name, file) => {
+    file.pipe(fs.createWriteStream(`./tmp/${name}`)); // unhandled 'error'
+  });
+  req.pipe(busboy);
+}
+
+module.exports = { upload };

--- a/benchmarks/corpus/CWE-248/vulnerable/pipe-no-error-listener.js
+++ b/benchmarks/corpus/CWE-248/vulnerable/pipe-no-error-listener.js
@@ -1,0 +1,14 @@
+// CWE-248: Uncaught Exception — piping a file stream with no error handler
+// @author       claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This MUST be detected — if the file is missing or the read fails, the stream
+// emits 'error' with no listener, which throws and crashes the process.
+const fs = require('fs');
+
+function download(req, res) {
+  const filePath = `./uploads/${req.params.id}`;
+  fs.createReadStream(filePath).pipe(res); // no .on('error', ...)
+}
+
+module.exports = { download };

--- a/benchmarks/corpus/CWE-295/manifest.json
+++ b/benchmarks/corpus/CWE-295/manifest.json
@@ -1,0 +1,17 @@
+{
+  "cwe": "CWE-295",
+  "name": "Improper Certificate Validation",
+  "owasp": "A07:2021",
+  "severity": "HIGH",
+  "expectedPlugins": ["eslint-plugin-node-security"],
+  "fixtures": {
+    "vulnerable": [
+      { "file": "reject-unauthorized-false.js", "description": "https.request({ rejectUnauthorized: false })" },
+      { "file": "tls-checkserveridentity-noop.js", "description": "tls.connect with checkServerIdentity: () => undefined" }
+    ],
+    "safe": [
+      { "file": "tls-default-verification.js", "description": "https.request with default certificate verification" },
+      { "file": "tls-checkserveridentity-validates.js", "description": "Custom checkServerIdentity that delegates + returns errors" }
+    ]
+  }
+}

--- a/benchmarks/corpus/CWE-295/safe/tls-checkserveridentity-validates.js
+++ b/benchmarks/corpus/CWE-295/safe/tls-checkserveridentity-validates.js
@@ -1,0 +1,24 @@
+// CWE-295: Safe — custom checkServerIdentity that still validates
+// @author       claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This must NOT be flagged — it delegates to tls.checkServerIdentity and
+// returns the Error on mismatch, then additionally pins the allowed host.
+const tls = require('tls');
+
+function connect(host) {
+  return tls.connect({
+    host,
+    port: 443,
+    checkServerIdentity: (hostname, cert) => {
+      const err = tls.checkServerIdentity(hostname, cert);
+      if (err) return err; // propagate the verification failure
+      if (hostname !== 'api.internal.example') {
+        return new Error(`unexpected host: ${hostname}`);
+      }
+      return undefined;
+    },
+  });
+}
+
+module.exports = { connect };

--- a/benchmarks/corpus/CWE-295/safe/tls-default-verification.js
+++ b/benchmarks/corpus/CWE-295/safe/tls-default-verification.js
@@ -1,0 +1,19 @@
+// CWE-295: Safe — default certificate verification
+// @author       claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This must NOT be flagged — no verification options are overridden, so Node
+// validates the chain and hostname with its built-in defaults.
+const https = require('https');
+
+function fetchSecret(host, cb) {
+  const req = https.request({ host, path: '/secret', method: 'GET' }, (res) => {
+    let body = '';
+    res.on('data', (c) => (body += c));
+    res.on('end', () => cb(null, body));
+  });
+  req.on('error', cb);
+  req.end();
+}
+
+module.exports = { fetchSecret };

--- a/benchmarks/corpus/CWE-295/vulnerable/reject-unauthorized-false.js
+++ b/benchmarks/corpus/CWE-295/vulnerable/reject-unauthorized-false.js
@@ -1,0 +1,22 @@
+// CWE-295: Improper Certificate Validation — rejectUnauthorized: false
+// @author       claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This MUST be detected — disabling rejectUnauthorized accepts any certificate,
+// including a MITM attacker's self-signed one, breaking TLS trust entirely.
+const https = require('https');
+
+function fetchSecret(host, cb) {
+  const req = https.request(
+    { host, path: '/secret', rejectUnauthorized: false },
+    (res) => {
+      let body = '';
+      res.on('data', (c) => (body += c));
+      res.on('end', () => cb(null, body));
+    }
+  );
+  req.on('error', cb);
+  req.end();
+}
+
+module.exports = { fetchSecret };

--- a/benchmarks/corpus/CWE-295/vulnerable/tls-checkserveridentity-noop.js
+++ b/benchmarks/corpus/CWE-295/vulnerable/tls-checkserveridentity-noop.js
@@ -1,0 +1,17 @@
+// CWE-295: Improper Certificate Validation — checkServerIdentity stubbed out
+// @author       claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This MUST be detected — returning undefined from checkServerIdentity signals
+// "hostname OK" for every cert, so a valid cert for any domain is accepted.
+const tls = require('tls');
+
+function connect(host) {
+  return tls.connect({
+    host,
+    port: 443,
+    checkServerIdentity: () => undefined, // never reports a mismatch
+  });
+}
+
+module.exports = { connect };

--- a/benchmarks/corpus/CWE-327/manifest.json
+++ b/benchmarks/corpus/CWE-327/manifest.json
@@ -1,6 +1,6 @@
 {
   "cwe": "CWE-327",
-  "name": "Use of a Broken or Risky Cryptographic Algorithm (JWT alg=none)",
+  "name": "Use of a Broken or Risky Cryptographic Algorithm",
   "owasp": "A02:2021",
   "severity": "CRITICAL",
   "expectedPlugins": [

--- a/benchmarks/corpus/CWE-327/manifest.json
+++ b/benchmarks/corpus/CWE-327/manifest.json
@@ -3,15 +3,46 @@
   "name": "Use of a Broken or Risky Cryptographic Algorithm (JWT alg=none)",
   "owasp": "A02:2021",
   "severity": "CRITICAL",
-  "expectedPlugins": ["eslint-plugin-jwt"],
+  "expectedPlugins": [
+    "eslint-plugin-jwt",
+    "eslint-plugin-node-security"
+  ],
   "fixtures": {
     "vulnerable": [
-      { "file": "sign-alg-none.js", "description": "jwt.sign with algorithm: 'none'" },
-      { "file": "verify-allows-none.js", "description": "jwt.verify with algorithms array including 'none'" }
+      {
+        "file": "sign-alg-none.js",
+        "description": "jwt.sign with algorithm: 'none'"
+      },
+      {
+        "file": "verify-allows-none.js",
+        "description": "jwt.verify with algorithms array including 'none'"
+      },
+      {
+        "file": "gcm-decipher-no-final.js",
+        "description": "AEAD misuse \u2014 aes-256-gcm decryption never calls .final(), auth tag unverified"
+      },
+      {
+        "file": "gcm-decrypt-no-authtag.js",
+        "description": "AEAD misuse \u2014 aes-256-gcm decryption without setAuthTag, integrity never checked"
+      }
     ],
     "safe": [
-      { "file": "sign-rs256.js", "description": "jwt.sign with explicit RS256 algorithm" },
-      { "file": "verify-allowlist.js", "description": "jwt.verify with explicit allowlist excluding none" }
+      {
+        "file": "sign-rs256.js",
+        "description": "jwt.sign with explicit RS256 algorithm"
+      },
+      {
+        "file": "verify-allowlist.js",
+        "description": "jwt.verify with explicit allowlist excluding none"
+      },
+      {
+        "file": "gcm-decrypt-verified.js",
+        "description": "aes-256-gcm decryption with setAuthTag + final() enforcing integrity"
+      },
+      {
+        "file": "gcm-encrypt-authtag.js",
+        "description": "aes-256-gcm encryption capturing the auth tag via getAuthTag()"
+      }
     ]
   }
 }

--- a/benchmarks/corpus/CWE-327/safe/gcm-decrypt-verified.js
+++ b/benchmarks/corpus/CWE-327/safe/gcm-decrypt-verified.js
@@ -1,0 +1,17 @@
+// CWE-327: Safe — GCM decryption verifies the auth tag
+// @author       claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This must NOT be flagged — setAuthTag() plus final() enforce integrity;
+// final() throws on a tag mismatch, so tampered ciphertext is rejected.
+const crypto = require('crypto');
+
+function decrypt(key, iv, authTag, ciphertext) {
+  const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+  decipher.setAuthTag(authTag);
+  let out = decipher.update(ciphertext, 'hex', 'utf8');
+  out += decipher.final('utf8'); // throws if the tag does not verify
+  return out;
+}
+
+module.exports = { decrypt };

--- a/benchmarks/corpus/CWE-327/safe/gcm-encrypt-authtag.js
+++ b/benchmarks/corpus/CWE-327/safe/gcm-encrypt-authtag.js
@@ -1,0 +1,18 @@
+// CWE-327: Safe — GCM encryption captures the auth tag
+// @author       claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This must NOT be flagged — the auth tag is produced via getAuthTag() after
+// final() and returned so the peer can verify integrity on decrypt.
+const crypto = require('crypto');
+
+function encrypt(key, plaintext) {
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+  let ct = cipher.update(plaintext, 'utf8', 'hex');
+  ct += cipher.final('hex');
+  const authTag = cipher.getAuthTag();
+  return { iv, ct, authTag };
+}
+
+module.exports = { encrypt };

--- a/benchmarks/corpus/CWE-327/vulnerable/gcm-decipher-no-final.js
+++ b/benchmarks/corpus/CWE-327/vulnerable/gcm-decipher-no-final.js
@@ -1,0 +1,17 @@
+// CWE-327: AEAD misuse — GCM decryption never calls .final()
+// @author       claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This MUST be detected — without decipher.final() the GCM auth tag is never
+// verified, so tampered ciphertext is accepted as authentic plaintext.
+const crypto = require('crypto');
+
+function decrypt(key, iv, authTag, ciphertext) {
+  const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+  decipher.setAuthTag(authTag);
+  const out = decipher.update(ciphertext, 'hex', 'utf8');
+  // BUG: decipher.final() omitted — the integrity check is skipped entirely
+  return out;
+}
+
+module.exports = { decrypt };

--- a/benchmarks/corpus/CWE-327/vulnerable/gcm-decrypt-no-authtag.js
+++ b/benchmarks/corpus/CWE-327/vulnerable/gcm-decrypt-no-authtag.js
@@ -1,0 +1,17 @@
+// CWE-327: AEAD misuse — GCM decryption without setAuthTag
+// @author       claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This MUST be detected — decrypting AES-GCM without setAuthTag() means the
+// authentication tag is never checked, defeating the whole point of AEAD.
+const crypto = require('crypto');
+
+function decrypt(key, iv, ciphertext) {
+  const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+  // BUG: no decipher.setAuthTag(tag) — forged ciphertext decrypts "successfully"
+  let out = decipher.update(ciphertext, 'hex', 'utf8');
+  out += decipher.final('utf8');
+  return out;
+}
+
+module.exports = { decrypt };

--- a/benchmarks/corpus/CWE-377/manifest.json
+++ b/benchmarks/corpus/CWE-377/manifest.json
@@ -1,0 +1,16 @@
+{
+  "cwe": "CWE-377",
+  "name": "Insecure Temporary File",
+  "owasp": "A04:2021",
+  "severity": "MEDIUM",
+  "expectedPlugins": ["eslint-plugin-node-security"],
+  "fixtures": {
+    "vulnerable": [
+      { "file": "static-tmp-write.js", "description": "fs.writeFileSync to a hard-coded /tmp/app-export.json path" },
+      { "file": "tmpdir-static-name.js", "description": "os.tmpdir() joined with a constant filename" }
+    ],
+    "safe": [
+      { "file": "mkdtemp-write.js", "description": "fs.mkdtempSync(path.join(os.tmpdir(), prefix)) creates a unique dir" }
+    ]
+  }
+}

--- a/benchmarks/corpus/CWE-377/safe/mkdtemp-write.js
+++ b/benchmarks/corpus/CWE-377/safe/mkdtemp-write.js
@@ -1,0 +1,18 @@
+// CWE-377: Safe — unique temp directory via mkdtempSync
+// @author       claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This must NOT be flagged — mkdtempSync creates a fresh 0700 directory with a
+// random suffix, so the path is unpredictable and not race-able.
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+function exportData(records) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'app-export-'));
+  const file = path.join(dir, 'export.json');
+  fs.writeFileSync(file, JSON.stringify(records));
+  return file;
+}
+
+module.exports = { exportData };

--- a/benchmarks/corpus/CWE-377/vulnerable/static-tmp-write.js
+++ b/benchmarks/corpus/CWE-377/vulnerable/static-tmp-write.js
@@ -1,0 +1,15 @@
+// CWE-377: Insecure Temporary File — predictable path in a shared directory
+// @author       claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This MUST be detected — a fixed /tmp path is world-predictable; an attacker
+// can pre-create or symlink it to clobber or hijack the written data.
+const fs = require('fs');
+
+function exportData(records) {
+  const file = '/tmp/app-export.json';
+  fs.writeFileSync(file, JSON.stringify(records));
+  return file;
+}
+
+module.exports = { exportData };

--- a/benchmarks/corpus/CWE-377/vulnerable/tmpdir-static-name.js
+++ b/benchmarks/corpus/CWE-377/vulnerable/tmpdir-static-name.js
@@ -1,0 +1,17 @@
+// CWE-377: Insecure Temporary File — os.tmpdir() joined with a static name
+// @author       claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This MUST be detected — the filename is constant, so the full path is
+// guessable and subject to a symlink race in the shared temp directory.
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+function cacheReport(buffer) {
+  const file = path.join(os.tmpdir(), 'report-cache.tmp');
+  fs.writeFileSync(file, buffer);
+  return file;
+}
+
+module.exports = { cacheReport };

--- a/benchmarks/corpus/CWE-409/manifest.json
+++ b/benchmarks/corpus/CWE-409/manifest.json
@@ -1,0 +1,15 @@
+{
+  "cwe": "CWE-409",
+  "name": "Improper Handling of Highly Compressed Data (Decompression Bomb)",
+  "owasp": "A05:2021",
+  "severity": "HIGH",
+  "expectedPlugins": ["eslint-plugin-node-security"],
+  "fixtures": {
+    "vulnerable": [
+      { "file": "gunzip-no-limit.js", "description": "zlib.gunzip(reqBody, cb) with no maxOutputLength" }
+    ],
+    "safe": [
+      { "file": "gunzip-limited.js", "description": "zlib.gunzip with { maxOutputLength } ceiling" }
+    ]
+  }
+}

--- a/benchmarks/corpus/CWE-409/safe/gunzip-limited.js
+++ b/benchmarks/corpus/CWE-409/safe/gunzip-limited.js
@@ -1,0 +1,18 @@
+// CWE-409: Safe — gunzip capped with maxOutputLength
+// @author       claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This must NOT be flagged — maxOutputLength makes zlib abort with an error
+// once output exceeds the cap, so a bomb cannot exhaust memory.
+const zlib = require('zlib');
+
+const MAX_OUTPUT = 10 * 1024 * 1024; // 10 MB ceiling
+
+function inflateBody(reqBody, cb) {
+  zlib.gunzip(reqBody, { maxOutputLength: MAX_OUTPUT }, (err, buf) => {
+    if (err) return cb(err);
+    cb(null, buf.toString('utf8'));
+  });
+}
+
+module.exports = { inflateBody };

--- a/benchmarks/corpus/CWE-409/vulnerable/gunzip-no-limit.js
+++ b/benchmarks/corpus/CWE-409/vulnerable/gunzip-no-limit.js
@@ -1,0 +1,16 @@
+// CWE-409: Decompression Bomb — gunzip without maxOutputLength
+// @author       claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This MUST be detected — a few KB of crafted gzip can inflate to gigabytes;
+// with no maxOutputLength the whole expansion is buffered into memory (DoS).
+const zlib = require('zlib');
+
+function inflateBody(reqBody, cb) {
+  zlib.gunzip(reqBody, (err, buf) => {
+    if (err) return cb(err);
+    cb(null, buf.toString('utf8'));
+  });
+}
+
+module.exports = { inflateBody };

--- a/benchmarks/corpus/CWE-444/manifest.json
+++ b/benchmarks/corpus/CWE-444/manifest.json
@@ -1,0 +1,17 @@
+{
+  "cwe": "CWE-444",
+  "name": "Inconsistent Interpretation of HTTP Requests (HTTP Request Smuggling)",
+  "owasp": "A03:2021",
+  "severity": "HIGH",
+  "expectedPlugins": ["eslint-plugin-node-security"],
+  "fixtures": {
+    "vulnerable": [
+      { "file": "server-insecure-parser.js", "description": "http.createServer({ insecureHTTPParser: true })" },
+      { "file": "request-insecure-parser.js", "description": "https.request with insecureHTTPParser: true" }
+    ],
+    "safe": [
+      { "file": "server-default-parser.js", "description": "http.createServer with default strict parser" },
+      { "file": "request-default-parser.js", "description": "https.request with default options, no insecureHTTPParser" }
+    ]
+  }
+}

--- a/benchmarks/corpus/CWE-444/safe/request-default-parser.js
+++ b/benchmarks/corpus/CWE-444/safe/request-default-parser.js
@@ -1,0 +1,19 @@
+// CWE-444: Safe — outbound request uses the default strict parser
+// @author       claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This must NOT be flagged — options omit insecureHTTPParser, so responses with
+// ambiguous framing are rejected rather than silently accepted.
+const https = require('https');
+
+function fetchProfile(host, path, cb) {
+  const req = https.request({ host, path, method: 'GET' }, (res) => {
+    let body = '';
+    res.on('data', (c) => (body += c));
+    res.on('end', () => cb(null, body));
+  });
+  req.on('error', cb);
+  req.end();
+}
+
+module.exports = { fetchProfile };

--- a/benchmarks/corpus/CWE-444/safe/server-default-parser.js
+++ b/benchmarks/corpus/CWE-444/safe/server-default-parser.js
@@ -1,0 +1,15 @@
+// CWE-444: Safe — server uses the strict default HTTP parser
+// @author       claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This must NOT be flagged — no insecureHTTPParser option is set; Node's strict
+// llhttp parser rejects ambiguous message framing.
+const http = require('http');
+
+const server = http.createServer((req, res) => {
+  res.end('ok');
+});
+
+server.listen(8080);
+
+module.exports = server;

--- a/benchmarks/corpus/CWE-444/vulnerable/request-insecure-parser.js
+++ b/benchmarks/corpus/CWE-444/vulnerable/request-insecure-parser.js
@@ -1,0 +1,22 @@
+// CWE-444: HTTP Request Smuggling — insecureHTTPParser on an outbound request
+// @author       claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This MUST be detected — a lenient client parser trusts sloppy upstream
+// framing, which can desync a shared proxy and poison other responses.
+const https = require('https');
+
+function fetchProfile(host, path, cb) {
+  const req = https.request(
+    { host, path, method: 'GET', insecureHTTPParser: true },
+    (res) => {
+      let body = '';
+      res.on('data', (c) => (body += c));
+      res.on('end', () => cb(null, body));
+    }
+  );
+  req.on('error', cb);
+  req.end();
+}
+
+module.exports = { fetchProfile };

--- a/benchmarks/corpus/CWE-444/vulnerable/server-insecure-parser.js
+++ b/benchmarks/corpus/CWE-444/vulnerable/server-insecure-parser.js
@@ -1,0 +1,15 @@
+// CWE-444: HTTP Request Smuggling — insecureHTTPParser enabled on the server
+// @author       claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This MUST be detected — insecureHTTPParser accepts malformed/ambiguous
+// framing (conflicting Content-Length/Transfer-Encoding), enabling smuggling.
+const http = require('http');
+
+const server = http.createServer({ insecureHTTPParser: true }, (req, res) => {
+  res.end('ok');
+});
+
+server.listen(8080);
+
+module.exports = server;

--- a/benchmarks/corpus/CWE-548/manifest.json
+++ b/benchmarks/corpus/CWE-548/manifest.json
@@ -1,0 +1,28 @@
+{
+  "cwe": "CWE-548",
+  "name": "Exposure of Information Through Directory Listing",
+  "owasp": "A01:2021",
+  "severity": "HIGH",
+  "expectedPlugins": [
+    "eslint-plugin-express-security"
+  ],
+  "coverageGap": "No rule yet detects express.static(__dirname) or serveIndex at the project root. Candidate: express-security/no-static-root-exposure. Today only generic hardening rules fire on these fixtures.",
+  "fixtures": {
+    "vulnerable": [
+      {
+        "file": "static-root-dirname.js",
+        "description": "express.static(__dirname) publishes the whole application directory"
+      },
+      {
+        "file": "serve-index-root.js",
+        "description": "serveIndex mounted at / renders a browsable listing of the project root"
+      }
+    ],
+    "safe": [
+      {
+        "file": "static-public-dir.js",
+        "description": "express.static scoped to a dedicated public/ directory with listings off"
+      }
+    ]
+  }
+}

--- a/benchmarks/corpus/CWE-548/safe/static-public-dir.js
+++ b/benchmarks/corpus/CWE-548/safe/static-public-dir.js
@@ -1,0 +1,24 @@
+// CWE-548: safe — static hosting scoped to a dedicated public directory
+// @author        claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This must NOT be flagged
+// Only files intentionally placed in public/ are reachable, directory
+// listings are disabled and dotfiles are ignored.
+const express = require('express');
+const helmet = require('helmet');
+const rateLimit = require('express-rate-limit');
+const path = require('path');
+
+const app = express();
+app.use(helmet());
+app.use(rateLimit({ windowMs: 60000, max: 100 }));
+
+app.use(
+  express.static(path.join(__dirname, 'public'), {
+    index: 'index.html',
+    dotfiles: 'ignore',
+  }),
+);
+
+module.exports = app;

--- a/benchmarks/corpus/CWE-548/vulnerable/serve-index-root.js
+++ b/benchmarks/corpus/CWE-548/vulnerable/serve-index-root.js
@@ -1,0 +1,14 @@
+// CWE-548: directory listing — serveIndex mounted at the project root
+// @author        claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This MUST be detected
+const express = require('express');
+const serveIndex = require('serve-index');
+
+const app = express();
+
+app.use(express.static(__dirname));
+app.use(serveIndex('/', { icons: true }));
+
+module.exports = app;

--- a/benchmarks/corpus/CWE-548/vulnerable/static-root-dirname.js
+++ b/benchmarks/corpus/CWE-548/vulnerable/static-root-dirname.js
@@ -1,0 +1,16 @@
+// CWE-548: private file exposure — the application directory served statically
+// @author        claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This MUST be detected
+// Serving __dirname publishes .env, package-lock.json, .git metadata and the
+// server source itself.
+const express = require('express');
+
+const app = express();
+
+app.use(express.static(__dirname));
+
+app.get('/health', (req, res) => res.send('ok'));
+
+module.exports = app;

--- a/benchmarks/corpus/CWE-598/manifest.json
+++ b/benchmarks/corpus/CWE-598/manifest.json
@@ -1,0 +1,28 @@
+{
+  "cwe": "CWE-598",
+  "name": "Use of GET Request Method With Sensitive Query Strings",
+  "owasp": "A09:2021",
+  "severity": "MEDIUM",
+  "expectedPlugins": [
+    "eslint-plugin-express-security"
+  ],
+  "coverageGap": "No rule yet detects credential-like req.query keys (password, token, otp, api_key) on a GET route. Candidate: express-security/no-sensitive-data-in-query. Today only generic hardening rules fire on these fixtures.",
+  "fixtures": {
+    "vulnerable": [
+      {
+        "file": "login-via-query.js",
+        "description": "GET /login reads username and password out of req.query"
+      },
+      {
+        "file": "token-in-query.js",
+        "description": "GET route consumes an API token and OTP from the query string"
+      }
+    ],
+    "safe": [
+      {
+        "file": "login-via-body-post.js",
+        "description": "Same credentials read from req.body on a POST route"
+      }
+    ]
+  }
+}

--- a/benchmarks/corpus/CWE-598/safe/login-via-body-post.js
+++ b/benchmarks/corpus/CWE-598/safe/login-via-body-post.js
@@ -1,0 +1,29 @@
+// CWE-598: safe — the same secrets travel in a POST body
+// @author        claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This must NOT be flagged
+// A request body is not logged by default, is not stored in browser history
+// and never leaks through Referer.
+const express = require('express');
+const helmet = require('helmet');
+const rateLimit = require('express-rate-limit');
+const csrf = require('csurf');
+
+const app = express();
+app.use(helmet());
+app.use(rateLimit({ windowMs: 60000, max: 10 }));
+app.use(express.json({ limit: '10kb' }));
+const csrfProtection = csrf();
+
+app.post('/login', csrfProtection, async (req, res) => {
+  const { username, password } = req.body;
+
+  const user = await authenticate(username, password);
+  if (!user) return res.status(401).json({ error: 'Invalid credentials' });
+
+  req.session.userId = user.id;
+  res.json({ ok: true });
+});
+
+module.exports = app;

--- a/benchmarks/corpus/CWE-598/vulnerable/login-via-query.js
+++ b/benchmarks/corpus/CWE-598/vulnerable/login-via-query.js
@@ -1,0 +1,22 @@
+// CWE-598: credentials in the query string of a GET request
+// @author        claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This MUST be detected
+// Query strings land in access logs, proxy logs, browser history and the
+// Referer header of every outbound link on the response page.
+const express = require('express');
+
+const app = express();
+
+app.get('/login', async (req, res) => {
+  const { username, password } = req.query;
+
+  const user = await authenticate(username, password);
+  if (!user) return res.status(401).send('Invalid credentials');
+
+  req.session.userId = user.id;
+  res.redirect('/dashboard');
+});
+
+module.exports = app;

--- a/benchmarks/corpus/CWE-598/vulnerable/token-in-query.js
+++ b/benchmarks/corpus/CWE-598/vulnerable/token-in-query.js
@@ -1,0 +1,21 @@
+// CWE-598: API token and one-time code carried in the query string
+// @author        claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This MUST be detected
+const express = require('express');
+
+const app = express();
+
+app.get('/api/export', async (req, res) => {
+  const apiToken = req.query.api_token;
+  const otp = req.query.otp;
+
+  if (!(await verifyToken(apiToken, otp))) {
+    return res.sendStatus(403);
+  }
+
+  res.json(await exportAccountData(apiToken));
+});
+
+module.exports = app;

--- a/benchmarks/corpus/CWE-636/manifest.json
+++ b/benchmarks/corpus/CWE-636/manifest.json
@@ -1,0 +1,29 @@
+{
+  "cwe": "CWE-636",
+  "name": "Not Failing Securely ('Failing Open')",
+  "owasp": "A07:2021",
+  "severity": "HIGH",
+  "expectedPlugins": ["eslint-plugin-secure-coding"],
+  "fixtures": {
+    "vulnerable": [
+      {
+        "file": "catch-returns-true.js",
+        "description": "try { verifyToken() } catch { return true } — failure grants access"
+      },
+      {
+        "file": "empty-catch-continues.js",
+        "description": "Empty catch around assertAdmin(), privileged destructive call continues"
+      }
+    ],
+    "safe": [
+      {
+        "file": "catch-denies.js",
+        "description": "Catch block returns false — verification failure denies access"
+      },
+      {
+        "file": "catch-rethrows.js",
+        "description": "Catch block logs and rethrows before the privileged call is reached"
+      }
+    ]
+  }
+}

--- a/benchmarks/corpus/CWE-636/safe/catch-denies.js
+++ b/benchmarks/corpus/CWE-636/safe/catch-denies.js
@@ -1,0 +1,21 @@
+// CWE-636: Safe — the catch block denies
+// @author      claude-fable-5
+// @reviewedBy  benchmark-validator
+// @lastReviewed 2026-07-31
+// This MUST NOT be flagged — any verification failure resolves to "not authorized"
+function isAuthorized(token) {
+  try {
+    return verifyToken(token).valid === true;
+  } catch (err) {
+    logger.warn({ event: 'token_verify_failed', reason: err.name });
+    return false;
+  }
+}
+
+function handleRequest(req, res) {
+  if (!isAuthorized(req.headers.authorization)) {
+    res.status(401).end();
+    return;
+  }
+  res.json(loadAccountData(req.params.id));
+}

--- a/benchmarks/corpus/CWE-636/safe/catch-rethrows.js
+++ b/benchmarks/corpus/CWE-636/safe/catch-rethrows.js
@@ -1,0 +1,17 @@
+// CWE-636: Safe — the catch block rethrows before any privileged work
+// @author      claude-fable-5
+// @reviewedBy  benchmark-validator
+// @lastReviewed 2026-07-31
+// This MUST NOT be flagged — the error is logged and rethrown, so the destructive call is never reached
+async function handleAdminAction(req, res) {
+  let actor;
+  try {
+    actor = await assertAdmin(req.headers.authorization);
+  } catch (err) {
+    logger.error({ event: 'admin_assert_failed', reason: err.name });
+    throw err;
+  }
+
+  await purgeTable(req.body.table);
+  res.json({ ok: true, actor: actor.id });
+}

--- a/benchmarks/corpus/CWE-636/vulnerable/catch-returns-true.js
+++ b/benchmarks/corpus/CWE-636/vulnerable/catch-returns-true.js
@@ -1,0 +1,20 @@
+// CWE-636: Fail-open — auth check whose catch block returns "authorized"
+// @author      claude-fable-5
+// @reviewedBy  benchmark-validator
+// @lastReviewed 2026-07-31
+// This MUST be detected — a malformed or expired token throws, and the catch grants access
+function isAuthorized(token) {
+  try {
+    return verifyToken(token).valid;
+  } catch (err) {
+    return true;
+  }
+}
+
+function handleRequest(req, res) {
+  if (!isAuthorized(req.headers.authorization)) {
+    res.status(401).end();
+    return;
+  }
+  res.json(loadAccountData(req.params.id));
+}

--- a/benchmarks/corpus/CWE-636/vulnerable/empty-catch-continues.js
+++ b/benchmarks/corpus/CWE-636/vulnerable/empty-catch-continues.js
@@ -1,0 +1,16 @@
+// CWE-636: Fail-open — empty catch around an auth check, privileged work continues
+// @author      claude-fable-5
+// @reviewedBy  benchmark-validator
+// @lastReviewed 2026-07-31
+// This MUST be detected — assertAdmin() throwing is swallowed and the destructive call runs anyway
+async function handleAdminAction(req, res) {
+  let actor = null;
+  try {
+    actor = await assertAdmin(req.headers.authorization);
+  } catch (err) {
+    // ignore
+  }
+
+  await purgeTable(req.body.table);
+  res.json({ ok: true, actor: actor && actor.id });
+}

--- a/benchmarks/corpus/CWE-640/manifest.json
+++ b/benchmarks/corpus/CWE-640/manifest.json
@@ -1,0 +1,28 @@
+{
+  "cwe": "CWE-640",
+  "name": "Weak Password Recovery Mechanism (host-header poisoning in reset links)",
+  "owasp": "A07:2021",
+  "severity": "HIGH",
+  "expectedPlugins": [
+    "eslint-plugin-express-security"
+  ],
+  "coverageGap": "No rule yet detects a reset/verification URL built from req.headers.host or x-forwarded-host and passed to a mail sender. Candidate: express-security/no-host-header-in-links. Today only generic hardening rules (require-helmet, require-rate-limiting) fire on these fixtures.",
+  "fixtures": {
+    "vulnerable": [
+      {
+        "file": "reset-link-host-header.js",
+        "description": "Password-reset URL built from req.headers.host and mailed to the user"
+      },
+      {
+        "file": "reset-link-forwarded-host.js",
+        "description": "Reset URL origin taken from the attacker-controllable X-Forwarded-Host header"
+      }
+    ],
+    "safe": [
+      {
+        "file": "reset-link-config-origin.js",
+        "description": "Reset URL origin read from a server-side configuration constant"
+      }
+    ]
+  }
+}

--- a/benchmarks/corpus/CWE-640/safe/reset-link-config-origin.js
+++ b/benchmarks/corpus/CWE-640/safe/reset-link-config-origin.js
@@ -1,0 +1,38 @@
+// CWE-640: safe — reset link origin comes from server-side config
+// @author        claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This must NOT be flagged
+// The public origin is a deployment constant. No request header participates
+// in building the link, so a poisoned Host cannot redirect the token.
+const express = require('express');
+const helmet = require('helmet');
+const rateLimit = require('express-rate-limit');
+const csrf = require('csurf');
+const nodemailer = require('nodemailer');
+
+const PUBLIC_ORIGIN = process.env.PUBLIC_ORIGIN || 'https://app.example.com';
+
+const app = express();
+app.use(helmet());
+app.use(rateLimit({ windowMs: 60000, max: 20 }));
+app.use(express.json({ limit: '10kb' }));
+const csrfProtection = csrf();
+
+const mailer = nodemailer.createTransport({ sendmail: true });
+
+app.post('/forgot-password', csrfProtection, async (req, res) => {
+  const user = await findUserByEmail(req.body.email);
+  const token = await createResetToken(user.id);
+  const resetUrl = PUBLIC_ORIGIN + '/reset?token=' + encodeURIComponent(token);
+
+  await mailer.sendMail({
+    to: user.email,
+    subject: 'Reset your password',
+    text: 'Reset here: ' + resetUrl,
+  });
+
+  res.sendStatus(202);
+});
+
+module.exports = app;

--- a/benchmarks/corpus/CWE-640/vulnerable/reset-link-forwarded-host.js
+++ b/benchmarks/corpus/CWE-640/vulnerable/reset-link-forwarded-host.js
@@ -1,0 +1,27 @@
+// CWE-640: host-header poisoning — reset origin from X-Forwarded-Host
+// @author        claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This MUST be detected
+// X-Forwarded-Host is set by the client on any request that reaches the app
+// directly, so the mailed reset origin is fully attacker-controlled.
+const express = require('express');
+const nodemailer = require('nodemailer');
+
+const app = express();
+const mailer = nodemailer.createTransport({ sendmail: true });
+
+app.post('/account/recover', async (req, res) => {
+  const origin = req.headers['x-forwarded-host'] || req.headers.host;
+  const token = await createResetToken(req.body.userId);
+
+  await mailer.sendMail({
+    to: req.body.email,
+    subject: 'Account recovery',
+    text: 'Recover here: https://' + origin + '/recover/' + token,
+  });
+
+  res.json({ sent: true });
+});
+
+module.exports = app;

--- a/benchmarks/corpus/CWE-640/vulnerable/reset-link-host-header.js
+++ b/benchmarks/corpus/CWE-640/vulnerable/reset-link-host-header.js
@@ -1,0 +1,29 @@
+// CWE-640: host-header poisoning — password-reset link built from req.headers.host
+// @author        claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This MUST be detected
+// An attacker sends a reset request with Host: evil.example and receives a
+// mail whose reset link points at their own server, leaking the token.
+const express = require('express');
+const nodemailer = require('nodemailer');
+
+const app = express();
+const transport = nodemailer.createTransport({ sendmail: true });
+
+app.post('/forgot-password', async (req, res) => {
+  const user = await findUserByEmail(req.body.email);
+  const token = await createResetToken(user.id);
+
+  const resetUrl = 'https://' + req.headers.host + '/reset?token=' + token;
+
+  await transport.sendMail({
+    to: user.email,
+    subject: 'Reset your password',
+    html: '<a href="' + resetUrl + '">Reset your password</a>',
+  });
+
+  res.sendStatus(202);
+});
+
+module.exports = app;

--- a/benchmarks/corpus/CWE-770/manifest.json
+++ b/benchmarks/corpus/CWE-770/manifest.json
@@ -1,0 +1,16 @@
+{
+  "cwe": "CWE-770",
+  "name": "Allocation of Resources Without Limits or Throttling",
+  "owasp": "A05:2021",
+  "severity": "HIGH",
+  "expectedPlugins": ["eslint-plugin-node-security"],
+  "fixtures": {
+    "vulnerable": [
+      { "file": "buffer-alloc-user.js", "description": "Buffer.alloc(Number(req.query.size)) — size straight from the request" },
+      { "file": "array-length-user.js", "description": "new Array(n) with n from the request body" }
+    ],
+    "safe": [
+      { "file": "buffer-alloc-clamped.js", "description": "Math.min(clamped, MAX) applied before Buffer.alloc" }
+    ]
+  }
+}

--- a/benchmarks/corpus/CWE-770/safe/buffer-alloc-clamped.js
+++ b/benchmarks/corpus/CWE-770/safe/buffer-alloc-clamped.js
@@ -1,0 +1,19 @@
+// CWE-770: Safe — allocation clamped to a hard maximum
+// @author       claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This must NOT be flagged — the requested size is bounded by MAX_BYTES before
+// any allocation, so a hostile value cannot exceed a small ceiling.
+const http = require('http');
+
+const MAX_BYTES = 64 * 1024;
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, 'http://localhost');
+  const requested = Number(url.searchParams.get('size')) || 0;
+  const size = Math.min(Math.max(requested, 0), MAX_BYTES);
+  const buf = Buffer.alloc(size);
+  res.end(`allocated ${buf.length} bytes`);
+});
+
+module.exports = server;

--- a/benchmarks/corpus/CWE-770/vulnerable/array-length-user.js
+++ b/benchmarks/corpus/CWE-770/vulnerable/array-length-user.js
@@ -1,0 +1,13 @@
+// CWE-770: Unbounded Allocation — Array length from the request body
+// @author       claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This MUST be detected — new Array(n) with a caller-controlled n lets a single
+// request reserve a massive array and starve the process.
+function buildSlots(req, res) {
+  const n = Number(req.body.count);
+  const slots = new Array(n).fill(null); // unbounded allocation
+  res.json({ length: slots.length });
+}
+
+module.exports = { buildSlots };

--- a/benchmarks/corpus/CWE-770/vulnerable/buffer-alloc-user.js
+++ b/benchmarks/corpus/CWE-770/vulnerable/buffer-alloc-user.js
@@ -1,0 +1,16 @@
+// CWE-770: Unbounded Allocation — Buffer size taken from the request
+// @author       claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This MUST be detected — an attacker sends ?size=2000000000 and each request
+// pins ~2 GB of heap, exhausting memory (DoS).
+const http = require('http');
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, 'http://localhost');
+  const size = Number(url.searchParams.get('size'));
+  const buf = Buffer.alloc(size); // unbounded, attacker-controlled
+  res.end(`allocated ${buf.length} bytes`);
+});
+
+module.exports = server;

--- a/benchmarks/corpus/CWE-798/manifest.json
+++ b/benchmarks/corpus/CWE-798/manifest.json
@@ -3,5 +3,35 @@
   "name": "Hardcoded Credentials",
   "owasp": "A07:2021",
   "severity": "HIGH",
-  "expectedPlugins": ["eslint-plugin-secure-coding", "eslint-plugin-node-security"]
+  "expectedPlugins": ["eslint-plugin-secure-coding", "eslint-plugin-node-security"],
+  "fixtures": {
+    "vulnerable": [
+      { "file": "api-key-in-source.js", "description": "Live API key literal used as a Bearer token" },
+      { "file": "password-in-config.js", "description": "Database password literal in a config object" },
+      {
+        "file": "aws-access-key-literal.js",
+        "description": "AWS AKIA-prefixed access key id plus 40-char secret literal"
+      },
+      {
+        "file": "github-token-literal.js",
+        "description": "GitHub ghp_-prefixed personal access token literal"
+      },
+      {
+        "file": "jwt-signing-secret-literal.js",
+        "description": "HS256 signing secret plus a JWT-shaped service token literal"
+      }
+    ],
+    "safe": [
+      { "file": "env-credentials.js", "description": "Credentials read from process.env" },
+      { "file": "password-label.js", "description": "The word 'password' as UI copy, not a value" },
+      {
+        "file": "provider-env-credentials.js",
+        "description": "Secret-shaped variable NAMES bound to process.env reads (no literal values)"
+      },
+      {
+        "file": "test-placeholder-values.js",
+        "description": "Obvious placeholders ('test-api-key', 'changeme', '<your-secret-here>')"
+      }
+    ]
+  }
 }

--- a/benchmarks/corpus/CWE-798/safe/provider-env-credentials.js
+++ b/benchmarks/corpus/CWE-798/safe/provider-env-credentials.js
@@ -1,0 +1,22 @@
+// CWE-798: Safe — provider credentials read from the environment
+// @author      claude-fable-5
+// @reviewedBy  benchmark-validator
+// @lastReviewed 2026-07-31
+// This MUST NOT be flagged — the variable NAMES look like secrets, but no secret value is present in source
+const AWS_ACCESS_KEY_ID = process.env.AWS_ACCESS_KEY_ID;
+const AWS_SECRET_ACCESS_KEY = process.env.AWS_SECRET_ACCESS_KEY;
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+const JWT_SECRET = process.env.JWT_SECRET;
+
+function assertConfigured() {
+  for (const [name, value] of Object.entries({
+    AWS_ACCESS_KEY_ID,
+    AWS_SECRET_ACCESS_KEY,
+    GITHUB_TOKEN,
+    JWT_SECRET,
+  })) {
+    if (!value) {
+      throw new Error(`missing required env var: ${name}`);
+    }
+  }
+}

--- a/benchmarks/corpus/CWE-798/safe/test-placeholder-values.js
+++ b/benchmarks/corpus/CWE-798/safe/test-placeholder-values.js
@@ -1,0 +1,18 @@
+// CWE-798: Safe — obvious test placeholders, not real credentials
+// @author      claude-fable-5
+// @reviewedBy  benchmark-validator
+// @lastReviewed 2026-07-31
+// This MUST NOT be flagged — these are self-evident fixtures with no provider pattern and no entropy
+const TEST_CREDENTIALS = {
+  apiKey: 'test-api-key',
+  token: 'xxxxxxxxxxxx',
+  password: 'changeme',
+  secret: '<your-secret-here>',
+};
+
+function buildTestClient(createClient) {
+  return createClient({
+    baseUrl: 'http://localhost:3000',
+    apiKey: TEST_CREDENTIALS.apiKey,
+  });
+}

--- a/benchmarks/corpus/CWE-798/vulnerable/aws-access-key-literal.js
+++ b/benchmarks/corpus/CWE-798/vulnerable/aws-access-key-literal.js
@@ -1,0 +1,17 @@
+// CWE-798: Hardcoded Credentials — AWS access key pair in source
+// @author      claude-fable-5
+// @reviewedBy  benchmark-validator
+// @lastReviewed 2026-07-31
+// This MUST be detected — AKIA-prefixed key id plus a 40-char secret is an unambiguous AWS provider pattern
+const AWS_ACCESS_KEY_ID = 'AKIAIOSFODNN7EXAMPLE';
+const AWS_SECRET_ACCESS_KEY = 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY';
+
+function buildS3Client(S3) {
+  return new S3({
+    region: 'us-east-1',
+    credentials: {
+      accessKeyId: AWS_ACCESS_KEY_ID,
+      secretAccessKey: AWS_SECRET_ACCESS_KEY,
+    },
+  });
+}

--- a/benchmarks/corpus/CWE-798/vulnerable/github-token-literal.js
+++ b/benchmarks/corpus/CWE-798/vulnerable/github-token-literal.js
@@ -1,0 +1,13 @@
+// CWE-798: Hardcoded Credentials — GitHub personal access token in source
+// @author      claude-fable-5
+// @reviewedBy  benchmark-validator
+// @lastReviewed 2026-07-31
+// This MUST be detected — the ghp_ prefix plus 36 base62 chars is GitHub's documented token shape
+const GITHUB_TOKEN = 'ghp_16C7e42F292c6912E7710c838347Ae178B4a';
+
+async function listRepos(org) {
+  const res = await fetch(`https://api.github.com/orgs/${org}/repos`, {
+    headers: { Authorization: `Bearer ${GITHUB_TOKEN}` },
+  });
+  return res.json();
+}

--- a/benchmarks/corpus/CWE-798/vulnerable/jwt-signing-secret-literal.js
+++ b/benchmarks/corpus/CWE-798/vulnerable/jwt-signing-secret-literal.js
@@ -1,0 +1,18 @@
+// CWE-798: Hardcoded Credentials — JWT signing secret and a baked-in token
+// @author      claude-fable-5
+// @reviewedBy  benchmark-validator
+// @lastReviewed 2026-07-31
+// This MUST be detected — a committed HS256 secret lets anyone mint valid admin tokens
+const JWT_SECRET = 's3cr3t-signing-key-9f2b1c8d4a6e';
+const SERVICE_TOKEN =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJzdmMtYmlsbGluZyIsInJvbGUiOiJhZG1pbiJ9.dBjftJeZ4CVPmB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+
+function signSession(jwt, userId) {
+  return jwt.sign({ sub: userId }, JWT_SECRET, { algorithm: 'HS256', expiresIn: '1h' });
+}
+
+function callBilling() {
+  return fetch('https://billing.internal/api/v1/charges', {
+    headers: { Authorization: `Bearer ${SERVICE_TOKEN}` },
+  });
+}

--- a/benchmarks/corpus/CWE-843/manifest.json
+++ b/benchmarks/corpus/CWE-843/manifest.json
@@ -1,0 +1,28 @@
+{
+  "cwe": "CWE-843",
+  "name": "Access of Resource Using Incompatible Type (req.query type confusion)",
+  "owasp": "A03:2021",
+  "severity": "MEDIUM",
+  "expectedPlugins": [
+    "eslint-plugin-express-security"
+  ],
+  "coverageGap": "No rule yet requires a typeof / Array.isArray guard before a req.query value is used as a string. Candidate: express-security/require-query-type-guard. Today only generic hardening rules fire on these fixtures.",
+  "fixtures": {
+    "vulnerable": [
+      {
+        "file": "query-string-methods.js",
+        "description": "String method called on req.query without a type guard — ?name=a&name=b yields an array"
+      },
+      {
+        "file": "query-object-spread.js",
+        "description": "Nested-object query value passed to a downstream filter as if it were a scalar"
+      }
+    ],
+    "safe": [
+      {
+        "file": "guarded-query-type.js",
+        "description": "typeof / Array.isArray guard runs before the value is used"
+      }
+    ]
+  }
+}

--- a/benchmarks/corpus/CWE-843/safe/guarded-query-type.js
+++ b/benchmarks/corpus/CWE-843/safe/guarded-query-type.js
@@ -1,0 +1,26 @@
+// CWE-843: safe — the query value is type-checked before use
+// @author        claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This must NOT be flagged
+// Arrays and objects are rejected up front, so everything downstream sees a
+// string and nothing else.
+const express = require('express');
+const helmet = require('helmet');
+const rateLimit = require('express-rate-limit');
+
+const app = express();
+app.use(helmet());
+app.use(rateLimit({ windowMs: 60000, max: 100 }));
+
+app.get('/search', async (req, res) => {
+  const raw = req.query.name;
+  if (Array.isArray(raw) || typeof raw !== 'string') {
+    return res.status(400).json({ error: 'name must be a single string value' });
+  }
+
+  const term = raw.replace(/[^a-z0-9 ]/gi, '').toLowerCase();
+  res.json(await searchProducts(term));
+});
+
+module.exports = app;

--- a/benchmarks/corpus/CWE-843/vulnerable/query-object-spread.js
+++ b/benchmarks/corpus/CWE-843/vulnerable/query-object-spread.js
@@ -1,0 +1,16 @@
+// CWE-843: req.query type confusion — object-valued query used as a scalar
+// @author        claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This MUST be detected
+const express = require('express');
+
+const app = express();
+
+app.get('/orders', async (req, res) => {
+  const status = req.query.status;
+  const orders = await db.orders.find({ status, ownerId: req.user.id });
+  res.json(orders.map((o) => ({ ...o, status: status.trim() })));
+});
+
+module.exports = app;

--- a/benchmarks/corpus/CWE-843/vulnerable/query-string-methods.js
+++ b/benchmarks/corpus/CWE-843/vulnerable/query-string-methods.js
@@ -1,0 +1,18 @@
+// CWE-843: req.query type confusion — string method on an unguarded query value
+// @author        claude-fable-5
+// @reviewedBy    benchmark-validator
+// @lastReviewed  2026-07-31
+// This MUST be detected
+// Express parses ?name=a&name=b into an array, so .replace throws (DoS) and
+// ?name[$ne]= produces an object that flows straight into the query layer.
+const express = require('express');
+
+const app = express();
+
+app.get('/search', async (req, res) => {
+  const term = req.query.name.replace(/[^a-z0-9 ]/gi, '');
+  const results = await searchProducts(term.toLowerCase());
+  res.json(results);
+});
+
+module.exports = app;


### PR DESCRIPTION
## What

A-lite Wave-2 item from the eslint-security-leadership plan: expand the ILB benchmark corpus with fixtures distilled from candidate-rule research.

- **21 new CWE dirs** (CWE-020, 073, 088, 094, 099, 1007, 116, 117, 178, 209, 248, 295, 377, 409, 444, 548, 598, 636, 640, 770, 843) + new fixtures appended to existing **CWE-327** (GCM auth-tag pitfalls) and **CWE-798** (provider-credential literals), ~80 new fixtures total (corpus now 31 CWEs / 129 fixtures)
- **CVE corpus 2 → 10 entries**: CVE-2025-27152 (axios absolute-URL override), CVE-2025-29927 (Next.js middleware-only auth), CVE-2025-30208 (Vite dev-server exposure), CVE-2025-48757 (Supabase service-role in client), CVE-2025-7338 (multer unhandled busboy error), CVE-2025-7783 (form-data Math.random boundary), CVE-2026-24120 (vm2 sandbox), GHSA-gpj5-g38j-94v9 (drizzle sql.identifier)
- Every fixture carries @author/@reviewedBy metadata; manifests record expected rules per fixture

## Why

Corpus-first discipline: fixtures land before rules, so every future rule claim is benchmarked against a pre-existing labelled corpus rather than fixtures written to fit the rule.

## Findings recorded in manifests

**7 express-security coverage gaps** (`coverageGap` field, each with a candidate rule name):

1. CWE-209 — err.stack / raw error object reaching res.send/res.json → `no-error-details-in-response`
2. CWE-548 — express.static(__dirname) / serveIndex at project root → `no-static-root-exposure`
3. CWE-178 — case-sensitive path guard vs case-insensitive route matcher → `require-case-insensitive-path-guard`
4. CWE-598 — credential-like req.query keys on GET routes → `no-sensitive-data-in-query`
5. CWE-073 — req.body/req.query spread into res.render locals → `no-user-controlled-render-locals`
6. CWE-640 — reset/verification URL built from Host / x-forwarded-host → `no-host-header-in-links`
7. CWE-843 — req.query value used as string without typeof/Array.isArray guard → `require-query-type-guard`

**2 FP bugs surfaced by the safe fixtures** (expected-domain rule fires on a safe fixture):

1. `node-security/no-ssrf` flags CWE-444 `safe/request-default-parser.js` — the URL-argument naming heuristic fires with no user-input flow
2. `secure-coding/no-hardcoded-credentials` flags CWE-798 `safe/test-placeholder-values.js` — obvious placeholder/test values reported as CRITICAL hardcoded credentials

## Validation

`npx tsx scripts/ilb-validate-fixtures.ts`: 129 fixtures, 0 metadata gaps, 32 label-drift issues — all within the 33 pre-existing known set; no new issues introduced. No package code changed, so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)