### PR TITLE
fix(ci): count the current run in the ingest failure streak

### DIFF
--- a/.github/workflows/daily-impact-ingest.yml
+++ b/.github/workflows/daily-impact-ingest.yml
@@ -141,8 +141,12 @@ jobs:
               owner: context.repo.owner, repo: context.repo.repo,
               workflow_id: 'daily-impact-ingest.yml', per_page: 30,
             });
+            // The run posting this comment is still in progress and so has a
+            // null conclusion — it is excluded here and counted explicitly.
+            // Without the +1 the message lags reality by a day and calls the
+            // second consecutive failure the first.
             const finished = runs.workflow_runs.filter((r) => r.conclusion !== null);
-            let streak = 0;
+            let streak = 1;
             for (const run of finished) {
               if (run.conclusion !== 'failure') break;
               streak += 1;
@@ -155,7 +159,7 @@ jobs:
               ``,
               streak > 1
                 ? `⚠️ **${streak} consecutive failures.** Supabase impact data has not advanced since the first one — every consumer is serving stale numbers as if they were current.`
-                : `First failure in this run of the schedule.`,
+                : `First failure — the previous run succeeded.`,
               ``,
               `- Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
               `- Trigger: ${context.eventName}`,


### PR DESCRIPTION
Follow-up to #384, which merged before this fix could land on it. The preflight from that PR is on `main`; this off-by-one is not.

## The bug

The step that posts the failure comment runs *inside* the failing run, so that run's `conclusion` is still `null` and the `filter(r => r.conclusion !== null)` drops it. `streak` therefore counted only **prior completed** failures.

On the second consecutive failure that gives `streak === 1`, which fails the `streak > 1` test — so the comment reads "First failure" on day two, and every day after is reported one short. The whole point of the counter is to make a multi-day outage visible, and it was under-reporting exactly when that mattered.

Caught in review on #384 by @claude.

## The fix

Seed at `1` for the run doing the reporting, rather than relaxing the comparison to `streak > 0`.

`streak > 0` makes the escalation *fire* at the right time but still prints the wrong number in the message body — and the number is the part a person reads. With the seed, the count is the real one.

Checked both directions against the actual failure history:

| situation | reports |
|---|---|
| 6 prior failures + the current run | **7** |
| first failure after a success | **1**, and reads "First failure — the previous run succeeded." |

Also reworded the singular branch: "First failure in this run of the schedule" was vague about what "this run" meant.

## Test plan

- [x] `npm run lint:workflows` — 32 files pass conventions.
- [x] YAML parses; 7 steps, preflight still first.
- [x] `github-script` body parses as an async function.
- [x] Streak arithmetic verified against both histories above.
- [x] Full pre-push gate green.

## After merge

#255 is still failing daily until `AGENTS_REPO_PAT` is rotated. Its next comment will now carry the true consecutive-failure count instead of one less.

🤖 Generated with [Claude Code](https://claude.com/claude-code)