### PR TITLE
fix(scripts): fence Options-table code cells that contain a backtick

### DIFF
--- a/.changeset/ai-sdk-family-changelogs.md
+++ b/.changeset/ai-sdk-family-changelogs.md
@@ -1,0 +1,10 @@
+---
+---
+
+Backfill CHANGELOG.md for the four AI-SDK-family plugins shipped in #335
+(anthropic-security, gemini-security, mcp-sdk-security, openai-security).
+`audit:changelogs` reported 4/32 missing; it now reports 0/32.
+
+Generated from git history by the repo's own scripts/generate-changelogs.ts.
+No package content changed, so this needs no version bump — the file simply
+documents releases that already happened.

--- a/.changeset/options-table-backtick-fence.md
+++ b/.changeset/options-table-backtick-fence.md
@@ -1,0 +1,17 @@
+---
+'eslint-plugin-secure-coding': patch
+---
+
+Fix the `dangerousChars` Options row, which rendered as truncated code
+
+`no-improper-sanitization` documents `dangerousChars`, and that option's
+default list contains a backtick among the characters it wants sanitized. The
+generated Options table wrapped the value in a single backtick, so CommonMark
+closed the inline code span at the one inside the array and the rest of the row
+rendered as unstyled plain text.
+
+Code cells are now fenced with a run of backticks longer than any run inside
+the value, padded with spaces so a leading or trailing backtick still belongs
+to the value rather than to the fence.
+
+Documentation only — no rule behaviour changed.

--- a/.changeset/options-table-backtick-fence.md
+++ b/.changeset/options-table-backtick-fence.md
@@ -5,7 +5,7 @@
 Fix the `dangerousChars` Options row, which rendered as truncated code
 
 `no-improper-sanitization` documents `dangerousChars`, and that option's
-default list contains a backtick among the characters it wants sanitized. The
+default list contains a backtick among the characters it expects a sanitizer to handle. The
 generated Options table wrapped the value in a single backtick, so CommonMark
 closed the inline code span at the one inside the array and the rest of the row
 rendered as unstyled plain text.

--- a/packages/eslint-plugin-anthropic-security/CHANGELOG.md
+++ b/packages/eslint-plugin-anthropic-security/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog — eslint-plugin-anthropic-security
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://www.conventionalcommits.org) for commit guidelines.
+
+## 0.1.0 (2026-08-05)
+
+### ✨ Features
+
+- AI SDK security family + fix the broken oxlint export (#335) (47cde07f) — 2026-08-04
+- add initial changelog and AI assistant instructions to multiple ESLint plugins (ad251958) — 2025-12-29
+- add component-specific Codecov badges to all README files (b71ce728) — 2025-12-29
+
+### 🐛 Bug Fixes
+
+- ignore plugin entry points (src/index.ts) from coverage (27c69e12) — 2025-12-29
+- change include pattern from 'src/rules/**/index.ts' to 'src/**/*.ts' (dccfc0fc) — 2025-12-29
+- update Codecov workflow to use CLI upload-process (60dd38cb) — 2025-12-29
+- make Codecov workflow resilient for monorepo (9daece7f) — 2025-12-29
+- add correct peer dependencies for eslint and ai sdk (c9cbc866) — 2025-12-13
+
+### 📝 Documentation
+
+- complete the logo row across every published package (#377) (85e57a7c) — 2026-08-04
+
+### 🔧 Chores
+
+- add MIT license and standard .npmignore files to various ESLint plugins (89f6ba76) — 2025-12-29
+

--- a/packages/eslint-plugin-gemini-security/CHANGELOG.md
+++ b/packages/eslint-plugin-gemini-security/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog — eslint-plugin-gemini-security
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://www.conventionalcommits.org) for commit guidelines.
+
+## 0.1.0 (2026-08-05)
+
+### ✨ Features
+
+- AI SDK security family + fix the broken oxlint export (#335) (47cde07f) — 2026-08-04
+
+### 📝 Documentation
+
+- complete the logo row across every published package (#377) (85e57a7c) — 2026-08-04
+

--- a/packages/eslint-plugin-mcp-sdk-security/CHANGELOG.md
+++ b/packages/eslint-plugin-mcp-sdk-security/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog — eslint-plugin-mcp-sdk-security
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://www.conventionalcommits.org) for commit guidelines.
+
+## 0.1.0 (2026-08-05)
+
+### ✨ Features
+
+- AI SDK security family + fix the broken oxlint export (#335) (47cde07f) — 2026-08-04
+
+### 📝 Documentation
+
+- complete the logo row across every published package (#377) (85e57a7c) — 2026-08-04
+

--- a/packages/eslint-plugin-openai-security/CHANGELOG.md
+++ b/packages/eslint-plugin-openai-security/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog — eslint-plugin-openai-security
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://www.conventionalcommits.org) for commit guidelines.
+
+## 0.1.0 (2026-08-05)
+
+### ✨ Features
+
+- AI SDK security family + fix the broken oxlint export (#335) (47cde07f) — 2026-08-04
+- add component-specific Codecov badges to all README files (b71ce728) — 2025-12-29
+
+### 🐛 Bug Fixes
+
+- ignore plugin entry points (src/index.ts) from coverage (27c69e12) — 2025-12-29
+- change include pattern from 'src/rules/**/index.ts' to 'src/**/*.ts' (dccfc0fc) — 2025-12-29
+- update Codecov workflow to use CLI upload-process (60dd38cb) — 2025-12-29
+- make Codecov workflow resilient for monorepo (9daece7f) — 2025-12-29
+- add correct peer dependencies for eslint and ai sdk (c9cbc866) — 2025-12-13
+
+### 📝 Documentation
+
+- complete the logo row across every published package (#377) (85e57a7c) — 2026-08-04
+
+### 🔧 Chores
+
+- remove eslint-plugin-openai-security package and its tsconfig alias (69c4cd92) — 2025-12-29
+- add MIT license and standard .npmignore files to various ESLint plugins (89f6ba76) — 2025-12-29
+

--- a/packages/eslint-plugin-secure-coding/docs/rules/no-improper-sanitization.md
+++ b/packages/eslint-plugin-secure-coding/docs/rules/no-improper-sanitization.md
@@ -114,7 +114,7 @@ db.query('SELECT * FROM users WHERE name = ?', [userInput]);
 | Option | Type | Default | Description |
 | ------ | ---- | ------- | ----------- |
 | `safeSanitizers` | `string[]` | `["DOMPurify.sanitize","he.encode","encodeURIComponent","encodeURI","escape"]` | Sanitizer calls treated as sufficient |
-| `dangerousChars` | `string[]` | `["<",">","\"","'","&","`","$","{","}","\|",";","(",")"]` | Characters a sanitizer is expected to handle |
+| `dangerousChars` | `string[]` | `` ["<",">","\"","'","&","`","$","{","}","\|",";","(",")"] `` | Characters a sanitizer is expected to handle |
 | `contexts` | `string[]` | `["html","url","sql","command","javascript","css"]` | Output contexts checked for a context-appropriate sanitizer |
 | `trustedLibraries` | `string[]` | `["DOMPurify","he","validator","express-validator"]` | Libraries whose sanitizers are trusted |
 | `trustedSanitizers` | `string[]` | `[]` | Additional function names to consider as sanitizers |

--- a/scripts/document-rule-options.ts
+++ b/scripts/document-rule-options.ts
@@ -82,7 +82,17 @@ function cell(text: string): string {
  * The pipe is the sole character that still breaks a table row inside code.
  */
 function codeCell(value: string): string {
-  return `\`${value.replace(/\|/g, '\\|').replace(/\r?\n/g, ' ')}\``;
+  const text = value.replace(/\|/g, '\\|').replace(/\r?\n/g, ' ');
+  // A backtick inside the value would close the span early — `dangerousChars`
+  // lists one among the characters it wants sanitized, so its default ended
+  // mid-array and the rest of the row rendered as plain text. CommonMark's
+  // answer is a fence longer than any run of backticks in the content, with a
+  // space of padding so a leading or trailing backtick still belongs to the
+  // value rather than to the fence.
+  const longest = Math.max(0, ...[...text.matchAll(/`+/g)].map((m) => m[0].length));
+  if (longest === 0) return `\`${text}\``;
+  const fence = '`'.repeat(longest + 1);
+  return `${fence} ${text} ${fence}`;
 }
 
 /** Render a schema property's type as it appears in the Type column. */

--- a/scripts/document-rule-options.ts
+++ b/scripts/document-rule-options.ts
@@ -84,7 +84,7 @@ function cell(text: string): string {
 function codeCell(value: string): string {
   const text = value.replace(/\|/g, '\\|').replace(/\r?\n/g, ' ');
   // A backtick inside the value would close the span early — `dangerousChars`
-  // lists one among the characters it wants sanitized, so its default ended
+  // lists one among the characters it expects a sanitizer to handle, so its default ended
   // mid-array and the rest of the row rendered as plain text. CommonMark's
   // answer is a fence longer than any run of backticks in the content, with a
   // space of padding so a leading or trailing backtick still belongs to the


### PR DESCRIPTION
Follow-up to #383, which merged before this fix could land on it.

## The bug

`no-improper-sanitization` documents `dangerousChars`, and that option's default list contains a **backtick** among the characters it wants sanitized. The generated Options row wrapped the value in a single backtick, so CommonMark closed the inline code span at the one *inside* the array:

```
| `dangerousChars` | `string[]` | `["<",">","\"","'","&","`","$","{","}","\|",";","(",")"]` | ... |
```

Everything after `"&","` renders as unstyled plain text. It is on `main` right now.

markdownlint did not catch it — MD056 checks table *structure*, and the row still has four cells. Only the rendering is wrong, which is the failure mode that survives a lint gate.

Caught in review on #383 by @claude.

## The fix

The suggestion was double-backticks. I went a step further: the fence is a run of backticks **one longer than the longest run inside the value**, plus a space of padding.

- Double-backticks fix today's case but break again on a value containing ` `` `.
- The padding is what keeps a *leading or trailing* backtick attached to the value instead of being absorbed into the fence — CommonMark strips one space from each end when both are present.

## Also in here

Two things the pre-push gate surfaced, both pre-existing on `main`:

- **Four packages had no `CHANGELOG.md`** — `anthropic-security`, `gemini-security`, `mcp-sdk-security`, `openai-security`, all shipped in #335. `audit:changelogs` reported `4/32 missing`; it now reports `0/32`. Generated by the repo's own `scripts/generate-changelogs.ts`, so they are git history, not prose I wrote.
- Changesets for both, including an empty one for the changelog backfill — those files document releases that already happened and need no version bump.

## Test plan

- [x] `npm run docs:options:check` — clean, 0 drift, idempotent.
- [x] `npm run test:documented-options` — 2 passed, both directions.
- [x] `markdownlint-cli2` on the changed doc — 0 issues.
- [x] `npm run audit:changelogs` — 0/32 missing (was 4/32).
- [x] `npm run changeset:status` — resolves.
- [x] Full pre-push gate green.

## After merge

Documentation only. The one changed row renders as complete inline code instead of truncating mid-array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added initial changelogs for the Anthropic, Gemini, MCP SDK, and OpenAI security plugins.
  - Documented previously shipped releases across the AI SDK plugin family.
  - Clarified the documented default value for the `dangerousChars` option.

- **Bug Fixes**
  - Improved generated Options tables so values containing backticks render correctly without losing formatting or content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->