### PR TITLE
perf(eslint-devkit): seed the deep-chain guard in memory, 34.3s → 1.7s

### DIFF
--- a/.changeset/devkit-deep-chain-fixture.md
+++ b/.changeset/devkit-deep-chain-fixture.md
@@ -1,0 +1,6 @@
+---
+---
+
+Test-only: the devkit deep-import-chain regression guard now seeds the resolver
+cache in memory instead of materializing 6,000 files on disk. No runtime or API
+change.

--- a/packages/eslint-devkit/src/resolver/dependency-analysis.coverage.test.ts
+++ b/packages/eslint-devkit/src/resolver/dependency-analysis.coverage.test.ts
@@ -231,28 +231,37 @@ describe('computeSCCsFromFile edge cases', () => {
       // no-cycle defaults to an unlimited maxDepth, so nothing capped it — the
       // whole lint run died.
       //
-      // 6,000 clears that observed ceiling by ~20% while costing 6,000 file
-      // writes and reads rather than 10,000. That matters: this suite runs
-      // under `turbo run test`, which executes every package's tests in
-      // parallel, and at 10,000 nodes the I/O contention pushed a ~2s test past
-      // a 120s timeout. If a future platform raises the stack limit past 6,000
-      // this guard weakens, so treat the number as tied to the figure above.
+      // 6,000 clears that observed ceiling by ~20%. If a future platform raises
+      // the stack limit past 6,000 this guard weakens, so treat the number as
+      // tied to the figure above.
       const DEPTH = 6_000;
 
-      // Written directly rather than through createTempFile: that helper calls
-      // realpathSync per file, and 10,000 extra syscalls slow this test enough
-      // to push unrelated tests in the suite past their own timeouts.
+      // The chain is seeded straight into the resolver cache instead of being
+      // materialized on disk. getFileImports() returns cache.dependencies.get()
+      // before it touches the filesystem, and the SCC walk follows
+      // ImportInfo.path, so the traversal Tarjan performs is byte-for-byte the
+      // one it performed against real files — this still indexes 6,000 nodes
+      // and still fails with `RangeError: Maximum call stack size exceeded` if
+      // anyone reintroduces per-node recursion.
+      //
+      // What it drops is pure I/O that proved nothing about the stack guard.
+      // Measured at DEPTH=6,000 on an idle machine: 2,437ms to write the files,
+      // 9,572ms for the resolver to read them back (331KB — it is per-file
+      // syscall overhead, not volume), and 3,700ms for the shared afterEach to
+      // `rmSync` them. That teardown is why this suite intermittently died with
+      // `Hook timed out in 10000ms` under the 58-task `turbo run test` fan-out:
+      // vitest's hookTimeout defaults to 10s and no config here raises it.
       const dir = path.join(testDir, 'src');
-      fs.mkdirSync(dir, { recursive: true });
-      fs.writeFileSync(path.join(dir, 'f0.ts'), 'export const f0 = 1;', 'utf-8');
-      for (let i = 1; i < DEPTH; i++) {
-        fs.writeFileSync(
-          path.join(dir, `f${i}.ts`),
-          `import { f${i - 1} } from './f${i - 1}';\nexport const f${i} = 1;\n`,
-          'utf-8',
+      const fileFor = (i: number) => path.join(dir, `f${i}.ts`);
+      for (let i = 0; i < DEPTH; i++) {
+        cache.dependencies.set(
+          fileFor(i),
+          i === 0
+            ? []
+            : [{ path: fileFor(i - 1), source: `./f${i - 1}` }],
         );
       }
-      const head = path.join(dir, `f${DEPTH - 1}.ts`);
+      const head = fileFor(DEPTH - 1);
 
       const sccs = computeSCCsFromFile(head, {
         maxDepth: Infinity,
@@ -263,11 +272,10 @@ describe('computeSCCsFromFile edge cases', () => {
       expect(sccs).toHaveLength(DEPTH);
       expect(sccs.every((s) => !s.hasCycle)).toBe(true);
     },
-    // Writing and walking thousands of files is inherently slow, and far slower
-    // when turbo runs every package's suite concurrently. The default 5s
-    // timeout is nowhere near enough; this budget is sized for the contended
-    // case, not the ~2s it takes on an idle machine.
-    300_000,
+    // Indexing 6,000 nodes is fast now that no I/O is involved, but keep a
+    // generous budget: this suite runs under a `turbo run test` fan-out that
+    // starves every task for CPU.
+    60_000,
   );
 });
 


### PR DESCRIPTION
## Summary

While profiling the CI pipeline I traced the `Unit Tests (Turbo)` bottleneck (551s, the entire merge-blocking critical path) down to one test file, then to one test inside it.

`dependency-analysis.coverage.test.ts` was **34.3s of devkit's 33.8s wall**, and devkit is **27% of the whole `turbo run test` cost**. Inside it, the deep-import-chain stack guard was **25.2s of 25.5s**, because it materialized a 6,000-file import chain on disk.

Measured at `DEPTH = 6_000` on an idle machine:

| phase | cost |
|---|---:|
| write 6,000 files | 2,437ms |
| read 6,000 files (331KB) | 9,572ms |
| `rmSync` 6,000 files — the shared `afterEach` | 3,700ms |

It's per-file syscall overhead, not volume — 331KB total.

That teardown is also the source of the intermittent `Hook timed out in 10000ms` that has been blocking unrelated pushes: vitest's `hookTimeout` defaults to 10s and **0 of 28** vitest configs in this repo raise it. Under the 58-task fan-out the same test was observed at **86,293ms**.

## The fix

None of that I/O proved anything about the guard. The guard is that Tarjan doesn't recurse once per node. `getFileImports()` returns `cache.dependencies.get(file)` *before* it touches the filesystem, and the SCC walk follows `ImportInfo.path` — so seeding the chain straight into the resolver cache gives Tarjan the identical 6,000-node traversal with zero files.

No production code changed. No API change. The changeset is empty by design (test-only, nothing published shifts).

## Test plan

- [x] File: **34.3s → 1.7s**. Package: devkit **36.0s → 25.3s** wall.
- [x] `1017 passed | 2 skipped` — identical to before.
- [x] Full devkit suite green after a clean `npm run build --workspace=@interlace/eslint-devkit`.
- [x] `turbo run test --filter="...[origin/main]"` — 61/61 successful.

### The guard still has teeth — verified, not assumed

The risk in this change is making the test fast by making it prove nothing. So I ran a **recursive** Tarjan (the implementation this guard exists to reject) over the same in-memory 6,000-node chain:

```
RangeError: Maximum call stack size exceeded
  -> died after indexing 4130 of 6000 nodes
```

`DEPTH = 6,000` keeps a ~45% margin over the recursion ceiling, consistent with the 4,974-of-5,000 figure the original comment recorded. The number stays tied to that rationale.

## Why this matters for the CI work

devkit's cost was so concentrated in this one file that **`vitest --shard` did nothing for it**:

```
before fix:  shard 1/4 = 34.6s   2/4 = 2.0s   3/4 = 1.8s   4/4 = 1.9s
after fix:   shard 1/4 = 10.0s   2/4 = 8.3s   3/4 = 4.0s   4/4 = 4.3s
```

Shards split by *file*; one file carried 95% of the cost, so no shard count divided it. Package-level shard packing flatlined the same way — 4, 6, 8 and 12 shards all bottomed out at 103.8s, devkit's indivisible task.

**Fix distribution first, then shard.** This PR is that first step; sharding is now worth adopting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)