### PR TITLE
fix(node-security,secure-coding): cut two benchmark-confirmed false positives

### DIFF
--- a/.changeset/ssrf-hardcoded-creds-false-positives.md
+++ b/.changeset/ssrf-hardcoded-creds-false-positives.md
@@ -1,0 +1,39 @@
+---
+'eslint-plugin-node-security': patch
+'eslint-plugin-secure-coding': patch
+---
+
+Cut two false positives confirmed against the benchmark corpus SAFE fixtures.
+
+**`node-security/no-ssrf`** — the user-input gate only ran when the URL argument
+was a bare identifier, so every other shape reported unconditionally. A Node
+options object built from a helper's own parameters —
+`https.request({ host, path, method: 'GET' })`, from
+`benchmarks/corpus/CWE-444/safe/request-default-parser.js` — was flagged with no
+user data anywhere in the flow.
+
+The gate now applies to every argument shape and requires evidence: a
+user-input-named identifier standing as the URL, a read off a request object
+(`req` / `request` / `ctx` / `event`), or a template literal or concatenation
+interpolating either. Options-object fields count when they are request-sourced,
+or when a `url` / `href` / `uri` key holds a user-input-named identifier.
+
+Newly ignored: options objects and interpolations built purely from locals.
+Still reported: `fetch(userUrl)`, `fetch(req.query.url)`,
+`https.request({ host: req.query.host })`, `` fetch(`https://${userHost}/x`) ``.
+
+**`secure-coding/no-hardcoded-credentials`** — `secret: '<your-secret-here>'`
+from `benchmarks/corpus/CWE-798/safe/test-placeholder-values.js` was reported at
+CVSS 9.8. The angle brackets are two character classes, which is all the shape
+gate asks for once the slot is credential-named.
+
+Self-evident placeholders are now skipped: bracketed template slots (`<…>`,
+`{{…}}`, `${…}`, `[…]`), placeholder words standing as their own token
+(`changeme`, `YOUR_API_KEY`, `example`), and one character repeated
+(`xxxxxxxxxxxx`). Whole-token matching only, so a real secret that merely
+contains such a substring is unaffected.
+
+The allowlist applies to non-structural findings only — a JWT, an `sk_live_`
+key, or a `postgres://user:pass@host` string still reports whatever words it
+contains. Set the new `allowPlaceholders: false` option to restore the previous
+behaviour.

--- a/packages/eslint-plugin-node-security/docs/rules/no-ssrf.md
+++ b/packages/eslint-plugin-node-security/docs/rules/no-ssrf.md
@@ -74,6 +74,28 @@ function safeFetch(rawUrl) {
 }
 ```
 
+### ✅ Also correct — no evidence of user flow
+
+The rule reports on evidence, not on the mere presence of a dynamic argument.
+A Node options object whose fields are plain locals is internal plumbing, not
+a user-controlled URL:
+
+```js
+function fetchProfile(host, path, cb) {
+  // host/path are this helper's own parameters — not flagged
+  return https.request({ host, path, method: 'GET' }, cb);
+}
+
+const r = await fetch(`https://api.internal/items/${id}`);   // id is a local
+```
+
+Three shapes count as evidence:
+
+1. The whole argument is a user-input-named identifier — `fetch(userUrl)`.
+2. Any part of the expression reads off a request object (`req`, `request`,
+   `ctx`, `event`) — `https.request({ host: req.query.host })`.
+3. A template literal or concatenation interpolating either of the above.
+
 ## Error Message Format
 
 ```text

--- a/packages/eslint-plugin-node-security/src/rules/no-ssrf/index.ts
+++ b/packages/eslint-plugin-node-security/src/rules/no-ssrf/index.ts
@@ -70,6 +70,93 @@ function isUserInputParamName(name: string): boolean {
   return USER_INPUT_SUBSTRINGS.some(sub => lower.includes(sub));
 }
 
+// Object roots whose members carry attacker-controlled data in the common
+// server frameworks: Express `req`/`request`, Koa `ctx`, Lambda `event`.
+const REQUEST_ROOT_NAMES = new Set(['req', 'request', 'ctx', 'event']);
+
+// Keys of a Node `http.request(options)` object that actually name a URL.
+// `host`/`hostname`/`path`/`port` are deliberately absent: a helper that
+// parameterises them is ordinary internal plumbing, not evidence of user flow.
+const URL_OPTION_KEYS = new Set(['url', 'href', 'uri']);
+
+/**
+ * True when the expression reads off a request object — `req.query.url`,
+ * `ctx.request.body.target`, `event.queryStringParameters.u`. Everything
+ * hanging off a request is untrusted, so the root name is the whole test.
+ */
+function isRequestSourced(node: TSESTree.Node): boolean {
+  let current: TSESTree.Node = node;
+  while (current.type === AST_NODE_TYPES.MemberExpression) {
+    current = current.object;
+  }
+  return (
+    current !== node &&
+    current.type === AST_NODE_TYPES.Identifier &&
+    REQUEST_ROOT_NAMES.has(current.name.toLowerCase())
+  );
+}
+
+/**
+ * Does the URL argument carry untrusted data into the request?
+ *
+ * The rule reports on evidence of flow, never on the mere presence of a
+ * dynamic argument. Three shapes qualify:
+ *
+ *   1. The whole argument is a user-input-named identifier — `fetch(userUrl)`.
+ *      This is the rule's documented naming heuristic: a bare identifier in
+ *      URL position *is* the URL.
+ *   2. Any part of the expression reads from a request object —
+ *      `fetch(req.query.url)`, `https.request({ host: req.query.h })`.
+ *   3. A template literal URL interpolates either of the above —
+ *      `fetch(\`https://\${userHost}/x\`)`.
+ *
+ * Everything else is not evidence. In particular an options object whose
+ * fields are plain locals — `https.request({ host, path, method: 'GET' })`,
+ * benchmarks/corpus/CWE-444/safe/request-default-parser.js — used to be
+ * reported unconditionally because a non-Identifier argument bypassed the
+ * name gate entirely.
+ */
+function carriesUntrustedUrl(node: TSESTree.Node): boolean {
+  switch (node.type) {
+    case AST_NODE_TYPES.Identifier:
+      return isUserInputParamName(node.name);
+
+    case AST_NODE_TYPES.MemberExpression:
+      return isRequestSourced(node);
+
+    case AST_NODE_TYPES.TemplateLiteral:
+      return node.expressions.some(carriesUntrustedUrl);
+
+    // `new URL(userUrl)` / `String(req.query.url)` — inspect the arguments.
+    case AST_NODE_TYPES.CallExpression:
+    case AST_NODE_TYPES.NewExpression:
+      return node.arguments.some(carriesUntrustedUrl);
+
+    // `'https://host' + userPath`
+    case AST_NODE_TYPES.BinaryExpression:
+      return carriesUntrustedUrl(node.left as TSESTree.Node) || carriesUntrustedUrl(node.right);
+
+    // `http.request({ url: x, host: y })` — only URL-naming keys count by
+    // name; every other key still counts if its value is request-sourced.
+    case AST_NODE_TYPES.ObjectExpression:
+      return node.properties.some(property => {
+        if (property.type !== AST_NODE_TYPES.Property) return false;
+        const value = property.value as TSESTree.Node;
+        if (isRequestSourced(value)) return true;
+        const key =
+          property.key.type === AST_NODE_TYPES.Identifier
+            ? property.key.name
+            : property.key.type === AST_NODE_TYPES.Literal
+              ? String(property.key.value)
+              : '';
+        return URL_OPTION_KEYS.has(key.toLowerCase()) && carriesUntrustedUrl(value);
+      });
+
+    default:
+      return false;
+  }
+}
+
 /**
  * AST-based check: does this node contain a validation pattern?
  * Walks the node tree looking for known validation constructs.
@@ -190,7 +277,7 @@ export const noSsrf = createRule<RuleOptions, MessageIds>({
     docs: {
       url: 'https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-node-security/docs/rules/no-ssrf.md',
       description:
-        'Flags HTTP calls whose URL argument is an identifier with a user-input-sounding name — a heuristic prompt for code review, not a proof of SSRF',
+        'Flags HTTP calls whose URL argument is a user-input-named identifier or reads off a request object — a heuristic prompt for code review, not a proof of SSRF',
       cwe: 'CWE-918',
       cvss: 9.1,
     },
@@ -261,30 +348,19 @@ export const noSsrf = createRule<RuleOptions, MessageIds>({
         const urlArg = node.arguments[0];
         if (!urlArg) return;
 
-        // Safe: literal string URL — fetch('https://api.example.com')
-        if (urlArg.type === AST_NODE_TYPES.Literal) return;
+        // Static URLs — fetch('https://api.example.com'), fetch(`https://…`) —
+        // carry nothing untrusted and fall out at the evidence gate below.
 
-        // Safe: template literal without expressions — fetch(`https://api.example.com`)
-        if (
-          urlArg.type === AST_NODE_TYPES.TemplateLiteral &&
-          urlArg.expressions.length === 0
-        ) {
-          return;
-        }
-
-        // The URL is dynamic (identifier, template with expressions, etc.)
         // Check if there is URL validation before this call
         if (hasValidationBefore(node)) {
           return;
         }
 
-        // Check if the argument is a function parameter that looks like user input
-        if (urlArg.type === AST_NODE_TYPES.Identifier) {
-          // If the variable name doesn't suggest user input, skip
-          // This reduces false positives on internal API calls
-          if (!isUserInputParamName(urlArg.name)) {
-            return;
-          }
+        // Require evidence that untrusted data reaches the URL. Applies to
+        // every argument shape — an options object or a template literal used
+        // to bypass this gate entirely and report unconditionally.
+        if (!carriesUntrustedUrl(urlArg as TSESTree.Node)) {
+          return;
         }
 
         context.report({

--- a/packages/eslint-plugin-node-security/src/rules/no-ssrf/no-ssrf.coverage.test.ts
+++ b/packages/eslint-plugin-node-security/src/rules/no-ssrf/no-ssrf.coverage.test.ts
@@ -72,6 +72,28 @@ describe('no-ssrf coverage gaps', () => {
       },
       // Zero-argument HTTP call — urlArg guard
       { code: 'fetch();' },
+
+      // --- carriesUntrustedUrl: shapes with no evidence of user flow ---
+      // Template literal interpolating a local with no user-input-sounding name
+      {
+        code: [
+          'function callApi(p) {',
+          '  return fetch(`https://x/${p}`);',
+          '}',
+        ].join('\n'),
+      },
+      // CallExpression argument whose own arguments are untainted
+      { code: 'fetch(buildUrl(id));' },
+      // Concatenation of two untainted operands
+      { code: 'fetch("https://x/" + id);' },
+      // Object spread — SpreadElement is not a Property
+      { code: 'got({ ...opts });' },
+      // Computed key that is neither Identifier nor Literal → not a URL key
+      { code: 'got({ ["ur" + "l"]: userUrl });' },
+      // Member chain whose root is a call, not a request identifier
+      { code: 'fetch(getReq().query.url);' },
+      // Member chain rooted at a non-request identifier
+      { code: 'fetch(config.query.url);' },
     ],
     invalid: [
       // Preceding member call whose method is not a validation method
@@ -131,13 +153,9 @@ describe('no-ssrf coverage gaps', () => {
         ].join('\n'),
         errors: [{ messageId: 'ssrfVulnerability' }],
       },
-      // Template literal with expressions — dynamic but not an Identifier
+      // CallExpression argument that wraps a user-input-named identifier
       {
-        code: [
-          'function callApi(p) {',
-          '  return fetch(`https://x/${p}`);',
-          '}',
-        ].join('\n'),
+        code: 'fetch(String(userUrl));',
         errors: [{ messageId: 'ssrfVulnerability' }],
       },
     ],

--- a/packages/eslint-plugin-node-security/src/rules/no-ssrf/no-ssrf.test.ts
+++ b/packages/eslint-plugin-node-security/src/rules/no-ssrf/no-ssrf.test.ts
@@ -124,4 +124,87 @@ describe('no-ssrf', () => {
       ],
     });
   });
+
+  /**
+   * Confirmed FP, 2026-07-31 — benchmarks/corpus/CWE-444/safe/
+   * request-default-parser.js. A Node options object is not a URL, and its
+   * fields being plain locals is not evidence of user flow. The old gate only
+   * ran for Identifier arguments, so every other shape reported unconditionally.
+   */
+  describe('Benchmark FP — options object with no user-data flow', () => {
+    ruleTester.run('CWE-444 safe corpus fixture', noSsrf, {
+      valid: [
+        // Verbatim from benchmarks/corpus/CWE-444/safe/request-default-parser.js
+        {
+          code: `
+            const https = require('https');
+
+            function fetchProfile(host, path, cb) {
+              const req = https.request({ host, path, method: 'GET' }, (res) => {
+                let body = '';
+                res.on('data', (c) => (body += c));
+                res.on('end', () => cb(null, body));
+              });
+              req.on('error', cb);
+              req.end();
+            }
+
+            module.exports = { fetchProfile };
+          `,
+        },
+        // Same shape, no callback — the options object alone is not a URL
+        { code: "http.request({ hostname: host, port, path });" },
+        // Interpolated path built from locals — no user-input-named identifier
+        { code: 'function load(id) { return fetch(`https://api.internal/items/${id}`); }' },
+        // Object literal in a non-URL key holding a local
+        { code: 'axios.request({ method: "GET", headers: authHeaders });' },
+      ],
+      invalid: [
+        // Still caught: the options object carries a request-sourced URL
+        {
+          code: "https.request({ host: req.query.host, path: '/' });",
+          errors: [{ messageId: 'ssrfVulnerability' }],
+        },
+        // Still caught: a url-naming key holding a user-input-named identifier
+        {
+          code: 'got({ url: targetUrl });',
+          errors: [{ messageId: 'ssrfVulnerability' }],
+        },
+        // Still caught: quoted url key
+        {
+          code: 'got({ "uri": userEndpoint });',
+          errors: [{ messageId: 'ssrfVulnerability' }],
+        },
+        // Still caught: URL read straight off the request
+        {
+          code: 'app.get("/p", (req, res) => fetch(req.query.url));',
+          errors: [{ messageId: 'ssrfVulnerability' }],
+        },
+        // Still caught: template literal interpolating a user-input-named id
+        {
+          code: 'fetch(`https://${userHost}/data`);',
+          errors: [{ messageId: 'ssrfVulnerability' }],
+        },
+        // Still caught: concatenation onto a fixed base
+        {
+          code: 'fetch("https://proxy/" + userUrl);',
+          errors: [{ messageId: 'ssrfVulnerability' }],
+        },
+        // Still caught: new URL(...) wrapping user input
+        {
+          code: 'axios.get(new URL(targetUrl, base));',
+          errors: [{ messageId: 'ssrfVulnerability' }],
+        },
+        // Still caught: ctx / event roots
+        {
+          code: 'fetch(ctx.request.body.feed);',
+          errors: [{ messageId: 'ssrfVulnerability' }],
+        },
+        {
+          code: 'fetch(event.queryStringParameters.u);',
+          errors: [{ messageId: 'ssrfVulnerability' }],
+        },
+      ],
+    });
+  });
 });

--- a/packages/eslint-plugin-secure-coding/docs/rules/no-hardcoded-credentials.md
+++ b/packages/eslint-plugin-secure-coding/docs/rules/no-hardcoded-credentials.md
@@ -189,6 +189,26 @@ export const SessionCacheProvider = 'SessionCacheProvider';        // ✅ DI tok
 const secret = 'experimental_onToolExecutionStart';                // ✅ identifier
 ```
 
+### ✅ Also correct — self-evident placeholders
+
+A value the developer is visibly expected to replace is not a leaked
+credential. Skipped by default; set `allowPlaceholders: false` to report them.
+
+```typescript
+const TEST_CREDENTIALS = {
+  apiKey: 'test-api-key',
+  token: 'xxxxxxxxxxxx',        // ✅ one character repeated
+  password: 'changeme',         // ✅ placeholder word
+  secret: '<your-secret-here>', // ✅ bracketed template slot
+};
+
+const key = '{{API_SECRET}}';   // ✅ also `${…}` and `[…]`
+```
+
+The allowlist applies only to non-structural findings. A JWT, an `sk_live_`
+key, or a `postgres://user:pass@host` string keeps its shape whatever words it
+contains, so those still report.
+
 ## Configuration
 
 ```javascript
@@ -201,7 +221,8 @@ const secret = 'experimental_onToolExecutionStart';                // ✅ identi
       detectApiKeys: true,                  // Detect API keys
       detectPasswords: true,                // Detect passwords
       detectTokens: true,                   // Detect tokens
-      detectDatabaseStrings: true          // Detect database strings
+      detectDatabaseStrings: true,         // Detect database strings
+      allowPlaceholders: true              // Skip <your-secret-here>, changeme, xxxxxxxx
     }]
   }
 }
@@ -218,6 +239,7 @@ const secret = 'experimental_onToolExecutionStart';                // ✅ identi
 | `detectPasswords`       | `boolean`  | `true`  | Detect common weak passwords                                      |
 | `detectTokens`          | `boolean`  | `true`  | Detect JWT and OAuth tokens                                       |
 | `detectDatabaseStrings` | `boolean`  | `true`  | Detect database connection strings with credentials               |
+| `allowPlaceholders`     | `boolean`  | `true`  | Skip self-evident placeholders (`<your-secret-here>`, `changeme`, `xxxxxxxx`) |
 
 ### Ignoring Test Credentials
 

--- a/packages/eslint-plugin-secure-coding/src/rules/no-hardcoded-credentials/index.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/no-hardcoded-credentials/index.ts
@@ -49,6 +49,9 @@ export interface Options {
 
   /** Strategy for fixing hardcoded credentials: 'env', 'config', 'vault', 'auto' */
   strategy?: 'env' | 'config' | 'vault' | 'auto';
+
+  /** Skip self-evident placeholder values (`<your-secret-here>`, `changeme`, `xxxxxxxx`). Default: true */
+  allowPlaceholders?: boolean;
 }
 
 type RuleOptions = [Options?];
@@ -256,6 +259,52 @@ export function isSecretShaped(value: string, minLength: number): boolean {
   // secrets like a 21-character lowercase blob — is long and high-entropy.
   if (classCount(charClasses(value)) >= 2) return true;
   return value.length >= 20 && shannonEntropy(value) >= 3.0;
+}
+
+/**
+ * Words that only ever appear in a value a developer expects to replace.
+ * Matched as whole words inside the string, so `changeme`, `change-me`,
+ * `YOUR_API_KEY`, and `<your-secret-here>` are all covered.
+ */
+const PLACEHOLDER_WORDS = new Set([
+  'changeme', 'change', 'replaceme', 'replace', 'yours', 'your',
+  'placeholder', 'example', 'sample', 'dummy', 'todo', 'tbd',
+  'redacted', 'notreal', 'xxx',
+]);
+
+/**
+ * True when the value is a self-evident stand-in rather than a secret.
+ *
+ * Three shapes, each unambiguous on its own:
+ *   1. Bracketed template slots — `<your-secret-here>`, `{{API_KEY}}`,
+ *      `${SECRET}`, `[token]`. No real credential is delimited this way, and
+ *      the brackets are what push the string past `isSecretShaped`'s
+ *      two-character-class gate in the first place.
+ *   2. A placeholder word standing as its own token — `changeme`,
+ *      `YOUR_API_KEY`, `example.com`. Substring matching is deliberately
+ *      avoided: a real key may contain `bar` by chance.
+ *   3. One character repeated — `xxxxxxxxxxxx`, `********`, `00000000`.
+ *
+ * Verified against benchmarks/corpus/CWE-798/safe/test-placeholder-values.js,
+ * where `secret: '<your-secret-here>'` was reported at CVSS 9.8.
+ */
+export function isPlaceholderValue(value: string): boolean {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return false;
+
+  // 1. Bracketed template slots.
+  if (/^(?:<.*>|\{\{.*\}\}|\$\{.*\}|\[.*\])$/.test(trimmed)) return true;
+
+  // 3. One character repeated (4+).
+  if (trimmed.length >= 4 && new Set(trimmed).size === 1) return true;
+
+  // 2. Placeholder word as a whole token.
+  const tokens = trimmed
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+  return tokens.some(token => PLACEHOLDER_WORDS.has(token));
 }
 
 /**
@@ -505,6 +554,11 @@ export const noHardcodedCredentials = createRule<RuleOptions, MessageIds>({
             default: 'auto',
             description: 'Strategy for fixing hardcoded credentials (auto = smart detection)'
           },
+          allowPlaceholders: {
+            type: 'boolean',
+            default: true,
+            description: 'Skip self-evident placeholder values (<your-secret-here>, changeme, xxxxxxxx)',
+          },
         },
         additionalProperties: false,
       },
@@ -521,6 +575,7 @@ export const noHardcodedCredentials = createRule<RuleOptions, MessageIds>({
       detectDatabaseStrings: true,
       customPatterns: [],
       strategy: 'auto',
+      allowPlaceholders: true,
     },
   ],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>) {
@@ -534,6 +589,7 @@ export const noHardcodedCredentials = createRule<RuleOptions, MessageIds>({
       detectTokens = true,
       detectDatabaseStrings = true,
       customPatterns = [],
+      allowPlaceholders = true,
     }: Options = options;
 
     const filename = context.filename;
@@ -853,6 +909,14 @@ export const noHardcodedCredentials = createRule<RuleOptions, MessageIds>({
         finalIsCredential = false;
       }
 
+      // Self-evident placeholders are not secrets. Gated to non-structural
+      // findings only: a JWT, an `sk_live_` key, or a DB connection string
+      // keeps its shape whatever words it contains, so those still report.
+      const isPlaceholder = allowPlaceholders && isPlaceholderValue(value);
+      if (isPlaceholder && confidence !== 'structural') {
+        finalIsCredential = false;
+      }
+
       // Context-positive: a *secret-shaped* string assigned to a
       // credential-named variable/property is a credential, even when no
       // structural pattern matches. Catches passwords like 'aaAA@123' that
@@ -872,6 +936,7 @@ export const noHardcodedCredentials = createRule<RuleOptions, MessageIds>({
       // bypasses the option. Map the var name back to its category and
       // honour the option.
       if (!finalIsCredential &&
+          !isPlaceholder &&
           !compiledIgnorePatterns.some((pattern) => pattern.test(value)) &&
           isSecretShaped(value, detectionOptions.minLength) &&
           isCredentialContext(node, parent)) {

--- a/packages/eslint-plugin-secure-coding/src/rules/no-hardcoded-credentials/no-hardcoded-credentials.test.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/no-hardcoded-credentials/no-hardcoded-credentials.test.ts
@@ -1134,6 +1134,122 @@ describe('no-hardcoded-credentials', () => {
       ],
     });
   });
+
+  /**
+   * Confirmed FP, 2026-07-31 — benchmarks/corpus/CWE-798/safe/
+   * test-placeholder-values.js. `secret: '<your-secret-here>'` was reported at
+   * CVSS 9.8: the angle brackets are two character classes, which is all
+   * `isSecretShaped` asks for once the slot is credential-named. A value a
+   * developer is visibly expected to replace is not a leaked credential.
+   */
+  describe('placeholder values — benchmark FP regression', () => {
+    ruleTester.run('placeholders are not credentials', noHardcodedCredentials, {
+      valid: [
+        // Verbatim from benchmarks/corpus/CWE-798/safe/test-placeholder-values.js
+        {
+          code: `
+            const TEST_CREDENTIALS = {
+              apiKey: 'test-api-key',
+              token: 'xxxxxxxxxxxx',
+              password: 'changeme',
+              secret: '<your-secret-here>',
+            };
+
+            function buildTestClient(createClient) {
+              return createClient({
+                baseUrl: 'http://localhost:3000',
+                apiKey: TEST_CREDENTIALS.apiKey,
+              });
+            }
+          `,
+        },
+        // Bracketed template slots, each delimiter style
+        { code: `const secret = '{{API_SECRET}}';` },
+        { code: 'const apiKey = "${STRIPE_KEY}";' },
+        { code: `const token = '[bearer-token]';` },
+        // Placeholder word as a whole token
+        { code: `const password = 'REPLACE_ME_BEFORE_DEPLOY';` },
+        { code: `const apiKey = 'your-api-key-goes-here';` },
+        { code: `const secret = 'sample_value_1234';` },
+        // Repeated single character
+        { code: `const password = '********';` },
+        { code: `const apiKey = 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';` },
+        // Empty string — not a placeholder, and not a credential either
+        { code: `const password = '';` },
+      ],
+      invalid: [
+        // Structural findings keep reporting even when they read like samples:
+        // the shape is unambiguous whatever words it contains.
+        {
+          code: `const dbUrl = 'postgres://admin:changeme@example.com:5432/app';`,
+          errors: [
+            {
+              messageId: 'useEnvironmentVariable',
+              data: { credentialType: 'Database connection string', envVarName: 'DB_URL' },
+              suggestions: [
+                {
+                  messageId: 'useEnvironmentVariable',
+                  data: { envVarName: 'DB_URL', credentialType: 'Database connection string' },
+                  output: `const dbUrl = process.env.DB_URL || 'postgres://admin:changeme@example.com:5432/app';`,
+                },
+                {
+                  messageId: 'useSecretManager',
+                  data: { credentialType: 'Database connection string' },
+                  output: `const dbUrl = await getSecret('db_url');`,
+                },
+              ],
+            },
+          ],
+        },
+        // A value that merely *contains* a placeholder word is not a
+        // placeholder — PLACEHOLDER_WORDS matches whole tokens only.
+        {
+          code: `const password = 'exampleton9!K';`,
+          errors: [
+            {
+              messageId: 'useEnvironmentVariable',
+              data: { credentialType: 'Credential value', envVarName: 'PASSWORD' },
+              suggestions: [
+                {
+                  messageId: 'useEnvironmentVariable',
+                  data: { envVarName: 'PASSWORD', credentialType: 'Credential value' },
+                  output: `const password = process.env.PASSWORD || 'exampleton9!K';`,
+                },
+                {
+                  messageId: 'useSecretManager',
+                  data: { credentialType: 'Credential value' },
+                  output: `const password = await getSecret('password');`,
+                },
+              ],
+            },
+          ],
+        },
+        // Opting out restores the old behaviour for the corpus fixture line.
+        {
+          code: `const secret = '<your-secret-here>';`,
+          options: [{ allowPlaceholders: false }],
+          errors: [
+            {
+              messageId: 'useEnvironmentVariable',
+              data: { credentialType: 'Credential value', envVarName: 'SECRET' },
+              suggestions: [
+                {
+                  messageId: 'useEnvironmentVariable',
+                  data: { envVarName: 'SECRET', credentialType: 'Credential value' },
+                  output: `const secret = process.env.SECRET || '<your-secret-here>';`,
+                },
+                {
+                  messageId: 'useSecretManager',
+                  data: { credentialType: 'Credential value' },
+                  output: `const secret = await getSecret('secret');`,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
 });
 
 /**


### PR DESCRIPTION
Two false positives confirmed on 2026-07-31 by benchmark corpus SAFE fixtures (`bench/a-lite-corpus-expansion`, #290). Both reproduced against the fixture before the fix and verified clear after.

## 1. `node-security/no-ssrf` — options object bypassed the gate entirely

`benchmarks/corpus/CWE-444/safe/request-default-parser.js` was flagged:

```js
function fetchProfile(host, path, cb) {
  const req = https.request({ host, path, method: 'GET' }, (res) => { /* … */ });
}
```

No user data reaches the request anywhere in the file. The cause: the user-input-name check only ran when the URL argument was a bare `Identifier`. Every other shape — an options object, a template literal, a member expression — skipped it and reported unconditionally.

The gate now applies to every argument shape and asks for evidence of flow:

1. The whole argument is a user-input-named identifier — `fetch(userUrl)`.
2. Any part of the expression reads off a request object (`req` / `request` / `ctx` / `event`) — `https.request({ host: req.query.host })`.
3. A template literal or concatenation interpolating either of the above.

Options-object fields count when they are request-sourced, or when a `url` / `href` / `uri` key holds a user-input-named identifier. `host` / `hostname` / `path` / `port` are deliberately excluded — a helper that parameterises them is internal plumbing.

**Newly ignored:** options objects and interpolations built purely from locals.
**Still reported:** `fetch(userUrl)`, `fetch(req.query.url)`, `https.request({ host: req.query.host })`, `` fetch(`https://${userHost}/x`) ``, `fetch('https://proxy/' + userUrl)`, `axios.get(new URL(targetUrl, base))`.

## 2. `secure-coding/no-hardcoded-credentials` — placeholders reported as CRITICAL

`benchmarks/corpus/CWE-798/safe/test-placeholder-values.js` produced one finding at CVSS 9.8:

```js
secret: '<your-secret-here>',
```

The angle brackets are two character classes, which is all `isSecretShaped` asks for once the slot is credential-named. (The other three lines in that fixture — `'test-api-key'`, `'xxxxxxxxxxxx'`, `'changeme'` — already fell out on shape.)

Self-evident placeholders are now skipped:

- Bracketed template slots — `<…>`, `{{…}}`, `${…}`, `[…]`
- A placeholder word standing as its own token — `changeme`, `YOUR_API_KEY`, `example`. Whole-token matching only, so a real secret containing such a substring is unaffected.
- One character repeated — `xxxxxxxxxxxx`, `********`

The allowlist is gated to **non-structural** findings. A JWT, an `sk_live_` key, or a `postgres://user:pass@host` string keeps its shape whatever words it contains, so those still report — covered by a test using `postgres://admin:changeme@example.com:5432/app`.

New option `allowPlaceholders` (default `true`) restores the previous behaviour when set to `false`.

## Verification

| Check | Result |
| --- | --- |
| `eslint-plugin-node-security` suite | 67 files, **874 tests**, 100% stmts/branch/func/lines |
| `eslint-plugin-secure-coding` suite | 34 files, **1485 tests**, 100% stmts/branch/func/lines |
| `tsc --noEmit` (both packages) | clean |
| `oxlint`, `markdownlint`, `oxlint:shims:check`, `docs:cwe-coverage:check`, `check-links` | clean |
| pre-push gate (24 tasks incl. build, typecheck, lockfile, shim-verify) | all green |

Both fixtures were linted before and after: 1 finding each → 0 findings each.

New tests quote the fixture code verbatim, alongside true-positive cases proving detection is not weakened. Rule docs and a changeset are included (rule behaviour change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
