### PR TITLE
fix(docs): unblock pre-push, revive a dead lock suite, repair broken config examples

### DIFF
--- a/.changeset/ready-pillows-ring.md
+++ b/.changeset/ready-pillows-ring.md
@@ -1,0 +1,9 @@
+---
+---
+
+Test-infrastructure only — no published artifact changes.
+
+De-flakes the pre-push `turbo run test` fan-out: `no-deprecated-plugin-references`
+now scans via `git grep` (tracked files only) instead of walking the working tree,
+and the I/O-bound lock suites in `docs` / `eslint-formatter` get a timeout that
+reflects cold-cache reality rather than vitest's 5s default.

--- a/.changeset/ready-pillows-ring.md
+++ b/.changeset/ready-pillows-ring.md
@@ -1,9 +1,18 @@
 ---
 ---
 
-Test-infrastructure only — no published artifact changes.
+No published artifact changes — `docs/` is not in any package's `files` array,
+so the corrected rule documentation reaches users through eslint.interlace.tools
+rather than the npm tarball.
 
-De-flakes the pre-push `turbo run test` fan-out: `no-deprecated-plugin-references`
-now scans via `git grep` (tracked files only) instead of walking the working tree,
-and the I/O-bound lock suites in `docs` / `eslint-formatter` get a timeout that
-reflects cold-cache reality rather than vitest's 5s default.
+Three things landed:
+
+1. `no-deprecated-plugin-references` scans via `git grep` over tracked files
+   instead of walking the working tree with `grep -r` (15.4s cold → 0.24s).
+2. `documentation-standards` had resolved its workspace root one level above the
+   repo, so it had been passing vacuously. Fixing it activated 24 tests and
+   surfaced ~26 broken config examples across the docs — `'architecture/'` and
+   stale `'secure-coding/'` rule prefixes, wrong npm package attributions, and
+   two references to rules that do not exist.
+3. Every package vitest config now carries a 30s testTimeout floor, so the
+   47-task pre-push fan-out stops mis-reporting I/O contention as failure.

--- a/apps/docs/content/docs/getting-started/advanced/ci-cd.mdx
+++ b/apps/docs/content/docs/getting-started/advanced/ci-cd.mdx
@@ -133,16 +133,18 @@ import secureCoding from 'eslint-plugin-secure-coding';
 import jwt from 'eslint-plugin-jwt';
 import nodeSecurity from 'eslint-plugin-node-security';
 import browserSecurity from 'eslint-plugin-browser-security';
+import pg from 'eslint-plugin-pg';
 
 export default [
   secureCoding.configs.recommended,
   jwt.configs.recommended,
   nodeSecurity.configs.recommended,
   browserSecurity.configs.recommended,
+  pg.configs.recommended,
   {
     rules: {
       // Critical (CVSS 9+): Always error
-      'secure-coding/no-sql-injection': 'error',
+      'pg/no-unsafe-query': 'error',
       'jwt/no-hardcoded-secret': 'error',
 
       // High (CVSS 7-8.9): Error in CI, warn locally

--- a/apps/docs/content/docs/getting-started/configuration.mdx
+++ b/apps/docs/content/docs/getting-started/configuration.mdx
@@ -89,17 +89,19 @@ Apply different rules to different file types:
 import browserSecurity from 'eslint-plugin-browser-security';
 import secureCoding from 'eslint-plugin-secure-coding';
 import jwt from 'eslint-plugin-jwt';
+import pg from 'eslint-plugin-pg';
 
 export default [
   browserSecurity.configs.recommended,
   secureCoding.configs.recommended,
   jwt.configs.recommended,
+  pg.configs.recommended,
 
   // Stricter rules for API routes
   {
     files: ['**/api/**/*.ts', '**/routes/**/*.ts'],
     rules: {
-      'secure-coding/no-sql-injection': 'error',
+      'pg/no-unsafe-query': 'error',
       'jwt/no-algorithm-none': 'error',
     },
   },

--- a/apps/docs/content/docs/learn/how-eslint-plugins-work/index.mdx
+++ b/apps/docs/content/docs/learn/how-eslint-plugins-work/index.mdx
@@ -231,23 +231,23 @@ A user writes a config:
 
 ```js
 // eslint.config.js
-import secureCoding from '@interlace/eslint-plugin-secure-coding';
+import secureCoding from 'eslint-plugin-secure-coding';
 
 export default [
   {
     plugins: { 'secure-coding': secureCoding },
     rules: {
-      'secure-coding/no-eval': 'error',
+      'secure-coding/no-hardcoded-credentials': 'error',
     },
   },
 ];
 ```
 
-ESLint resolves `secure-coding/no-eval` by:
+ESLint resolves `secure-coding/no-hardcoded-credentials` by:
 
 1. Look up the plugin named `'secure-coding'` in the config's `plugins`
    map → finds the `secureCoding` import.
-2. Look up `'no-eval'` in `secureCoding.rules` → finds the rule module
+2. Look up `'no-hardcoded-credentials'` in `secureCoding.rules` → finds the rule module
    (the `{ meta, create }` object).
 3. Call `create(context)` for each file being linted.
 

--- a/apps/docs/content/docs/quality/plugin-conventions/rules/consistent-existence-index-check.mdx
+++ b/apps/docs/content/docs/quality/plugin-conventions/rules/consistent-existence-index-check.mdx
@@ -66,7 +66,7 @@ if (index !== -1) {
 ```javascript
 {
   rules: {
-    'architecture/consistent-existence-index-check': 'warn'
+    'conventions/consistent-existence-index-check': 'warn'
   }
 }
 ```

--- a/apps/docs/content/docs/quality/plugin-conventions/rules/filename-case.mdx
+++ b/apps/docs/content/docs/quality/plugin-conventions/rules/filename-case.mdx
@@ -120,7 +120,7 @@ src/
 ```javascript
 {
   rules: {
-    'architecture/filename-case': 'error'
+    'conventions/filename-case': 'error'
   }
 }
 ```
@@ -130,7 +130,7 @@ src/
 ```javascript
 {
   rules: {
-    'architecture/filename-case': ['error', {
+    'conventions/filename-case': ['error', {
       case: 'pascalCase',
       allowedKebabCase: ['index', 'main']
     }]
@@ -143,7 +143,7 @@ src/
 ```javascript
 {
   rules: {
-    'architecture/filename-case': ['error', {
+    'conventions/filename-case': ['error', {
       case: 'kebabCase',
       allowedPascalCase: ['App', 'Button', 'Modal'],  // React components
       allowedSnakeCase: ['db_migrations'],            // Legacy
@@ -158,7 +158,7 @@ src/
 ```javascript
 {
   rules: {
-    'architecture/filename-case': ['error', {
+    'conventions/filename-case': ['error', {
       case: 'kebabCase',
       allowedUppercaseFiles: []  // Disable all uppercase exceptions
     }]

--- a/apps/docs/content/docs/quality/plugin-maintainability/rules/consistent-function-scoping.mdx
+++ b/apps/docs/content/docs/quality/plugin-maintainability/rules/consistent-function-scoping.mdx
@@ -80,7 +80,7 @@ function createMultiplier(factor: number) {
 ```javascript
 {
   rules: {
-    'architecture/consistent-function-scoping': 'warn'
+    'maintainability/consistent-function-scoping': 'warn'
   }
 }
 ```

--- a/apps/docs/content/docs/quality/plugin-maintainability/rules/no-unreadable-iife.mdx
+++ b/apps/docs/content/docs/quality/plugin-maintainability/rules/no-unreadable-iife.mdx
@@ -74,7 +74,7 @@ const config = (() => {
 ```javascript
 {
   rules: {
-    'architecture/no-unreadable-iife': 'warn'
+    'maintainability/no-unreadable-iife': 'warn'
   }
 }
 ```

--- a/apps/docs/content/docs/quality/plugin-modernization/rules/prefer-at.mdx
+++ b/apps/docs/content/docs/quality/plugin-modernization/rules/prefer-at.mdx
@@ -76,7 +76,7 @@ const lastChar = string.at(-1);
 ```javascript
 {
   rules: {
-    'architecture/prefer-at': 'warn'
+    'modernization/prefer-at': 'warn'
   }
 }
 ```

--- a/apps/docs/content/docs/quality/plugin-modernization/rules/prefer-event-target.mdx
+++ b/apps/docs/content/docs/quality/plugin-modernization/rules/prefer-event-target.mdx
@@ -74,7 +74,7 @@ emitter.dispatch('change', { value: 42 });
 ```javascript
 {
   rules: {
-    'architecture/prefer-event-target': 'warn'
+    'modernization/prefer-event-target': 'warn'
   }
 }
 ```

--- a/apps/docs/content/docs/quality/plugin-modularity/rules/ddd-value-object-immutability.mdx
+++ b/apps/docs/content/docs/quality/plugin-modularity/rules/ddd-value-object-immutability.mdx
@@ -90,7 +90,7 @@ flowchart TD
 export default [
   {
     rules: {
-      'architecture/ddd-value-object-immutability': 'error',
+      'modularity/ddd-value-object-immutability': 'error',
     },
   },
 ];

--- a/apps/docs/content/docs/quality/plugin-modularity/rules/enforce-naming.mdx
+++ b/apps/docs/content/docs/quality/plugin-modularity/rules/enforce-naming.mdx
@@ -114,7 +114,7 @@ class CustomerOrder {
 ```javascript
 {
   rules: {
-    'architecture/enforce-naming': ['error', {
+    'modularity/enforce-naming': ['error', {
       domain: 'e-commerce',
       glossaryUrl: 'https://wiki.company.com/glossary',
       terms: [
@@ -147,7 +147,7 @@ class CustomerOrder {
 ```javascript
 {
   rules: {
-    'architecture/enforce-naming': ['error', {
+    'modularity/enforce-naming': ['error', {
       domain: 'finance',
       glossaryUrl: 'https://internal.bank.com/glossary',
       terms: [
@@ -180,7 +180,7 @@ class CustomerOrder {
 ```javascript
 {
   rules: {
-    'architecture/enforce-naming': ['error', {
+    'modularity/enforce-naming': ['error', {
       domain: 'healthcare',
       glossaryUrl: 'https://hipaa.health.gov/glossary',
       terms: [
@@ -213,7 +213,7 @@ class CustomerOrder {
 ```javascript
 {
   rules: {
-    'architecture/enforce-naming': ['error', {
+    'modularity/enforce-naming': ['error', {
       domain: 'shipping',
       terms: [
         {
@@ -301,7 +301,7 @@ function calculateOrderTotal(order: Order) {
 ```javascript
 {
   rules: {
-    'architecture/enforce-naming': ['error', {
+    'modularity/enforce-naming': ['error', {
       domain: 'e-commerce',
       terms: [
         {

--- a/apps/docs/content/docs/quality/plugin-modularity/rules/enforce-rest-conventions.mdx
+++ b/apps/docs/content/docs/quality/plugin-modularity/rules/enforce-rest-conventions.mdx
@@ -90,7 +90,7 @@ flowchart TD
 export default [
   {
     rules: {
-      'architecture/enforce-rest-conventions': 'error',
+      'modularity/enforce-rest-conventions': 'error',
     },
   },
 ];

--- a/apps/docs/content/docs/quality/plugin-modularity/rules/no-external-api-calls-in-utils.mdx
+++ b/apps/docs/content/docs/quality/plugin-modularity/rules/no-external-api-calls-in-utils.mdx
@@ -90,7 +90,7 @@ flowchart TD
 export default [
   {
     rules: {
-      'architecture/no-external-api-calls-in-utils': 'error',
+      'modularity/no-external-api-calls-in-utils': 'error',
     },
   },
 ];

--- a/apps/docs/content/docs/quality/plugin-reliability/rules/no-await-in-loop.mdx
+++ b/apps/docs/content/docs/quality/plugin-reliability/rules/no-await-in-loop.mdx
@@ -142,7 +142,7 @@ async function fetchWithLimit(urls: string[]) {
 ```javascript
 {
   rules: {
-    'architecture/no-await-in-loop': 'warn'
+    'reliability/no-await-in-loop': 'warn'
   }
 }
 ```
@@ -152,7 +152,7 @@ async function fetchWithLimit(urls: string[]) {
 ```javascript
 {
   rules: {
-    'architecture/no-await-in-loop': ['warn', {
+    'reliability/no-await-in-loop': ['warn', {
       allowForOf: true,
       allowWhile: false
     }]
@@ -165,7 +165,7 @@ async function fetchWithLimit(urls: string[]) {
 ```javascript
 {
   rules: {
-    'architecture/no-await-in-loop': ['error', {
+    'reliability/no-await-in-loop': ['error', {
       allowForOf: false,
       allowWhile: false,
       checkConcurrency: true

--- a/apps/docs/content/docs/security/plugin-browser-security/rules/no-clickjacking.mdx
+++ b/apps/docs/content/docs/security/plugin-browser-security/rules/no-clickjacking.mdx
@@ -89,7 +89,7 @@ const csp = "default-src 'self'"; // No frame protection!
 ```javascript
 {
   rules: {
-    'secure-coding/no-clickjacking': ['error', {
+    'browser-security/no-clickjacking': ['error', {
       trustedSources: ['self', 'https://trusted.com'],
       requireFrameBusting: true,
       detectTransparentOverlays: true

--- a/apps/docs/content/docs/security/plugin-browser-security/rules/no-insecure-redirects.mdx
+++ b/apps/docs/content/docs/security/plugin-browser-security/rules/no-insecure-redirects.mdx
@@ -101,7 +101,7 @@ flowchart TD
 export default [
   {
     rules: {
-      'secure-coding/no-insecure-redirects': 'error',
+      'browser-security/no-insecure-redirects': 'error',
     },
   },
 ];

--- a/apps/docs/content/docs/security/plugin-browser-security/rules/no-missing-security-headers.mdx
+++ b/apps/docs/content/docs/security/plugin-browser-security/rules/no-missing-security-headers.mdx
@@ -101,7 +101,7 @@ flowchart TD
 export default [
   {
     rules: {
-      'secure-coding/no-missing-security-headers': 'error',
+      'browser-security/no-missing-security-headers': 'error',
     },
   },
 ];

--- a/apps/docs/content/docs/security/plugin-browser-security/rules/no-unescaped-url-parameter.mdx
+++ b/apps/docs/content/docs/security/plugin-browser-security/rules/no-unescaped-url-parameter.mdx
@@ -131,7 +131,7 @@ const url = `https://example.com?${params}`; // ✅ Safe
 ```javascript
 {
   rules: {
-    'secure-coding/no-unescaped-url-parameter': ['error', {
+    'browser-security/no-unescaped-url-parameter': ['error', {
       allowInTests: false,                    // Allow in test files
       trustedLibraries: ['url', 'querystring'], // Trusted URL construction libraries
       ignorePatterns: []                     // Additional safe patterns to ignore

--- a/apps/docs/content/docs/security/plugin-node-security/rules/detect-suspicious-dependencies.mdx
+++ b/apps/docs/content/docs/security/plugin-node-security/rules/detect-suspicious-dependencies.mdx
@@ -76,7 +76,7 @@ If a package name is within 2 edits of a popular package name, it's flagged as s
 ```javascript
 {
   rules: {
-    'secure-coding/detect-suspicious-dependencies': 'error'
+    'node-security/detect-suspicious-dependencies': 'error'
   }
 }
 ```

--- a/apps/docs/content/docs/security/plugin-node-security/rules/no-dynamic-require.mdx
+++ b/apps/docs/content/docs/security/plugin-node-security/rules/no-dynamic-require.mdx
@@ -76,7 +76,7 @@ const plugin = plugins[name];
 ```javascript
 {
   rules: {
-    'architecture/no-dynamic-require': 'warn'
+    'node-security/no-dynamic-require': 'warn'
   }
 }
 ```

--- a/apps/docs/vitest.config.ts
+++ b/apps/docs/vitest.config.ts
@@ -43,6 +43,13 @@ export default defineConfig({
       '**/storybook-static/**',
       '**/coverage/**',
     ],
+    // Most of this suite is structural lock tests that glob + read the whole
+    // monorepo (mermaid-syntax alone reads ~940 markdown files). That is ~0.3s
+    // warm but ~6s cold, so vitest's 5s default turned a cold page cache into a
+    // "failure" — reliably, under the 44-task `turbo run test` fan-out that the
+    // lefthook pre-push `tests` hook runs, which starves every task for I/O.
+    // These tests are I/O-bound, not compute-bound; give them room.
+    testTimeout: 30_000,
     passWithNoTests: true,
     globalSetup: ['../../vitest.global-setup.ts'],
     name: 'docs',

--- a/benchmarks/vitest.config.mts
+++ b/benchmarks/vitest.config.mts
@@ -9,6 +9,12 @@ import { defineConfig } from 'vitest/config';
  */
 export default defineConfig({
   test: {
+    // Repo-wide floor: pre-push runs 47 turbo tasks concurrently, so I/O-bound
+    // tests are routinely starved. Vitest's 5s default is tuned for unit tests on
+    // an idle machine and mis-reports contention as failure. A hang still fails,
+    // just at 30s instead of 5s.
+    testTimeout: 30_000,
+
     environment: 'node',
     watch: false,
     include: ['__tests__/**/*.test.ts'],

--- a/packages/eslint-config-interlace/vitest.config.mts
+++ b/packages/eslint-config-interlace/vitest.config.mts
@@ -50,6 +50,12 @@ export default defineConfig({
     alias: PLUGIN_ALIASES,
   },
   test: {
+    // Repo-wide floor: pre-push runs 47 turbo tasks concurrently, so I/O-bound
+    // tests are routinely starved. Vitest's 5s default is tuned for unit tests on
+    // an idle machine and mis-reports contention as failure. A hang still fails,
+    // just at 30s instead of 5s.
+    testTimeout: 30_000,
+
     globals: true,
     environment: 'node',
     watch: false,

--- a/packages/eslint-devkit/src/tests/documentation-standards.test.ts
+++ b/packages/eslint-devkit/src/tests/documentation-standards.test.ts
@@ -12,8 +12,13 @@ import { execSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-// Get workspace root (3 levels up from this test file)
-const WORKSPACE_ROOT = path.resolve(__dirname, '../../../../..');
+// This file lives at packages/eslint-devkit/src/tests/ — four `../` reach the
+// repo root. It previously used five, which resolved *above* the repo: every
+// `grep ... packages` below scanned a directory with no `packages/` and returned
+// nothing, and PACKAGES_DIR failed every existsSync, so the whole suite passed
+// vacuously (and the per-plugin describe generated zero tests). Keep this in sync
+// with no-deprecated-plugin-references.test.ts, which resolves the same root.
+const WORKSPACE_ROOT = path.resolve(__dirname, '../../../..');
 const PACKAGES_DIR = path.join(WORKSPACE_ROOT, 'packages');
 
 // List of valid plugin names in the Interlace ecosystem.
@@ -48,6 +53,28 @@ const INVALID_PLUGINS = [
   'eslint-plugin-architecture', // Never existed, was placeholder
 ];
 
+// This guard's own source necessarily contains every name it forbids (in the
+// table above and in the grep patterns below), so it is excluded from its own
+// scans. Same rationale as THIS_TEST in no-deprecated-plugin-references.test.ts.
+const THIS_TEST = 'packages/eslint-devkit/src/tests/documentation-standards.test.ts';
+
+/**
+ * `git grep -l` over tracked files, minus this test.
+ *
+ * `git grep` rather than `grep -r`: it never walks node_modules or any other
+ * gitignored tree, which is both dramatically faster and the reason the old
+ * `.filter(f => !f.includes('node_modules'))` hand-filtering is no longer needed.
+ */
+function grepFiles(pattern: string, pathspecs: string[]): string[] {
+  const cmd = ['git', 'grep', '-l', `"${pattern}"`, '--', ...pathspecs, '2>/dev/null || true'].join(
+    ' ',
+  );
+  return execSync(cmd, { cwd: WORKSPACE_ROOT, encoding: 'utf-8' })
+    .trim()
+    .split('\n')
+    .filter((f) => f && f !== THIS_TEST);
+}
+
 // Every test here shells out to `grep` over the whole workspace. The grep itself
 // is sub-second, but process spawn + I/O contention under `turbo run test`
 // (20+ test processes in parallel) blows the default 5s budget. 30s is slack for
@@ -55,15 +82,11 @@ const INVALID_PLUGINS = [
 describe('Documentation Standards', { timeout: 30_000 }, () => {
   describe('No @eslint/ Prefixed Plugin Names', () => {
     it('should not have @eslint/eslint-plugin-* references in any docs or source', () => {
-      const result = execSync(
-        `grep -r "@eslint/eslint-plugin" packages --include="*.md" --include="*.ts" --include="*.tsx" -l 2>/dev/null || true`,
-        { cwd: WORKSPACE_ROOT, encoding: 'utf-8' },
-      );
-
-      const files = result
-        .trim()
-        .split('\n')
-        .filter((f) => f && !f.includes('node_modules'));
+      const files = grepFiles('@eslint/eslint-plugin', [
+        'packages/**/*.md',
+        'packages/**/*.ts',
+        'packages/**/*.tsx',
+      ]);
 
       expect(files).toEqual([]);
     });
@@ -72,15 +95,7 @@ describe('Documentation Standards', { timeout: 30_000 }, () => {
   describe('No References to Non-Existent Plugins', () => {
     for (const invalidPlugin of INVALID_PLUGINS) {
       it(`should not reference ${invalidPlugin}`, () => {
-        const result = execSync(
-          `grep -r "${invalidPlugin}" packages --include="*.md" --include="*.ts" -l 2>/dev/null || true`,
-          { cwd: WORKSPACE_ROOT, encoding: 'utf-8' },
-        );
-
-        const files = result
-          .trim()
-          .split('\n')
-          .filter((f) => f && !f.includes('node_modules'));
+        const files = grepFiles(invalidPlugin, ['packages/**/*.md', 'packages/**/*.ts']);
 
         expect(files).toEqual([]);
       });
@@ -118,17 +133,26 @@ describe('Documentation Standards', { timeout: 30_000 }, () => {
             expect(pluginMatch[1]).toBe(plugin);
           }
 
-          // Check that config examples use correct prefix
+          // Check that config examples use correct prefix.
+          //
+          // Both severity forms must be covered: the array form
+          // `'x/rule': ['error', {...}]` AND the bare-string form
+          // `'x/rule': 'warn'`. The original pattern only matched the array
+          // form, which is why stale `architecture/` prefixes survived in
+          // maintainability / modernization / node-security docs while their
+          // tests reported green.
           const pluginPrefix = plugin.replace('eslint-plugin-', '');
           const configMatches = content.match(
-            /'([a-z-]+)\/[a-z-]+': \[['"](?:error|warn)/g,
+            /'([a-z-]+)\/[a-z-]+':\s*(?:\[\s*)?['"](?:error|warn|off)['"]/g,
           );
 
           if (configMatches) {
             for (const match of configMatches) {
               const usedPrefix = match.match(/'([a-z-]+)\//)?.[1];
               if (usedPrefix) {
-                expect(usedPrefix).toBe(pluginPrefix);
+                expect(usedPrefix, `${ruleFile}: config example uses '${usedPrefix}/' prefix`).toBe(
+                  pluginPrefix,
+                );
               }
             }
           }
@@ -140,15 +164,11 @@ describe('Documentation Standards', { timeout: 30_000 }, () => {
   describe('LLM Format Documentation Standards', () => {
     it('should have consistent Error Message Format sections where applicable', () => {
       // Find all rule docs that mention LLM-optimized
-      const result = execSync(
-        `grep -r "LLM-optimized" packages --include="*.md" -l 2>/dev/null || true`,
-        { cwd: WORKSPACE_ROOT, encoding: 'utf-8' },
+      const files = grepFiles('LLM-optimized', ['packages/**/*.md']).filter((f) =>
+        f.includes('/docs/'),
       );
 
-      const files = result
-        .trim()
-        .split('\n')
-        .filter((f) => f && !f.includes('node_modules') && f.includes('/docs/'));
+      const missingFormat: string[] = [];
 
       // Check that each file with LLM-optimized mention has proper format
       for (const file of files) {
@@ -164,9 +184,13 @@ describe('Documentation Standards', { timeout: 30_000 }, () => {
             content.includes('```\n🔒') || // Security rules format
             content.includes('errorMessageFormat'); // Config option
 
-          expect(hasErrorFormat).toBe(true);
+          if (!hasErrorFormat) missingFormat.push(file);
         }
       }
+
+      // Collect-then-assert rather than failing on the first offender, so the
+      // message names every doc that needs fixing in one run.
+      expect(missingFormat, `Docs promising LLM-optimized messages without an Error Message Format section:\n  ${missingFormat.join('\n  ')}`).toEqual([]);
     });
   });
 

--- a/packages/eslint-devkit/src/tests/documentation-standards.test.ts
+++ b/packages/eslint-devkit/src/tests/documentation-standards.test.ts
@@ -21,6 +21,17 @@ import * as path from 'node:path';
 const WORKSPACE_ROOT = path.resolve(__dirname, '../../../..');
 const PACKAGES_DIR = path.join(WORKSPACE_ROOT, 'packages');
 
+// Fail loudly if the `../` count ever drifts again. The original bug was silent:
+// a wrong root meant every scan hit an empty directory and every existsSync
+// returned false, so the per-plugin describe generated zero tests and the suite
+// reported green. A throw at module scope turns that into a collection error.
+if (!fs.existsSync(PACKAGES_DIR)) {
+  throw new Error(
+    `PACKAGES_DIR does not exist (${PACKAGES_DIR}). WORKSPACE_ROOT resolution in ` +
+      'this file is wrong — check the `../` count against the file location.',
+  );
+}
+
 // List of valid plugin names in the Interlace ecosystem.
 // Deprecated / removed plugins are intentionally excluded — their docs hygiene is enforced
 // separately and they are not recommended in cross-plugin docs.
@@ -142,8 +153,10 @@ describe('Documentation Standards', { timeout: 30_000 }, () => {
           // maintainability / modernization / node-security docs while their
           // tests reported green.
           const pluginPrefix = plugin.replace('eslint-plugin-', '');
+          // `0-9` matters: node-security ships `no-sha1-hash`, so a digit-free
+          // character class silently exempts real rules from this check.
           const configMatches = content.match(
-            /'([a-z-]+)\/[a-z-]+':\s*(?:\[\s*)?['"](?:error|warn|off)['"]/g,
+            /'([a-z0-9-]+)\/[a-z0-9-]+':\s*(?:\[\s*)?['"](?:error|warn|off)['"]/g,
           );
 
           if (configMatches) {

--- a/packages/eslint-devkit/src/tests/no-deprecated-plugin-references.test.ts
+++ b/packages/eslint-devkit/src/tests/no-deprecated-plugin-references.test.ts
@@ -80,18 +80,11 @@ function isAllowed(relPath: string, allowlist: Array<string | RegExp>): boolean 
   return false;
 }
 
-const SHARED_EXCLUDES = [
-  '--exclude-dir=node_modules',
-  '--exclude-dir=dist',
-  '--exclude-dir=build',
-  '--exclude-dir=.turbo',
-  '--exclude-dir=.next',
-  '--exclude-dir=coverage',
-  '--exclude-dir=benchmark-results',
-  '--exclude-dir=results',
-  '--exclude-dir=.claude',
-  '--exclude-dir=.agent',
-];
+// `git grep` only walks *tracked* files, so node_modules/dist/build/.turbo/.next/
+// coverage/benchmark-results/results and every other gitignored artifact are
+// already out of scope — no --exclude-dir list needed. These two are tracked,
+// so they still need explicit exclusion.
+const SHARED_EXCLUDES = [`':(exclude).claude/'`, `':(exclude).agent/'`];
 
 interface Hit {
   file: string;
@@ -99,9 +92,17 @@ interface Hit {
   snippet: string;
 }
 
-/** Run `grep -rn[E]` with the given args and parse `path:line:content` rows into hits. */
+/**
+ * Run `git grep -n[E]` and parse `path:line:content` rows into hits.
+ *
+ * `git grep` over tracked files rather than `grep -r` over the working tree:
+ * ~0.25s vs 3s warm / 15s cold, because it never walks node_modules or the
+ * other ignored trees. The old walk exceeded vitest's 5s default testTimeout
+ * under the 44-task `turbo run test` fan-out (the lefthook pre-push `tests`
+ * hook), flaking pushes with a timeout that read as a violation.
+ */
 function grepRepo(grepArgs: string[]): Hit[] {
-  const cmd = ['grep', ...grepArgs, '.', '2>/dev/null || true'].join(' ');
+  const cmd = ['git', 'grep', ...grepArgs, '2>/dev/null || true'].join(' ');
   const raw = execSync(cmd, {
     cwd: WORKSPACE_ROOT,
     encoding: 'utf-8',
@@ -128,13 +129,7 @@ function grepRepo(grepArgs: string[]): Hit[] {
 
 /** Mentions of `term` in markdown/MDX. */
 function findMarkdownReferences(term: string): Hit[] {
-  return grepRepo([
-    '-rn',
-    `"${term}"`,
-    '--include="*.md"',
-    '--include="*.mdx"',
-    ...SHARED_EXCLUDES,
-  ]);
+  return grepRepo(['-n', `"${term}"`, '--', `'*.md'`, `'*.mdx'`, ...SHARED_EXCLUDES]);
 }
 
 /**
@@ -147,16 +142,17 @@ function findImportReferences(term: string): Hit[] {
   // (from|import|require) ...quote... <anything>eslint-plugin-crypto
   const pattern = `(from|import|require)[[:space:]]*\\(?[[:space:]]*['\\"][^'\\"]*${term}`;
   return grepRepo([
-    '-rnE',
+    '-nE',
     `"${pattern}"`,
-    '--include="*.mjs"',
-    '--include="*.mts"',
-    '--include="*.cts"',
-    '--include="*.ts"',
-    '--include="*.tsx"',
-    '--include="*.js"',
-    '--include="*.cjs"',
-    '--include="*.jsx"',
+    '--',
+    `'*.mjs'`,
+    `'*.mts'`,
+    `'*.cts'`,
+    `'*.ts'`,
+    `'*.tsx'`,
+    `'*.js'`,
+    `'*.cjs'`,
+    `'*.jsx'`,
     ...SHARED_EXCLUDES,
   ]);
 }
@@ -186,7 +182,11 @@ function violationMessage(
 // this by widening SHARED_EXCLUDES.
 describe('No Deprecated Plugin References', { timeout: 30_000 }, () => {
   for (const plugin of DEPRECATED_PLUGINS) {
-    it(`should not recommend ${plugin.name} in markdown (use ${plugin.successor})`, () => {
+    // Explicit timeout: a repo-wide scan is fast (~0.25s) but shells out, so it
+    // is at the mercy of I/O contention under the full `turbo run test` fan-out.
+    // The default 5s left too little headroom and turned contention into a
+    // "violation".
+    it(`should not recommend ${plugin.name} in markdown (use ${plugin.successor})`, { timeout: 60_000 }, () => {
       const violations = findMarkdownReferences(plugin.name).filter(
         (hit) => !isAllowed(hit.file, plugin.allowlist),
       );
@@ -196,7 +196,7 @@ describe('No Deprecated Plugin References', { timeout: 30_000 }, () => {
       ).toEqual([]);
     });
 
-    it(`should not import ${plugin.name} from any code/config file (deleted; use ${plugin.successor})`, () => {
+    it(`should not import ${plugin.name} from any code/config file (deleted; use ${plugin.successor})`, { timeout: 60_000 }, () => {
       const violations = findImportReferences(plugin.name).filter(
         (hit) => !isAllowed(hit.file, plugin.importAllowlist),
       );

--- a/packages/eslint-devkit/src/tests/no-deprecated-plugin-references.test.ts
+++ b/packages/eslint-devkit/src/tests/no-deprecated-plugin-references.test.ts
@@ -175,18 +175,18 @@ function violationMessage(
   );
 }
 
-// Both layers shell out to `grep` over the whole workspace. The grep itself is
-// sub-second (measured 0.65–0.74s from repo root); what blows the default 5s
-// budget is process spawn + I/O contention when `turbo run test` runs 20+ test
-// processes in parallel. 30s is slack for load, not for the scan — do not "fix"
-// this by widening SHARED_EXCLUDES.
+// Both layers shell out to `git grep` over the whole workspace (~0.25s). What
+// blows vitest's default 5s budget is process spawn + I/O contention when
+// `turbo run test` runs 20+ test processes in parallel. 30s is slack for load,
+// not for the scan — do not "fix" this by widening SHARED_EXCLUDES.
+//
+// (#324 set this timeout while the scan was still `grep -r` over the working
+// tree, and measured it warm at 0.65–0.74s; cold it was 15.4s. The engine is now
+// `git grep`, which is 40x faster and immune to the cold walk — but the timeout
+// stays, because contention is the actual failure mode and it is unbounded.)
 describe('No Deprecated Plugin References', { timeout: 30_000 }, () => {
   for (const plugin of DEPRECATED_PLUGINS) {
-    // Explicit timeout: a repo-wide scan is fast (~0.25s) but shells out, so it
-    // is at the mercy of I/O contention under the full `turbo run test` fan-out.
-    // The default 5s left too little headroom and turned contention into a
-    // "violation".
-    it(`should not recommend ${plugin.name} in markdown (use ${plugin.successor})`, { timeout: 60_000 }, () => {
+    it(`should not recommend ${plugin.name} in markdown (use ${plugin.successor})`, () => {
       const violations = findMarkdownReferences(plugin.name).filter(
         (hit) => !isAllowed(hit.file, plugin.allowlist),
       );
@@ -196,7 +196,7 @@ describe('No Deprecated Plugin References', { timeout: 30_000 }, () => {
       ).toEqual([]);
     });
 
-    it(`should not import ${plugin.name} from any code/config file (deleted; use ${plugin.successor})`, { timeout: 60_000 }, () => {
+    it(`should not import ${plugin.name} from any code/config file (deleted; use ${plugin.successor})`, () => {
       const violations = findImportReferences(plugin.name).filter(
         (hit) => !isAllowed(hit.file, plugin.importAllowlist),
       );

--- a/packages/eslint-devkit/vitest.config.mts
+++ b/packages/eslint-devkit/vitest.config.mts
@@ -24,6 +24,12 @@ export default defineConfig({
   root: __dirname,
   plugins: [],
   test: {
+    // Repo-wide floor: pre-push runs 47 turbo tasks concurrently, so I/O-bound
+    // tests are routinely starved. Vitest's 5s default is tuned for unit tests on
+    // an idle machine and mis-reports contention as failure. A hang still fails,
+    // just at 30s instead of 5s.
+    testTimeout: 30_000,
+
     globals: true,
     environment: 'node',
     watch: false,

--- a/packages/eslint-formatter-sarif/vitest.config.mts
+++ b/packages/eslint-formatter-sarif/vitest.config.mts
@@ -3,6 +3,12 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   root: __dirname,
   test: {
+    // Repo-wide floor: pre-push runs 47 turbo tasks concurrently, so I/O-bound
+    // tests are routinely starved. Vitest's 5s default is tuned for unit tests on
+    // an idle machine and mis-reports contention as failure. A hang still fails,
+    // just at 30s instead of 5s.
+    testTimeout: 30_000,
+
     globals: true,
     environment: 'node',
     watch: false,

--- a/packages/eslint-formatter/vitest.config.mts
+++ b/packages/eslint-formatter/vitest.config.mts
@@ -8,6 +8,12 @@ export default defineConfig({
     watch: false,
     include: ['src/**/*.test.ts', 'src/**/*.spec.ts'],
     passWithNoTests: true,
+    // The `real ESLint -f handshake` integration test loads ESLint itself, which
+    // is I/O-heavy on a cold page cache (~8s observed). Vitest's 5s default
+    // turned that into a "failure" under the 44-task `turbo run test` fan-out
+    // behind the lefthook pre-push hook. Same remedy as
+    // eslint-plugin-import-next/vitest.config.mts.
+    testTimeout: 30_000,
     pool: 'vmThreads',
     coverage: {
       enabled: true,

--- a/packages/eslint-plugin-browser-security/docs/rules/no-clickjacking.md
+++ b/packages/eslint-plugin-browser-security/docs/rules/no-clickjacking.md
@@ -17,7 +17,7 @@ Detects clickjacking vulnerabilities and missing frame protections
 **CWE:** [CWE-693](https://cwe.mitre.org/data/definitions/693.html)  
 **OWASP Mobile:** [OWASP Mobile Top 10](https://owasp.org/www-project-mobile-top-10/)
 
-Detects clickjacking vulnerabilities and missing frame protections. This rule is part of [`eslint-plugin-secure-coding`](https://www.npmjs.com/package/eslint-plugin-secure-coding).
+Detects clickjacking vulnerabilities and missing frame protections. This rule is part of [`eslint-plugin-browser-security`](https://www.npmjs.com/package/eslint-plugin-browser-security).
 
 💼 This rule is set to **error** in the `recommended` config.
 
@@ -87,7 +87,7 @@ const csp = "default-src 'self'"; // No frame protection!
 ```javascript
 {
   rules: {
-    'secure-coding/no-clickjacking': ['error', {
+    'browser-security/no-clickjacking': ['error', {
       trustedSources: ['self', 'https://trusted.com'],
       requireFrameBusting: true,
       detectTransparentOverlays: true

--- a/packages/eslint-plugin-browser-security/docs/rules/no-insecure-redirects.md
+++ b/packages/eslint-plugin-browser-security/docs/rules/no-insecure-redirects.md
@@ -17,7 +17,7 @@ ESLint Rule: no-insecure-redirects
 **CWE:** [CWE-693](https://cwe.mitre.org/data/definitions/693.html)  
 **OWASP Mobile:** [OWASP Mobile Top 10](https://owasp.org/www-project-mobile-top-10/)
 
-ESLint Rule: no-insecure-redirects. This rule is part of [`eslint-plugin-secure-coding`](https://www.npmjs.com/package/eslint-plugin-secure-coding).
+ESLint Rule: no-insecure-redirects. This rule is part of [`eslint-plugin-browser-security`](https://www.npmjs.com/package/eslint-plugin-browser-security).
 
 ## Quick Summary
 
@@ -99,7 +99,7 @@ flowchart TD
 export default [
   {
     rules: {
-      'secure-coding/no-insecure-redirects': 'error',
+      'browser-security/no-insecure-redirects': 'error',
     },
   },
 ];

--- a/packages/eslint-plugin-browser-security/docs/rules/no-missing-cors-check.md
+++ b/packages/eslint-plugin-browser-security/docs/rules/no-missing-cors-check.md
@@ -17,7 +17,7 @@ Detects missing CORS validation (wildcard CORS, missing origin check) that can a
 **CWE:** [CWE-942](https://cwe.mitre.org/data/definitions/942.html)  
 **OWASP Mobile:** [M8: Security Misconfiguration](https://owasp.org/www-project-mobile-top-10/)
 
-Detects missing CORS validation (wildcard CORS, missing origin check) that can allow unauthorized cross-origin requests. This rule is part of [`eslint-plugin-secure-coding`](https://www.npmjs.com/package/eslint-plugin-secure-coding) and provides LLM-optimized error messages that AI assistants can automatically fix.
+Detects missing CORS validation (wildcard CORS, missing origin check) that can allow unauthorized cross-origin requests. This rule is part of [`eslint-plugin-browser-security`](https://www.npmjs.com/package/eslint-plugin-browser-security) and provides LLM-optimized error messages that AI assistants can automatically fix.
 
 ⚠️ This rule **_warns_** by default in the `recommended` config.
 

--- a/packages/eslint-plugin-browser-security/docs/rules/no-missing-csrf-protection.md
+++ b/packages/eslint-plugin-browser-security/docs/rules/no-missing-csrf-protection.md
@@ -17,7 +17,7 @@ Detects missing CSRF token validation in POST/PUT/DELETE requests
 **CWE:** [CWE-352](https://cwe.mitre.org/data/definitions/352.html)  
 **OWASP Mobile:** [OWASP Mobile Top 10](https://owasp.org/www-project-mobile-top-10/)
 
-Detects missing CSRF token validation in POST/PUT/DELETE requests. This rule is part of [`eslint-plugin-secure-coding`](https://www.npmjs.com/package/eslint-plugin-secure-coding) and provides LLM-optimized error messages that AI assistants can automatically fix.
+Detects missing CSRF token validation in POST/PUT/DELETE requests. This rule is part of [`eslint-plugin-browser-security`](https://www.npmjs.com/package/eslint-plugin-browser-security) and provides LLM-optimized error messages that AI assistants can automatically fix.
 
 💼 This rule is set to **error** by default in the `recommended` config.
 

--- a/packages/eslint-plugin-browser-security/docs/rules/no-missing-security-headers.md
+++ b/packages/eslint-plugin-browser-security/docs/rules/no-missing-security-headers.md
@@ -17,7 +17,7 @@ ESLint Rule: no-missing-security-headers
 **CWE:** [CWE-693](https://cwe.mitre.org/data/definitions/693.html)  
 **OWASP Mobile:** [OWASP Mobile Top 10](https://owasp.org/www-project-mobile-top-10/)
 
-ESLint Rule: no-missing-security-headers. This rule is part of [`eslint-plugin-secure-coding`](https://www.npmjs.com/package/eslint-plugin-secure-coding).
+ESLint Rule: no-missing-security-headers. This rule is part of [`eslint-plugin-browser-security`](https://www.npmjs.com/package/eslint-plugin-browser-security).
 
 ## Quick Summary
 
@@ -99,7 +99,7 @@ flowchart TD
 export default [
   {
     rules: {
-      'secure-coding/no-missing-security-headers': 'error',
+      'browser-security/no-missing-security-headers': 'error',
     },
   },
 ];

--- a/packages/eslint-plugin-browser-security/docs/rules/no-unencrypted-transmission.md
+++ b/packages/eslint-plugin-browser-security/docs/rules/no-unencrypted-transmission.md
@@ -17,7 +17,7 @@ Detects unencrypted data transmission (HTTP vs HTTPS, plain text protocols)
 **CWE:** [CWE-693](https://cwe.mitre.org/data/definitions/693.html)  
 **OWASP Mobile:** [OWASP Mobile Top 10](https://owasp.org/www-project-mobile-top-10/)
 
-Detects unencrypted data transmission (HTTP vs HTTPS, plain text protocols). This rule is part of [`eslint-plugin-secure-coding`](https://www.npmjs.com/package/eslint-plugin-secure-coding) and provides LLM-optimized error messages that AI assistants can automatically fix.
+Detects unencrypted data transmission (HTTP vs HTTPS, plain text protocols). This rule is part of [`eslint-plugin-browser-security`](https://www.npmjs.com/package/eslint-plugin-browser-security) and provides LLM-optimized error messages that AI assistants can automatically fix.
 
 💼 This rule is set to **error** by default in the `recommended` config.
 

--- a/packages/eslint-plugin-browser-security/docs/rules/no-unescaped-url-parameter.md
+++ b/packages/eslint-plugin-browser-security/docs/rules/no-unescaped-url-parameter.md
@@ -17,7 +17,7 @@ Detects unescaped URL parameters that can lead to Cross-Site Scripting (XSS) or 
 **CWE:** [CWE-116](https://cwe.mitre.org/data/definitions/116.html)  
 **OWASP Mobile:** [M4: Insufficient Input/Output Validation](https://owasp.org/www-project-mobile-top-10/)
 
-Detects unescaped URL parameters that can lead to Cross-Site Scripting (XSS) or open redirect vulnerabilities. This rule is part of [`eslint-plugin-secure-coding`](https://www.npmjs.com/package/eslint-plugin-secure-coding) and provides LLM-optimized error messages that AI assistants can automatically fix.
+Detects unescaped URL parameters that can lead to Cross-Site Scripting (XSS) or open redirect vulnerabilities. This rule is part of [`eslint-plugin-browser-security`](https://www.npmjs.com/package/eslint-plugin-browser-security) and provides LLM-optimized error messages that AI assistants can automatically fix.
 
 ⚠️ This rule **_warns_** by default in the `recommended` config.
 
@@ -129,7 +129,7 @@ const url = `https://example.com?${params}`; // ✅ Safe
 ```javascript
 {
   rules: {
-    'secure-coding/no-unescaped-url-parameter': ['error', {
+    'browser-security/no-unescaped-url-parameter': ['error', {
       allowInTests: false,                    // Allow in test files
       trustedLibraries: ['url', 'querystring'], // Trusted URL construction libraries
       ignorePatterns: []                     // Additional safe patterns to ignore

--- a/packages/eslint-plugin-browser-security/vitest.config.mts
+++ b/packages/eslint-plugin-browser-security/vitest.config.mts
@@ -8,6 +8,12 @@ export default defineConfig({
   },
   root: __dirname,
     test: {
+    // Repo-wide floor: pre-push runs 47 turbo tasks concurrently, so I/O-bound
+    // tests are routinely starved. Vitest's 5s default is tuned for unit tests on
+    // an idle machine and mis-reports contention as failure. A hang still fails,
+    // just at 30s instead of 5s.
+    testTimeout: 30_000,
+
     globals: true,
     environment: 'node',
     watch: false,

--- a/packages/eslint-plugin-conventions/docs/rules/consistent-existence-index-check.md
+++ b/packages/eslint-plugin-conventions/docs/rules/consistent-existence-index-check.md
@@ -65,7 +65,7 @@ if (index !== -1) {
 ```javascript
 {
   rules: {
-    'architecture/consistent-existence-index-check': 'warn'
+    'conventions/consistent-existence-index-check': 'warn'
   }
 }
 ```

--- a/packages/eslint-plugin-conventions/docs/rules/filename-case.md
+++ b/packages/eslint-plugin-conventions/docs/rules/filename-case.md
@@ -117,7 +117,7 @@ src/
 ```javascript
 {
   rules: {
-    'architecture/filename-case': 'error'
+    'conventions/filename-case': 'error'
   }
 }
 ```
@@ -127,7 +127,7 @@ src/
 ```javascript
 {
   rules: {
-    'architecture/filename-case': ['error', {
+    'conventions/filename-case': ['error', {
       case: 'pascalCase',
       allowedKebabCase: ['index', 'main']
     }]
@@ -140,7 +140,7 @@ src/
 ```javascript
 {
   rules: {
-    'architecture/filename-case': ['error', {
+    'conventions/filename-case': ['error', {
       case: 'kebabCase',
       allowedPascalCase: ['App', 'Button', 'Modal'],  // React components
       allowedSnakeCase: ['db_migrations'],            // Legacy
@@ -155,7 +155,7 @@ src/
 ```javascript
 {
   rules: {
-    'architecture/filename-case': ['error', {
+    'conventions/filename-case': ['error', {
       case: 'kebabCase',
       allowedUppercaseFiles: []  // Disable all uppercase exceptions
     }]

--- a/packages/eslint-plugin-express-security/vitest.config.mts
+++ b/packages/eslint-plugin-express-security/vitest.config.mts
@@ -8,6 +8,12 @@ export default defineConfig({
   },
   root: __dirname,
     test: {
+    // Repo-wide floor: pre-push runs 47 turbo tasks concurrently, so I/O-bound
+    // tests are routinely starved. Vitest's 5s default is tuned for unit tests on
+    // an idle machine and mis-reports contention as failure. A hang still fails,
+    // just at 30s instead of 5s.
+    testTimeout: 30_000,
+
     globals: true,
     environment: 'node',
     watch: false,

--- a/packages/eslint-plugin-jwt/vitest.config.mts
+++ b/packages/eslint-plugin-jwt/vitest.config.mts
@@ -8,6 +8,12 @@ export default defineConfig({
   },
   root: __dirname,
     test: {
+    // Repo-wide floor: pre-push runs 47 turbo tasks concurrently, so I/O-bound
+    // tests are routinely starved. Vitest's 5s default is tuned for unit tests on
+    // an idle machine and mis-reports contention as failure. A hang still fails,
+    // just at 30s instead of 5s.
+    testTimeout: 30_000,
+
     globals: true,
     environment: 'node',
     watch: false,

--- a/packages/eslint-plugin-lambda-security/vitest.config.mts
+++ b/packages/eslint-plugin-lambda-security/vitest.config.mts
@@ -3,6 +3,12 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   root: __dirname,
     test: {
+    // Repo-wide floor: pre-push runs 47 turbo tasks concurrently, so I/O-bound
+    // tests are routinely starved. Vitest's 5s default is tuned for unit tests on
+    // an idle machine and mis-reports contention as failure. A hang still fails,
+    // just at 30s instead of 5s.
+    testTimeout: 30_000,
+
     globals: true,
     environment: 'node',
     watch: false,

--- a/packages/eslint-plugin-maintainability/docs/rules/consistent-function-scoping.md
+++ b/packages/eslint-plugin-maintainability/docs/rules/consistent-function-scoping.md
@@ -79,7 +79,7 @@ function createMultiplier(factor: number) {
 ```javascript
 {
   rules: {
-    'architecture/consistent-function-scoping': 'warn'
+    'maintainability/consistent-function-scoping': 'warn'
   }
 }
 ```

--- a/packages/eslint-plugin-maintainability/docs/rules/no-unreadable-iife.md
+++ b/packages/eslint-plugin-maintainability/docs/rules/no-unreadable-iife.md
@@ -73,7 +73,7 @@ const config = (() => {
 ```javascript
 {
   rules: {
-    'architecture/no-unreadable-iife': 'warn'
+    'maintainability/no-unreadable-iife': 'warn'
   }
 }
 ```

--- a/packages/eslint-plugin-maintainability/vitest.config.mts
+++ b/packages/eslint-plugin-maintainability/vitest.config.mts
@@ -7,6 +7,12 @@ export default defineConfig({
   root: __dirname,
   plugins: [],
   test: {
+    // Repo-wide floor: pre-push runs 47 turbo tasks concurrently, so I/O-bound
+    // tests are routinely starved. Vitest's 5s default is tuned for unit tests on
+    // an idle machine and mis-reports contention as failure. A hang still fails,
+    // just at 30s instead of 5s.
+    testTimeout: 30_000,
+
     globals: true,
     environment: 'node',
     watch: false,

--- a/packages/eslint-plugin-modernization/docs/rules/prefer-at.md
+++ b/packages/eslint-plugin-modernization/docs/rules/prefer-at.md
@@ -75,7 +75,7 @@ const lastChar = string.at(-1);
 ```javascript
 {
   rules: {
-    'architecture/prefer-at': 'warn'
+    'modernization/prefer-at': 'warn'
   }
 }
 ```

--- a/packages/eslint-plugin-modernization/docs/rules/prefer-event-target.md
+++ b/packages/eslint-plugin-modernization/docs/rules/prefer-event-target.md
@@ -73,7 +73,7 @@ emitter.dispatch('change', { value: 42 });
 ```javascript
 {
   rules: {
-    'architecture/prefer-event-target': 'warn'
+    'modernization/prefer-event-target': 'warn'
   }
 }
 ```

--- a/packages/eslint-plugin-modularity/docs/rules/ddd-value-object-immutability.md
+++ b/packages/eslint-plugin-modularity/docs/rules/ddd-value-object-immutability.md
@@ -89,7 +89,7 @@ flowchart TD
 export default [
   {
     rules: {
-      'architecture/ddd-value-object-immutability': 'error',
+      'modularity/ddd-value-object-immutability': 'error',
     },
   },
 ];

--- a/packages/eslint-plugin-modularity/docs/rules/enforce-naming.md
+++ b/packages/eslint-plugin-modularity/docs/rules/enforce-naming.md
@@ -111,7 +111,7 @@ class CustomerOrder {
 ```javascript
 {
   rules: {
-    'architecture/enforce-naming': ['error', {
+    'modularity/enforce-naming': ['error', {
       domain: 'e-commerce',
       glossaryUrl: 'https://wiki.company.com/glossary',
       terms: [
@@ -144,7 +144,7 @@ class CustomerOrder {
 ```javascript
 {
   rules: {
-    'architecture/enforce-naming': ['error', {
+    'modularity/enforce-naming': ['error', {
       domain: 'finance',
       glossaryUrl: 'https://internal.bank.com/glossary',
       terms: [
@@ -177,7 +177,7 @@ class CustomerOrder {
 ```javascript
 {
   rules: {
-    'architecture/enforce-naming': ['error', {
+    'modularity/enforce-naming': ['error', {
       domain: 'healthcare',
       glossaryUrl: 'https://hipaa.health.gov/glossary',
       terms: [
@@ -210,7 +210,7 @@ class CustomerOrder {
 ```javascript
 {
   rules: {
-    'architecture/enforce-naming': ['error', {
+    'modularity/enforce-naming': ['error', {
       domain: 'shipping',
       terms: [
         {
@@ -298,7 +298,7 @@ function calculateOrderTotal(order: Order) {
 ```javascript
 {
   rules: {
-    'architecture/enforce-naming': ['error', {
+    'modularity/enforce-naming': ['error', {
       domain: 'e-commerce',
       terms: [
         {

--- a/packages/eslint-plugin-modularity/docs/rules/enforce-rest-conventions.md
+++ b/packages/eslint-plugin-modularity/docs/rules/enforce-rest-conventions.md
@@ -89,7 +89,7 @@ flowchart TD
 export default [
   {
     rules: {
-      'architecture/enforce-rest-conventions': 'error',
+      'modularity/enforce-rest-conventions': 'error',
     },
   },
 ];

--- a/packages/eslint-plugin-modularity/docs/rules/no-external-api-calls-in-utils.md
+++ b/packages/eslint-plugin-modularity/docs/rules/no-external-api-calls-in-utils.md
@@ -89,7 +89,7 @@ flowchart TD
 export default [
   {
     rules: {
-      'architecture/no-external-api-calls-in-utils': 'error',
+      'modularity/no-external-api-calls-in-utils': 'error',
     },
   },
 ];

--- a/packages/eslint-plugin-mongodb-security/vitest.config.mts
+++ b/packages/eslint-plugin-mongodb-security/vitest.config.mts
@@ -7,6 +7,12 @@ export default defineConfig({
     alias: { '@interlace/eslint-devkit': resolve(__dirname, '../eslint-devkit/src/index.ts') },
   },
   test: {
+    // Repo-wide floor: pre-push runs 47 turbo tasks concurrently, so I/O-bound
+    // tests are routinely starved. Vitest's 5s default is tuned for unit tests on
+    // an idle machine and mis-reports contention as failure. A hang still fails,
+    // just at 30s instead of 5s.
+    testTimeout: 30_000,
+
     name: 'eslint-plugin-mongodb-security',
     globals: true,
     environment: 'node',

--- a/packages/eslint-plugin-nestjs-security/vitest.config.mts
+++ b/packages/eslint-plugin-nestjs-security/vitest.config.mts
@@ -3,6 +3,12 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   root: __dirname,
     test: {
+    // Repo-wide floor: pre-push runs 47 turbo tasks concurrently, so I/O-bound
+    // tests are routinely starved. Vitest's 5s default is tuned for unit tests on
+    // an idle machine and mis-reports contention as failure. A hang still fails,
+    // just at 30s instead of 5s.
+    testTimeout: 30_000,
+
     globals: true,
     environment: 'node',
     watch: false,

--- a/packages/eslint-plugin-node-security/docs/rules/detect-suspicious-dependencies.md
+++ b/packages/eslint-plugin-node-security/docs/rules/detect-suspicious-dependencies.md
@@ -75,7 +75,7 @@ If a package name is within 2 edits of a popular package name, it's flagged as s
 ```javascript
 {
   rules: {
-    'secure-coding/detect-suspicious-dependencies': 'error'
+    'node-security/detect-suspicious-dependencies': 'error'
   }
 }
 ```

--- a/packages/eslint-plugin-node-security/docs/rules/no-dynamic-require.md
+++ b/packages/eslint-plugin-node-security/docs/rules/no-dynamic-require.md
@@ -75,7 +75,7 @@ const plugin = plugins[name];
 ```javascript
 {
   rules: {
-    'architecture/no-dynamic-require': 'warn'
+    'node-security/no-dynamic-require': 'warn'
   }
 }
 ```

--- a/packages/eslint-plugin-node-security/vitest.config.mts
+++ b/packages/eslint-plugin-node-security/vitest.config.mts
@@ -4,6 +4,12 @@ export default defineConfig({
   root: __dirname,
   cacheDir: '../../node_modules/.vite/packages/eslint-plugin-node-security',
   test: {
+    // Repo-wide floor: pre-push runs 47 turbo tasks concurrently, so I/O-bound
+    // tests are routinely starved. Vitest's 5s default is tuned for unit tests on
+    // an idle machine and mis-reports contention as failure. A hang still fails,
+    // just at 30s instead of 5s.
+    testTimeout: 30_000,
+
     watch: false,
     globals: true,
     environment: 'node',

--- a/packages/eslint-plugin-pg/vitest.config.mts
+++ b/packages/eslint-plugin-pg/vitest.config.mts
@@ -17,6 +17,12 @@ export default defineConfig({
     alias: { '@interlace/eslint-devkit': resolve(__dirname, '../eslint-devkit/src/index.ts') },
   },
     test: {
+    // Repo-wide floor: pre-push runs 47 turbo tasks concurrently, so I/O-bound
+    // tests are routinely starved. Vitest's 5s default is tuned for unit tests on
+    // an idle machine and mis-reports contention as failure. A hang still fails,
+    // just at 30s instead of 5s.
+    testTimeout: 30_000,
+
     globals: true,
     environment: 'node',
     watch: false,

--- a/packages/eslint-plugin-react-a11y/vitest.config.mts
+++ b/packages/eslint-plugin-react-a11y/vitest.config.mts
@@ -13,6 +13,12 @@ export default defineConfig({
   root: __dirname,
   plugins: [],
   test: {
+    // Repo-wide floor: pre-push runs 47 turbo tasks concurrently, so I/O-bound
+    // tests are routinely starved. Vitest's 5s default is tuned for unit tests on
+    // an idle machine and mis-reports contention as failure. A hang still fails,
+    // just at 30s instead of 5s.
+    testTimeout: 30_000,
+
     globals: true,
     environment: 'node',
     watch: false,

--- a/packages/eslint-plugin-react-features/vitest.config.mts
+++ b/packages/eslint-plugin-react-features/vitest.config.mts
@@ -7,6 +7,12 @@ export default defineConfig({
   root: __dirname,
   plugins: [],
   test: {
+    // Repo-wide floor: pre-push runs 47 turbo tasks concurrently, so I/O-bound
+    // tests are routinely starved. Vitest's 5s default is tuned for unit tests on
+    // an idle machine and mis-reports contention as failure. A hang still fails,
+    // just at 30s instead of 5s.
+    testTimeout: 30_000,
+
     globals: true,
     environment: 'node',
     watch: false,

--- a/packages/eslint-plugin-reliability/docs/rules/no-await-in-loop.md
+++ b/packages/eslint-plugin-reliability/docs/rules/no-await-in-loop.md
@@ -139,7 +139,7 @@ async function fetchWithLimit(urls: string[]) {
 ```javascript
 {
   rules: {
-    'architecture/no-await-in-loop': 'warn'
+    'reliability/no-await-in-loop': 'warn'
   }
 }
 ```
@@ -149,7 +149,7 @@ async function fetchWithLimit(urls: string[]) {
 ```javascript
 {
   rules: {
-    'architecture/no-await-in-loop': ['warn', {
+    'reliability/no-await-in-loop': ['warn', {
       allowForOf: true,
       allowWhile: false
     }]
@@ -162,7 +162,7 @@ async function fetchWithLimit(urls: string[]) {
 ```javascript
 {
   rules: {
-    'architecture/no-await-in-loop': ['error', {
+    'reliability/no-await-in-loop': ['error', {
       allowForOf: false,
       allowWhile: false,
       checkConcurrency: true

--- a/packages/eslint-plugin-secure-coding/vitest.config.mts
+++ b/packages/eslint-plugin-secure-coding/vitest.config.mts
@@ -13,6 +13,12 @@ export default defineConfig({
   root: __dirname,
   plugins: [],
   test: {
+    // Repo-wide floor: pre-push runs 47 turbo tasks concurrently, so I/O-bound
+    // tests are routinely starved. Vitest's 5s default is tuned for unit tests on
+    // an idle machine and mis-reports contention as failure. A hang still fails,
+    // just at 30s instead of 5s.
+    testTimeout: 30_000,
+
     globals: true,
     environment: 'node',
     watch: false,

--- a/packages/eslint-plugin-vercel-ai-security/vitest.config.mts
+++ b/packages/eslint-plugin-vercel-ai-security/vitest.config.mts
@@ -13,6 +13,12 @@ export default defineConfig({
   root: __dirname,
   plugins: [],
   test: {
+    // Repo-wide floor: pre-push runs 47 turbo tasks concurrently, so I/O-bound
+    // tests are routinely starved. Vitest's 5s default is tuned for unit tests on
+    // an idle machine and mis-reports contention as failure. A hang still fails,
+    // just at 30s instead of 5s.
+    testTimeout: 30_000,
+
     globals: true,
     environment: 'node',
     watch: false,

--- a/scripts/__tests__/vitest.config.mts
+++ b/scripts/__tests__/vitest.config.mts
@@ -21,6 +21,12 @@ export default defineConfig({
   },
   root: resolve(__dirname, '../..'),
   test: {
+    // Repo-wide floor: pre-push runs 47 turbo tasks concurrently, so I/O-bound
+    // tests are routinely starved. Vitest's 5s default is tuned for unit tests on
+    // an idle machine and mis-reports contention as failure. A hang still fails,
+    // just at 30s instead of 5s.
+    testTimeout: 30_000,
+
     environment: 'node',
     watch: false,
     include: ['scripts/__tests__/**/*.test.ts'],


### PR DESCRIPTION
## Summary

Started as "the `no-deprecated-plugin-references` test flakes under the pre-push fan-out." Fixing it properly surfaced two larger problems.

**1. The flake — fixed at the cause, not just the symptom.**
The test walked the working tree with `grep -r` from the repo root: **15.4s cold / 3.0s warm**, measured. It now scans with `git grep` over tracked files: **0.24s**, identical hits. Tracked-only is the right scope for a regression guard (untracked files never ship) and it retires the `--exclude-dir` list, since gitignored trees are out of scope by construction.

#324 landed a `describe`-level timeout for the same symptom while this was in flight. Both are kept — the rebase reconciled them, my redundant per-test timeouts were dropped, and #324's comment (which measured the grep warm at 0.65–0.74s) is updated with the cold number.

**2. A lock suite that had been dead.**
`documentation-standards.test.ts` resolved `WORKSPACE_ROOT` five `../` from `src/tests/`, landing *above* the repo. Every `grep ... packages` scanned a directory with no `packages/`; `PACKAGES_DIR` failed `existsSync` for all 19 plugins, so the per-plugin `describe` generated **zero** tests. The suite passed vacuously. Fixing the root activates 24 tests — 8 failed immediately.

**3. What the blind spot was hiding — broken copy-paste config in the docs.**

| Defect | Scope | Effect on a user |
|---|---|---|
| `'architecture/<rule>'` config examples | 12 docs, 6 plugins | `eslint-plugin-architecture` never existed → config fails to load |
| Wrong npm package attribution | 7 browser-security docs | Sent to `eslint-plugin-secure-coding` |
| Stale `'secure-coding/'` prefix | 5 docs | Rules actually live in browser-security / node-security |
| `'secure-coding/no-sql-injection'` | getting-started + ci-cd | **Rule exists nowhere in the ecosystem** → now `'pg/no-unsafe-query'` |
| `@interlace/eslint-plugin-secure-coding` | learn page | 404s on npm; package is unscoped |

Fixed in both the package docs (SSOT) and the synced site MDX, so `sync-rules-docs` stays a no-op.

**4. The guard is hardened so it cannot go blind again.** It excludes only itself instead of hand-filtering `node_modules`, scans via `git grep`, and its config-prefix regex now matches the bare-string severity form (`'x/rule': 'warn'`) as well as the array form — that gap alone hid the maintainability / modernization / node-security defects above.

**5. A 30s `testTimeout` floor on the remaining 18 package configs.** Three separate packages surfaced this flake while working the branch, so per-package patching is whack-a-mole. Vitest's 5s default assumes an idle machine; pre-push runs 47 tasks at once. A genuine hang still fails, at 30s instead of 5s.

## Test plan

- [x] `turbo run test --force` — **47/47, six consecutive runs**, zero `Test timed out`.
- [x] `TURBO_FORCE=true lefthook run pre-push` — `tests` green at 124s under real parallel load (typecheck + build + 8 others competing).
- [x] Regression contract, `no-deprecated-plugin-references`: planted a violation in a tracked `.md` and a tracked `.ts`; both layers fail with correct `file:line`; removed → green.
- [x] Regression contract, `documentation-standards`: the 8 failures *are* the proof — the suite fails on the unfixed docs and passes on the fixed ones. 24/24 now.
- [x] Verified `docs/` is absent from every package's `files` array, so the changeset is correctly empty (no version bump).

## After merge

Docs-only user-visible change; it reaches production via eslint.interlace.tools, not npm. Watch the auto-deploy for `docs`.

Two things I did **not** touch, both pre-existing:
- `npx prettier --check` fails on the vitest configs — identically on unmodified `main`. Reformatting would have buried the diff in unrelated churn.
- CLAUDE.md lists "Prettier (format check)" as a required CI check, but there is no prettier step in `lefthook.yml` *or* in `.github/workflows/`. Either the doc is stale or the gate went missing — worth a decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)