### PR TITLE
fix(workspace): take the ILB result corpus to zero validator issues

### DIFF
--- a/benchmarks/__tests__/methodology-lock.test.ts
+++ b/benchmarks/__tests__/methodology-lock.test.ts
@@ -57,7 +57,7 @@ describe('methodology receipt — emission lock', () => {
     // suite *losing* its receipt — at >= 13 the ilb-formatter regression this
     // number was raised for would have slipped through at 14. Ratchet this
     // when a suite is added; that edit is the point.
-    expect(sources.length).toBe(15);
+    expect(sources.length).toBe(17);
   });
 
   it.each(sources.map((p) => [path.relative(REPO_ROOT, p), p]))(

--- a/benchmarks/results/ilb-oxlint-parity/2026-05-14.json
+++ b/benchmarks/results/ilb-oxlint-parity/2026-05-14.json
@@ -1,4 +1,16 @@
 {
+  "bench": "ILB-Wild",
+  "benchVersion": "v0.0",
+  "toolchain": {
+    "node": "unknown",
+    "eslint": "unknown",
+    "typescript": "unknown",
+    "tsCompiler": "unknown",
+    "platform": "unknown",
+    "backfilled": true,
+    "backfilledAt": "2026-08-03T02:33:16.402Z",
+    "backfilledBy": "scripts/ilb-result-schema-backfill.ts"
+  },
   "suite": "ilb-oxlint-parity",
   "version": "1.0",
   "runAt": "2026-05-14T01:24:14.791Z",
@@ -12,5 +24,6 @@
   "eslintOnlyAllowlisted": 0,
   "oxlintOnlyAllowlisted": 0,
   "eslintOnlyUnexplained": [],
-  "oxlintOnlyUnexplained": []
+  "oxlintOnlyUnexplained": [],
+  "timestamp": "2026-05-14T00:00:00.000Z"
 }

--- a/benchmarks/results/ilb-oxlint-parity/2026-07-04.json
+++ b/benchmarks/results/ilb-oxlint-parity/2026-07-04.json
@@ -1,4 +1,16 @@
 {
+  "bench": "ILB-Wild",
+  "benchVersion": "v0.0",
+  "toolchain": {
+    "node": "unknown",
+    "eslint": "unknown",
+    "typescript": "unknown",
+    "tsCompiler": "unknown",
+    "platform": "unknown",
+    "backfilled": true,
+    "backfilledAt": "2026-08-03T02:33:16.404Z",
+    "backfilledBy": "scripts/ilb-result-schema-backfill.ts"
+  },
   "suite": "ilb-oxlint-parity",
   "version": "1.0",
   "runAt": "2026-07-04T20:30:16.029Z",
@@ -12,5 +24,6 @@
   "eslintOnlyAllowlisted": 0,
   "oxlintOnlyAllowlisted": 0,
   "eslintOnlyUnexplained": [],
-  "oxlintOnlyUnexplained": []
+  "oxlintOnlyUnexplained": [],
+  "timestamp": "2026-07-04T00:00:00.000Z"
 }

--- a/benchmarks/results/ilb-perf-import-nestjs/2026-05-14.json
+++ b/benchmarks/results/ilb-perf-import-nestjs/2026-05-14.json
@@ -1,4 +1,16 @@
 {
+  "bench": "ILB-Perf",
+  "benchVersion": "v0.0",
+  "toolchain": {
+    "node": "unknown",
+    "eslint": "unknown",
+    "typescript": "unknown",
+    "tsCompiler": "unknown",
+    "platform": "unknown",
+    "backfilled": true,
+    "backfilledAt": "2026-08-03T02:33:16.405Z",
+    "backfilledBy": "scripts/ilb-result-schema-backfill.ts"
+  },
   "suite": "ilb-perf-import-nestjs",
   "timestamp": "2026-05-14T04:37:01.326Z",
   "environment": {

--- a/benchmarks/results/ilb-perf-import-nestjs/cycles-import-next.json
+++ b/benchmarks/results/ilb-perf-import-nestjs/cycles-import-next.json
@@ -1,4 +1,16 @@
 {
+  "bench": "ILB-Perf",
+  "benchVersion": "v0.0",
+  "toolchain": {
+    "node": "unknown",
+    "eslint": "unknown",
+    "typescript": "unknown",
+    "tsCompiler": "unknown",
+    "platform": "unknown",
+    "backfilled": true,
+    "backfilledAt": "2026-08-03T02:33:16.585Z",
+    "backfilledBy": "scripts/ilb-result-schema-backfill.ts"
+  },
   "competitor": "import-next",
   "host": "eslint",
   "package": "eslint-plugin-import-next",
@@ -3139,5 +3151,6 @@
       "line": 2,
       "message": "🏗️ CWE-407 OWASP:A06-Insecure CVSS:5.3 | Circular dependency detected | CRITICAL\n   Fix: Split catch.decorator into .core and .extended | https://en.wikipedia.org/wiki/Circular_dependency"
     }
-  ]
+  ],
+  "timestamp": "2026-05-17T04:38:53.000Z"
 }

--- a/benchmarks/results/ilb-perf-import-nestjs/cycles-import-official.json
+++ b/benchmarks/results/ilb-perf-import-nestjs/cycles-import-official.json
@@ -1,4 +1,16 @@
 {
+  "bench": "ILB-Perf",
+  "benchVersion": "v0.0",
+  "toolchain": {
+    "node": "unknown",
+    "eslint": "unknown",
+    "typescript": "unknown",
+    "tsCompiler": "unknown",
+    "platform": "unknown",
+    "backfilled": true,
+    "backfilledAt": "2026-08-03T02:33:16.637Z",
+    "backfilledBy": "scripts/ilb-result-schema-backfill.ts"
+  },
   "competitor": "import-official",
   "host": "eslint",
   "package": "eslint-plugin-import",
@@ -974,5 +986,6 @@
       "line": 2,
       "message": "Dependency cycle via ./nest-application-context.interface:22=>../services/logger.service:2=>../decorators/core:1"
     }
-  ]
+  ],
+  "timestamp": "2026-05-17T04:38:53.000Z"
 }

--- a/benchmarks/results/ilb-perf-import-nestjs/cycles-oxlint-builtin.json
+++ b/benchmarks/results/ilb-perf-import-nestjs/cycles-oxlint-builtin.json
@@ -1,4 +1,16 @@
 {
+  "bench": "ILB-Perf",
+  "benchVersion": "v0.0",
+  "toolchain": {
+    "node": "unknown",
+    "eslint": "unknown",
+    "typescript": "unknown",
+    "tsCompiler": "unknown",
+    "platform": "unknown",
+    "backfilled": true,
+    "backfilledAt": "2026-08-03T02:33:16.687Z",
+    "backfilledBy": "scripts/ilb-result-schema-backfill.ts"
+  },
   "competitor": "oxlint-builtin",
   "host": "oxlint",
   "package": "oxlint",
@@ -2506,5 +2518,6 @@
       "message": "Dependency cycle detected",
       "note": "These paths form a cycle:\n╭──▶ ./testing-injector (packages/testing/testing-injector.ts)\n│         ⬇ imports\n│    ./interfaces (packages/testing/interfaces/index.ts)\n│         ⬇ imports\n│    ./override-by.interface (packages/testing/interfaces/override-by.interface.ts)\n│         ⬇ imports\n│    ../testing-module.builder (packages/testing/testing-module.builder.ts)\n│         ⬇ imports\n│    ./testing-instance-loader (packages/testing/testing-instance-loader.ts)\n╰─────────╯ imports the current file"
     }
-  ]
+  ],
+  "timestamp": "2026-05-17T04:38:53.000Z"
 }

--- a/benchmarks/results/ilb-perf-import-nestjs/cycles-oxlint-import-next.json
+++ b/benchmarks/results/ilb-perf-import-nestjs/cycles-oxlint-import-next.json
@@ -1,4 +1,16 @@
 {
+  "bench": "ILB-Perf",
+  "benchVersion": "v0.0",
+  "toolchain": {
+    "node": "unknown",
+    "eslint": "unknown",
+    "typescript": "unknown",
+    "tsCompiler": "unknown",
+    "platform": "unknown",
+    "backfilled": true,
+    "backfilledAt": "2026-08-03T02:33:16.741Z",
+    "backfilledBy": "scripts/ilb-result-schema-backfill.ts"
+  },
   "competitor": "oxlint-import-next",
   "host": "oxlint",
   "package": "eslint-plugin-import-next + oxlint",
@@ -3684,5 +3696,6 @@
       "line": 14,
       "message": "🏗️ CWE-407 OWASP:A06-Insecure CVSS:5.3 | Circular dependency detected | CRITICAL\n   Fix: Split internal-core-module-factory into .core and .extended | https://en.wikipedia.org/wiki/Circular_dependency"
     }
-  ]
+  ],
+  "timestamp": "2026-05-17T04:38:53.000Z"
 }

--- a/benchmarks/suites/ilb-oxlint-parity/run.ts
+++ b/benchmarks/suites/ilb-oxlint-parity/run.ts
@@ -351,7 +351,11 @@ function main() {
   const total = d.shared + d.eslintOnly.length + d.oxlintOnly.length;
   const parityRate = total === 0 ? 1.0 : d.shared / total;
 
-  const prereg = capturePreregistration({ allowDirty: true, entrypoint: import.meta.url });
+  // `allowDirty` is documented "NOT for CI" (benchmarks/lib/preregister.ts:112):
+  // a hash computed over uncommitted method files looks verifiable but is not,
+  // which is the precise failure this receipt exists to prevent. Locally it
+  // stays permissive so a work-in-progress run still completes.
+  const prereg = capturePreregistration({ allowDirty: !CI, entrypoint: import.meta.url });
 
   const envelope = {
     suite: 'ilb-oxlint-parity',

--- a/benchmarks/suites/ilb-oxlint-parity/run.ts
+++ b/benchmarks/suites/ilb-oxlint-parity/run.ts
@@ -21,6 +21,8 @@ import crypto from 'node:crypto';
 import { execSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
+import { getToolchain } from '../../lib/toolchain.ts';
+import { capturePreregistration } from '../../lib/preregister.ts';
 
 const require = createRequire(import.meta.url);
 
@@ -349,9 +351,22 @@ function main() {
   const total = d.shared + d.eslintOnly.length + d.oxlintOnly.length;
   const parityRate = total === 0 ? 1.0 : d.shared / total;
 
+  const prereg = capturePreregistration({ allowDirty: true, entrypoint: import.meta.url });
+
   const envelope = {
     suite: 'ilb-oxlint-parity',
     version: '1.0',
+    // Vocabulary-contract fields (benchmarks/lib/result-schema.json) plus the
+    // squash-proof receipt. Without these every run wrote a file that
+    // ilb-validate-results could only grandfather as a warning — the debt grew
+    // by one file per run and never shrank.
+    bench: 'ILB-Wild',
+    benchVersion: '0.1',
+    timestamp: new Date().toISOString(),
+    toolchain: getToolchain(),
+    methodologyCommit: prereg.methodologyCommit,
+    methodologyHash: prereg.methodologyHash,
+    methodologyPaths: prereg.methodologyPaths,
     runAt: new Date().toISOString(),
     corpus: path.relative(REPO_ROOT, CORPUS),
     eslintFindings: eslintFindings.length,

--- a/benchmarks/suites/ilb-perf-import-nestjs/run.ts
+++ b/benchmarks/suites/ilb-perf-import-nestjs/run.ts
@@ -21,6 +21,8 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { globSync } from 'glob';
 import { cloneRepo, resolveBenchDir } from '../../lib/clone-repo';
+import { getToolchain } from '../../lib/toolchain';
+import { capturePreregistration } from '../../lib/preregister';
 
 const SUITE_DIR = path.dirname(fileURLToPath(import.meta.url));
 const BENCHMARKS_ROOT = path.resolve(SUITE_DIR, '..', '..');
@@ -114,8 +116,6 @@ function buildWorkerScript(configPath: string, files: string[], ruleId: string, 
   return `
 import { ESLint } from 'eslint';
 import { pathToFileURL } from 'url';
-import { getToolchain } from '../../lib/toolchain.ts';
-import { capturePreregistration } from '../../lib/preregister.ts';
 
 async function run() {
   const configMod = await import(pathToFileURL(${JSON.stringify(configPath)}).href);

--- a/benchmarks/suites/ilb-perf-import-nestjs/run.ts
+++ b/benchmarks/suites/ilb-perf-import-nestjs/run.ts
@@ -535,7 +535,10 @@ function writeJson(corpus: CorpusSpec, fileCount: number, loc: number, results: 
     comparison[host] = { baseline: baseline.id, vs };
   }
 
-  const prereg = capturePreregistration({ allowDirty: true, entrypoint: import.meta.url });
+  // See the note in ilb-oxlint-parity/run.ts — never allow a dirty tree to
+  // produce a receipt in CI.
+  const CI = process.argv.includes('--ci') || Boolean(process.env.CI);
+  const prereg = capturePreregistration({ allowDirty: !CI, entrypoint: import.meta.url });
 
   const payload = {
     suite: 'ilb-perf-import-nestjs',

--- a/benchmarks/suites/ilb-perf-import-nestjs/run.ts
+++ b/benchmarks/suites/ilb-perf-import-nestjs/run.ts
@@ -114,6 +114,8 @@ function buildWorkerScript(configPath: string, files: string[], ruleId: string, 
   return `
 import { ESLint } from 'eslint';
 import { pathToFileURL } from 'url';
+import { getToolchain } from '../../lib/toolchain.ts';
+import { capturePreregistration } from '../../lib/preregister.ts';
 
 async function run() {
   const configMod = await import(pathToFileURL(${JSON.stringify(configPath)}).href);
@@ -533,9 +535,19 @@ function writeJson(corpus: CorpusSpec, fileCount: number, loc: number, results: 
     comparison[host] = { baseline: baseline.id, vs };
   }
 
+  const prereg = capturePreregistration({ allowDirty: true, entrypoint: import.meta.url });
+
   const payload = {
     suite: 'ilb-perf-import-nestjs',
+    // Vocabulary-contract fields + squash-proof receipt — see the note in
+    // ilb-oxlint-parity/run.ts. `timestamp` alone was not enough.
+    bench: 'ILB-Perf',
+    benchVersion: '0.1',
     timestamp: new Date().toISOString(),
+    toolchain: getToolchain(),
+    methodologyCommit: prereg.methodologyCommit,
+    methodologyHash: prereg.methodologyHash,
+    methodologyPaths: prereg.methodologyPaths,
     environment: {
       node: process.version,
       platform: process.platform,

--- a/scripts/ilb-result-schema-backfill.ts
+++ b/scripts/ilb-result-schema-backfill.ts
@@ -191,7 +191,10 @@ for (const benchDir of fs.readdirSync(RESULTS_DIR)) {
       if (dateInName) {
         updatedDoc.timestamp = `${dateInName[1]}T00:00:00.000Z`;
       } else {
+        // Pin cwd: run from outside the repo root, git exits non-zero and the
+        // date silently degrades to "unknown".
         const added = spawnSync('git', ['log', '--diff-filter=A', '--format=%aI', '-1', '--', fp], {
+          cwd: ROOT,
           encoding: 'utf8',
         });
         const gitDate = added.status === 0 ? added.stdout.trim().split('\n')[0] : '';

--- a/scripts/ilb-result-schema-backfill.ts
+++ b/scripts/ilb-result-schema-backfill.ts
@@ -23,6 +23,7 @@
  */
 
 import fs from 'node:fs';
+import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -35,16 +36,24 @@ const APPLY = process.argv.includes('--apply');
 // Map result directory names to the canonical bench enum value defined
 // in benchmarks/lib/result-schema.json. New entries here must match the
 // schema's `bench.enum` list — anything else fails strict validation.
+const SCHEMA_BENCH_ENUM: Set<string> = new Set(
+  JSON.parse(
+    fs.readFileSync(path.join(ROOT, 'benchmarks/lib/result-schema.json'), 'utf8'),
+  ).properties.bench.enum as string[],
+);
+
 const BENCH_DIR_TO_NAME: Record<string, string> = {
   'ilb-arena': 'ILB-Arena',
   'ilb-arena-quality': 'ILB-Arena-Quality',
-  'ilb-cwe-corpus': 'ILB-CWE-Corpus',
+  // The schema enum carries the original name; the directory was renamed but
+  // the contract value was not. Map to the enum value, never the dir name.
+  'ilb-cwe-corpus': 'ILB-Juliet',
   // Legacy aliases — kept so backfill can still recognize pre-2026-05-13 result
   // dirs. The `ilb-juliet-cwe/` directory is an orphan from an earlier schema
   // pass; leave it labeled with the legacy bench name until it's pruned
   // (tracked as Tier 0.8 follow-up in the plan file).
-  'ilb-juliet': 'ILB-CWE-Corpus',
-  'ilb-juliet-cwe': 'ILB-CWE-Corpus',
+  'ilb-juliet': 'ILB-Juliet',
+  'ilb-juliet-cwe': 'ILB-Juliet',
   'ilb-wild': 'ILB-Wild',
   'ilb-edge': 'ILB-Edge',
   'ilb-cov': 'ILB-Cov',
@@ -76,6 +85,14 @@ const BENCH_DIR_TO_NAME: Record<string, string> = {
   // `ilb-oxlint-parity` is a comparative parity report against Wild.
   'ilb-flagship': 'ILB-Wild',
   'ilb-oxlint-parity': 'ILB-Wild',
+  // The NestJS import-perf variant belongs with the other `ilb-perf-import-*`
+  // dirs above; `ilb-remediation` and `landscape-data` have had dedicated enum
+  // values in result-schema.json since they were added. Without these three
+  // entries the walker logged "unknown bench dir" and skipped their files, so
+  // they stayed non-conforming no matter how often the backfill was run.
+  'ilb-perf-import-nestjs': 'ILB-Perf',
+  'ilb-remediation': 'ILB-Remediation',
+  'landscape-data': 'ILB-Landscape',
 };
 
 function deriveBenchName(dirName: string): string | null {
@@ -127,7 +144,11 @@ for (const benchDir of fs.readdirSync(RESULTS_DIR)) {
       continue;
     }
     if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) continue;
-    const ALLOWED_BENCH_NAMES = new Set(Object.values(BENCH_DIR_TO_NAME));
+    // Read the allow-list from the schema, not from this file's own map. Using
+    // the map's values meant any label that is valid per the contract but not
+    // produced by the map — `ILB-Juliet`, for one — counted as "missing" and
+    // got silently rewritten, relabelling historical results.
+    const ALLOWED_BENCH_NAMES = SCHEMA_BENCH_ENUM;
     const needsBench = parsed.bench === undefined || !ALLOWED_BENCH_NAMES.has(parsed.bench as string);
     const needsVersion =
       parsed.benchVersion === undefined ||
@@ -155,18 +176,32 @@ for (const benchDir of fs.readdirSync(RESULTS_DIR)) {
     // explicit zero-major-version makes "this is unversioned legacy
     // data" unambiguous to anyone querying for trend lines.
     if (needsVersion) updatedDoc.benchVersion = 'v0.0';
-    // Timestamp must be ISO-8601 date-time. For legacy files we infer
-    // from the filename (`YYYY-MM-DD.json`) or fall back to file mtime.
+    // Timestamp must be ISO-8601 date-time. For legacy files, infer from the
+    // filename (`YYYY-MM-DD.json`), else from the commit that first added the
+    // file.
+    //
+    // mtime is NOT a usable signal here: in a fresh clone or git worktree every
+    // file carries the checkout time, so it stamps historical results with
+    // today's date. That is false provenance in a record whose whole purpose is
+    // provenance — and it also pushes the file past METHODOLOGY_HASH_SINCE in
+    // ilb-validate-results, turning a grandfathered warning into a fatal error
+    // for a run that genuinely predates the field.
     if (needsTimestamp) {
       const dateInName = file.match(/(\d{4}-\d{2}-\d{2})/);
-      const isoDate = dateInName ? `${dateInName[1]}T00:00:00.000Z` : null;
-      if (isoDate) {
-        updatedDoc.timestamp = isoDate;
+      if (dateInName) {
+        updatedDoc.timestamp = `${dateInName[1]}T00:00:00.000Z`;
       } else {
-        try {
-          updatedDoc.timestamp = fs.statSync(fp).mtime.toISOString();
-        } catch {
-          updatedDoc.timestamp = new Date().toISOString();
+        const added = spawnSync('git', ['log', '--diff-filter=A', '--format=%aI', '-1', '--', fp], {
+          encoding: 'utf8',
+        });
+        const gitDate = added.status === 0 ? added.stdout.trim().split('\n')[0] : '';
+        if (gitDate) {
+          updatedDoc.timestamp = new Date(gitDate).toISOString();
+        } else {
+          // Untracked and undated — the only remaining honest statement is
+          // that we do not know when this ran. Leave `timestamp` absent
+          // rather than invent one; the validator grandfathers it.
+          console.log(`  ⚠️  no date in filename and not tracked by git, leaving timestamp unset: ${file}`);
         }
       }
     }


### PR DESCRIPTION
`npm run ilb:validate-results` reported **27 issues across 7 files**. It now reports **`✅ 80 files pass the vocabulary contract`**.

## Why there were issues at all

Not frozen legacy residue — a leak. Two suites were never migrated to the vocabulary contract:

- `ilb-oxlint-parity/run.ts` emitted **none** of `bench` / `benchVersion` / `timestamp` / `toolchain`
- `ilb-perf-import-nestjs/run.ts` emitted only `timestamp`

The validator grandfathers such files as `(warning — pre-vocabulary-contract file)` so the contract could ship without blocking. The effect was that **every run of either suite wrote another non-conforming file**, and the warning channel kept it quiet. The count sat at exactly 27 because that is the output of two unmigrated suites.

## Why the existing backfill had never fixed it

`scripts/ilb-result-schema-backfill.ts` exists for precisely this, and `benchmarks/FP_FN_REMEDIATION_TRACKER.md:169` records it reaching 67/67 strict once before. It could not clear these, for three separate reasons:

1. **Seven files were invisible to it.** `BENCH_DIR_TO_NAME` had no entry for `ilb-perf-import-nestjs`, `ilb-remediation` or `landscape-data`, so the walker printed `⚠️ unknown bench dir` and skipped them. Adding the three mappings took the scan from 73 files to 80.

2. **It stamped historical results with today's date.** Timestamps fell back to `fs.statSync().mtime`, which in a fresh clone or git worktree is just the checkout time. A result genuinely produced 2026-05-16 was written as produced today — false provenance in a record whose entire purpose is provenance. It also pushed those files past `METHODOLOGY_HASH_SINCE` in the validator, converting a grandfathered warning into a **fatal** error. Now derived from the commit that first added the file, after the filename date, with an explicit "leave it unset rather than invent one" fallback.

3. **It silently relabelled historical results.** `ALLOWED_BENCH_NAMES` was built from the script's own `BENCH_DIR_TO_NAME` values instead of the schema enum. `ILB-Juliet` is valid per the contract but is not a map value, so files already labelled correctly counted as "missing" and were rewritten to `ILB-CWE-Corpus` — a name `result-schema.json` does not allow. Three historical results were changed that way. Now read from the schema; the juliet / cwe-corpus dirs map to the enum value.

I hit (2) and (3) by running the backfill and watching 27 warnings become 7 fatal, then 3 fatal. Both are fixed at the source rather than papered over — an earlier revision of this branch widened the schema enum to accommodate the relabelling, which was the wrong direction and has been reverted.

## Stopping the regrowth

Both generators now emit the contract fields plus the squash-proof pre-registration receipt, so future runs conform and the debt cannot rebuild. That takes the receipt-emitting source count from 15 to 17, and the emission lock added in #331 ratchets to match — it caught the change with `expected 17 to be 15`, which is the friction working as designed.

## What did not change

No measurement data. The result-file diffs add metadata only, and no historical `bench` label is rewritten (verified: `git diff benchmarks/results/ | grep '^-' | grep '"bench"'` is empty). The `toolchain` stubs remain honest — `"unknown"` values with `backfilled: true` and the script that wrote them — rather than inventing versions nobody can recover.

## On strict mode

`ilb:validate-results:strict` exists in `package.json` and is invoked nowhere. It still reports 80 warnings, by design: it flags every pre-2026-08-03 file for the missing methodology receipt, and the validator's own comment explains why that corpus is never regenerated. Enabling it would require rewriting 80 historical results, so this PR does not touch it. Default mode — the one CI runs — is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Benchmark results now include standardized toolchain, platform, timestamp, methodology, and provenance metadata.
  * New benchmark runs record preregistration details for improved reproducibility.
  * Existing benchmark findings remain unchanged while outputs gain clearer identification.

* **Bug Fixes**
  * Timestamp backfilling now prioritizes source dates and avoids inaccurate checkout-time values.

* **Tests**
  * Updated regression coverage to reflect the current number of methodology-emitting sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->