### PR TITLE
fix(docs): de-violet the hero code block and fix its light-theme AA

### DIFF
--- a/apps/docs/src/__tests__/homepage-lock.test.tsx
+++ b/apps/docs/src/__tests__/homepage-lock.test.tsx
@@ -529,16 +529,22 @@ describe('Homepage: Code Block WCAG Compliance', () => {
   });
 
   describe('Light/Dark Theme Color Contrast', () => {
-    it('uses theme-aware purple for keywords (WCAG 4.5:1 contrast)', () => {
-      expect(homepageSource).toContain('text-purple-600 dark:text-purple-400');
+    // Brand chassis: the keyword hue is burnt orange, never violet. The light
+    // shades are the -800 steps because this block sits on #f1f1f1, where the
+    // -600 steps measured 2.83:1 (amber) and 2.85:1 (green) — both below AA
+    // (brand QA sweep, 2026-08-02). On that surface the -800 steps measure
+    // orange 8.36:1, amber 5.97:1, green 6.31:1.
+    it('uses theme-aware burnt orange for keywords — never violet (WCAG 4.5:1)', () => {
+      expect(homepageSource).toContain('text-orange-800 dark:text-orange-300');
+      expect(homepageSource).not.toContain('text-purple-600');
     });
 
     it('uses theme-aware amber/yellow for identifiers (WCAG 4.5:1 contrast)', () => {
-      expect(homepageSource).toContain('text-amber-600 dark:text-yellow-400');
+      expect(homepageSource).toContain('text-amber-800 dark:text-yellow-400');
     });
 
     it('uses theme-aware green for strings (WCAG 4.5:1 contrast)', () => {
-      expect(homepageSource).toContain('text-green-600 dark:text-green-400');
+      expect(homepageSource).toContain('text-green-800 dark:text-green-400');
     });
 
     it('uses fd-muted-foreground for comments (theme-aware)', () => {

--- a/apps/docs/src/app/(home)/page.tsx
+++ b/apps/docs/src/app/(home)/page.tsx
@@ -171,12 +171,12 @@ export default async function HomePage() {
             {/* Code Content — WCAG accessible colors for light/dark themes */}
             <pre className="p-6 text-sm md:text-base overflow-x-auto">
               <code className="font-mono">
-                <span className="text-purple-600 dark:text-purple-400">import</span> <span className="text-amber-600 dark:text-yellow-400">browserSecurity</span> <span className="text-purple-600 dark:text-purple-400">from</span> <span className="text-green-600 dark:text-green-400">&apos;eslint-plugin-browser-security&apos;</span>;{'\n'}
-                <span className="text-purple-600 dark:text-purple-400">import</span> <span className="text-amber-600 dark:text-yellow-400">jwt</span> <span className="text-purple-600 dark:text-purple-400">from</span> <span className="text-green-600 dark:text-green-400">&apos;eslint-plugin-jwt&apos;</span>;{'\n'}
+                <span className="text-orange-800 dark:text-orange-300">import</span> <span className="text-amber-800 dark:text-yellow-400">browserSecurity</span> <span className="text-orange-800 dark:text-orange-300">from</span> <span className="text-green-800 dark:text-green-400">&apos;eslint-plugin-browser-security&apos;</span>;{'\n'}
+                <span className="text-orange-800 dark:text-orange-300">import</span> <span className="text-amber-800 dark:text-yellow-400">jwt</span> <span className="text-orange-800 dark:text-orange-300">from</span> <span className="text-green-800 dark:text-green-400">&apos;eslint-plugin-jwt&apos;</span>;{'\n'}
                 {'\n'}
-                <span className="text-purple-600 dark:text-purple-400">export default</span> [{'\n'}
-                {'  '}browserSecurity.configs.<span className="text-amber-600 dark:text-yellow-400">recommended</span>,{'\n'}
-                {'  '}jwt.configs.<span className="text-amber-600 dark:text-yellow-400">recommended</span>,{'\n'}
+                <span className="text-orange-800 dark:text-orange-300">export default</span> [{'\n'}
+                {'  '}browserSecurity.configs.<span className="text-amber-800 dark:text-yellow-400">recommended</span>,{'\n'}
+                {'  '}jwt.configs.<span className="text-amber-800 dark:text-yellow-400">recommended</span>,{'\n'}
                 {'  '}<span className="text-fd-muted-foreground">{'// Start protecting your code instantly'}</span>{'\n'}
                 ];
               </code>


### PR DESCRIPTION
Found by the full-brand QA sweep (2026-08-02) across all six live surfaces.

## What was wrong

The homepage `eslint.config.js` sample carried **the last rendered violet in the ecosystem**:
`text-purple-600 dark:text-purple-400` on the keyword tokens (`#9810fa` light / `#c27aff` dark).
Every other surface came back clean on all four banned hexes; this was the one hit.

The same block also **failed WCAG AA in light mode**. It sits on `#f1f1f1`, where:

| token | class | measured | need |
|---|---|---|---|
| identifier | `amber-600` `#e17100` | **2.83:1** | 4.5 |
| string | `green-600` `#00a63e` | **2.85:1** | 4.5 |

(The purple actually passed at 4.91:1 — it was a brand violation, not a contrast one.)

## What changed

Moved to the **-800 steps**, keeping the brand chassis (burnt orange for keywords, never violet):

| token | was | now | on `#f1f1f1` |
|---|---|---|---|
| keyword | `text-purple-600 dark:text-purple-400` | `text-orange-800 dark:text-orange-300` | **8.36:1** |
| identifier | `text-amber-600 dark:text-yellow-400` | `text-amber-800 dark:text-yellow-400` | **5.97:1** |
| string | `text-green-600 dark:text-green-400` | `text-green-800 dark:text-green-400` | **6.31:1** |

Dark theme already passed and is unchanged — orange-300 10.51:1, yellow-400 12.39:1,
green-400 10.08:1 on `#171717`.

## The lock test was pinning the bug

`homepage-lock.test.tsx` asserted `toContain('text-purple-600 dark:text-purple-400')` under the
description *"uses theme-aware purple for keywords (WCAG 4.5:1 contrast)"* — so the violet could
not be removed without touching the test. Updated to pin the new tokens, and it now also asserts
`text-purple-600` never comes back.

## Verification

- `homepage-lock.test.tsx` — 136/136 pass
- Full `apps/docs` suite: identical before and after (1485 pass / 17 fail). The 17 are a local
  `--ignore-scripts` artifact — unresolved `@interlace/ui/*` imports in files this PR does not
  touch — and reproduce on a clean `origin/main` checkout.
- All pre-commit hooks green (stale-build-artifacts, shim-drift, tests-affected 20/20, commitlint).

Full sweep report: `brand-assets/qa-2026-08-02/REPORT.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)