### PR TITLE
fix(eslint-devkit): no-unsafe-query follows same-file query helpers

### DIFF
--- a/.changeset/sql-wrapper-taint.md
+++ b/.changeset/sql-wrapper-taint.md
@@ -1,0 +1,50 @@
+---
+'@interlace/eslint-devkit': minor
+'eslint-plugin-pg': patch
+---
+
+`no-unsafe-query` now follows same-file query helpers
+
+The rule only ever treated a literal driver method call as a sink. Real
+codebases do not call `client.query` at every call site — they wrap it once:
+
+```ts
+const q = (sql: string, params: unknown[]) => pool.query(sql, params);
+
+q(`SELECT * FROM users WHERE id = ${userInput}`, []); // was silent
+q('SELECT * FROM users WHERE id = ' + userInput, []); // was silent
+```
+
+Both of those are textbook CWE-89 and both went unreported — not because the
+helper was hard to reach, but because the callee was named `q` instead of
+`query`. The helper being in the _same file_, three lines above, made no
+difference. Any project that wraps its driver once, which is most of them, was
+getting no SQL injection coverage at all from this rule.
+
+A function whose parameter is handed straight to a driver sink is now itself a
+sink at that argument position, and calls to it are checked like the driver call
+they stand for. `function` declarations, arrow functions in a `const`, class
+methods and object-literal methods are all traced, including when the helper is
+declared below its call site. Concatenation, interpolation, and a
+previously-tainted variable passed to the helper all report.
+
+Findings through a helper require the string to contain SQL keywords, even for
+instances configured with `requireSqlKeywords: false` (`eslint-plugin-pg`).
+"This identifier eventually reaches a sink" is weaker evidence than a literal
+driver call, and without the gate a file that defined any helper over
+`pool.query` would start reporting unrelated calls like ``log(`hello ${name}`)``.
+A bare `query(...)` with no member access is likewise never treated as a driver
+sink — only as a possible helper.
+
+Parameterized calls through a helper stay silent, which is what
+[#261](https://github.com/ofri-peretz/eslint/issues/261) asked for:
+``q(`SELECT * FROM users WHERE id = $1`, [id])`` interpolates nothing and is
+safe at any distance.
+
+Helpers imported from another module are still not traced — that needs type
+information the rule does not request. This is documented as a known false
+negative rather than silently missing.
+
+Affects `no-unsafe-query` in all eight SQL plugins: `pg`, `mysql-security`,
+`prisma-security`, `drizzle-security`, `knex-security`, `sqlite-security`,
+`typeorm-security` and `sequelize-security`.

--- a/packages/eslint-devkit/src/rule-creation/sql-injection-rule.test.ts
+++ b/packages/eslint-devkit/src/rule-creation/sql-injection-rule.test.ts
@@ -229,6 +229,28 @@ describe('createSqlInjectionRule', () => {
             'q(label, []);',
           ].join('\n'),
         },
+        // Matching is by bare name, so a name meaning two different things in
+        // one file is unusable. The adapter pattern — several repositories
+        // exposing an identically-named method — is where this bites, and
+        // reporting the non-wrapping one would be precisely the false
+        // positive #261 described.
+        {
+          name: 'same method name on a wrapping and a non-wrapping class',
+          code: [
+            'class PgRepo { run(sql) { return this.pool.query(sql); } }',
+            'class CacheRepo { run(sql) { return this.cache.get(sql); } }',
+            'new CacheRepo().run(`SELECT * FROM users WHERE id = ${id}`);',
+          ].join('\n'),
+        },
+        {
+          name: 'same free function name, only one of which wraps a sink',
+          code: [
+            'function send(sql) { return pool.query(sql); }',
+            'function send2(x) { return x; }',
+            'const send3 = (sql) => sql;',
+            'send3(`SELECT * FROM users WHERE id = ${id}`);',
+          ].join('\n'),
+        },
         {
           name: 'unrelated helper of the same name is not a sink',
           code: 'log(`SELECT ${x}`);',
@@ -317,6 +339,19 @@ describe('createSqlInjectionRule', () => {
           code: [
             'const q = (conn, sql) => conn.query(sql);',
             'q(pool, `SELECT * FROM users WHERE id = ${id}`);',
+          ].join('\n'),
+          errors: [{ messageId: 'unsafeTemplateLiteral' }],
+        },
+        // The variable acquires its SQL-ness at the `+=`, not at its
+        // declaration. `pool.query(sql)` always caught this; `q(sql)` used to
+        // drop it, because `sqlish` was only ever seeded from a declarator.
+        {
+          name: 'variable made SQL-ish by += then handed to a wrapper',
+          code: [
+            'const q = (sql) => pool.query(sql);',
+            "let sql = '';",
+            'sql += `SELECT * FROM users WHERE id = ${id}`;',
+            'q(sql);',
           ].join('\n'),
           errors: [{ messageId: 'unsafeTemplateLiteral' }],
         },

--- a/packages/eslint-devkit/src/rule-creation/sql-injection-rule.test.ts
+++ b/packages/eslint-devkit/src/rule-creation/sql-injection-rule.test.ts
@@ -75,7 +75,9 @@ describe('createSqlInjectionRule', () => {
       expect(ungated.meta.docs?.description).toBe('test rule (ungated)');
       expect(ungated.meta.docs?.url).toBe('https://example.test/ungated');
       expect(ungated.meta.messages.noUnsafeQuery).toContain('$1, $2');
-      expect(gated.meta.messages.unsafeTemplateLiteral).toContain('placeholders');
+      expect(gated.meta.messages.unsafeTemplateLiteral).toContain(
+        'placeholders',
+      );
     });
 
     // Both messageIds are primary findings — `create` picks between them on
@@ -100,25 +102,58 @@ describe('createSqlInjectionRule', () => {
       valid: [
         { name: 'no arguments', code: `client.query();` },
         { name: 'non-sink method', code: `client.other('SELECT ' + 1);` },
-        { name: 'bare identifier callee', code: `query(\`SELECT * FROM t WHERE id = \${id}\`);` },
+        {
+          name: 'bare identifier callee',
+          code: `query(\`SELECT * FROM t WHERE id = \${id}\`);`,
+        },
         // Known limitation, inherited from the original pg rule: only
         // identifier property access is matched, so `client['query']` is a
         // false negative. Documented in both rule docs.
-        { name: 'non-identifier member property', code: `client['query'](\`SELECT \${x}\`);` },
-        { name: 'parameterized', code: `client.query('SELECT * FROM users WHERE id = $1', [id]);` },
-        { name: 'template without expressions', code: 'pool.query(`SELECT * FROM users`);' },
+        {
+          name: 'non-identifier member property',
+          code: `client['query'](\`SELECT \${x}\`);`,
+        },
+        {
+          name: 'parameterized',
+          code: `client.query('SELECT * FROM users WHERE id = $1', [id]);`,
+        },
+        {
+          name: 'template without expressions',
+          code: 'pool.query(`SELECT * FROM users`);',
+        },
         { name: 'spread argument', code: `client.query(...args);` },
-        { name: 'declarator without init', code: `let q; db.query('SELECT 1');` },
-        { name: 'destructured declarator', code: `const { sql } = cfg; db.query(sql);` },
-        { name: 'untainted identifier', code: `const q = 'SELECT 1'; db.query(q);` },
-        { name: 'plain string +=', code: `let q = 'SELECT 1'; q += ' WHERE active'; db.query(q);` },
+        {
+          name: 'declarator without init',
+          code: `let q; db.query('SELECT 1');`,
+        },
+        {
+          name: 'destructured declarator',
+          code: `const { sql } = cfg; db.query(sql);`,
+        },
+        {
+          name: 'untainted identifier',
+          code: `const q = 'SELECT 1'; db.query(q);`,
+        },
+        {
+          name: 'plain string +=',
+          code: `let q = 'SELECT 1'; q += ' WHERE active'; db.query(q);`,
+        },
         { name: 'non-+= operator', code: `let n = 1; n -= step; db.query(n);` },
-        { name: 'member-expression += target', code: `state.q += 'a' + suffix; db.query(state.q);` },
+        {
+          name: 'member-expression += target',
+          code: `state.q += 'a' + suffix; db.query(state.q);`,
+        },
         // Regression: `+` is also numeric addition. With no string literal in
         // the expression there is no evidence of SQL, so even the ungated
         // instance must stay silent.
-        { name: 'numeric addition is not concatenation', code: `db.query(1 + offset);` },
-        { name: 'variable-only addition has no static text', code: `db.query(a + b);` },
+        {
+          name: 'numeric addition is not concatenation',
+          code: `db.query(1 + offset);`,
+        },
+        {
+          name: 'variable-only addition has no static text',
+          code: `db.query(a + b);`,
+        },
       ],
       invalid: [
         {
@@ -145,6 +180,154 @@ describe('createSqlInjectionRule', () => {
           name: 'template-tainted variable via +=',
           code: 'let q = "SELECT 1"; q += ` AND id = ${id}`; db.query(q);',
           errors: [{ messageId: 'unsafeTemplateLiteral' }],
+        },
+      ],
+    });
+  });
+
+  // Reported as a false positive in #261 ("wrapper flags my parameterized
+  // query"); the FP could not be reproduced, but the same shape turned out to
+  // be a total *false negative* — a genuinely injectable query was invisible
+  // the moment it went through a one-line helper, even with the helper three
+  // lines above in the same file. Every `invalid` case here reported nothing
+  // before this rule learned about wrappers.
+  describe('same-file query wrappers', () => {
+    ruleTester.run('wrapper-aware (ungated)', ungated, {
+      valid: [
+        // The exact snippet from #261. A wrapper is only a sink for unsafe
+        // *construction* — a non-interpolated template stays safe forever.
+        {
+          name: 'issue #261: parameterized call through an arrow wrapper',
+          code: [
+            'const q = (sql, params) => pool.query(sql, params);',
+            'q(`SELECT * FROM users WHERE id = $1`, [id]);',
+          ].join('\n'),
+        },
+        // An anonymous function has no name to match at a call site, so it
+        // never becomes a wrapper — `callableName` returns undefined.
+        {
+          name: 'anonymous callback around a sink is not a named wrapper',
+          code: [
+            'items.forEach(function (sql) { pool.query(sql); });',
+            'send(`SELECT * FROM users WHERE id = ${id}`);',
+          ].join('\n'),
+        },
+        {
+          name: 'spread argument into a helper carries no analysable shape',
+          code: [
+            'const q = (sql, params) => pool.query(sql, params);',
+            'q(...args);',
+          ].join('\n'),
+        },
+        // Tainted, but with no SQL keyword anywhere — the forced gate applies
+        // to the identifier path too, not just to inline construction.
+        {
+          name: 'tainted-but-not-SQL variable through a wrapper',
+          code: [
+            'const q = (sql, params) => pool.query(sql, params);',
+            'const label = `run ${id}`;',
+            'q(label, []);',
+          ].join('\n'),
+        },
+        {
+          name: 'unrelated helper of the same name is not a sink',
+          code: 'log(`SELECT ${x}`);',
+        },
+        // The wrapper's own forwarding call must not report: `sql` is an
+        // opaque parameter, not something this file concatenated.
+        {
+          name: 'the wrapper body itself',
+          code: 'const q = (sql, params) => pool.query(sql, params);',
+        },
+        // Argument position matters — the params array is not the query.
+        {
+          name: 'interpolation in a non-query argument',
+          code: [
+            'const q = (sql, params) => pool.query(sql, params);',
+            'q("SELECT * FROM users WHERE id = $1", [`${id}`]);',
+          ].join('\n'),
+        },
+        // Forced keyword gate: the ungated instance reports keyword-free
+        // interpolation at a *real* sink, but must not through a wrapper —
+        // that is how fixing this FN would have created a new FP class.
+        {
+          name: 'keyword-free interpolation through a wrapper stays gated',
+          code: [
+            'const q = (sql, params) => pool.query(sql, params);',
+            'q(`give me ${everything}`, []);',
+          ].join('\n'),
+        },
+      ],
+      invalid: [
+        {
+          name: 'interpolation through an arrow wrapper',
+          code: [
+            'const q = (sql, params) => pool.query(sql, params);',
+            'q(`SELECT * FROM users WHERE id = ${id}`, []);',
+          ].join('\n'),
+          errors: [{ messageId: 'unsafeTemplateLiteral' }],
+        },
+        {
+          name: 'concatenation through an arrow wrapper',
+          code: [
+            'const q = (sql, params) => pool.query(sql, params);',
+            'q("SELECT * FROM users WHERE id = " + id, []);',
+          ].join('\n'),
+          errors: [{ messageId: 'noUnsafeQuery' }],
+        },
+        // Hoisting: the helper is declared *below* its caller, which is why
+        // wrapper findings are resolved at Program:exit rather than inline.
+        {
+          name: 'function declaration hoisted below its call site',
+          code: [
+            'run(`SELECT * FROM users WHERE id = ${id}`);',
+            'function run(sql) { return pool.query(sql); }',
+          ].join('\n'),
+          errors: [{ messageId: 'unsafeTemplateLiteral' }],
+        },
+        {
+          name: 'class method wrapper',
+          code: [
+            'class Db { run(sql, p) { return this.pool.query(sql, p); } }',
+            'new Db().run(`SELECT * FROM users WHERE id = ${id}`, []);',
+          ].join('\n'),
+          errors: [{ messageId: 'unsafeTemplateLiteral' }],
+        },
+        // Class field holding an arrow — the shape NestJS services use, where
+        // the helper is a property rather than a method.
+        {
+          name: 'class field arrow wrapper',
+          code: [
+            'class Db { q = (sql) => this.pool.query(sql); }',
+            'new Db().q(`SELECT * FROM users WHERE id = ${id}`);',
+          ].join('\n'),
+          errors: [{ messageId: 'unsafeTemplateLiteral' }],
+        },
+        {
+          name: 'object-literal method wrapper',
+          code: [
+            'const db = { run(sql) { return pool.query(sql); } };',
+            'db.run("SELECT * FROM users WHERE id = " + id);',
+          ].join('\n'),
+          errors: [{ messageId: 'noUnsafeQuery' }],
+        },
+        // The query is not the first parameter of the helper.
+        {
+          name: 'query at a non-zero parameter index',
+          code: [
+            'const q = (conn, sql) => conn.query(sql);',
+            'q(pool, `SELECT * FROM users WHERE id = ${id}`);',
+          ].join('\n'),
+          errors: [{ messageId: 'unsafeTemplateLiteral' }],
+        },
+        {
+          name: 'tainted variable handed to a wrapper',
+          code: [
+            'const q = (sql, params) => pool.query(sql, params);',
+            'const sql = "SELECT * FROM users WHERE id = " + id;',
+            'q(sql, []);',
+          ].join('\n'),
+          errors: [{ messageId: 'noUnsafeQuery' }],
         },
       ],
     });
@@ -194,7 +377,7 @@ describe('createSqlInjectionRule', () => {
           name: 'keyword-free fragment appended to a SQL-seeded variable',
           code: [
             "let sql = 'SELECT * FROM products WHERE 1=1';",
-            'sql += ` AND name = \'${name}\'`;',
+            "sql += ` AND name = '${name}'`;",
             'db.query(sql);',
           ].join('\n'),
           errors: [{ messageId: 'unsafeTemplateLiteral' }],

--- a/packages/eslint-devkit/src/rule-creation/sql-injection-rule.ts
+++ b/packages/eslint-devkit/src/rule-creation/sql-injection-rule.ts
@@ -233,6 +233,17 @@ export function createSqlInjectionRule(
       // observed handing to a real sink. `pool.query(sql, params)` inside
       // `const q = (sql, params) => …` makes `q` a sink at argument 0.
       const wrappers = new Map<string, number>();
+      // Every named callable defined in this file, and the subset of those
+      // proven to forward a parameter into a sink. A name is only usable as a
+      // wrapper when *every* definition of it is one: matching is by bare
+      // name, so a file holding both `PgRepo.run` (wraps `pool.query`) and
+      // `CacheRepo.run` (does not) cannot tell the two apart, and reporting
+      // `new CacheRepo().run(...)` would be exactly the false positive this
+      // rule is being fixed for. Ambiguous name -> no wrapper finding.
+      const definitions = new Map<string, number>();
+      // Keyed by function node so a body calling the sink twice counts once;
+      // the value is the name, already resolved at detection.
+      const wrapperFns = new Map<TSESTree.FunctionLike, string>();
       // Calls that would be findings *if* their callee turns out to be a
       // wrapper. Deferred to Program:exit because a helper may be declared
       // below its call site (hoisted `function`, or a class used top-down).
@@ -252,6 +263,16 @@ export function createSqlInjectionRule(
       };
 
       return {
+        // Count every named callable so Program:exit can tell a name with one
+        // meaning from a name shared by a wrapper and a non-wrapper.
+        'FunctionDeclaration, FunctionExpression, ArrowFunctionExpression'(
+          node: TSESTree.FunctionLike,
+        ) {
+          const name = callableName(node);
+          if (name !== undefined)
+            definitions.set(name, (definitions.get(name) ?? 0) + 1);
+        },
+
         // const query = "SELECT ..." + userId;
         // const query = `SELECT ...${email}`;
         VariableDeclarator(node: TSESTree.VariableDeclarator) {
@@ -275,6 +296,13 @@ export function createSqlInjectionRule(
               config.requireSqlKeywords && !sqlish.has(node.left.name);
             const kind = classify(node.right, gate);
             if (kind) tainted.set(node.left.name, kind);
+            // A variable can acquire its SQL-ness here rather than at its
+            // declaration (`let sql = ''; sql += 'SELECT …${id}'`). Without
+            // this, the wrapper path's `sqlish` guard dropped that variable
+            // while the direct-sink path still reported it — the same code
+            // flagged at `pool.query(sql)` and silent at `q(sql)`.
+            if (SQL_KEYWORDS.test(staticText(node.right)))
+              sqlish.add(node.left.name);
           }
         },
 
@@ -332,7 +360,10 @@ export function createSqlInjectionRule(
                   p.name === queryArg.name,
               ) ?? -1;
             const name = fn && index >= 0 ? callableName(fn) : undefined;
-            if (name !== undefined) wrappers.set(name, index);
+            if (name !== undefined && fn) {
+              wrappers.set(name, index);
+              wrapperFns.set(fn, name);
+            }
           }
 
           const direct = classify(queryArg, config.requireSqlKeywords);
@@ -348,8 +379,16 @@ export function createSqlInjectionRule(
         },
 
         'Program:exit'() {
+          // How many definitions of each name were proven to be wrappers.
+          const proven = new Map<string, number>();
+          for (const name of wrapperFns.values())
+            proven.set(name, (proven.get(name) ?? 0) + 1);
+
           for (const { name, index, arg, kind } of pending) {
             if (wrappers.get(name) !== index) continue;
+            // Every definition of this name must be a wrapper, or we cannot
+            // tell which one a call site meant.
+            if (definitions.get(name) !== proven.get(name)) continue;
             if (kind) {
               report(arg, kind);
               continue;

--- a/packages/eslint-devkit/src/rule-creation/sql-injection-rule.ts
+++ b/packages/eslint-devkit/src/rule-creation/sql-injection-rule.ts
@@ -75,6 +75,52 @@ const SQL_KEYWORDS =
 
 type UnsafeKind = 'concat' | 'template';
 
+const FUNCTION_TYPES = new Set<string>([
+  AST_NODE_TYPES.FunctionDeclaration,
+  AST_NODE_TYPES.FunctionExpression,
+  AST_NODE_TYPES.ArrowFunctionExpression,
+]);
+
+/** Nearest enclosing function of `node`, or `undefined` at module top level. */
+function enclosingFunction(
+  node: TSESTree.Node,
+): TSESTree.FunctionLike | undefined {
+  for (let n = node.parent; n; n = n.parent) {
+    if (FUNCTION_TYPES.has(n.type)) return n as TSESTree.FunctionLike;
+  }
+  return undefined;
+}
+
+/**
+ * The name a function is reached by at its call sites, or `undefined` when it
+ * has none we can match on (IIFE, default export, callback argument).
+ *
+ * Covers the four ways a query helper is normally written: `function q()`,
+ * `const q = (...) => …`, a class method, and an object-literal method.
+ */
+function callableName(fn: TSESTree.FunctionLike): string | undefined {
+  if (fn.type === AST_NODE_TYPES.FunctionDeclaration && fn.id)
+    return fn.id.name;
+  // Every function reachable here is nested inside a Program, so `parent` is
+  // always set — no guard, which would be an untestable branch.
+  const parent = fn.parent;
+  if (
+    parent.type === AST_NODE_TYPES.VariableDeclarator &&
+    parent.id.type === AST_NODE_TYPES.Identifier
+  ) {
+    return parent.id.name;
+  }
+  if (
+    (parent.type === AST_NODE_TYPES.MethodDefinition ||
+      parent.type === AST_NODE_TYPES.PropertyDefinition ||
+      parent.type === AST_NODE_TYPES.Property) &&
+    parent.key.type === AST_NODE_TYPES.Identifier
+  ) {
+    return parent.key.name;
+  }
+  return undefined;
+}
+
 /** Literal text of a string expression, ignoring interpolated/concatenated values. */
 function staticText(node: TSESTree.Node): string {
   if (node.type === AST_NODE_TYPES.TemplateLiteral) {
@@ -90,14 +136,20 @@ function staticText(node: TSESTree.Node): string {
 }
 
 /** Classify an expression as unsafe SQL construction, or `false` if it is not. */
-function classify(node: TSESTree.Node, requireSqlKeywords: boolean): UnsafeKind | false {
+function classify(
+  node: TSESTree.Node,
+  requireSqlKeywords: boolean,
+): UnsafeKind | false {
   let kind: UnsafeKind | false = false;
   // Concatenation: "SELECT ... " + value
   if (node.type === AST_NODE_TYPES.BinaryExpression && node.operator === '+') {
     kind = 'concat';
   }
   // Interpolation: `SELECT ... ${value}`
-  if (node.type === AST_NODE_TYPES.TemplateLiteral && node.expressions.length > 0) {
+  if (
+    node.type === AST_NODE_TYPES.TemplateLiteral &&
+    node.expressions.length > 0
+  ) {
     kind = 'template';
   }
   if (kind === false) return false;
@@ -113,9 +165,10 @@ function classify(node: TSESTree.Node, requireSqlKeywords: boolean): UnsafeKind 
 /**
  * Build a CWE-89 rule for the given sinks and remediation copy.
  *
- * Detects three shapes: direct concatenation into a sink, direct
- * interpolation into a sink, and a variable tainted by either (including via
- * `+=`) that is later passed to a sink.
+ * Detects four shapes: direct concatenation into a sink, direct
+ * interpolation into a sink, a variable tainted by either (including via
+ * `+=`) that is later passed to a sink, and either of those passed to a
+ * same-file helper that forwards the argument into a sink.
  */
 export function createSqlInjectionRule(
   config: SqlInjectionRuleConfig,
@@ -133,7 +186,8 @@ export function createSqlInjectionRule(
         noUnsafeQuery: formatLLMMessage({
           icon: MessageIcons.SECURITY,
           issueName: 'SQL Injection Risk',
-          description: 'Unsafe SQL query detected. Variable interpolation found.',
+          description:
+            'Unsafe SQL query detected. Variable interpolation found.',
           severity: 'CRITICAL',
           // Same source as meta.docs.cwe, so the emitted CVSS can never drift
           // from the documented one (security-cvss-docs-consistency.lock).
@@ -154,7 +208,8 @@ export function createSqlInjectionRule(
         unsafeTemplateLiteral: formatLLMMessage({
           icon: MessageIcons.SECURITY,
           issueName: 'SQL Injection Risk',
-          description: 'Unsafe SQL query construction detected (template literal).',
+          description:
+            'Unsafe SQL query construction detected (template literal).',
           severity: 'CRITICAL',
           cwe: config.meta.docs.cwe,
           owasp: 'A03:2021',
@@ -174,11 +229,25 @@ export function createSqlInjectionRule(
       // and the injection in the appended fragment (`sql += ` AND n =
       // ${n}``), which carries no keyword of its own.
       const sqlish = new Set<string>();
+      // Same-file query helpers: name -> index of the parameter this file was
+      // observed handing to a real sink. `pool.query(sql, params)` inside
+      // `const q = (sql, params) => …` makes `q` a sink at argument 0.
+      const wrappers = new Map<string, number>();
+      // Calls that would be findings *if* their callee turns out to be a
+      // wrapper. Deferred to Program:exit because a helper may be declared
+      // below its call site (hoisted `function`, or a class used top-down).
+      const pending: {
+        name: string;
+        index: number;
+        arg: TSESTree.Node;
+        kind: UnsafeKind | undefined;
+      }[] = [];
 
       const report = (node: TSESTree.Node, kind: UnsafeKind): void => {
         context.report({
           node,
-          messageId: kind === 'template' ? 'unsafeTemplateLiteral' : 'noUnsafeQuery',
+          messageId:
+            kind === 'template' ? 'unsafeTemplateLiteral' : 'noUnsafeQuery',
         });
       };
 
@@ -189,32 +258,82 @@ export function createSqlInjectionRule(
           if (node.id.type === AST_NODE_TYPES.Identifier && node.init) {
             const kind = classify(node.init, config.requireSqlKeywords);
             if (kind) tainted.set(node.id.name, kind);
-            if (SQL_KEYWORDS.test(staticText(node.init))) sqlish.add(node.id.name);
+            if (SQL_KEYWORDS.test(staticText(node.init)))
+              sqlish.add(node.id.name);
           }
         },
 
         // query += ` AND name = '${name}'`;
         AssignmentExpression(node: TSESTree.AssignmentExpression) {
-          if (node.operator === '+=' && node.left.type === AST_NODE_TYPES.Identifier) {
+          if (
+            node.operator === '+=' &&
+            node.left.type === AST_NODE_TYPES.Identifier
+          ) {
             // Skip the keyword gate when the target was already seeded with
             // SQL — the fragment alone rarely contains a keyword.
-            const gate = config.requireSqlKeywords && !sqlish.has(node.left.name);
+            const gate =
+              config.requireSqlKeywords && !sqlish.has(node.left.name);
             const kind = classify(node.right, gate);
             if (kind) tainted.set(node.left.name, kind);
           }
         },
 
         CallExpression(node: TSESTree.CallExpression) {
-          if (
-            node.callee.type !== AST_NODE_TYPES.MemberExpression ||
-            node.callee.property.type !== AST_NODE_TYPES.Identifier ||
-            !sinks.has(node.callee.property.name)
-          ) {
+          // The name this call is written with: `db.query(…)` -> `query`,
+          // `q(…)` -> `q`. Anything else (computed access, an immediately
+          // invoked expression) is out of reach, as it always was.
+          const isMember =
+            node.callee.type === AST_NODE_TYPES.MemberExpression &&
+            node.callee.property.type === AST_NODE_TYPES.Identifier;
+          const calleeName = isMember
+            ? (
+                (node.callee as TSESTree.MemberExpression)
+                  .property as TSESTree.Identifier
+              ).name
+            : node.callee.type === AST_NODE_TYPES.Identifier
+              ? node.callee.name
+              : undefined;
+          if (calleeName === undefined) return;
+
+          // A driver sink is always a *method* call. A bare `query(…)` is some
+          // local function that happens to share the name, and stays a mere
+          // wrapper candidate — matching it as a sink would report every
+          // project with its own free-standing `query()` helper.
+          if (!isMember || !sinks.has(calleeName)) {
+            // Not a driver method. Bank it in case the callee turns out to be
+            // a local wrapper — the keyword gate is forced on here regardless
+            // of `requireSqlKeywords`, because "this identifier reaches a
+            // sink" is weaker evidence than a literal driver call, and an
+            // ungated instance would otherwise start reporting
+            // `log(`hello ${name}`)` the moment the file happened to define a
+            // `log` helper over `pool.query`.
+            for (const [index, arg] of node.arguments.entries()) {
+              if (arg.type === AST_NODE_TYPES.SpreadElement) continue;
+              const kind = classify(arg, true);
+              if (kind) pending.push({ name: calleeName, index, arg, kind });
+              else if (arg.type === AST_NODE_TYPES.Identifier)
+                pending.push({ name: calleeName, index, arg, kind: undefined });
+            }
             return;
           }
 
           const queryArg = node.arguments[0];
           if (!queryArg) return;
+
+          // A sink fed straight from a parameter is the wrapper shape:
+          // `(sql, params) => pool.query(sql, params)`. Record which argument
+          // position callers must treat as the query.
+          if (queryArg.type === AST_NODE_TYPES.Identifier) {
+            const fn = enclosingFunction(node);
+            const index =
+              fn?.params.findIndex(
+                (p) =>
+                  p.type === AST_NODE_TYPES.Identifier &&
+                  p.name === queryArg.name,
+              ) ?? -1;
+            const name = fn && index >= 0 ? callableName(fn) : undefined;
+            if (name !== undefined) wrappers.set(name, index);
+          }
 
           const direct = classify(queryArg, config.requireSqlKeywords);
           if (direct) {
@@ -225,6 +344,21 @@ export function createSqlInjectionRule(
           if (queryArg.type === AST_NODE_TYPES.Identifier) {
             const taint = tainted.get(queryArg.name);
             if (taint) report(queryArg, taint);
+          }
+        },
+
+        'Program:exit'() {
+          for (const { name, index, arg, kind } of pending) {
+            if (wrappers.get(name) !== index) continue;
+            if (kind) {
+              report(arg, kind);
+              continue;
+            }
+            // Tainted variable handed to the wrapper. `sqlish` keeps the
+            // forced keyword gate honest for the identifier path too.
+            const varName = (arg as TSESTree.Identifier).name;
+            const taint = tainted.get(varName);
+            if (taint && sqlish.has(varName)) report(arg, taint);
           }
         },
       };

--- a/packages/eslint-plugin-pg/docs/rules/no-unsafe-query.md
+++ b/packages/eslint-plugin-pg/docs/rules/no-unsafe-query.md
@@ -10,8 +10,8 @@ autofix: false
 
 > Prevents SQL injection by detecting string concatenation or template literals with variables in `client.query()` calls.
 
-
 <!-- @rule-summary -->
+
 SQL injection is one of the most critical security vulnerabilities
 <!-- @/rule-summary -->
 
@@ -24,7 +24,7 @@ SQL injection is one of the most critical security vulnerabilities
 | **CWE Reference** | [CWE-89](https://cwe.mitre.org/data/definitions/89.html) (SQL Injection) |
 | **Severity**      | Critical (CVSS: 9.8)                                                     |
 | **Auto-Fix**      | ❌ No auto-fix available                                                 |
-| **Category**   | Security |
+| **Category**      | Security                                                                 |
 | **ESLint MCP**    | ✅ Optimized for AI assistant integration                                |
 | **Best For**      | Protecting database operations from SQL injection vulnerabilities        |
 
@@ -32,13 +32,13 @@ SQL injection is one of the most critical security vulnerabilities
 
 > Why this rule pays for itself. Framework: [`cicd-impact/philosophy.md`](../../../../cicd-impact/philosophy.md).
 
-| Dimension | Value |
-| :--- | :--- |
-| **CWE** | [CWE-89](https://cwe.mitre.org/data/definitions/89.html) — Improper Neutralization of Special Elements used in an SQL Command (CVSS 9.8 Critical) |
-| **Feedback-loop tier** | Editor / pre-commit (sub-second) — cheapest layer per the [feedback-loop hierarchy](../../../../cicd-impact/philosophy.md#the-feedback-loop-hierarchy--why-a-high-end-static-analyzer-is-the-highest-leverage-investment) |
+| Dimension                    | Value                                                                                                                                                                                                                                                                              |
+| :--------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **CWE**                      | [CWE-89](https://cwe.mitre.org/data/definitions/89.html) — Improper Neutralization of Special Elements used in an SQL Command (CVSS 9.8 Critical)                                                                                                                                  |
+| **Feedback-loop tier**       | Editor / pre-commit (sub-second) — cheapest layer per the [feedback-loop hierarchy](../../../../cicd-impact/philosophy.md#the-feedback-loop-hierarchy--why-a-high-end-static-analyzer-is-the-highest-leverage-investment)                                                          |
 | **Defensive-layer leverage** | ~10× cheaper than unit-test · ~1,000× cheaper than production rollback · **10,000+× cheaper than disclosure** — SQL injection is the most-cited OWASP A03 finding ([cost-ratio anchors](../../../../cicd-impact/philosophy.md#deliverability-axis--quality-risk-and-ma-diligence)) |
-| **Niche relevance** | **Critical:** fintech (regulatory + transaction data), healthtech (PHI), B2B SaaS (multi-tenant exposure), cybersecurity · **High:** marketplaces, infra/devtools · **Medium:** B2C |
-| **Investor-frame impact** | SQL injection → full database disclosure → mandatory disclosure cycle. The most-cited single attack class in security-incident reports for two decades. Lint-time enforcement of parameterized queries is the cheapest possible structural defense. |
+| **Niche relevance**          | **Critical:** fintech (regulatory + transaction data), healthtech (PHI), B2B SaaS (multi-tenant exposure), cybersecurity · **High:** marketplaces, infra/devtools · **Medium:** B2C                                                                                                |
+| **Investor-frame impact**    | SQL injection → full database disclosure → mandatory disclosure cycle. The most-cited single attack class in security-incident reports for two decades. Lint-time enforcement of parameterized queries is the cheapest possible structural defense.                                |
 
 **Read also:** [`philosophy.md` §investor-frame](../../../../cicd-impact/philosophy.md#the-investor-frame--engineering-efficiency-as-a-portfolio-metric) · [`niche-presets.json`](../../../../cicd-impact/data/niche-presets.json) · [`analyzer-evaluation-framework.md`](../../../../cicd-impact/analyzer-evaluation-framework.md)
 
@@ -72,6 +72,36 @@ const result = await client.query({
 });
 ```
 
+### Query helpers
+
+Almost nobody calls `client.query` directly everywhere; the driver call gets
+wrapped in a one-line helper. When that helper lives in the same file, the rule
+follows it: a parameter handed straight to `client.query` makes the helper a
+sink at that argument position, and calls to it are checked like the driver
+call they stand for.
+
+```typescript
+const q = (sql: string, params: unknown[]) => client.query(sql, params);
+
+q(`SELECT * FROM users WHERE id = ${userId}`, []); // ❌ reported
+q('SELECT * FROM users WHERE id = ' + userId, []); // ❌ reported
+q('SELECT * FROM users WHERE id = $1', [userId]); // ✅ fine — nothing interpolated
+```
+
+`function` declarations, class methods and object-literal methods are traced
+the same way. Because a helper is weaker evidence than a literal driver call,
+findings through one require the string to actually look like SQL:
+
+```typescript
+const q = (sql: string, params: unknown[]) => client.query(sql, params);
+
+q(`hello ${name}`, []); // ✅ no SQL keywords — not a SQL finding
+client.query(`hello ${name}`); // ❌ still reported at the driver call itself
+```
+
+For helpers imported from another module, see
+[the known false negative below](#query-helpers-defined-in-another-file).
+
 ## Error Message Format
 
 The rule provides **LLM-optimized error messages** (Compact 2-line format) with actionable security guidance:
@@ -83,13 +113,13 @@ The rule provides **LLM-optimized error messages** (Compact 2-line format) with 
 
 ### Message Components
 
-| Component                 | Purpose                | Example                                                                                                                                                                                                                       |
-| :------------------------ | :--------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Component                 | Purpose                | Example                                                                                                                                                                                                                                                     |
+| :------------------------ | :--------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Risk Standards**        | Security benchmarks    | [CWE-89](https://cwe.mitre.org/data/definitions/89.html) [OWASP:A05](https://owasp.org/Top10/A05_2021-Injection/) [CVSS:9.8](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV%3AN%2FAC%3AL%2FPR%3AN%2FUI%3AN%2FS%3AU%2FC%3AH%2FI%3AH%2FA%3AH) |
-| **Issue Description**     | Specific vulnerability | `SQL Injection detected`                                                                                                                                                                                                      |
-| **Severity & Compliance** | Impact assessment      | `CRITICAL [SOC2,PCI-DSS,HIPAA,ISO27001]`                                                                                                                                                                                      |
-| **Fix Instruction**       | Actionable remediation | `Follow the remediation steps below`                                                                                                                                                                                          |
-| **Technical Truth**       | Official reference     | [OWASP Top 10](https://owasp.org/Top10/A05_2021-Injection/)                                                                                                                                                                   |
+| **Issue Description**     | Specific vulnerability | `SQL Injection detected`                                                                                                                                                                                                                                    |
+| **Severity & Compliance** | Impact assessment      | `CRITICAL [SOC2,PCI-DSS,HIPAA,ISO27001]`                                                                                                                                                                                                                    |
+| **Fix Instruction**       | Actionable remediation | `Follow the remediation steps below`                                                                                                                                                                                                                        |
+| **Technical Truth**       | Official reference     | [OWASP Top 10](https://owasp.org/Top10/A05_2021-Injection/)                                                                                                                                                                                                 |
 
 ## Known False Negatives
 
@@ -120,19 +150,25 @@ await client.query(unsafeQuery);
 
 **Mitigation**: Always use parameterized queries `($1, $2)` directly in literals.
 
-### Nested Function Calls
+### Query Helpers Defined in Another File
 
-**Why**: Queries passed through helper functions aren't traced.
+Helpers **declared in the same file** as the call site are traced (see
+[Query helpers](#query-helpers) above). Helpers imported from another module
+are not: the rule is not type-aware, so it cannot see that `q` forwards its
+first argument to `client.query`.
 
 ```typescript
-// ❌ NOT DETECTED
-function executeQuery(query: string) {
-  return client.query(query);
-}
-executeQuery(`SELECT * FROM users WHERE id = ${userId}`);
+// db.ts
+export const q = (sql: string, params: unknown[]) => client.query(sql, params);
+
+// user.ts
+import { q } from './db';
+q(`SELECT * FROM users WHERE id = ${userId}`, []); // ❌ NOT DETECTED
 ```
 
-**Mitigation**: Apply the rule to helper functions that execute queries.
+**Mitigation**: Keep the driver call and the interpolation in the same module,
+or interpolate nothing — build the string with `$1, $2` placeholders and pass
+values through the `params` array, which is safe at any distance.
 
 ### Format Functions with User Input
 


### PR DESCRIPTION
## Summary

Closes the investigation on #261. The reported false positive is not reproducible — 32 plugins / 559 rules enabled at `error` over the reporter's exact two files produce zero SQL-injection findings. But the same shape turned out to be a total **false negative**, and that is what this PR fixes.

`no-unsafe-query` only ever treated a literal driver *method* call as a sink. Wrapping the driver once — which nearly every codebase does — removed all SQL injection coverage from the rule:

```ts
const q = (sql: string, params: unknown[]) => pool.query(sql, params);

q(`SELECT * FROM users WHERE id = ${userInput}`, []); // was silent
q('SELECT * FROM users WHERE id = ' + userInput, []); // was silent
q(`SELECT * FROM users WHERE id = $1`, [userInput]); // correctly silent
```

This is not the cross-file taint problem we assumed. The helper is three lines above in the *same file*; the finding was lost purely because the callee is spelled `q` instead of `query`.

- A function whose parameter is handed straight to a driver sink is now a sink itself, at that argument position. Function declarations, `const` arrows, class methods, class field arrows and object-literal methods are all traced, including when the helper is declared **below** its call site (hence resolving wrapper findings at `Program:exit`).
- Concatenation, interpolation, and a previously-tainted variable passed to the helper all report.
- Two guards keep the fix from creating the FP class #261 actually described:
  - findings through a helper require SQL keywords **even when `requireSqlKeywords: false`** (`eslint-plugin-pg`) — "this identifier reaches a sink" is weaker evidence than `pool.query(...)`, and without the gate any file defining a helper over `pool.query` would start reporting ``log(`hello ${name}`)``;
  - a bare `query(...)` with no member access is never a driver sink, only a possible helper (this also preserves the existing `bare identifier callee` valid case).
- Imported helpers are still not traced — that needs type information the rule does not request. Rewritten in the pg rule docs from a vague "Nested Function Calls" FN into the precise cross-module one, plus a new "Query helpers" section documenting what *is* covered.

Affects `no-unsafe-query` in all eight SQL plugins: `pg`, `mysql-security`, `prisma-security`, `drizzle-security`, `knex-security`, `sqlite-security`, `typeorm-security`, `sequelize-security`.

## Test plan

- [x] **Regression lock**: 16 new cases in `packages/eslint-devkit/src/rule-creation/sql-injection-rule.test.ts`, under `describe('same-file query wrappers')`. Reverting only `sql-injection-rule.ts` to `origin/main` fails **8 of them** (every injectable-through-wrapper case) and passes the 8 valid ones — verified by checking the file out from `origin/main` and re-running.
- [x] The reporter's exact snippet is a named valid case: `issue #261: parameterized call through an arrow wrapper`.
- [x] `npm run test -w @interlace/eslint-devkit` — 1132 passed, and the enforced **100% line/branch/statement coverage gate passes** (three consecutive runs).
- [x] `turbo run build test` across devkit + all 8 SQL plugins — 18/18 tasks successful.
- [x] `apps/docs` vitest — 74 files / 1668 tests passed.
- [x] `npm run typecheck` (whole-graph tsgo), `oxlint`, `prettier --check`, `lint:md`, `changeset:status` all clean.
- [x] End-to-end through the real `eslint-plugin-pg` build: interpolated and concatenated wrapper calls report `CWE-89 ... CVSS:9.8`; the parameterized call and a keyword-free helper call stay silent.

## After merge

`@interlace/eslint-devkit` minor, `eslint-plugin-pg` patch (docs). The eight SQL plugins pick the behaviour up through the devkit dependency bump.

Expect this to *increase* findings on real codebases — it closes a gap that silenced the rule for anyone wrapping their driver, so a repo that reported zero SQL findings may now report real ones. Worth calling out in the release notes.

Follow-up left open on #261: cross-module helper tracing, and the reporter's offer of an anonymized wrapper corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
