### PR TITLE
test(eslint-devkit): give repo-scan suites a 30s timeout

### DIFF
--- a/packages/eslint-devkit/src/tests/documentation-standards.test.ts
+++ b/packages/eslint-devkit/src/tests/documentation-standards.test.ts
@@ -48,7 +48,11 @@ const INVALID_PLUGINS = [
   'eslint-plugin-architecture', // Never existed, was placeholder
 ];
 
-describe('Documentation Standards', () => {
+// Every test here shells out to `grep` over the whole workspace. The grep itself
+// is sub-second, but process spawn + I/O contention under `turbo run test`
+// (20+ test processes in parallel) blows the default 5s budget. 30s is slack for
+// load, not for the scan.
+describe('Documentation Standards', { timeout: 30_000 }, () => {
   describe('No @eslint/ Prefixed Plugin Names', () => {
     it('should not have @eslint/eslint-plugin-* references in any docs or source', () => {
       const result = execSync(

--- a/packages/eslint-devkit/src/tests/no-deprecated-plugin-references.test.ts
+++ b/packages/eslint-devkit/src/tests/no-deprecated-plugin-references.test.ts
@@ -179,7 +179,12 @@ function violationMessage(
   );
 }
 
-describe('No Deprecated Plugin References', () => {
+// Both layers shell out to `grep` over the whole workspace. The grep itself is
+// sub-second (measured 0.65–0.74s from repo root); what blows the default 5s
+// budget is process spawn + I/O contention when `turbo run test` runs 20+ test
+// processes in parallel. 30s is slack for load, not for the scan — do not "fix"
+// this by widening SHARED_EXCLUDES.
+describe('No Deprecated Plugin References', { timeout: 30_000 }, () => {
   for (const plugin of DEPRECATED_PLUGINS) {
     it(`should not recommend ${plugin.name} in markdown (use ${plugin.successor})`, () => {
       const violations = findMarkdownReferences(plugin.name).filter(


### PR DESCRIPTION
## Problem

`packages/eslint-devkit/src/tests/no-deprecated-plugin-references.test.ts` fails intermittently with `Error: Test timed out in 5000ms`, blocking `git push` (lefthook pre-push runs `npx turbo run test`). It passes reliably standalone.

## Root cause (measured 2026-08-02)

Both devkit repo-scan suites shell out to `grep -rn[E]` over the whole workspace. The grep is **not** the bottleneck — timed at 0.65–0.74s from the repo root, and excluding `.git` changes it by <0.1s. What blows the 5s budget is process spawn + I/O contention when turbo runs 20+ vitest processes in parallel across the monorepo.

## Fix

Suite-level `{ timeout: 30_000 }` on both files. `documentation-standards.test.ts` had identical exposure (every test in it greps the workspace) and is included.

Deliberately **not** done:
- widening `SHARED_EXCLUDES` — the exclude list is already correct and the walk isn't the bottleneck
- weakening any assertion — the import layer is a regression guard for a real shipped bug (a stale `import('./packages/eslint-plugin-crypto/...')` that crashed every consumer of a shared config)

## Verification

- `npm run test -w @interlace/eslint-devkit` → 965 passed / 2 skipped, 30 files
- `npx --no turbo run test --output-logs=errors-only` (full pre-push battery, under concurrent-agent load) → 47/47 tasks successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)