### PR TITLE
perf(ci): dispatch only build shards that have work

### DIFF
--- a/.github/workflows/quality-full.yml
+++ b/.github/workflows/quality-full.yml
@@ -72,6 +72,8 @@ jobs:
       shards: ${{ steps.matrix.outputs.shards }}
       any: ${{ steps.matrix.outputs.any }}
       heavy: ${{ steps.matrix.outputs.heavy }}
+      build_shards: ${{ steps.build_matrix.outputs.build_shards }}
+      build_any: ${{ steps.build_matrix.outputs.build_any }}
     steps:
       - id: decide
         env:
@@ -123,6 +125,18 @@ jobs:
           CI_TEST_SHARD_ALL: ${{ github.event_name == 'pull_request' && '0' || '1' }}
         run: node scripts/ci-test-shard.mts --matrix 10
 
+      # Same treatment for the build matrix. It was static [1,2,3,4], so on a
+      # PR touching one plugin all four shards acquired a runner, paid ~24s of
+      # checkout+setup, found they owned nothing affected, and exited 0. Warm,
+      # a build shard does 2-8s of real work inside a ~24s job — the overhead
+      # IS the job — so dispatching empty ones is pure waste of the scarce
+      # resource. Measured on a true single-plugin diff: 1 of 4 shards.
+      - id: build_matrix
+        if: steps.decide.outputs.run == 'true'
+        env:
+          CI_TEST_SHARD_ALL: ${{ github.event_name == 'pull_request' && '0' || '1' }}
+        run: node scripts/ci-build.mts --matrix 4
+
       # The matrix step is now a single point of failure for the whole test
       # gate: if it dies, `shards` is empty, every shard's `if` evaluates false,
       # all of them skip, and the aggregate gate still goes green. That is the
@@ -133,10 +147,15 @@ jobs:
         env:
           SHARDS: ${{ steps.matrix.outputs.shards }}
           HEAVY: ${{ steps.matrix.outputs.heavy }}
+          BUILD_SHARDS: ${{ steps.build_matrix.outputs.build_shards }}
         run: |
           set -euo pipefail
           if [ -z "$SHARDS" ] || [ -z "$HEAVY" ]; then
             echo "::error::The shard matrix step produced no output. Every test shard would skip while this gate reported success. Failing instead."
+            exit 1
+          fi
+          if [ -z "$BUILD_SHARDS" ]; then
+            echo "::error::The build shard matrix is empty. scripts/ci-build.mts --matrix did not emit build_shards, so every build shard would silently skip while this gate reported success."
             exit 1
           fi
           echo "Shard matrix: $SHARDS (heavy=$HEAVY)"
@@ -205,12 +224,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: ${{ fromJSON(needs.gate.outputs.build_shards) }}
     # `heavy` is false when the diff touches no package source at all — a
     # root README, a workflow comment, a .md doc. Nothing those can break is
     # observable to build/typecheck/portability, and markdown still gets linted
     # by quality.yml, which is a separate workflow and always runs.
-    if: needs.gate.outputs.run == 'true' && needs.gate.outputs.heavy == 'true'
+    if: needs.gate.outputs.run == 'true' && needs.gate.outputs.build_any == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -330,6 +349,7 @@ jobs:
           # testable package is affected.
           HEAVY: ${{ needs.gate.outputs.heavy }}
           ANY: ${{ needs.gate.outputs.any }}
+          BUILD_ANY: ${{ needs.gate.outputs.build_any }}
         run: |
           set -euo pipefail
           icon() {
@@ -370,7 +390,8 @@ jobs:
           [ "$ANY"   = "true" ] && test_skip_ok=false || test_skip_ok=true
           [ "$HEAVY" = "true" ] && heavy_skip_ok=false || heavy_skip_ok=true
           check "$R_TEST"        "$test_skip_ok"  "Unit tests"       || all_pass=false
-          check "$R_BUILD"       "$heavy_skip_ok" "Build"            || all_pass=false
+          [ "$BUILD_ANY" = "true" ] && build_skip_ok=false || build_skip_ok=true
+          check "$R_BUILD"       "$build_skip_ok" "Build"            || all_pass=false
           check "$R_TYPECHECK"   "$heavy_skip_ok" "Typecheck"        || all_pass=false
           check "$R_PORTABILITY" "$heavy_skip_ok" "Rule portability" || all_pass=false
           if $all_pass; then

--- a/scripts/ci-build.mts
+++ b/scripts/ci-build.mts
@@ -99,6 +99,19 @@ if (all.length === 0) {
 }
 
 const REVERSE_DEPS = reverseDeps(all);
+const MATRIX_MODE = process.argv[2] === '--matrix';
+
+/** Emit the build matrix to GITHUB_OUTPUT (and stdout when run locally). */
+function emitBuildMatrix(shardNumbers: number[]): void {
+  const json = JSON.stringify(shardNumbers);
+  if (process.env.GITHUB_OUTPUT) {
+    fs.appendFileSync(
+      process.env.GITHUB_OUTPUT,
+      `build_shards=${json}\nbuild_any=${shardNumbers.length > 0}\n`,
+    );
+  }
+  console.log(`build_matrix=${json}`);
+}
 
 // ── What to build ───────────────────────────────────────────────────────────
 let selected: BuildPkg[] = all;
@@ -116,6 +129,10 @@ if (process.env.CI_TEST_SHARD_ALL !== '1') {
     process.exit(1);
   }
   if (decision.mode === 'none') {
+    // Emit an EMPTY matrix rather than exiting silently — the workflow feeds
+    // this straight into fromJSON(), and an unset output would be a parse
+    // error, not a skip.
+    if (MATRIX_MODE) emitBuildMatrix([]);
     console.log(`Nothing to build: ${decision.why} vs ${BASE_REF}.`);
     process.exit(0);
   }
@@ -145,6 +162,30 @@ if (process.env.CI_TEST_SHARD_ALL !== '1') {
 // reintroducing exactly the duplication this sharding removes, while every
 // job still reported success. So: if either variable is set at all, both must
 // be valid.
+// `--matrix <total>` prints the GitHub matrix of build shards that have work,
+// for `strategy.matrix.shard: fromJSON(...)` — the same trick the test sharder
+// uses. Without it the matrix is static [1,2,3,4] and every shard spins up a
+// runner, pays ~24s of checkout+setup, discovers it owns nothing affected, and
+// exits 0. On a typical one-plugin PR that is 3 wasted runner slots against an
+// account-wide cap of 20, which is the binding constraint on this repo's CI.
+if (MATRIX_MODE) {
+  const total = Number(process.argv[3]);
+  if (!Number.isInteger(total) || total < 1) {
+    console.error('Usage: node scripts/ci-build.mts --matrix <shardTotal>');
+    process.exit(2);
+  }
+  const ordered = [...all].sort((a, b) => b.cost - a.cost || a.name.localeCompare(b.name));
+  const buckets = bucket(ordered, total);
+  const selectedNames = new Set(selected.map((p) => p.name));
+  const live = buckets
+    .map((b, i) => ({ shard: i + 1, pkgs: b.filter((p) => selectedNames.has(p.name)) }))
+    .filter((s) => s.pkgs.length > 0);
+  for (const s of live) console.log(`  build shard ${s.shard}: ${s.pkgs.map((p) => p.name).join(', ')}`);
+  console.log(`Dispatching ${live.length} of ${total} build shards (${note}).`);
+  emitBuildMatrix(live.map((s) => s.shard));
+  process.exit(0);
+}
+
 const rawShard = process.env.CI_BUILD_SHARD;
 const rawTotal = process.env.CI_BUILD_SHARD_TOTAL;
 const shardIndex = Number(rawShard ?? '0');


### PR DESCRIPTION
Follow-up to #363. That PR made sharding correct; this one addresses what the measurements then revealed.

## The finding

On the warm re-run of `d8d4a0c7`, a build shard does **2–8s of real work inside a ~24s job**:

| step | Build (3/4) — 24s | Build (1/4) — 47s |
|---|---|---|
| checkout | 4s | 4s |
| setup | 12s | 19s |
| **actual build** | **2s** | **8s** |
| cache save | 3s | 7s |

Every job has that shape — Typecheck 24s for 5s of work, Portability Audit 19s for ~0s, a test shard 24s for 2s. **The overhead is the job.** Sharding is no longer the lever; job *count* is, because runners are capped at 20 account-wide.

## The waste

The build matrix was static `[1, 2, 3, 4]`. On a PR touching one plugin, all four shards acquire a runner, pay ~24s of checkout+setup, discover they own nothing affected, and exit 0. The test matrix already emits only non-empty shards; this does the same for builds.

Measured on a probe commit touching only `eslint-plugin-jwt`:

```
build shard 4: eslint-plugin-jwt, @interlace/eslint-config
Dispatching 1 of 4 build shards (2 affected workspace(s) incl. dependents).
build_matrix=[4]
```

**1 shard instead of 4** — three runner slots back on a typical PR.

The matrix is computed from the *same* full-universe bucketing the shard runner uses, so a package cannot be dispatched to a shard that does not own it, and shard→cache-lineage stability is preserved.

## Correctness

- The `none` path emits an **empty** matrix instead of exiting silently. The workflow feeds this to `fromJSON()`, where an unset output is a parse error, not a skip.
- The gate guard now fails on an empty `build_shards`, matching the existing test-matrix guard — otherwise a dead matrix step would skip every build shard while the aggregate gate reported success.
- A skipped Build is authorised by `build_any`, not `heavy`. Re-verified all six gate states:

| scenario | result |
|---|---|
| normal PR, all green | pass |
| md-only, everything skipped | pass |
| nothing to build but tests ran | pass |
| real build failure | fail |
| build skipped while `build_any=true` | fail |
| cancelled | fail |

## Not included

Two further job-count reductions I did **not** make, for review first:
- **Merge Portability Audit into Typecheck** — 19s + 24s jobs doing ~0s and 5s of work; merging saves a runner slot and ~17s of duplicate setup.
- **Reduce the 11–13s setup** — the `node_modules` cache is 421 MB. Cache usage overall is healthy (1.82 GB of 10 GB).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI/CD Improvements**
  * Build checks now run only for affected workspaces.
  * Build work is distributed across dynamically calculated, cost-balanced shards.
  * Unnecessary build jobs are skipped when no affected packages are detected.
  * The overall quality check now handles skipped builds independently from unrelated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->