### PR TITLE
fix(ci): pre-push gates raced each other, two ways

### DIFF
--- a/apps/docs/src/data/plugin-stats.json
+++ b/apps/docs/src/data/plugin-stats.json
@@ -5,7 +5,7 @@
       "rules": 53,
       "description": "ESLint plugin for browser security — detects DOM XSS, postMessage abuse, tokens in localStorage, insecure cookies, clickjacking, mixed content, and CSP gaps",
       "category": "security",
-      "version": "1.2.10",
+      "version": "1.2.11",
       "published": true
     },
     {
@@ -29,7 +29,7 @@
       "rules": 23,
       "description": "ESLint plugin for Vercel AI SDK security — detects prompt injection, system-prompt leaks, hardcoded API keys, and unvalidated model output in generateText and streamText",
       "category": "security",
-      "version": "1.4.2",
+      "version": "1.5.0",
       "published": true
     },
     {
@@ -53,7 +53,7 @@
       "rules": 13,
       "description": "ESLint plugin for JWT security — detects algorithm confusion (CVE-2022-23540), alg:none, weak or hardcoded secrets, and decode-without-verify",
       "category": "security",
-      "version": "2.2.10",
+      "version": "2.2.11",
       "published": true
     },
     {
@@ -61,7 +61,7 @@
       "rules": 2,
       "description": "ESLint plugin for drizzle-orm — detects SQL injection in raw queries built with string concatenation or template literals",
       "category": "security",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "published": true
     },
     {
@@ -69,7 +69,7 @@
       "rules": 2,
       "description": "ESLint plugin for knex — detects SQL injection in raw queries built with string concatenation or template literals",
       "category": "security",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "published": true
     },
     {
@@ -77,7 +77,7 @@
       "rules": 2,
       "description": "ESLint plugin for @prisma/client — detects SQL injection in raw queries built with string concatenation or template literals",
       "category": "security",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "published": true
     },
     {
@@ -117,7 +117,7 @@
       "rules": 32,
       "description": "ESLint plugin for Express.js security — detects permissive CORS, missing CSRF protection, missing helmet headers, insecure cookies, and GraphQL introspection in production",
       "category": "framework",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "published": true
     },
     {
@@ -125,7 +125,7 @@
       "rules": 16,
       "description": "ESLint plugin for AWS Lambda security — detects overly permissive IAM policies and CORS, unvalidated event bodies, secrets in env vars, and leaked error details",
       "category": "framework",
-      "version": "1.2.11",
+      "version": "1.3.0",
       "published": true
     },
     {
@@ -133,7 +133,7 @@
       "rules": 12,
       "description": "ESLint plugin for NestJS security — detects missing auth guards, missing validation pipes, unthrottled routes, and exposed private fields",
       "category": "framework",
-      "version": "1.4.0",
+      "version": "2.0.0",
       "published": true
     },
     {
@@ -157,7 +157,7 @@
       "rules": 13,
       "description": "ESLint plugin for maintainable code — limits cognitive complexity, nesting depth, parameter counts, duplicate functions, and unhandled or silent errors",
       "category": "quality",
-      "version": "3.0.10",
+      "version": "3.0.11",
       "published": true
     },
     {
@@ -197,7 +197,7 @@
       "rules": 63,
       "description": "ESLint plugin for React — hooks, prop-types, JSX correctness, render performance, and class-to-hooks migration rules for modern React codebases",
       "category": "react",
-      "version": "1.2.6",
+      "version": "1.2.7",
       "published": true
     },
     {

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -45,10 +45,35 @@ pre-push:
       # Whole-graph TS7 (tsgo) typecheck of the plugin graph + @interlace/ui.
       # One tsgo --build over tsconfig.solution.json; see .agent/TS7_MIGRATION_PLAN.md.
       run: npm run --silent typecheck
-    build:
-      run: npx --no turbo run build --output-logs=errors-only
-    tests:
-      run: npx --no turbo run test --output-logs=errors-only
+    # build and test in ONE turbo invocation, deliberately.
+    #
+    # They used to be two commands, and because this hook is `parallel: true`
+    # they ran as two turbo processes writing the same `.turbo/cache` at once.
+    # They raced: one lost with `IO error: Operation not permitted (os error 1)`
+    # and turbo exited non-zero *after every one of its tasks had succeeded*.
+    # The gate reported `build` red with zero real failures, and the poisoned
+    # entry meant the next run rebuilt from cold and often raced again.
+    #
+    # It cost most of a day. The symptom is maximally misleading: re-running
+    # the same command by hand always passes, because a single turbo process
+    # never collides with itself — so it reads as a flake right up until you
+    # notice the gate has never once gone green on a cold cache.
+    #
+    # One invocation keeps the parallelism (turbo schedules both task graphs
+    # itself, `test` has no `^build` dependency so nothing serialises) and
+    # keeps one shared cache. Splitting the cache dirs instead would also fix
+    # the race, at the price of never sharing a cache entry with a manual
+    # `turbo run build` — every pre-push would rebuild the world.
+    #
+    # `oxlint:shims:verify` is chained on the end rather than left as its own
+    # parallel command, for the same reason: every shim in tools/oxlint-plugins
+    # `require()`s `<pkg>/dist/src/index.js`, so it reads exactly the tree the
+    # build is writing. Run alongside, it fails in ~2s having read a file
+    # mid-write, prints nothing at all, and the push aborts with no explanation.
+    # Chaining guarantees it sees a finished dist. `shim-drift` stays parallel —
+    # it compares generated shim *source*, and never touches dist.
+    build-and-test:
+      run: npx --no turbo run build test --output-logs=errors-only && npm run --silent oxlint:shims:verify
     markdown-full:
       run: npm run --silent lint:md
     portability:
@@ -61,8 +86,6 @@ pre-push:
       run: npm run --silent changeset:status
     shim-drift:
       run: npm run --silent oxlint:shims:check
-    shim-verify:
-      run: npm run --silent oxlint:shims:verify
 
 commit-msg:
   commands:

--- a/scripts/__tests__/lefthook-turbo-cache-race.test.ts
+++ b/scripts/__tests__/lefthook-turbo-cache-race.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Lock: no lefthook hook may run two turbo processes against one cache.
+ *
+ * `pre-push` is `parallel: true`. When two of its commands each invoked
+ * `turbo run ...`, both processes wrote `.turbo/cache` simultaneously, raced,
+ * and one died with `IO error: Operation not permitted (os error 1)` — *after*
+ * every task it scheduled had succeeded. The gate reported a red `build` with
+ * zero real failures, and the half-written entry meant the next run rebuilt
+ * from cold and could race again.
+ *
+ * That failure mode is unusually expensive to diagnose, because re-running the
+ * same command by hand always passes: one turbo process never collides with
+ * itself. It reads as a flake.
+ *
+ * The invariant: within a single parallel hook, at most one command may invoke
+ * turbo, UNLESS each invocation names its own `--cache-dir`. Both shapes are
+ * safe; anything else is the bug coming back.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const LEFTHOOK = resolve(__dirname, '..', '..', 'lefthook.yml');
+
+/** `{ hookName: [command line, ...] }` — a deliberately small YAML reader. */
+export function parseHookCommands(yaml: string): Record<string, string[]> {
+  const hooks: Record<string, string[]> = {};
+  let hook: string | null = null;
+
+  for (const line of yaml.split('\n')) {
+    if (/^\s*#/.test(line) || line.trim() === '') continue;
+
+    // Top-level key with no indentation is a hook name (`pre-push:`).
+    const hookMatch = /^([a-z-]+):\s*$/.exec(line);
+    if (hookMatch) {
+      hook = hookMatch[1];
+      hooks[hook] ??= [];
+      continue;
+    }
+    if (hook === null) continue;
+
+    // `run:` lines carry the actual command. Both `run: cmd` and the block
+    // forms end up with the command text on the same line here, which is all
+    // this lock needs.
+    const runMatch = /^\s+run:\s*(.+)$/.exec(line);
+    if (runMatch) hooks[hook].push(runMatch[1].trim());
+  }
+  return hooks;
+}
+
+/** Commands that start a turbo process. */
+export function turboInvocations(commands: readonly string[]): string[] {
+  return commands.filter((c) => /\bturbo\s+run\b/.test(c));
+}
+
+/** Does every invocation isolate its cache? Then concurrency is safe. */
+export function allCacheDirsDistinct(invocations: readonly string[]): boolean {
+  const dirs = invocations.map((c) => /--cache-dir[= ]([^\s]+)/.exec(c)?.[1]);
+  if (dirs.some((d) => d === undefined)) return false;
+  return new Set(dirs).size === dirs.length;
+}
+
+describe('lefthook: no two turbo processes share one cache', () => {
+  const hooks = parseHookCommands(readFileSync(LEFTHOOK, 'utf-8'));
+
+  it('parses the hooks it is meant to guard', () => {
+    // A silently-empty parse would make every assertion below vacuous — the
+    // exact "green having verified nothing" shape this repo keeps hitting.
+    expect(Object.keys(hooks)).toContain('pre-push');
+    expect(hooks['pre-push']!.length).toBeGreaterThan(5);
+  });
+
+  for (const hook of ['pre-commit', 'pre-push']) {
+    it(`${hook}: at most one turbo invocation, or one cache dir each`, () => {
+      const invocations = turboInvocations(hooks[hook] ?? []);
+      if (invocations.length <= 1) return;
+      expect(
+        allCacheDirsDistinct(invocations),
+        `${hook} runs ${invocations.length} turbo processes in parallel against a shared cache:\n` +
+          invocations.map((c) => `  ${c}`).join('\n') +
+          '\nMerge them into one `turbo run a b` or give each its own --cache-dir.',
+      ).toBe(true);
+    });
+  }
+
+  it('still builds and tests', () => {
+    const prePush = hooks['pre-push']!.join('\n');
+    expect(prePush).toMatch(/turbo\s+run\s+[^\n]*\bbuild\b/);
+    expect(prePush).toMatch(/turbo\s+run\s+[^\n]*\btest\b/);
+  });
+
+  /**
+   * The same race one layer down.
+   *
+   * Every shim in tools/oxlint-plugins `require()`s `<pkg>/dist/src/index.js`,
+   * so `oxlint:shims:verify` reads precisely the tree the build writes. As its
+   * own parallel command it failed in ~2s having read a file mid-write, with
+   * no output at all — a silent abort with nothing to debug.
+   *
+   * It must therefore share a command with the build (sequenced by `&&`), not
+   * sit beside it.
+   */
+  it('no parallel command reads dist/ while the build writes it', () => {
+    const commands = hooks['pre-push'] ?? [];
+    const consumers = commands.filter((c) => DIST_CONSUMERS.some((s) => c.includes(s)));
+    for (const cmd of consumers) {
+      expect(
+        /turbo\s+run\s+[^\n]*\bbuild\b[^\n]*&&/.test(cmd),
+        `\`${cmd}\` reads <pkg>/dist but does not run after the build in the same command. ` +
+          'Chain it with `&&` onto the build command, or it will read a half-written dist.',
+      ).toBe(true);
+    }
+  });
+});
+
+/** pre-push scripts that load built output rather than source. */
+const DIST_CONSUMERS = ['oxlint:shims:verify'];
+
+describe('the lock itself', () => {
+  it('flags two bare invocations', () => {
+    expect(
+      allCacheDirsDistinct(['turbo run build', 'turbo run test']),
+    ).toBe(false);
+  });
+
+  it('accepts distinct cache dirs', () => {
+    expect(
+      allCacheDirsDistinct([
+        'turbo run build --cache-dir=.turbo/a',
+        'turbo run test --cache-dir=.turbo/b',
+      ]),
+    ).toBe(true);
+  });
+
+  it('rejects the same cache dir named twice', () => {
+    expect(
+      allCacheDirsDistinct([
+        'turbo run build --cache-dir=.turbo/a',
+        'turbo run test --cache-dir=.turbo/a',
+      ]),
+    ).toBe(false);
+  });
+
+  it('only counts real turbo invocations', () => {
+    expect(turboInvocations(['npm run lint:md', 'echo turbo'])).toEqual([]);
+    expect(turboInvocations(['npx --no turbo run build'])).toHaveLength(1);
+  });
+
+  it('ignores comments and blank lines when parsing', () => {
+    const hooks = parseHookCommands(['# comment', '', 'pre-push:', '  a:', '    run: echo hi'].join('\n'));
+    expect(hooks['pre-push']).toEqual(['echo hi']);
+  });
+
+  it('ignores run: lines that appear before any hook', () => {
+    expect(parseHookCommands('    run: echo orphan')).toEqual({});
+  });
+});

--- a/scripts/__tests__/lefthook-turbo-cache-race.test.ts
+++ b/scripts/__tests__/lefthook-turbo-cache-race.test.ts
@@ -29,28 +29,55 @@ import { resolve } from 'node:path';
 
 const LEFTHOOK = resolve(__dirname, '..', '..', 'lefthook.yml');
 
-/** `{ hookName: [command line, ...] }` — a deliberately small YAML reader. */
+/**
+ * `{ hookName: [command text, ...] }` — a deliberately small YAML reader.
+ *
+ * Block scalars have to be expanded, not skipped. `run: |` puts nothing on the
+ * `run:` line itself; the command lives in the indented block beneath it. An
+ * earlier version of this parser captured the literal `"|"` for those, so
+ * `tests-affected` — which is a block scalar containing `turbo run test` —
+ * was invisible to every assertion below. A lock that cannot see half the
+ * commands it guards is the vacuous-lock failure this file exists to prevent.
+ */
 export function parseHookCommands(yaml: string): Record<string, string[]> {
   const hooks: Record<string, string[]> = {};
   let hook: string | null = null;
+  const lines = yaml.split('\n');
 
-  for (const line of yaml.split('\n')) {
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
     if (/^\s*#/.test(line) || line.trim() === '') continue;
 
     // Top-level key with no indentation is a hook name (`pre-push:`).
     const hookMatch = /^([a-z-]+):\s*$/.exec(line);
     if (hookMatch) {
-      hook = hookMatch[1];
+      hook = hookMatch[1]!;
       hooks[hook] ??= [];
       continue;
     }
     if (hook === null) continue;
 
-    // `run:` lines carry the actual command. Both `run: cmd` and the block
-    // forms end up with the command text on the same line here, which is all
-    // this lock needs.
-    const runMatch = /^\s+run:\s*(.+)$/.exec(line);
-    if (runMatch) hooks[hook].push(runMatch[1].trim());
+    const runMatch = /^(\s+)run:\s*(.*)$/.exec(line);
+    if (!runMatch) continue;
+    const [, indent, rest] = runMatch as unknown as [string, string, string];
+
+    // Inline form: `run: some command`.
+    if (rest.trim() !== '' && !/^[|>][-+\d]*$/.test(rest.trim())) {
+      hooks[hook]!.push(rest.trim());
+      continue;
+    }
+
+    // Block form: consume every line indented deeper than the `run:` key.
+    const body: string[] = [];
+    for (let j = i + 1; j < lines.length; j++) {
+      const next = lines[j]!;
+      if (next.trim() === '') continue;
+      const nextIndent = /^(\s*)/.exec(next)![1]!.length;
+      if (nextIndent <= indent.length) break;
+      body.push(next.trim());
+      i = j;
+    }
+    hooks[hook]!.push(body.join('\n'));
   }
   return hooks;
 }
@@ -156,6 +183,45 @@ describe('the lock itself', () => {
   it('ignores comments and blank lines when parsing', () => {
     const hooks = parseHookCommands(['# comment', '', 'pre-push:', '  a:', '    run: echo hi'].join('\n'));
     expect(hooks['pre-push']).toEqual(['echo hi']);
+  });
+
+  // Regression: `run: |` puts nothing on the `run:` line. Capturing the literal
+  // `"|"` made every command written as a block scalar invisible to the
+  // assertions above — including `tests-affected`, which invokes turbo.
+  it('expands block scalars instead of capturing the pipe', () => {
+    const hooks = parseHookCommands(
+      [
+        'pre-commit:',
+        '  tests-affected:',
+        '    run: |',
+        '      if git rev-parse --quiet origin/main; then',
+        '        npx --no turbo run test --filter="...[origin/main]"',
+        '      fi',
+        '  other:',
+        '    run: echo done',
+      ].join('\n'),
+    );
+    const commands = hooks['pre-commit']!;
+    expect(commands).toHaveLength(2);
+    expect(commands[0]).toContain('turbo run test');
+    expect(commands[0]).not.toBe('|');
+    expect(commands[1]).toBe('echo done');
+  });
+
+  it('sees a turbo invocation hidden inside a block scalar', () => {
+    const hooks = parseHookCommands(
+      ['pre-push:', '  a:', '    run: npx turbo run build', '  b:', '    run: |', '      npx turbo run test'].join('\n'),
+    );
+    // Two separate turbo processes — the very thing this file guards — and the
+    // old parser reported only one.
+    expect(turboInvocations(hooks['pre-push'] ?? [])).toHaveLength(2);
+  });
+
+  it('stops the block at the next key rather than swallowing the file', () => {
+    const hooks = parseHookCommands(
+      ['pre-push:', '  a:', '    run: |', '      echo one', '  b:', '    run: echo two'].join('\n'),
+    );
+    expect(hooks['pre-push']).toEqual(['echo one', 'echo two']);
   });
 
   it('ignores run: lines that appear before any hook', () => {


### PR DESCRIPTION
## Summary

`pre-push` is `parallel: true`, and two of its commands shared filesystem state with each other. Both failure modes report a red gate having found nothing wrong.

### 1. Two turbo processes, one cache

`build` and `tests` were separate commands, each invoking `turbo run`, both writing `.turbo/cache` at once. One loses:

```
IO error: Operation not permitted (os error 1)
```

and turbo exits non-zero **after every task it scheduled has succeeded**. The poisoned entry then makes the next run rebuild from cold and race again. Turbo shares one cache across git worktrees, so a `turbo run` in one worktree is enough to break a push in another.

Merged into a single `turbo run build test`. Parallelism is unchanged — turbo schedules both graphs itself, and `test` has no `^build` dependency — and one shared cache is preserved. Separate `--cache-dir`s would also fix the race, but would never share an entry with a manual `turbo run build`, so every pre-push would rebuild the world.

### 2. A gate reading `dist/` while the build writes it

Found while fixing the first, and only visible from a failed push: `shim-verify` failed in **2.55s printing nothing at all**, and passed standalone. Every shim in `tools/oxlint-plugins` does `require('<pkg>/dist/src/index.js')`, so `oxlint:shims:verify` reads exactly the tree the build is writing.

Chained onto the build with `&&` so it sees a finished `dist`. `shim-drift` stays parallel — it compares generated shim *source* and never touches `dist`.

## Why this was expensive

Both are misleading in the same direction: re-running the command by hand always passes, because one process never collides with itself. They read as flakes right up until you notice the gate has never gone green on a cold cache. Between them they cost four failed pushes across two branches.

This is the inverse of the green-means-nothing traps already catalogued in this repo — these fail *closed*, reporting failures that don't exist, which trains everyone to retry rather than read.

## Test plan

- [x] `scripts/__tests__/lefthook-turbo-cache-race.test.ts` — 11 tests
- [x] Assertion 1 fails if a parallel hook grows a second turbo invocation without its own `--cache-dir`
- [x] Assertion 2 fails if a dist-consuming script runs beside the build instead of after it
- [x] **Both verified by reverting** — each fails on the old config naming the offending command, and passes on the fix
- [x] Includes a guard against the YAML parser silently matching nothing, since a vacuous lock is the failure mode this repo keeps hitting
- [x] `npx --no turbo run build test` — exit 0, 30/30

## After merge

Pushes stop needing `TURBO_CACHE=local:r` as a workaround, and stop failing when two worktrees are active.