### PR TITLE
ci(workspace): fast static runtime-dependency gate, wired into the Build job

### DIFF
--- a/.github/workflows/quality-full.yml
+++ b/.github/workflows/quality-full.yml
@@ -118,6 +118,11 @@ jobs:
       # tarball and is ~2.5min — too slow for every push, kept for pre-release.
       - name: Runtime dependency check (published packages must be requirable)
         run: npm run verify:runtime-deps
+      # The detection logic itself is locked: a plausible tidy-up of either the
+      # eager-require pattern or the optional-peer rule silently disarms the gate
+      # above, so both mutations are asserted against.
+      - name: Lock the runtime-dependency detection logic
+        run: npm run test:runtime-deps
 
   typecheck:
     name: Typecheck (whole-graph tsgo)

--- a/.github/workflows/quality-full.yml
+++ b/.github/workflows/quality-full.yml
@@ -110,6 +110,14 @@ jobs:
           next-cache: "true"
       - name: Build via Turbo
         run: npx turbo run build ${{ env.TURBO_FILTER_ARGS }}
+      # Runs here because the artifacts already exist — no extra runner, no
+      # second build, ~5s. Reads the emitted JS for module-scope requires of
+      # packages the manifest does not guarantee are installed. On PRs the build
+      # is filtered to affected packages, so this checks those; main builds all.
+      # The exhaustive `npm run verify:published-install` actually installs each
+      # tarball and is ~2.5min — too slow for every push, kept for pre-release.
+      - name: Runtime dependency check (published packages must be requirable)
+        run: npm run verify:runtime-deps
 
   typecheck:
     name: Typecheck (whole-graph tsgo)

--- a/apps/docs/src/data/plugin-stats.json
+++ b/apps/docs/src/data/plugin-stats.json
@@ -29,7 +29,7 @@
       "rules": 23,
       "description": "ESLint plugin for Vercel AI SDK security — detects prompt injection, system-prompt leaks, hardcoded API keys, and unvalidated model output in generateText and streamText",
       "category": "security",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "published": true
     },
     {
@@ -141,7 +141,7 @@
       "rules": 61,
       "description": "ESLint plugin for imports and module boundaries — drop-in replacement for eslint-plugin-import, 3.1x faster end-to-end, zero-config migration",
       "category": "architecture",
-      "version": "2.3.12",
+      "version": "2.3.13",
       "published": true
     },
     {
@@ -212,5 +212,5 @@
   "totalRules": 484,
   "totalPlugins": 26,
   "allPluginsCount": 26,
-  "generatedAt": "2026-08-03T17:13:44.342Z"
+  "generatedAt": "2026-08-04T02:32:45.468Z"
 }

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "oxlint:shims:check": "tsx scripts/generate-oxlint-shims.ts --check",
     "oxlint:shims:verify": "tsx scripts/verify-oxlint-shims.ts",
     "verify:published-install": "tsx scripts/verify-published-install.ts",
+    "verify:runtime-deps": "tsx scripts/verify-runtime-deps.ts",
     "test:oxlint-exports": "vitest run --config scripts/__tests__/vitest.config.mts scripts/__tests__/oxlint-export-lock.test.ts",
     "oxlint:verify-runtime": "tsx scripts/verify-oxlint-runtime.ts",
     "oxlint:verify-runtime:update": "tsx scripts/verify-oxlint-runtime.ts --update",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "verify:published-install": "tsx scripts/verify-published-install.ts",
     "verify:runtime-deps": "tsx scripts/verify-runtime-deps.ts",
     "test:oxlint-exports": "vitest run --config scripts/__tests__/vitest.config.mts scripts/__tests__/oxlint-export-lock.test.ts",
+    "test:runtime-deps": "vitest run --config scripts/__tests__/vitest.config.mts scripts/__tests__/runtime-deps.test.ts",
     "oxlint:verify-runtime": "tsx scripts/verify-oxlint-runtime.ts",
     "oxlint:verify-runtime:update": "tsx scripts/verify-oxlint-runtime.ts --update",
     "audit:meta": "tsx scripts/audit-rule-meta-completeness.ts",

--- a/scripts/__tests__/runtime-deps.test.ts
+++ b/scripts/__tests__/runtime-deps.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Locks for the runtime-dependency gate.
+ *
+ * These three functions are the entire reason two production breaks are now
+ * catchable, and the plausible "tidy-ups" of each are exactly what would let the
+ * breaks back through:
+ *
+ *   - tightening the eager-require pattern's `.*?` to `= ` stops matching
+ *     `__importDefault(require("x"))` — the precise miss that let the
+ *     import-next break past the first version of this check
+ *   - inverting `meta[p]?.optional !== true` turns the devkit's optional-peer
+ *     trap back into a pass
+ *
+ * Each case below is written so that mutation fails it.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  BUILTINS,
+  eagerRequires,
+  guaranteed,
+  packageOf,
+  violationsIn,
+  type Manifest,
+} from '../lib/runtime-deps';
+
+describe('packageOf', () => {
+  it('reduces a deep specifier to its package', () => {
+    expect(packageOf('typescript')).toBe('typescript');
+    expect(packageOf('pkg/deep/path')).toBe('pkg');
+    expect(packageOf('@scope/pkg')).toBe('@scope/pkg');
+    expect(packageOf('@typescript-eslint/utils/ts-eslint')).toBe('@typescript-eslint/utils');
+  });
+
+  it('ignores relative and absolute specifiers — those ship with the package', () => {
+    expect(packageOf('./rules/named')).toBeNull();
+    expect(packageOf('../utils/typescript-peer')).toBeNull();
+    expect(packageOf('/abs/path')).toBeNull();
+  });
+});
+
+describe('guaranteed', () => {
+  it('counts dependencies and the package itself', () => {
+    const m: Manifest = { name: 'me', dependencies: { tslib: '^2' } };
+    expect([...guaranteed(m)].sort()).toEqual(['me', 'tslib']);
+  });
+
+  it('counts a non-optional peer — npm 7+ auto-installs those', () => {
+    const m: Manifest = { peerDependencies: { eslint: '^9' } };
+    expect(guaranteed(m).has('eslint')).toBe(true);
+  });
+
+  it('EXCLUDES an optional peer — npm does not install those', () => {
+    // The devkit trap, exactly: declared as a peer, marked optional, imported
+    // as a runtime value. Inverting this guard re-arms the outage.
+    const m: Manifest = {
+      peerDependencies: { '@typescript-eslint/utils': '^8' },
+      peerDependenciesMeta: { '@typescript-eslint/utils': { optional: true } },
+    };
+    expect(guaranteed(m).has('@typescript-eslint/utils')).toBe(false);
+  });
+});
+
+describe('eagerRequires', () => {
+  it('matches a plain named import', () => {
+    expect(eagerRequires('const x_1 = require("pkg");')).toEqual(['pkg']);
+  });
+
+  it('matches a default import through __importDefault', () => {
+    // tsc's emit for `import ts from 'typescript'`. An anchor of `= require(`
+    // misses this — and that is how the import-next break got through.
+    expect(
+      eagerRequires('const typescript_1 = tslib_1.__importDefault(require("typescript"));'),
+    ).toEqual(['typescript']);
+  });
+
+  it('matches a destructured require', () => {
+    expect(eagerRequires('const { createRule } = require("@typescript-eslint/utils");')).toEqual([
+      '@typescript-eslint/utils',
+    ]);
+  });
+
+  it('matches a side-effect-only require', () => {
+    expect(eagerRequires('require("polyfill");')).toEqual(['polyfill']);
+  });
+
+  it('matches single-quoted specifiers', () => {
+    expect(eagerRequires("const a_1 = require('pkg');")).toEqual(['pkg']);
+  });
+
+  it('IGNORES an indented require — a deliberate lazy load', () => {
+    // resolver.ts and typescript-peer.ts both try/catch a missing optional peer
+    // into a typed result. Flagging these would fail the pattern this gate
+    // recommends as the fix.
+    const lazy = [
+      'function load() {',
+      '  try {',
+      '    cached = require("oxc-resolver");',
+      '  } catch { cached = null; }',
+      '}',
+    ].join('\n');
+    expect(eagerRequires(lazy)).toEqual([]);
+  });
+
+  it('finds every module-scope require in a file', () => {
+    const source = [
+      'const a_1 = require("alpha");',
+      'const b_1 = tslib_1.__importDefault(require("beta"));',
+      'const { c } = require("gamma");',
+    ].join('\n');
+    expect(eagerRequires(source)).toEqual(['alpha', 'beta', 'gamma']);
+  });
+});
+
+describe('violationsIn', () => {
+  const manifest: Manifest = {
+    name: 'eslint-plugin-example',
+    dependencies: { tslib: '^2' },
+    peerDependencies: { eslint: '^9', 'opt-peer': '^1' },
+    peerDependenciesMeta: { 'opt-peer': { optional: true } },
+  };
+
+  it('passes builtins, relatives, dependencies and required peers', () => {
+    const source = [
+      'const fs_1 = require("node:fs");',
+      'const path_1 = require("path");',
+      'const rel_1 = require("./local");',
+      'const tslib_1 = require("tslib");',
+      'const eslint_1 = require("eslint");',
+    ].join('\n');
+    expect(violationsIn(source, manifest, 'index.js')).toEqual([]);
+  });
+
+  it('flags an optional peer, naming it as such', () => {
+    const [v] = violationsIn('const o_1 = require("opt-peer");', manifest, 'index.js');
+    expect(v?.specifier).toBe('opt-peer');
+    expect(v?.reason).toMatch(/OPTIONAL peer/);
+  });
+
+  it('flags a wholly undeclared module', () => {
+    const [v] = violationsIn('const t_1 = require("typescript");', manifest, 'rules/named.js');
+    expect(v?.specifier).toBe('typescript');
+    expect(v?.reason).toMatch(/not declared/);
+    expect(v?.file).toBe('rules/named.js');
+  });
+});
+
+describe('BUILTINS', () => {
+  it('covers both bare and node:-prefixed names', () => {
+    expect(BUILTINS.has('fs')).toBe(true);
+    expect(BUILTINS.has('node:fs')).toBe(true);
+    expect(BUILTINS.has('typescript')).toBe(false);
+  });
+});

--- a/scripts/lib/runtime-deps.ts
+++ b/scripts/lib/runtime-deps.ts
@@ -1,0 +1,108 @@
+/**
+ * Detection logic for the runtime-dependency gate.
+ *
+ * Lives apart from the CLI so it can be unit-tested: these three functions are
+ * the entire reason two production breaks are now catchable, and a plausible
+ * "tidy-up" of any of them silently disarms the gate. Specifically, tightening
+ * `.*?` in the eager-require pattern to `= ` reintroduces the exact miss that
+ * let the import-next break through, and inverting the optional-peer test turns
+ * the devkit trap back into a pass.
+ *
+ * See scripts/__tests__/runtime-deps.test.ts for the locks.
+ */
+import { builtinModules } from 'node:module';
+
+/** Node builtins, bare and `node:`-prefixed. */
+export const BUILTINS: ReadonlySet<string> = new Set([
+  ...builtinModules,
+  ...builtinModules.map((m) => `node:${m}`),
+]);
+
+/**
+ * The bare package a specifier resolves to.
+ * `@scope/pkg/deep` → `@scope/pkg`; `pkg/deep` → `pkg`; relative/absolute → null.
+ */
+export function packageOf(specifier: string): string | null {
+  if (specifier.startsWith('.') || specifier.startsWith('/')) return null;
+  const parts = specifier.split('/');
+  return specifier.startsWith('@') ? parts.slice(0, 2).join('/') : (parts[0] ?? null);
+}
+
+export interface Manifest {
+  name?: string;
+  dependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+}
+
+/**
+ * Modules the package guarantees exist at runtime.
+ *
+ * `dependencies` are installed outright, and npm 7+ auto-installs non-optional
+ * `peerDependencies`. Peers marked `optional` are deliberately NOT included —
+ * npm skips those, which is precisely how every published plugin ended up
+ * throwing `Cannot find module '@typescript-eslint/utils'`.
+ */
+export function guaranteed(manifest: Manifest): Set<string> {
+  const meta = manifest.peerDependenciesMeta ?? {};
+  const requiredPeers = Object.keys(manifest.peerDependencies ?? {}).filter(
+    (p) => meta[p]?.optional !== true,
+  );
+  const names = [...Object.keys(manifest.dependencies ?? {}), ...requiredPeers];
+  if (manifest.name !== undefined) names.push(manifest.name);
+  return new Set(names);
+}
+
+/**
+ * Specifiers `require`d at module scope in emitted CommonJS.
+ *
+ * Only column-0 requires count. A require indented inside a function is a
+ * deliberate lazy load that tolerates absence (see
+ * `eslint-devkit/src/resolver/resolver.ts` and
+ * `eslint-plugin-import-next/src/utils/typescript-peer.ts`, both of which
+ * try/catch a missing optional peer into a typed result) — flagging those would
+ * fail the very pattern this gate tells people to adopt.
+ *
+ * The binding prefix is optional and loose on purpose. tsc emits several forms:
+ *
+ *   const x_1 = require("pkg");                             // named import
+ *   const x_1 = tslib_1.__importDefault(require("pkg"));    // default import
+ *   const { a } = require("pkg");                           // destructured
+ *   require("pkg");                                         // side-effect only
+ *
+ * An anchor of `= require(` matches only the first, and that gap is not
+ * hypothetical: it let the `import ts from 'typescript'` break pass unnoticed.
+ */
+export function eagerRequires(source: string): string[] {
+  const pattern = /^(?:(?:const|var|let)\s+(?:[\w$]+|\{[^}]*\}|\[[^\]]*\])\s*=\s*.*?)?require\(\s*['"]([^'"]+)['"]\s*\)/gm;
+  return [...source.matchAll(pattern)].map((m) => m[1]!);
+}
+
+/** A require of something the package does not guarantee is installed. */
+export interface Violation {
+  pkg: string;
+  file: string;
+  specifier: string;
+  reason: string;
+}
+
+/** Violations in one emitted file, given its owning manifest. */
+export function violationsIn(source: string, manifest: Manifest, file: string): Violation[] {
+  const allowed = guaranteed(manifest);
+  const peers = manifest.peerDependencies ?? {};
+  const out: Violation[] = [];
+  for (const specifier of eagerRequires(source)) {
+    const pkg = packageOf(specifier);
+    if (pkg === null || BUILTINS.has(pkg) || allowed.has(pkg)) continue;
+    out.push({
+      pkg: manifest.name ?? '(unnamed)',
+      file,
+      specifier: pkg,
+      reason:
+        pkg in peers
+          ? 'declared only as an OPTIONAL peer — npm will not install it'
+          : 'not declared as a dependency or required peer',
+    });
+  }
+  return out;
+}

--- a/scripts/verify-runtime-deps.ts
+++ b/scripts/verify-runtime-deps.ts
@@ -1,5 +1,5 @@
 /**
- * Static runtime-dependency check — the CI-speed version of the clean-install sweep.
+ * Static runtime-dependency gate — the CI-speed version of the clean-install sweep.
  *
  * On 2026-08-03 every published plugin threw on `require`, from two separate
  * causes: the devkit imported a runtime value from a peer marked `optional`
@@ -8,29 +8,21 @@
  *
  * Both are the same shape — **emitted JS requires a module the package does not
  * guarantee is installed** — and both are decidable by reading the build output.
- * No install, no network, no sandbox: `verify-published-install.ts` proves the
+ * No install, no network, no sandbox. `verify-published-install.ts` proves the
  * same thing by actually installing, but takes ~2.5 minutes, which is too slow
- * to sit in front of every push. This runs in well under a second and belongs in
- * CI; keep the install sweep for pre-release and for anything this can't see
- * (a dependency that is declared but broken).
+ * to sit in front of every push; keep it for pre-release and for what static
+ * analysis cannot see, such as a dependency that is declared but broken.
+ *
+ * Detection lives in scripts/lib/runtime-deps.ts so it can be unit-tested —
+ * see scripts/__tests__/runtime-deps.test.ts.
  *
  *   tsx scripts/verify-runtime-deps.ts
  */
 import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
-import { builtinModules } from 'node:module';
 import { join, resolve } from 'node:path';
+import { violationsIn, type Manifest, type Violation } from './lib/runtime-deps';
 
-const ROOT = resolve(__dirname, '..');
-const PACKAGES = join(ROOT, 'packages');
-
-const BUILTINS = new Set([...builtinModules, ...builtinModules.map((m) => `node:${m}`)]);
-
-interface Violation {
-  pkg: string;
-  file: string;
-  specifier: string;
-  reason: string;
-}
+const PACKAGES = join(resolve(__dirname, '..'), 'packages');
 
 /** Every emitted `.js` beneath `dir`. */
 function emittedJs(dir: string): string[] {
@@ -43,70 +35,24 @@ function emittedJs(dir: string): string[] {
   return out;
 }
 
-/**
- * The bare package name a specifier resolves to.
- * `@scope/pkg/deep` → `@scope/pkg`; `pkg/deep` → `pkg`; `./rel` → null.
- */
-function packageOf(specifier: string): string | null {
-  if (specifier.startsWith('.') || specifier.startsWith('/')) return null;
-  const parts = specifier.split('/');
-  return specifier.startsWith('@') ? parts.slice(0, 2).join('/') : parts[0]!;
-}
-
-/**
- * Modules the package guarantees are present at runtime.
- *
- * `dependencies` are installed outright. Non-optional `peerDependencies` are
- * auto-installed by npm 7+. Anything in `peerDependenciesMeta` marked
- * `optional` is NOT — that is precisely the trap, so it is excluded here even
- * though it appears in `peerDependencies`.
- */
-function guaranteed(manifest: Record<string, unknown>): Set<string> {
-  const deps = Object.keys((manifest.dependencies as object) ?? {});
-  const peers = Object.keys((manifest.peerDependencies as object) ?? {});
-  const meta = (manifest.peerDependenciesMeta as Record<string, { optional?: boolean }>) ?? {};
-  const requiredPeers = peers.filter((p) => meta[p]?.optional !== true);
-  return new Set([...deps, ...requiredPeers, manifest.name as string]);
-}
-
 const violations: Violation[] = [];
 const checked: string[] = [];
 
 for (const dir of readdirSync(PACKAGES).sort()) {
+  // `<pkg>/dist` is the publishable artifact (see scripts/build-package.ts).
+  // Absent when the package is not built — on PRs turbo filters to affected
+  // packages, so this checks those; main builds everything.
   const distRoot = join(PACKAGES, dir, 'dist');
   const manifestPath = join(distRoot, 'package.json');
-  if (!existsSync(manifestPath)) continue; // not built, or not a publishable package
+  if (!existsSync(manifestPath)) continue;
 
-  const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8')) as Record<string, unknown>;
-  const allowed = guaranteed(manifest);
-  checked.push(manifest.name as string);
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8')) as Manifest;
+  checked.push(manifest.name ?? dir);
 
   for (const file of emittedJs(distRoot)) {
-    const source = readFileSync(file, 'utf-8');
-    // Only EAGER requires matter — the ones that run at import time and throw
-    // before a consumer can do anything about it. In tsc's CommonJS output those
-    // are `const x_1 = require("…")` at column 0; a deliberate lazy load lives
-    // inside a function and is therefore indented (see
-    // eslint-devkit/src/resolver/resolver.ts, which try/catches a missing
-    // oxc-resolver into a typed error). Flagging indented requires would fail
-    // the very pattern this check tells people to adopt.
-    // Anchored at column 0 = module scope. The wrapper is deliberately loose:
-    // a default import compiles to `const ts_1 = __importDefault(require("ts"))`,
-    // which an `= require(` anchor misses entirely — that is exactly how the
-    // import-next break would have slipped through this check.
-    for (const match of source.matchAll(
-      /^(?:(?:const|var|let)\s+[\w$]+\s*=\s*.*?)?require\(\s*['"]([^'"]+)['"]\s*\)/gm,
-    )) {
-      const pkg = packageOf(match[1]!);
-      if (pkg === null || BUILTINS.has(pkg) || allowed.has(pkg)) continue;
-
-      const peers = (manifest.peerDependencies as Record<string, string>) ?? {};
-      const reason =
-        pkg in peers
-          ? `declared only as an OPTIONAL peer — npm will not install it`
-          : `not declared as a dependency or required peer`;
-      violations.push({ pkg: manifest.name as string, file: file.slice(distRoot.length + 1), specifier: pkg, reason });
-    }
+    violations.push(
+      ...violationsIn(readFileSync(file, 'utf-8'), manifest, file.slice(distRoot.length + 1)),
+    );
   }
 }
 

--- a/scripts/verify-runtime-deps.ts
+++ b/scripts/verify-runtime-deps.ts
@@ -1,0 +1,131 @@
+/**
+ * Static runtime-dependency check — the CI-speed version of the clean-install sweep.
+ *
+ * On 2026-08-03 every published plugin threw on `require`, from two separate
+ * causes: the devkit imported a runtime value from a peer marked `optional`
+ * (npm does not install those), and `eslint-plugin-import-next` imported
+ * `typescript` while declaring no dependency on it at all.
+ *
+ * Both are the same shape — **emitted JS requires a module the package does not
+ * guarantee is installed** — and both are decidable by reading the build output.
+ * No install, no network, no sandbox: `verify-published-install.ts` proves the
+ * same thing by actually installing, but takes ~2.5 minutes, which is too slow
+ * to sit in front of every push. This runs in well under a second and belongs in
+ * CI; keep the install sweep for pre-release and for anything this can't see
+ * (a dependency that is declared but broken).
+ *
+ *   tsx scripts/verify-runtime-deps.ts
+ */
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { builtinModules } from 'node:module';
+import { join, resolve } from 'node:path';
+
+const ROOT = resolve(__dirname, '..');
+const PACKAGES = join(ROOT, 'packages');
+
+const BUILTINS = new Set([...builtinModules, ...builtinModules.map((m) => `node:${m}`)]);
+
+interface Violation {
+  pkg: string;
+  file: string;
+  specifier: string;
+  reason: string;
+}
+
+/** Every emitted `.js` beneath `dir`. */
+function emittedJs(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...emittedJs(full));
+    else if (entry.endsWith('.js')) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * The bare package name a specifier resolves to.
+ * `@scope/pkg/deep` → `@scope/pkg`; `pkg/deep` → `pkg`; `./rel` → null.
+ */
+function packageOf(specifier: string): string | null {
+  if (specifier.startsWith('.') || specifier.startsWith('/')) return null;
+  const parts = specifier.split('/');
+  return specifier.startsWith('@') ? parts.slice(0, 2).join('/') : parts[0]!;
+}
+
+/**
+ * Modules the package guarantees are present at runtime.
+ *
+ * `dependencies` are installed outright. Non-optional `peerDependencies` are
+ * auto-installed by npm 7+. Anything in `peerDependenciesMeta` marked
+ * `optional` is NOT — that is precisely the trap, so it is excluded here even
+ * though it appears in `peerDependencies`.
+ */
+function guaranteed(manifest: Record<string, unknown>): Set<string> {
+  const deps = Object.keys((manifest.dependencies as object) ?? {});
+  const peers = Object.keys((manifest.peerDependencies as object) ?? {});
+  const meta = (manifest.peerDependenciesMeta as Record<string, { optional?: boolean }>) ?? {};
+  const requiredPeers = peers.filter((p) => meta[p]?.optional !== true);
+  return new Set([...deps, ...requiredPeers, manifest.name as string]);
+}
+
+const violations: Violation[] = [];
+const checked: string[] = [];
+
+for (const dir of readdirSync(PACKAGES).sort()) {
+  const distRoot = join(PACKAGES, dir, 'dist');
+  const manifestPath = join(distRoot, 'package.json');
+  if (!existsSync(manifestPath)) continue; // not built, or not a publishable package
+
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8')) as Record<string, unknown>;
+  const allowed = guaranteed(manifest);
+  checked.push(manifest.name as string);
+
+  for (const file of emittedJs(distRoot)) {
+    const source = readFileSync(file, 'utf-8');
+    // Only EAGER requires matter — the ones that run at import time and throw
+    // before a consumer can do anything about it. In tsc's CommonJS output those
+    // are `const x_1 = require("…")` at column 0; a deliberate lazy load lives
+    // inside a function and is therefore indented (see
+    // eslint-devkit/src/resolver/resolver.ts, which try/catches a missing
+    // oxc-resolver into a typed error). Flagging indented requires would fail
+    // the very pattern this check tells people to adopt.
+    // Anchored at column 0 = module scope. The wrapper is deliberately loose:
+    // a default import compiles to `const ts_1 = __importDefault(require("ts"))`,
+    // which an `= require(` anchor misses entirely — that is exactly how the
+    // import-next break would have slipped through this check.
+    for (const match of source.matchAll(
+      /^(?:(?:const|var|let)\s+[\w$]+\s*=\s*.*?)?require\(\s*['"]([^'"]+)['"]\s*\)/gm,
+    )) {
+      const pkg = packageOf(match[1]!);
+      if (pkg === null || BUILTINS.has(pkg) || allowed.has(pkg)) continue;
+
+      const peers = (manifest.peerDependencies as Record<string, string>) ?? {};
+      const reason =
+        pkg in peers
+          ? `declared only as an OPTIONAL peer — npm will not install it`
+          : `not declared as a dependency or required peer`;
+      violations.push({ pkg: manifest.name as string, file: file.slice(distRoot.length + 1), specifier: pkg, reason });
+    }
+  }
+}
+
+console.log(`Checked runtime requires across ${checked.length} built package(s).\n`);
+
+if (violations.length > 0) {
+  for (const v of violations) {
+    console.error(`  ✗ ${v.pkg}\n      ${v.file} requires "${v.specifier}"\n      ${v.reason}`);
+  }
+  console.error(
+    `\n${violations.length} runtime require(s) that a consumer may not have.\n` +
+      `A plain \`npm i -D <pkg>\` would throw Cannot find module.\n\n` +
+      `Fix by one of:\n` +
+      `  • import the value from a local shim (see eslint-devkit/src/ast-node-types.ts)\n` +
+      `  • use \`import type\`, which is erased at compile time\n` +
+      `  • load it lazily and tolerate absence (see import-next/src/utils/typescript-peer.ts)\n` +
+      `  • or, if it genuinely must always be present, move it to \`dependencies\``,
+  );
+  process.exit(1);
+}
+
+console.log('No package requires a module it does not guarantee is installed.');


### PR DESCRIPTION
## Why not the install sweep

`verify:published-install` proves the right thing, but ~2.5 min is too slow for every push.

Both of yesterday's breaks were the **same shape** — emitted JS requiring a module the package doesn't guarantee is installed — and that's decidable by *reading the build output*. No install, no network, no sandbox.

## What it does

Scans each built package's emitted JS for **module-scope** requires and checks them against `dependencies` + non-optional `peerDependencies` + Node builtins.

Optional peers are excluded deliberately — **npm does not install them**, which is exactly the trap the devkit fell into.

Runs as a step on the existing **`Build (Turbo)`** job where `dist/` already exists: **no extra runner, no second build, ~5s**.

## Verified against both real bugs

Reintroduced each and confirmed it fails:

```
✗ @interlace/eslint-devkit
    src/rule-creation/sql-injection-rule.js requires "@typescript-eslint/utils"
    declared only as an OPTIONAL peer — npm will not install it

✗ eslint-plugin-import-next
    src/rules/named.js requires "typescript"
    not declared as a dependency or required peer
```

## Two things that had to be right

Both found by testing against real emitted output rather than assuming:

1. **Only column-0 requires count.** A deliberate lazy load — `resolver.ts` try/catching a missing `oxc-resolver`, `typescript-peer.ts` doing the same — is indented inside a function. Flagging those would fail the very pattern this check tells people to adopt. My first version did exactly that and reported both as violations.

2. **The wrapper must be loose.** A default import emits `const ts_1 = tslib_1.__importDefault(require("typescript"))`. An anchored `= require(` misses it — **the import-next break slipped straight through my first version that way**, and I only caught it because I reintroduced the bug instead of trusting the check.

## Scope, stated plainly

- On PRs the build is filtered to affected packages, so this checks those. `main` builds everything.
- Static analysis can't see a dependency that's *declared but broken*. `npm run verify:published-install` stays for pre-release and covers that.

## Test plan

- [x] `npm run verify:runtime-deps` — 28 built packages, clean, **~5s**
- [x] Fails on each reintroduced bug (output above), passes after restoring
- [x] `npm run lint:workflows` — 32 workflow files pass conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)