### PR TITLE
feat(docs): branded 500 / error pages with a retry, plus a lock

### DIFF
--- a/apps/docs/src/__tests__/error-page-lock.test.ts
+++ b/apps/docs/src/__tests__/error-page-lock.test.ts
@@ -112,6 +112,24 @@ describe('error page lock', () => {
     // It replaces the root layout, so without these the page renders nothing.
     expect(globalErrorSource).toContain('<html');
     expect(globalErrorSource).toContain('<body');
+
+    // And its own <head>: Next injects nothing here, so a missing viewport
+    // meta silently drops mobile browsers back to ~980px desktop-zoom
+    // rendering — a broken-looking page on exactly the devices least able to
+    // recover from one.
+    expect(globalErrorSource).toContain('<head');
+    // Two independent checks, not one regex: requiring `name` to precede
+    // `content` in the same tag would go quietly false-negative the first
+    // time a formatter reorders the props.
+    expect(globalErrorSource).toContain('name="viewport"');
+    expect(globalErrorSource).toContain('width=device-width');
+  });
+
+  it('global-error.tsx keeps the skip-link target', () => {
+    // error.tsx and not-found.tsx both carry id="main"; dropping it here would
+    // strand keyboard and screen-reader users on the one page they most need
+    // to escape.
+    expect(globalErrorSource).toContain('id="main"');
   });
 
   it('global-error.tsx stays dependency-free apart from its stylesheet', () => {

--- a/apps/docs/src/__tests__/error-page-lock.test.ts
+++ b/apps/docs/src/__tests__/error-page-lock.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+/**
+ * Error Page Lock Tests
+ *
+ * error.tsx and global-error.tsx are the two pages nobody sees during normal
+ * development, so regressions here surface only in front of a real user who
+ * already hit a failure. Two classes of invariant are worth locking:
+ *
+ *  1. SECURITY — the page must never render `error.message` or `error.stack`.
+ *     Next deliberately withholds those from the client in production and
+ *     hands over an opaque `digest` instead; printing the message would leak
+ *     server internals (paths, query fragments, upstream responses) onto a
+ *     public page. This is the assertion that matters most.
+ *  2. LAYOUT — `max-w-prose`, never `max-w-sm..2xl`, which the design-system
+ *     spacing tokens shadow into a ~96px container.
+ *
+ * global-error.tsx additionally must stay dependency-free: it replaces the
+ * root layout, so anything it imports is code that can itself throw while
+ * handling a throw. It inlines the mark for exactly that reason.
+ */
+
+const APP_ROOT = resolve(__dirname, '../..');
+const ERROR_PATH = join(APP_ROOT, 'src/app/error.tsx');
+const GLOBAL_ERROR_PATH = join(APP_ROOT, 'src/app/global-error.tsx');
+
+/** Utilities the DS spacing tokens shadow — see the interlace-theme spacing scale. */
+const SHADOWED_MAX_W = [
+  'max-w-sm',
+  'max-w-md',
+  'max-w-lg',
+  'max-w-xl',
+  'max-w-2xl',
+];
+
+/**
+ * Renders of the raw error object that would leak server internals.
+ *
+ * Patterns, not literal strings: an exact-string list only catches the exact
+ * spelling it was written for, and `{error?.message}`, `{error["message"]}`
+ * and `{error.toString()}` are the same leak in different clothes.
+ *
+ * The `console.error(..., error)` call in the logging effect is deliberately
+ * NOT matched — that goes to the browser console, not into the rendered page.
+ */
+const LEAKY_RENDER_PATTERNS: Array<[string, RegExp]> = [
+  ['{error.message} / {error?.message}', /\{[^}]*\berror\s*\??\.\s*message\b/],
+  ['{error.stack} / {error?.stack}', /\{[^}]*\berror\s*\??\.\s*stack\b/],
+  [
+    '{error["message"]} / {error["stack"]}',
+    /\{[^}]*\berror\s*\[\s*['"](?:message|stack)['"]\s*\]/,
+  ],
+  ['{error.toString()}', /\{[^}]*\berror\s*\??\.\s*toString\s*\(/],
+  ['{String(error)}', /\{[^}]*\bString\s*\(\s*error\b/],
+  ['{`${error}`}', /\{\s*`[^`]*\$\{\s*error\s*\}/],
+];
+
+describe('error page lock', () => {
+  let errorSource: string;
+  let globalErrorSource: string;
+
+  beforeAll(() => {
+    errorSource = readFileSync(ERROR_PATH, 'utf8');
+    globalErrorSource = readFileSync(GLOBAL_ERROR_PATH, 'utf8');
+  });
+
+  it.each([
+    ['error.tsx', () => errorSource],
+    ['global-error.tsx', () => globalErrorSource],
+  ])('%s never renders the raw error message or stack', (_name, get) => {
+    const source = get();
+    for (const [label, pattern] of LEAKY_RENDER_PATTERNS) {
+      expect(
+        pattern.test(source),
+        `${label} leaks server internals onto a public page — render error.digest instead`,
+      ).toBe(false);
+    }
+    // The digest is the sanctioned, opaque handle.
+    expect(source).toContain('error.digest');
+  });
+
+  it.each([
+    ['error.tsx', () => errorSource],
+    ['global-error.tsx', () => globalErrorSource],
+  ])('%s uses max-w-prose and no DS-shadowed max-w utility', (_name, get) => {
+    const source = get();
+    expect(source).toContain('max-w-prose');
+
+    // Collect the max-w tokens with ONE literal regex and compare sets, rather
+    // than building a regex per class from a string. Same word-boundary effect
+    // (max-w-xl can never match inside max-w-2xl), no dynamic RegExp.
+    const used = new Set(
+      [...source.matchAll(/\bmax-w-([a-z0-9-]+)\b/g)].map((m) => m[1]),
+    );
+    for (const cls of SHADOWED_MAX_W) {
+      expect(
+        used.has(cls.replace('max-w-', '')),
+        `${cls} is shadowed by the DS spacing tokens and renders ~96px wide`,
+      ).toBe(false);
+    }
+  });
+
+  it('error.tsx is a client boundary that offers a retry', () => {
+    expect(errorSource).toMatch(/^['"]use client['"]/m);
+    expect(errorSource).toContain('reset');
+    expect(errorSource).toContain('onClick={reset}');
+  });
+
+  it('global-error.tsx supplies its own document shell', () => {
+    // It replaces the root layout, so without these the page renders nothing.
+    expect(globalErrorSource).toContain('<html');
+    expect(globalErrorSource).toContain('<body');
+  });
+
+  it('global-error.tsx stays dependency-free apart from its stylesheet', () => {
+    const imports = [
+      ...globalErrorSource.matchAll(/^import\s.*?from\s+['"](.+?)['"]/gm),
+    ]
+      .map((m) => m[1])
+      .filter((spec) => !spec.endsWith('.css'));
+
+    // A boundary that imports app code can throw while handling a throw —
+    // which is why the mark is inlined here rather than imported.
+    expect(
+      imports,
+      `global-error.tsx must not import app modules (found: ${imports.join(', ')})`,
+    ).toEqual([]);
+  });
+});

--- a/apps/docs/src/app/error.tsx
+++ b/apps/docs/src/app/error.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+
+import { buttonVariants } from '#interlace/components/ui/button-variants';
+import { InterlaceMark } from '#interlace/layouts/layout-options';
+
+/**
+ * Route-level error boundary. Catches render/data errors in any segment below
+ * the root layout and replaces just that subtree — the shell stays mounted.
+ *
+ * Must be a Client Component (React error boundaries are client-only), which
+ * is also why there is no `metadata` export here: Next serves a 500 for these
+ * and the page is never indexable anyway.
+ *
+ * Errors in the ROOT layout itself escape this boundary — global-error.tsx
+ * catches those.
+ */
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  // Surface the failure to client-side monitoring. Without this the error
+  // exists only in the server log and is invisible to anything running in
+  // the browser. Mirrors the scorecard boundary's convention.
+  useEffect(() => {
+    console.error('[error-boundary] render failed:', error);
+  }, [error]);
+
+  return (
+    <main
+      id="main"
+      data-slot="error-page"
+      className="mx-auto flex min-h-[70vh] w-full max-w-prose flex-col items-center justify-center px-6 py-24 text-center"
+    >
+      <InterlaceMark size={56} />
+
+      <p className="mt-8 font-mono text-sm tracking-widest text-fd-muted-foreground">
+        500
+      </p>
+
+      <h1 className="mt-3 text-3xl font-bold tracking-tight text-fd-foreground">
+        Something broke on our end
+      </h1>
+
+      <p className="mt-4 text-fd-muted-foreground">
+        This one is not your fault. The page failed to render — retrying often
+        clears it, and the failure has been logged either way.
+      </p>
+
+      <div className="mt-8 flex flex-wrap justify-center gap-3">
+        {/* reset() re-renders the failed segment without a full page load. */}
+        <button
+          type="button"
+          onClick={reset}
+          className={buttonVariants({ variant: 'default' })}
+        >
+          Try again
+        </button>
+        <Link href="/" className={buttonVariants({ variant: 'outline' })}>
+          Go home
+        </Link>
+      </div>
+
+      {/*
+        The digest is a hash Next assigns to the server-side error; the real
+        message and stack stay on the server. Showing it lets someone quote a
+        reference in an issue without us leaking internals into the page.
+      */}
+      {error.digest ? (
+        <p className="mt-8 font-mono text-xs text-fd-muted-foreground">
+          Reference: {error.digest}
+        </p>
+      ) : null}
+    </main>
+  );
+}

--- a/apps/docs/src/app/global-error.tsx
+++ b/apps/docs/src/app/global-error.tsx
@@ -24,8 +24,17 @@ export default function GlobalError({
 }) {
   return (
     <html lang="en">
+      {/* Next injects nothing here: global-error replaces the root layout,
+          which is what normally supplies these. Without the viewport meta,
+          mobile browsers fall back to ~980px desktop-zoom rendering. */}
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Something went wrong</title>
+      </head>
       <body className="bg-fd-background text-fd-foreground antialiased">
         <main
+          id="main"
           data-slot="global-error-page"
           className="mx-auto flex min-h-screen w-full max-w-prose flex-col items-center justify-center px-6 py-24 text-center"
         >

--- a/apps/docs/src/app/global-error.tsx
+++ b/apps/docs/src/app/global-error.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import './global.css';
+
+/**
+ * Last-resort error boundary. Only fires when the ROOT layout itself throws —
+ * error.tsx cannot catch that, because it renders *inside* the root layout.
+ *
+ * Because it replaces the root layout, it must supply its own <html>/<body>,
+ * and it cannot use anything the layout provides: no theme provider, no font
+ * loader, no nav. It imports global.css directly so the brand tokens resolve;
+ * if even that fails, the markup below is still semantic and readable.
+ *
+ * Deliberately dependency-free otherwise — a boundary that can itself throw is
+ * worse than no boundary. That includes the mark, which is inlined here rather
+ * than imported from the baseline for the same reason.
+ */
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <html lang="en">
+      <body className="bg-fd-background text-fd-foreground antialiased">
+        <main
+          data-slot="global-error-page"
+          className="mx-auto flex min-h-screen w-full max-w-prose flex-col items-center justify-center px-6 py-24 text-center"
+        >
+          <svg
+            viewBox="0 0 100 100"
+            width={56}
+            height={56}
+            aria-hidden="true"
+            className="shrink-0"
+          >
+            <g transform="rotate(-30 50 50)">
+              <rect
+                x="10"
+                y="18"
+                width="62"
+                height="28"
+                rx="14"
+                fill="var(--brand-mark-bar-o)"
+              />
+              <rect
+                x="28"
+                y="54"
+                width="62"
+                height="28"
+                rx="14"
+                fill="var(--brand-mark-bar-g)"
+              />
+            </g>
+          </svg>
+
+          <p className="mt-8 font-mono text-sm tracking-widest text-fd-muted-foreground">
+            500
+          </p>
+
+          <h1 className="mt-3 text-3xl font-bold tracking-tight">
+            Something broke on our end
+          </h1>
+
+          <p className="mt-4 text-fd-muted-foreground">
+            This one is not your fault. The page failed to load — retrying often
+            clears it, and the failure has been logged either way.
+          </p>
+
+          <div className="mt-8 flex flex-wrap justify-center gap-3">
+            <button
+              type="button"
+              onClick={reset}
+              className="inline-flex h-9 items-center justify-center rounded-md bg-fd-primary px-4 text-sm font-medium text-fd-primary-foreground"
+            >
+              Try again
+            </button>
+            {/* Deliberately a plain <a>, not next/link: this boundary runs when the
+                root layout itself failed, so client-side navigation is exactly the
+                thing that cannot be trusted. A full document load is the reliable
+                escape hatch. */}
+            {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+            <a
+              href="/"
+              className="inline-flex h-9 items-center justify-center rounded-md border border-fd-border px-4 text-sm font-medium"
+            >
+              Go home
+            </a>
+          </div>
+
+          {error.digest ? (
+            <p className="mt-8 font-mono text-xs text-fd-muted-foreground">
+              Reference: {error.digest}
+            </p>
+          ) : null}
+        </main>
+      </body>
+    </html>
+  );
+}


### PR DESCRIPTION
## Summary

Follow-on to the 404 work (#306). The site had **no error boundary at all** — any render or data failure fell through to Next's stock unstyled error screen, on the more alarming of the two pages.

| File | Catches | Notes |
|---|---|---|
| `error.tsx` | failures in any segment **below** the root layout | shell stays mounted; `reset()` as "Try again"; logs to the browser console for client-side monitoring |
| `global-error.tsx` | failures **in** the root layout | `error.tsx` can't catch these — it renders *inside* the layout. Supplies its own `<html>`/`<body>` |

### The part that matters most

**Neither page renders `error.message` or `error.stack`.** Next withholds those from the client in production and supplies an opaque `digest`; the pages surface the digest so a user can quote a reference without us leaking server internals (paths, query fragments, upstream responses) onto a public page.

`global-error.tsx` is deliberately dependency-free apart from its stylesheet — a boundary that imports app code can throw *while handling a throw*, which is why it inlines the mark. Its "Go home" is a plain `<a>`, not `next/link`, for the same reason: client-side navigation is exactly what can't be trusted when the root layout has failed.

## Test plan

- [x] `error-page-lock.test.ts` — 7 tests, green.
- [x] **Mutation-tested**, not just asserted green — each of these turns the suite red, then reverts clean:
  - `{error.message}`, `{error?.message}`, `{error["message"]}`, `{error.toString()}`, `{String(error)}`
  - `max-w-prose` → `max-w-2xl` (DS spacing tokens shadow it into a ~96px container)
  - adding an app-code import to `global-error.tsx`
- [x] **Verified against a production build**, not dev — dev ships error details for the overlay, which would have made the leak check meaningless. `next build && next start`, then a temporary throwing route:
  - HTTP **500**; branded page renders; digest shown and matching the server log
  - the thrown message and source path appear **nowhere** in the served HTML
  - "Try again" re-runs the failed segment
  - probe route removed before commit

## Known limitation

Next renders these boundaries **client-side after hydration** — the initial 500 body is Next's minimal `__next_error__` shell, so with JS disabled a user sees a blank page. Inherent to `error.tsx`, not introduced here.

## Note on the local hook

The pre-push hook's `lockfile` gate is currently red on `main` for unrelated reasons: npm has `eslint-plugin-vercel-ai-security@1.4.0` published ahead of `package.json`, and the open changesets PR #315 doesn't cover that package. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)