### PR TITLE
fix(eslint-devkit): stop requiring an optional peer at runtime — every plugin failed to load

### DIFF
--- a/.changeset/devkit-runtime-utils-import.md
+++ b/.changeset/devkit-runtime-utils-import.md
@@ -1,0 +1,32 @@
+---
+'@interlace/eslint-devkit': patch
+---
+
+Fix "Cannot find module '@typescript-eslint/utils'" on a clean install — every
+published plugin was failing to load.
+
+`rule-creation/sql-injection-rule.ts` imported `AST_NODE_TYPES` from
+`@typescript-eslint/utils`. That is an **enum — a runtime value**, so the built
+output emitted `require("@typescript-eslint/utils")`. But the devkit declares
+that package as an `optional` peer dependency, which npm does not install. The
+result: any project doing `npm i -D eslint-plugin-<any>` got a package that threw
+on `require`.
+
+Reproduced from nothing:
+
+```
+npm i -D eslint eslint-plugin-mongodb-security
+node -e "require('eslint-plugin-mongodb-security')"
+→ Error: Cannot find module '@typescript-eslint/utils'
+```
+
+Verified on `nestjs-security`, `secure-coding`, `node-security` and `jwt` too —
+**all four failed identically**, so this affected the whole published ecosystem.
+
+The fix keeps the zero-dependency goal intact: `AST_NODE_TYPES` now comes from the
+local `../ast-node-types` shim that exists for exactly this reason, and
+`TSESLint` / `TSESTree` become `import type`, which is erased at compile time.
+No dependency added, no artifact-size regression.
+
+A lock test asserts the built output contains no runtime `require` of
+`@typescript-eslint/utils`, so this cannot regress silently again.

--- a/apps/docs/src/data/plugin-stats.json
+++ b/apps/docs/src/data/plugin-stats.json
@@ -5,7 +5,7 @@
       "rules": 53,
       "description": "ESLint plugin for browser security — detects DOM XSS, postMessage abuse, tokens in localStorage, insecure cookies, clickjacking, mixed content, and CSP gaps",
       "category": "security",
-      "version": "1.2.9",
+      "version": "1.2.10",
       "published": true
     },
     {
@@ -13,7 +13,7 @@
       "rules": 38,
       "description": "ESLint plugin for Node.js security — detects command injection, path traversal, SSRF, zip slip, and weak crypto (MD5/SHA-1, ECB, static IV) in fs, child_process, vm, and crypto",
       "category": "security",
-      "version": "4.6.0",
+      "version": "4.7.1",
       "published": true
     },
     {
@@ -21,7 +21,7 @@
       "rules": 34,
       "description": "ESLint plugin for secure coding — detects LDAP, XPath, XXE, GraphQL and template injection, unsafe deserialization, ReDoS, missing authentication, and PII in logs",
       "category": "security",
-      "version": "3.4.0",
+      "version": "3.4.1",
       "published": true
     },
     {
@@ -29,7 +29,7 @@
       "rules": 23,
       "description": "ESLint plugin for Vercel AI SDK security — detects prompt injection, system-prompt leaks, hardcoded API keys, and unvalidated model output in generateText and streamText",
       "category": "security",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "published": true
     },
     {
@@ -37,7 +37,7 @@
       "rules": 20,
       "description": "ESLint plugin for MongoDB and Mongoose security — detects NoSQL operator injection, unsafe queries and regex, hardcoded connection strings, and missing TLS",
       "category": "security",
-      "version": "8.2.8",
+      "version": "8.3.1",
       "published": true
     },
     {
@@ -45,7 +45,7 @@
       "rules": 15,
       "description": "ESLint plugin for the pg PostgreSQL driver — detects SQL injection, unreleased clients, floating queries, unsafe search_path, and insecure SSL",
       "category": "security",
-      "version": "1.4.9",
+      "version": "1.4.11",
       "published": true
     },
     {
@@ -53,7 +53,7 @@
       "rules": 13,
       "description": "ESLint plugin for JWT security — detects algorithm confusion (CVE-2022-23540), alg:none, weak or hardcoded secrets, and decode-without-verify",
       "category": "security",
-      "version": "2.2.9",
+      "version": "2.2.10",
       "published": true
     },
     {
@@ -61,7 +61,7 @@
       "rules": 1,
       "description": "ESLint plugin for drizzle-orm — detects SQL injection in raw queries built with string concatenation or template literals",
       "category": "security",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "published": true
     },
     {
@@ -69,7 +69,7 @@
       "rules": 1,
       "description": "ESLint plugin for knex — detects SQL injection in raw queries built with string concatenation or template literals",
       "category": "security",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "published": true
     },
     {
@@ -77,7 +77,7 @@
       "rules": 1,
       "description": "ESLint plugin for mysql2 / mysql — detects SQL injection in raw queries built with string concatenation or template literals",
       "category": "security",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "published": true
     },
     {
@@ -85,7 +85,7 @@
       "rules": 1,
       "description": "ESLint plugin for @prisma/client — detects SQL injection in raw queries built with string concatenation or template literals",
       "category": "security",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "published": true
     },
     {
@@ -93,7 +93,7 @@
       "rules": 1,
       "description": "ESLint plugin for the Sequelize ORM — detects SQL injection in raw sequelize.query() and Sequelize.literal() calls built with string concatenation or template literals",
       "category": "security",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "published": true
     },
     {
@@ -101,7 +101,7 @@
       "rules": 1,
       "description": "ESLint plugin for better-sqlite3 / sqlite3 — detects SQL injection in raw queries built with string concatenation or template literals",
       "category": "security",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "published": true
     },
     {
@@ -109,7 +109,7 @@
       "rules": 1,
       "description": "ESLint plugin for typeorm — detects SQL injection in raw queries built with string concatenation or template literals",
       "category": "security",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "published": true
     },
     {
@@ -117,7 +117,7 @@
       "rules": 32,
       "description": "ESLint plugin for Express.js security — detects permissive CORS, missing CSRF protection, missing helmet headers, insecure cookies, and GraphQL introspection in production",
       "category": "framework",
-      "version": "1.4.0",
+      "version": "1.5.1",
       "published": true
     },
     {
@@ -125,7 +125,7 @@
       "rules": 16,
       "description": "ESLint plugin for AWS Lambda security — detects overly permissive IAM policies and CORS, unvalidated event bodies, secrets in env vars, and leaked error details",
       "category": "framework",
-      "version": "1.2.9",
+      "version": "1.2.11",
       "published": true
     },
     {
@@ -133,7 +133,7 @@
       "rules": 12,
       "description": "ESLint plugin for NestJS security — detects missing auth guards, missing validation pipes, unthrottled routes, and exposed private fields",
       "category": "framework",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "published": true
     },
     {
@@ -141,7 +141,7 @@
       "rules": 61,
       "description": "ESLint plugin for imports and module boundaries — drop-in replacement for eslint-plugin-import, 3.1x faster end-to-end, zero-config migration",
       "category": "architecture",
-      "version": "2.3.10",
+      "version": "2.3.12",
       "published": true
     },
     {
@@ -149,7 +149,7 @@
       "rules": 15,
       "description": "ESLint plugin for team code conventions — enforces filename case, magic-number bans, commented-out code, expiring TODOs, and deprecated-API usage",
       "category": "quality",
-      "version": "4.2.3",
+      "version": "4.2.4",
       "published": true
     },
     {
@@ -157,7 +157,7 @@
       "rules": 13,
       "description": "ESLint plugin for maintainable code — limits cognitive complexity, nesting depth, parameter counts, duplicate functions, and unhandled or silent errors",
       "category": "quality",
-      "version": "3.0.9",
+      "version": "3.0.10",
       "published": true
     },
     {
@@ -165,7 +165,7 @@
       "rules": 9,
       "description": "ESLint plugin for runtime reliability — enforces error handling, network timeouts, null checks, and safe type narrowing",
       "category": "quality",
-      "version": "3.1.7",
+      "version": "3.1.8",
       "published": true
     },
     {
@@ -173,7 +173,7 @@
       "rules": 8,
       "description": "ESLint plugin for module architecture — enforces DDD value objects and anemic-model checks, naming, REST conventions, and utility isolation",
       "category": "quality",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "published": true
     },
     {
@@ -181,7 +181,7 @@
       "rules": 7,
       "description": "ESLint plugin for production operability — bans debug code and console logging in production, verbose error messages, and process.exit calls",
       "category": "quality",
-      "version": "3.0.11",
+      "version": "3.0.12",
       "published": true
     },
     {
@@ -189,7 +189,7 @@
       "rules": 6,
       "description": "ESLint plugin for modernizing JavaScript — auto-fixes legacy patterns to ES2022+ (Array.at, template literals, EventTarget, Array.isArray)",
       "category": "quality",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "published": true
     },
     {
@@ -197,7 +197,7 @@
       "rules": 63,
       "description": "ESLint plugin for React — hooks, prop-types, JSX correctness, render performance, and class-to-hooks migration rules for modern React codebases",
       "category": "react",
-      "version": "1.2.5",
+      "version": "1.2.6",
       "published": true
     },
     {
@@ -205,12 +205,12 @@
       "rules": 39,
       "description": "ESLint plugin for React accessibility — WCAG 2.1 rules for ARIA, alt text, keyboard interaction, and focus management, with auto-fixes",
       "category": "react",
-      "version": "2.1.9",
+      "version": "2.1.10",
       "published": true
     }
   ],
   "totalRules": 484,
   "totalPlugins": 26,
   "allPluginsCount": 26,
-  "generatedAt": "2026-08-03T04:46:26.945Z"
+  "generatedAt": "2026-08-03T17:13:44.342Z"
 }

--- a/packages/eslint-devkit/src/no-runtime-optional-peer.test.ts
+++ b/packages/eslint-devkit/src/no-runtime-optional-peer.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Lock: the built devkit must not `require` an optional peer at runtime.
+ *
+ * `@typescript-eslint/utils` is declared `optional: true` in
+ * peerDependenciesMeta, so npm does not install it. Any *value* imported from it
+ * (notably `AST_NODE_TYPES`, which is an enum) survives compilation as a real
+ * `require`, and every published plugin then throws
+ * "Cannot find module '@typescript-eslint/utils'" on a clean install.
+ *
+ * That shipped once. This test fails the moment it would ship again.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+/** Every emitted .js file under the package's published output. */
+function emittedJsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...emittedJsFiles(full));
+    else if (entry.endsWith('.js')) out.push(full);
+  }
+  return out;
+}
+
+/** Peers npm will not install, so a runtime require of them crashes consumers. */
+const OPTIONAL_PEERS = ['@typescript-eslint/utils', '@typescript-eslint/types'];
+
+describe('published output does not require optional peers at runtime', () => {
+  const distRoot = resolve(__dirname, '..', 'dist', 'src');
+
+  it('emits no runtime require of an optional peer', () => {
+    const offenders: string[] = [];
+    for (const file of emittedJsFiles(distRoot)) {
+      const source = readFileSync(file, 'utf-8');
+      for (const peer of OPTIONAL_PEERS) {
+        // `require("pkg")` — the compiled form of a value import. Type-only
+        // imports are erased and never appear here.
+        if (source.includes(`require("${peer}")`) || source.includes(`require('${peer}')`)) {
+          offenders.push(`${file.slice(distRoot.length + 1)} → ${peer}`);
+        }
+      }
+    }
+    expect(
+      offenders,
+      `These files require an optional peer at runtime, which npm does not install.\n` +
+        `Import the value from a local shim instead (see src/ast-node-types.ts), or use\n` +
+        `\`import type\` if only the type is needed:\n  ${offenders.join('\n  ')}`,
+    ).toEqual([]);
+  });
+});

--- a/packages/eslint-devkit/src/rule-creation/sql-injection-rule.ts
+++ b/packages/eslint-devkit/src/rule-creation/sql-injection-rule.ts
@@ -23,7 +23,13 @@
  * plugins (`secure-coding`, `node-security`, `browser-security`).
  */
 
-import { AST_NODE_TYPES, TSESLint, TSESTree } from '@typescript-eslint/utils';
+// AST_NODE_TYPES must come from the local shim, not upstream. It is an enum —
+// a *runtime value* — and `@typescript-eslint/utils` is an optional peer that npm
+// does not install, so importing it here made every published plugin throw
+// "Cannot find module '@typescript-eslint/utils'" on a clean install. Types are
+// erased at compile time and stay safe to import from upstream.
+import { AST_NODE_TYPES } from '../ast-node-types';
+import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
 import { formatLLMMessage, MessageIcons } from '../messaging';
 
 /** Message ids every rule built by this factory reports. */


### PR DESCRIPTION
## Every published plugin currently fails to load

Reproduced from nothing, on the latest published versions:

```
npm i -D eslint eslint-plugin-mongodb-security
node -e "require('eslint-plugin-mongodb-security')"
→ Error: Cannot find module '@typescript-eslint/utils'
```

Verified identical on **`nestjs-security`, `secure-coding`, `node-security` and `jwt`** — all four throw. That's the whole published ecosystem, and it is live right now.

Found while re-running the mikemajesty dry-run: the scan wouldn't start.

## Cause

`rule-creation/sql-injection-rule.ts` imported `AST_NODE_TYPES` from `@typescript-eslint/utils`. That's an **enum — a runtime value** — so the emitted JS contains:

```js
const utils_1 = require("@typescript-eslint/utils");
```

But the devkit declares that package `optional: true` in `peerDependenciesMeta`, so **npm doesn't install it**. Optional-but-required is the bug: the declaration says "you may omit this", the code says "I crash without it".

The file arrived with the SQL-injection generalisation work, after #334 had made the devkit zero-dependency — it bypassed the local shim #334 introduced for exactly this purpose.

## Fix

Keeps #334's zero-dependency goal fully intact — **no dependency added, no artifact-size regression**:

- `AST_NODE_TYPES` now comes from the local `../ast-node-types` shim
- `TSESLint` / `TSESTree` become `import type`, erased at compile time

## Test plan

- [x] `turbo run test --filter=@interlace/eslint-devkit` — **32/32 test files**
- [x] **Proved against the actual broken install**: applied the equivalent substitution to the published package inside a clean `node_modules` with `@typescript-eslint` absent — goes from `Cannot find module` to **loading 16 rules**
- [x] Built output no longer emits any `require` of the peer

## Lock

`src/no-runtime-optional-peer.test.ts` scans the built output for a runtime `require` of any optional peer and names the offending file. **Verified to fail on the unfixed code:**

```
These files require an optional peer at runtime, which npm does not install.
  rule-creation/sql-injection-rule.js → @typescript-eslint/utils
```

## After merge

Should go out ahead of anything else queued — every install between #334 shipping and this landing gets a package that throws on `require`, and the awesome-nestjs listing is driving new installs right now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)