### PR TITLE
fix(node-security): put no-timing-unsafe-compare in recommended (restore CWE-697 coverage)

### DIFF
--- a/.changeset/restore-timing-unsafe-coverage.md
+++ b/.changeset/restore-timing-unsafe-coverage.md
@@ -1,0 +1,24 @@
+---
+'eslint-plugin-node-security': minor
+---
+
+Add `no-timing-unsafe-compare` to the `recommended` preset, restoring CWE-697
+coverage.
+
+`secure-coding/no-insecure-comparison` was removed from every `secure-coding`
+preset, with `node-security/no-timing-unsafe-compare` named as the replacement.
+But that rule was not in any `recommended` preset, so the practical result was
+that **no `recommended` preset anywhere covered CWE-697 timing-unsafe
+comparison**, and the migration note pointed users at a rule they would have had
+to enable by hand — which the note did not say.
+
+It enters at `'warn'` rather than `'error'`, matching the precedent already set
+by `no-deprecated-buffer` in this preset: adopters shouldn't have CI turn red on
+a version bump. Promote to `'error'` on the next major.
+
+Note the coverage now lives in a different package than before. A project that
+installs only `eslint-plugin-secure-coding` and relied on its presets for this
+check needs `eslint-plugin-node-security` as well.
+
+A lock test in `src/index.test.ts` fails if the rule leaves `recommended` again,
+since that would silently make the migration note false.

--- a/packages/eslint-plugin-node-security/src/index.test.ts
+++ b/packages/eslint-plugin-node-security/src/index.test.ts
@@ -67,6 +67,23 @@ describe('eslint-plugin-node-security plugin interface', () => {
       );
     });
 
+    // Regression lock. `secure-coding/no-insecure-comparison` was removed from
+    // every secure-coding preset in favour of this rule, but this rule was not
+    // in any `recommended` preset — so CWE-697 timing-unsafe comparison briefly
+    // had no preset coverage anywhere in the ecosystem while the migration note
+    // told users it lived here. If this rule leaves `recommended` again, the
+    // migration note in
+    // `packages/eslint-plugin-secure-coding/src/index.ts` becomes false.
+    it('keeps no-timing-unsafe-compare in recommended (CWE-697 preset coverage)', () => {
+      const recommendedRules = configs['recommended'].rules || {};
+      expect(
+        recommendedRules['node-security/no-timing-unsafe-compare'],
+        'no-timing-unsafe-compare must stay in recommended: it is the documented ' +
+          'replacement for secure-coding/no-insecure-comparison, which was removed ' +
+          'from every secure-coding preset.',
+      ).toBeDefined();
+    });
+
     it('should provide strict configuration', () => {
       expect(configs['strict']).toBeDefined();
       expect(configs['strict'].plugins?.['node-security']).toBeDefined();

--- a/packages/eslint-plugin-node-security/src/index.ts
+++ b/packages/eslint-plugin-node-security/src/index.ts
@@ -122,6 +122,15 @@ const recommendedRules: Record<string, TSESLint.FlatConfig.RuleEntry> = {
   'node-security/no-ssrf': 'warn',
   'node-security/no-shell-injection': 'error',
   'node-security/no-dynamic-algorithm-selection': 'error',
+  // Added to `recommended` 2026-08-02. `secure-coding/no-insecure-comparison`
+  // was removed from every `secure-coding` preset in favour of this rule, but
+  // this rule was not in any `recommended` preset — so CWE-697 timing-unsafe
+  // comparison had no preset coverage anywhere in the ecosystem, and the
+  // migration note pointed at a rule users would have had to enable by hand.
+  // Enters at 'warn' rather than 'error' for the same reason as
+  // `no-deprecated-buffer` above: adopters already on this preset shouldn't
+  // have CI turn red on a version bump. Promote on the next major.
+  'node-security/no-timing-unsafe-compare': 'warn',
 
   // Migrated Rules
   'node-security/detect-suspicious-dependencies': 'warn',

--- a/packages/eslint-plugin-secure-coding/src/index.ts
+++ b/packages/eslint-plugin-secure-coding/src/index.ts
@@ -167,7 +167,11 @@ const recommendedRules: Record<string, TSESLint.FlatConfig.RuleEntry> = {
   // check wearing a security hat.
   //
   // The timing-attack half (a secret compared with `===`) is the part worth
-  // keeping, and `node-security/no-timing-unsafe-compare` is where it lives.
+  // keeping, and `node-security/no-timing-unsafe-compare` is where it lives —
+  // in that plugin's `recommended` preset since 2026-08-02, so consumers on
+  // presets keep CWE-697 coverage. It does mean the coverage now lives in a
+  // different package: a project that installs only `eslint-plugin-secure-coding`
+  // needs `eslint-plugin-node-security` as well to keep it.
   // The rule remains exported and available via `strict` / explicit opt-in.
 
   // Critical - Template injection


### PR DESCRIPTION
## Summary

Found while resolving a review thread on the release PR (#289), before it published.

`secure-coding/no-insecure-comparison` was removed from `recommended`, `recommended-strict` and `owasp-top-10`, with `node-security/no-timing-unsafe-compare` named in the code comment as the replacement. That removal was right — 876 findings on a 1,470-file corpus, all already covered by core `eqeqeq`.

But **`no-timing-unsafe-compare` was not in any `recommended` preset either.** The net effect of shipping #289 as-is would have been that no `recommended` preset anywhere in the ecosystem covered CWE-697 timing-unsafe comparison, while our own in-code migration note told users it "lives" in node-security — a rule they'd have had to enable by hand, which the note didn't say.

- Adds `node-security/no-timing-unsafe-compare` to `recommended` at **`'warn'`**, not `'error'`. That matches the precedent already documented a few lines above it for `no-deprecated-buffer`: adopters on the preset shouldn't get a red CI from a version bump. Promote on the next major.
- Corrects the `secure-coding` comment to say the coverage now lives in a *different package* — a project installing only `eslint-plugin-secure-coding` needs `eslint-plugin-node-security` too.

## Test plan

- [x] `turbo run test --filter=eslint-plugin-node-security --filter=eslint-plugin-secure-coding` — **node-security 67/67, secure-coding 34/34**.
- [x] **Lock added** in `packages/eslint-plugin-node-security/src/index.test.ts`: fails if the rule leaves `recommended` again, because that silently falsifies the migration note in `secure-coding/src/index.ts`. Asserts on the resolved `configs['recommended'].rules`, so it breaks on the real preset, not on a copy of the list.

## After merge

The release PR regenerates and picks this up, so `secure-coding`'s preset removal and `node-security`'s replacement coverage publish together rather than leaving a window where neither preset covers CWE-697.

Semver note for the record: the reviewer on #289 argued the `secure-coding` preset removal should be a major. With this change the coverage is *relocated* rather than dropped, which is the case minor describes — but it does now span two packages, and that is called out explicitly in both the changeset and the code comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)