### PR TITLE
fix(workspace): ILB-Formatter emits the methodologyHash its own gate requires

### DIFF
--- a/benchmarks/__tests__/methodology-lock.test.ts
+++ b/benchmarks/__tests__/methodology-lock.test.ts
@@ -53,7 +53,11 @@ describe('methodology receipt — emission lock', () => {
 
   it('finds the suites that emit a pre-registration receipt', () => {
     // Guards the guard: a broken walker would vacuously pass every case below.
-    expect(sources.length).toBeGreaterThanOrEqual(13);
+    // Exact, not a floor. A floor set below the true count cannot detect a
+    // suite *losing* its receipt — at >= 13 the ilb-formatter regression this
+    // number was raised for would have slipped through at 14. Ratchet this
+    // when a suite is added; that edit is the point.
+    expect(sources.length).toBe(15);
   });
 
   it.each(sources.map((p) => [path.relative(REPO_ROOT, p), p]))(

--- a/benchmarks/suites/ilb-formatter/runner.ts
+++ b/benchmarks/suites/ilb-formatter/runner.ts
@@ -35,6 +35,7 @@ import {
   type Shape,
   type SyntheticFixture,
 } from './fixtures';
+import { capturePreregistration } from '../../lib/preregister.ts';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const SUITE_NAME = 'ilb-formatter';
@@ -1068,11 +1069,21 @@ async function main(): Promise<void> {
     throw new Error('Provenance contract violation: tools.count !== tools.items.length');
   }
 
+  // Squash-proof pre-registration receipt. Without this the envelope carries
+  // the vocabulary-contract fields but no `methodologyHash`, which
+  // scripts/ilb-validate-results.ts treats as fatal rather than as a
+  // grandfathered pre-contract file — so the suite fails its own gate on the
+  // results it just wrote.
+  const prereg = capturePreregistration({ allowDirty: true, entrypoint: import.meta.url });
+
   const result = {
     // Vocabulary-contract fields (required by benchmarks/lib/result-schema.json).
     bench: 'ILB-Formatter',
     benchVersion: METHODOLOGY_VERSION.replace(/^v/, ''),
     timestamp: new Date().toISOString(),
+    methodologyCommit: prereg.methodologyCommit,
+    methodologyHash: prereg.methodologyHash,
+    methodologyPaths: prereg.methodologyPaths,
     toolchain,
     cost,
     effectiveness,


### PR DESCRIPTION
The **ILB-Formatter (signal + latency + regression gate)** check has been failing on every PR that triggers it. The failure is not in anyone's changes — the job fails the validator on the two result files it has just written itself.

## Root cause

`benchmarks/suites/ilb-formatter/runner.ts` builds a full vocabulary-contract envelope — `bench`, `benchVersion`, `timestamp`, `toolchain` — but never captures a pre-registration receipt. `scripts/ilb-validate-results.ts` only grandfathers files that predate the contract *entirely*; an envelope carrying the contract fields but no `methodologyHash` is fatal (`:147`), not a warning.

So every run writes `latest.json` and a dated result, then immediately fails on them:

```
• benchmarks/results/ilb-formatter/2026-08-03-formatter-0.1.0.json: missing "methodologyHash"
• benchmarks/results/ilb-formatter/latest.json: missing "methodologyHash"
ilb-validate-results: 9/81 files have issues (29 total, 2 fatal)
```

This is invisible when you validate locally — the tracked result files *are* grandfathered, so a bare `npm run ilb:validate-results` reports `7/80 … 0 fatal` and looks clean. The two offenders do not exist until the bench runs.

## Fix

Capture the receipt the way every other suite already does (`benchmarks/suites/ilb-diff/run.ts:217`):

```ts
const prereg = capturePreregistration({ allowDirty: true, entrypoint: import.meta.url });
```

…and carry `methodologyCommit` / `methodologyHash` / `methodologyPaths` on the envelope. Three lines; `ilb-formatter` was the only suite missing it.

## Verification

Reproduced the CI job locally step for step — build `@interlace/eslint-formatter`, `npm run ilb:formatter`, `npm run ilb:validate-results`:

| | files with issues | total | fatal | job |
|---|---|---|---|---|
| before | 9/81 | 29 | **2** | fails |
| after | 7/81 | 27 | **0** | passes |

The 27 remaining are genuine pre-contract warnings on old result files, untouched by this PR. The regenerated envelope now carries `methodologyHash: sha256:41c2f232…` over 4 `methodologyPaths`.

The bench's own gates passed on that run too: latency contract PASS, regression check PASS across 270 cells (18 comparator-drift entries, informational — we don't own those formatters).

## Not committed

The regenerated `latest.json` and `2026-08-03-formatter-0.1.0.json` are deliberately left out: they carry local machine timings, and CI rewrites both on every run. Only the runner change ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)