### PR TITLE
feat(eslint-plugin-mcp-sdk-security): no-unvalidated-tool-args (CWE-20)

### DIFF
--- a/.agent/oxlint-jsplugins-manifest.json
+++ b/.agent/oxlint-jsplugins-manifest.json
@@ -2,8 +2,8 @@
   "generatedBy": "scripts/generate-oxlint-shims.mjs",
   "generatedAt": "2026-08-05",
   "totalPlugins": 32,
-  "totalRules": 483,
-  "oxlintCompatible": 483,
+  "totalRules": 484,
+  "oxlintCompatible": 484,
   "oxlintPartial": 0,
   "oxlintBlocked": 0,
   "plugins": [
@@ -1356,7 +1356,7 @@
       "short": "mcp-sdk-security",
       "shim": "tools/oxlint-plugins/interlace-mcp-sdk-security.cjs",
       "subpath": "eslint-plugin-mcp-sdk-security/oxlint",
-      "ruleCount": 3,
+      "ruleCount": 4,
       "rules": [
         {
           "name": "no-command-injection-in-tool",

--- a/.agent/oxlint-jsplugins-manifest.json
+++ b/.agent/oxlint-jsplugins-manifest.json
@@ -2,8 +2,8 @@
   "generatedBy": "scripts/generate-oxlint-shims.mjs",
   "generatedAt": "2026-08-05",
   "totalPlugins": 32,
-  "totalRules": 482,
-  "oxlintCompatible": 482,
+  "totalRules": 483,
+  "oxlintCompatible": 483,
   "oxlintPartial": 0,
   "oxlintBlocked": 0,
   "plugins": [
@@ -1356,10 +1356,16 @@
       "short": "mcp-sdk-security",
       "shim": "tools/oxlint-plugins/interlace-mcp-sdk-security.cjs",
       "subpath": "eslint-plugin-mcp-sdk-security/oxlint",
-      "ruleCount": 2,
+      "ruleCount": 3,
       "rules": [
         {
           "name": "no-tool-description-injection",
+          "portability": "compatible",
+          "blockers": [],
+          "isTypeAware": false
+        },
+        {
+          "name": "no-unvalidated-tool-args",
           "portability": "compatible",
           "blockers": [],
           "isTypeAware": false
@@ -3434,6 +3440,7 @@
     ],
     "mcp-sdk-security": [
       "no-tool-description-injection",
+      "no-unvalidated-tool-args",
       "require-tool-input-schema"
     ],
     "modernization": [

--- a/.agent/plugin-rule-manifest.json
+++ b/.agent/plugin-rule-manifest.json
@@ -1003,6 +1003,12 @@
     }
   },
   "eslint-plugin-mcp-sdk-security": {
+    "no-unvalidated-tool-args": {
+      "environment": "mcp",
+      "detection": "structural-pattern",
+      "confidence": "enforcement",
+      "notes": "Compares the handler destructuring against the declared inputSchema keys. Silent for any schema it cannot statically read, since judging a handler against an invisible shape would report correct code."
+    },
     "no-tool-description-injection": {
       "environment": "mcp",
       "detection": "structural-pattern",

--- a/.changeset/mcp-unvalidated-tool-args.md
+++ b/.changeset/mcp-unvalidated-tool-args.md
@@ -1,0 +1,25 @@
+---
+'eslint-plugin-mcp-sdk-security': minor
+---
+
+Add `no-unvalidated-tool-args` (CWE-20).
+
+`require-tool-input-schema` makes sure a schema exists. This rule makes that
+schema mean something, by checking the handler only reads keys the schema
+declares.
+
+The SDK validates what arrives against the declared shape; nothing checks that
+the handler confines itself to the same shape. When it does not, either the
+value was stripped — so the handler reads `undefined` and the tool is quietly
+broken — or it was not, and the handler is reading raw model-controlled input
+that passed no check, while every reviewer assumes the schema covered it.
+
+```ts
+server.registerTool('read', { inputSchema: { path: z.string() } },
+  async ({ path, encoding }) => readFile(path, encoding));  // `encoding` undeclared
+```
+
+Silent for any schema it cannot read — `z.object(…)`, a shared reference, a
+spread — because judging a handler against a shape the file does not contain
+would report correct code. Also silent for the whole-args form, which would need
+the data-flow analysis this rule is built to avoid.

--- a/ORM-AGENTIC-RULE-PLAN.md
+++ b/ORM-AGENTIC-RULE-PLAN.md
@@ -209,8 +209,8 @@ profile on the corpus.
 | Wave | State |
 |---|---|
 | W0 | **Done.** PR #335 merged: agentic peers fixed, AI SDK family landed, `eslint-plugin-pg` / `-jwt` superseded by the `-security` renames. ORM peers were verified correct already. Remaining: the two `npm deprecate` calls need an interactive `npm login` — `latest` on both old packages still carries no notice, so installs are silent today. |
-| W1 | **O2 `no-unscoped-mutation` shipped** for prisma / drizzle / knex — factory `createUnscopedMutationRule` at 100/100/100/100, self-suppression lock verified by reverting the guard. **Sequelize deliberately excluded**, see §5.1. **O4 `require-tls` shipped** (PR #373) for knex / mysql / sequelize / typeorm — factory `createRequireTlsRule`, URL findings scoped to connection positions. **O1 `no-raw-identifier-interpolation` shipped** for drizzle / prisma only — factory `createRawIdentifierRule`; see §5.2 for why two and not seven. O3, O5 not started. |
-| W2 | not started |
+| W1 | **Done.** O2 `no-unscoped-mutation` for prisma / drizzle / knex — factory `createUnscopedMutationRule`, self-suppression lock verified by reverting the guard; **sequelize deliberately excluded**, see §5.1. O4 `require-tls` (#373) for knex / mysql / sequelize / typeorm — `createRequireTlsRule`, URL findings scoped to connection positions. O1 `no-raw-identifier-interpolation` (#385) for drizzle / prisma only — `createRawIdentifierRule`; §5.2 says why two and not seven. O5 `no-hardcoded-credentials` (#386) — `createHardcodedCredentialsRule`. O3 `no-mass-assignment` (#389) — `createMassAssignmentRule`. All at 100/100/100/100. |
+| W2 | **Done — 3 of 4 shipped, M4 dropped with cause.** M2 `no-tool-description-injection` (#396), M5 `no-command-injection-in-tool` (#397), M3 `no-unvalidated-tool-args` (#400). **M4 `no-path-traversal-in-resource` does not ship** — see §5.3. All rules held out of `minimal` / `recommended` pending W6, locked by a preset test. |
 | W3 | not started |
 | W4 | not started |
 | W5 | not started |
@@ -282,7 +282,41 @@ a missing rule — tracked for W4 as a remediation split inside
 Net: 2 instantiations that each detect something nothing else in the ecosystem
 detects, rather than 7 of which 5 would be duplicates.
 
-### 5.3 Installing in a fresh worktree
+### 5.3 M4 does not ship — the finding is the deliverable
+
+`no-path-traversal-in-resource` was to report an MCP resource URI reaching a
+filesystem path. The taxonomy check that precedes every rule (§1.1) asked what
+already owns the generic fs sink: `node-security/detect-non-literal-fs-filename`.
+Running it against six real shapes:
+
+```
+✅ reports | fs.readFile(userPath)
+❌ MISSED  | import { readFile } from 'node:fs/promises'
+❌ MISSED  | renamed default import
+❌ MISSED  | renamed require
+❌ MISSED  | fs.promises.readFile
+❌ MISSED  | namespace import
+```
+
+The gate required the receiver be literally the identifier `fs`
+(`node.callee.object.name !== 'fs'`), so the module's most common modern import
+styles were unchecked — including the shape the rule's **own documentation**
+used as its first incorrect example. That is §1.2's self-suppression class, in a
+rule already shipping at `error` in `recommended`.
+
+Writing M4 would have papered over that inside one plugin while leaving every
+other consumer exposed. The generic fs sink belongs to `node-security`, so the
+fix went there (#401): resolve the binding across `fs`, `node:fs`,
+`fs/promises`, `node:fs/promises`; judge at `Program:exit` so a `require` below
+its call site still counts. Measured blast radius on this repo: 854 findings,
+555 outside test files — so the rule drops to `warn` in `recommended` until W6
+measures its FP profile, with the severity locked by a test.
+
+With that fixed there is nothing left for M4 to detect that would not be a
+second plugin reporting the same line. **W2 ships 3 of 4 rules; the fourth is
+the fix it exposed.**
+
+### 5.4 Installing in a fresh worktree
 
 A plain install, run outside the agent sandbox:
 

--- a/apps/docs/src/data/interlace-numbers.json
+++ b/apps/docs/src/data/interlace-numbers.json
@@ -8,8 +8,8 @@
     "react": 2
   },
   "rules": {
-    "total": 457,
-    "security": 252,
+    "total": 458,
+    "security": 253,
     "quality": 107,
     "react": 98
   },

--- a/apps/docs/src/data/interlace-numbers.json
+++ b/apps/docs/src/data/interlace-numbers.json
@@ -8,8 +8,8 @@
     "react": 2
   },
   "rules": {
-    "total": 456,
-    "security": 251,
+    "total": 457,
+    "security": 252,
     "quality": 107,
     "react": 98
   },

--- a/apps/docs/src/data/plugin-stats.json
+++ b/apps/docs/src/data/plugin-stats.json
@@ -89,6 +89,14 @@
       "published": true
     },
     {
+      "name": "eslint-plugin-mcp-sdk-security",
+      "rules": 4,
+      "description": "ESLint plugin for Model Context Protocol (MCP) SDK security — catches tools registered without an input schema, so handlers never run on unvalidated client-supplied arguments",
+      "category": "security",
+      "version": "0.1.1",
+      "published": true
+    },
+    {
       "name": "eslint-plugin-prisma-security",
       "rules": 4,
       "description": "ESLint plugin for @prisma/client — detects SQL injection in raw queries built with string concatenation or template literals",
@@ -110,14 +118,6 @@
       "description": "ESLint plugin for typeorm — detects SQL injection in raw queries built with string concatenation or template literals, connection configuration that disables TLS or certificate validation, and hardcoded database credentials",
       "category": "security",
       "version": "0.2.0",
-      "published": true
-    },
-    {
-      "name": "eslint-plugin-mcp-sdk-security",
-      "rules": 3,
-      "description": "ESLint plugin for Model Context Protocol (MCP) SDK security — catches tools registered without an input schema, so handlers never run on unvalidated client-supplied arguments",
-      "category": "security",
-      "version": "0.1.1",
       "published": true
     },
     {
@@ -257,7 +257,7 @@
       "published": true
     }
   ],
-  "totalRules": 457,
+  "totalRules": 458,
   "totalPlugins": 30,
   "allPluginsCount": 32,
   "generatedAt": "2026-08-05"

--- a/apps/docs/src/data/plugin-stats.json
+++ b/apps/docs/src/data/plugin-stats.json
@@ -91,7 +91,7 @@
     {
       "name": "eslint-plugin-mcp-sdk-security",
       "rules": 4,
-      "description": "ESLint plugin for Model Context Protocol (MCP) SDK security — catches tools registered without an input schema, so handlers never run on unvalidated client-supplied arguments",
+      "description": "ESLint plugin for Model Context Protocol (MCP) SDK security — catches tools registered without an input schema, handlers reading arguments the schema never declared, model-visible descriptions built from dynamic text, and tool arguments reaching a shell",
       "category": "security",
       "version": "0.1.1",
       "published": true

--- a/apps/docs/src/data/plugin-stats.json
+++ b/apps/docs/src/data/plugin-stats.json
@@ -113,19 +113,19 @@
       "published": true
     },
     {
+      "name": "eslint-plugin-mcp-sdk-security",
+      "rules": 3,
+      "description": "ESLint plugin for Model Context Protocol (MCP) SDK security — catches tools registered without an input schema, so handlers never run on unvalidated client-supplied arguments",
+      "category": "security",
+      "version": "0.1.1",
+      "published": true
+    },
+    {
       "name": "eslint-plugin-mysql-security",
       "rules": 3,
       "description": "ESLint plugin for mysql2 / mysql — detects SQL injection in raw queries built with string concatenation or template literals, connection configuration that disables TLS or certificate validation, and hardcoded database credentials",
       "category": "security",
       "version": "0.2.0",
-      "published": true
-    },
-    {
-      "name": "eslint-plugin-mcp-sdk-security",
-      "rules": 2,
-      "description": "ESLint plugin for Model Context Protocol (MCP) SDK security — catches tools registered without an input schema, so handlers never run on unvalidated client-supplied arguments",
-      "category": "security",
-      "version": "0.1.1",
       "published": true
     },
     {
@@ -257,7 +257,7 @@
       "published": true
     }
   ],
-  "totalRules": 456,
+  "totalRules": 457,
   "totalPlugins": 30,
   "allPluginsCount": 32,
   "generatedAt": "2026-08-05"

--- a/packages/eslint-plugin-mcp-sdk-security/docs/rules/no-unvalidated-tool-args.md
+++ b/packages/eslint-plugin-mcp-sdk-security/docs/rules/no-unvalidated-tool-args.md
@@ -1,0 +1,117 @@
+---
+title: no-unvalidated-tool-args
+description: Disallow a tool handler reading an argument its declared input schema does not include.
+tags: ['security', 'mcp']
+category: security
+severity: high
+cwe: CWE-20
+autofix: false
+---
+
+> **Keywords:** input validation, CWE-20, MCP, Model Context Protocol, inputSchema, tool handler, schema contract, unvalidated input, agent security
+
+<!-- @rule-summary -->
+Disallow a tool handler reading an argument its declared input schema does not include.
+<!-- @/rule-summary -->
+
+**CWE:** [CWE-20](https://cwe.mitre.org/data/definitions/20.html)
+**OWASP:** [A03:2021 – Injection](https://owasp.org/Top10/A03_2021-Injection/)
+
+Detects a destructured handler argument that the tool's `inputSchema` does not declare. This rule is part of [`eslint-plugin-mcp-sdk-security`](https://www.npmjs.com/package/eslint-plugin-mcp-sdk-security).
+
+💼 This rule is set to **error** in the `strict` config.
+
+## Quick Summary
+
+| Aspect            | Details                                                                          |
+| ----------------- | -------------------------------------------------------------------------------- |
+| **CWE Reference** | [CWE-20](https://cwe.mitre.org/data/definitions/20.html) (Improper Input Validation) |
+| **Severity**      | High (CVSS 7.5)                                                                  |
+| **Auto-Fix**      | ❌ No auto-fix available                                                         |
+| **Category**      | Security                                                                         |
+
+## Why this matters
+
+[`require-tool-input-schema`](./require-tool-input-schema.md) makes sure a schema
+exists. This rule makes that schema *mean* something.
+
+A schema is a contract with two sides, and only one of them is enforced at
+runtime. The SDK validates what arrives against the declared shape. Nothing
+checks that the handler confines itself to the same shape — so when it does not,
+one of two things is true, and neither is fine:
+
+- The value was **stripped**, so the handler reads `undefined` and the tool is
+  quietly broken in a way no test with a well-formed call will catch.
+- The value was **not stripped** — a passthrough schema, a hand-rolled
+  validator, a server that skips validation — in which case the handler is
+  reading raw model-controlled input that passed no check at all, while every
+  reviewer assumes the schema covered it.
+
+The second is the security case, and it is invisible precisely because the
+schema *looks* like it covers the handler:
+
+```ts
+server.registerTool('read', { inputSchema: { path: z.string() } },
+  async ({ path, encoding }) => {          // `encoding` is not declared
+    return readFile(path, encoding);
+  });
+```
+
+Both sides are statically visible in the same expression, so this needs no
+inference — the declared keys and the read keys are right there.
+
+## ❌ Incorrect
+
+```ts
+// ❌ `encoding` is read but never declared
+server.registerTool('read', { inputSchema: { path: z.string() } },
+  async ({ path, encoding }) => readFile(path, encoding));
+
+// ❌ an empty schema declares nothing, so every read is undeclared
+server.registerTool('read', { inputSchema: {} },
+  async ({ path }) => readFile(path));
+
+// ❌ renaming does not change which key is read
+server.registerTool('read', { inputSchema: { path: z.string() } },
+  async ({ encoding: enc }) => enc);
+```
+
+## ✅ Correct
+
+```ts
+// ✅ every read key is declared, with the type it needs
+server.registerTool('read', { inputSchema: { path: z.string(), encoding: z.enum(['utf8', 'base64']) } },
+  async ({ path, encoding }) => readFile(path, encoding));
+
+// ✅ reading a subset is fine — the contract is an upper bound
+server.registerTool('read', { inputSchema: { path: z.string(), mode: z.string() } },
+  async ({ path }) => readFile(path));
+```
+
+## What this rule deliberately does not report
+
+- **A schema it cannot read.** `inputSchema: z.object({ … })`,
+  `inputSchema: SharedSchema`, or one built with a spread could declare
+  anything. Judging a handler against a shape this file does not contain would
+  report correct code, so the whole registration is skipped.
+- **A registration with no `inputSchema`.** That is
+  [`require-tool-input-schema`](./require-tool-input-schema.md)'s question.
+- **The whole-args form.** `async (args) => read(args.extra)` hands the object
+  around; following every `args.x` through a body is data-flow analysis this
+  rule is built to avoid. The destructured shape is where the mismatch is
+  visible in one place, and it is the shape the SDK documentation uses.
+- **A rest element.** `{ path, ...rest }` names no specific key.
+- **A file that never imports `@modelcontextprotocol/sdk`.**
+
+## When Not To Use It
+
+If your server validates with something the rule cannot read — a shared schema
+object, a factory — it stays silent by design, and there is nothing to switch
+off. Adopting it is a reason to inline the schema at the registration, which is
+also what makes the contract reviewable.
+
+## Further Reading
+
+- [CWE-20: Improper Input Validation](https://cwe.mitre.org/data/definitions/20.html)
+- [OWASP A03:2021 – Injection](https://owasp.org/Top10/A03_2021-Injection/)
+- [MCP: Tools](https://modelcontextprotocol.io/docs/concepts/tools)

--- a/packages/eslint-plugin-mcp-sdk-security/package.json
+++ b/packages/eslint-plugin-mcp-sdk-security/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-plugin-mcp-sdk-security",
   "version": "0.1.1",
-  "description": "ESLint plugin for Model Context Protocol (MCP) SDK security — catches tools registered without an input schema, so handlers never run on unvalidated client-supplied arguments.",
+  "description": "ESLint plugin for Model Context Protocol (MCP) SDK security — catches tools registered without an input schema, handlers reading arguments the schema never declared, model-visible descriptions built from dynamic text, and tool arguments reaching a shell.",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/eslint-plugin-mcp-sdk-security/src/index.test.ts
+++ b/packages/eslint-plugin-mcp-sdk-security/src/index.test.ts
@@ -12,6 +12,7 @@ import plugin, {
   configs,
   plugin as namedPlugin,
   noToolDescriptionInjection,
+  noUnvalidatedToolArgs,
   requireToolInputSchema,
 } from './index';
 
@@ -19,11 +20,13 @@ describe('eslint-plugin-mcp-sdk-security', () => {
   it('exposes every rule under its documented id', () => {
     expect(Object.keys(rules).sort()).toEqual([
       'no-tool-description-injection',
+      'no-unvalidated-tool-args',
       'require-tool-input-schema',
     ]);
     // Reference equality, not just presence: a rule id can be wired to the
     // wrong module and every id-based assertion still passes.
     expect(rules['require-tool-input-schema']).toBe(requireToolInputSchema);
+    expect(rules['no-unvalidated-tool-args']).toBe(noUnvalidatedToolArgs);
     expect(rules['no-tool-description-injection']).toBe(noToolDescriptionInjection);
   });
 
@@ -60,6 +63,7 @@ describe('eslint-plugin-mcp-sdk-security', () => {
     // rather than an oversight.
     for (const preset of ['minimal', 'recommended'] as const) {
       expect(configs[preset].rules?.['mcp-sdk-security/no-tool-description-injection']).toBeUndefined();
+      expect(configs[preset].rules?.['mcp-sdk-security/no-unvalidated-tool-args']).toBeUndefined();
     }
   });
 

--- a/packages/eslint-plugin-mcp-sdk-security/src/index.ts
+++ b/packages/eslint-plugin-mcp-sdk-security/src/index.ts
@@ -19,9 +19,11 @@
 import type { TSESLint } from '@interlace/eslint-devkit';
 
 import { noToolDescriptionInjection } from './rules/no-tool-description-injection';
+import { noUnvalidatedToolArgs } from './rules/no-unvalidated-tool-args';
 import { requireToolInputSchema } from './rules/require-tool-input-schema';
 
 export { noToolDescriptionInjection } from './rules/no-tool-description-injection';
+export { noUnvalidatedToolArgs } from './rules/no-unvalidated-tool-args';
 export { requireToolInputSchema } from './rules/require-tool-input-schema';
 
 /**
@@ -35,6 +37,8 @@ export { requireToolInputSchema } from './rules/require-tool-input-schema';
 export const rules: Record<string, TSESLint.RuleModule<string, readonly unknown[]>> = {
   // CWE-1427: Improper Neutralization of Input Used for LLM Prompting
   'no-tool-description-injection': noToolDescriptionInjection,
+  // CWE-20: Improper Input Validation — the handler side of the schema contract
+  'no-unvalidated-tool-args': noUnvalidatedToolArgs,
   // CWE-20: Improper Input Validation
   'require-tool-input-schema': requireToolInputSchema,
 } satisfies Record<string, TSESLint.RuleModule<string, readonly unknown[]>>;

--- a/packages/eslint-plugin-mcp-sdk-security/src/rules/no-unvalidated-tool-args/index.ts
+++ b/packages/eslint-plugin-mcp-sdk-security/src/rules/no-unvalidated-tool-args/index.ts
@@ -185,8 +185,10 @@ export const noUnvalidatedToolArgs = createRule<[], MessageIds>({
         // require-tool-input-schema's question, not this rule's.
         if (declared === undefined) return;
 
-        const handler = node.arguments[node.arguments.length - 1];
-        if (handler === undefined) return;
+        // Reaching here means `arguments[1]` is an ObjectExpression, so the
+        // call has at least two arguments and a last one always exists. No
+        // undefined guard, because no input reaches it.
+        const handler = node.arguments[node.arguments.length - 1]!;
 
         for (const read of destructuredArgNames(handler)) {
           if (declared.has(read.name)) continue;

--- a/packages/eslint-plugin-mcp-sdk-security/src/rules/no-unvalidated-tool-args/index.ts
+++ b/packages/eslint-plugin-mcp-sdk-security/src/rules/no-unvalidated-tool-args/index.ts
@@ -1,0 +1,205 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * @fileoverview Disallow reading a tool argument the input schema does not declare
+ * @description `require-tool-input-schema` makes sure a schema exists. This
+ * rule makes that schema *mean* something, by checking the handler only reads
+ * keys the schema declares.
+ *
+ * A schema is a contract with two sides, and only one of them is enforced at
+ * runtime. The SDK validates what arrives against the declared shape; nothing
+ * checks that the handler confines itself to the same shape. When it does not,
+ * one of two things is true, and neither is fine:
+ *
+ *   - The value was stripped, so the handler reads `undefined` and the tool is
+ *     quietly broken in a way no test with a well-formed call will catch.
+ *   - The value was *not* stripped — a passthrough schema, a hand-rolled
+ *     validator, a server that skips validation — in which case the handler is
+ *     reading raw model-controlled input that passed no check at all, while
+ *     every reviewer assumes the schema covered it.
+ *
+ * The second is the security case, and it is invisible precisely because the
+ * schema *looks* like it covers the handler.
+ *
+ *     server.registerTool('read', { inputSchema: { path: z.string() } },
+ *       async ({ path, encoding }) => {          // `encoding` is not declared
+ *         return readFile(path, encoding);
+ *       });
+ *
+ * Both sides are statically visible in the same expression, so this needs no
+ * inference: the declared keys and the read keys are right there.
+ *
+ * @see https://modelcontextprotocol.io/docs/concepts/tools
+ */
+
+import { TSESTree, createRule, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
+
+type MessageIds = 'undeclaredArg';
+
+const MCP_MODULE_PREFIX = '@modelcontextprotocol/sdk';
+
+const REGISTER_TOOL = 'registerTool';
+const LEGACY_TOOL = 'tool';
+
+/** The statically-readable key name of a property, or `undefined`. */
+export function propertyKey(prop: TSESTree.ObjectLiteralElement): string | undefined {
+  if (prop.type !== 'Property' || prop.computed) return undefined;
+  if (prop.key.type === 'Identifier') return prop.key.name;
+  if (prop.key.type === 'Literal' && typeof prop.key.value === 'string') return prop.key.value;
+  return undefined;
+}
+
+/**
+ * The keys an `inputSchema` declares, or `undefined` if it cannot be read.
+ *
+ * `undefined` means "do not judge this registration". A schema built by a call
+ * (`z.object({...})`, `buildSchema()`) or spread from elsewhere may declare
+ * anything, and reporting against a shape this file cannot see would flag
+ * correct code.
+ */
+export function declaredSchemaKeys(
+  config: TSESTree.ObjectExpression,
+): Set<string> | undefined {
+  for (const prop of config.properties) {
+    if (propertyKey(prop) !== 'inputSchema') continue;
+    const value = (prop as TSESTree.Property).value;
+    if (value.type !== 'ObjectExpression') return undefined;
+
+    const keys = new Set<string>();
+    for (const entry of value.properties) {
+      // A spread could contribute any key, so the whole schema becomes
+      // unreadable rather than partially known.
+      if (entry.type === 'SpreadElement') return undefined;
+      const key = propertyKey(entry);
+      if (key === undefined) return undefined;
+      keys.add(key);
+    }
+    return keys;
+  }
+  return undefined;
+}
+
+/**
+ * Argument names a handler reads out of its first parameter.
+ *
+ * Only the destructured form is read. `async (args) => …` hands the whole
+ * object around, and following every `args.x` through the body is the
+ * data-flow analysis this rule is built to avoid — the destructured shape is
+ * where the mismatch is visible in one place, and it is also the shape the SDK
+ * documentation uses.
+ */
+export function destructuredArgNames(
+  handler: TSESTree.Node,
+): Array<{ name: string; node: TSESTree.Node }> {
+  if (
+    handler.type !== 'ArrowFunctionExpression' &&
+    handler.type !== 'FunctionExpression' &&
+    handler.type !== 'FunctionDeclaration'
+  ) {
+    return [];
+  }
+  const first = handler.params[0];
+  if (first === undefined || first.type !== 'ObjectPattern') return [];
+
+  const found: Array<{ name: string; node: TSESTree.Node }> = [];
+  for (const prop of first.properties) {
+    // A rest element collects whatever is left; it names no specific key.
+    if (prop.type === 'RestElement') continue;
+    const key = propertyKey(prop);
+    if (key === undefined) continue;
+    found.push({ name: key, node: prop });
+  }
+  return found;
+}
+
+export const noUnvalidatedToolArgs = createRule<[], MessageIds>({
+  name: 'no-unvalidated-tool-args',
+  meta: {
+    type: 'problem',
+    docs: {
+      url: 'https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-mcp-sdk-security/docs/rules/no-unvalidated-tool-args.md',
+      description:
+        'Disallow a tool handler reading an argument its declared input schema does not include',
+      cwe: 'CWE-20',
+      cvss: 7.5,
+    },
+    messages: {
+      undeclaredArg: formatLLMMessage({
+        icon: MessageIcons.SECURITY,
+        issueName: 'MCP Tool Argument Outside the Declared Schema',
+        cwe: 'CWE-20',
+        owasp: 'A03:2021',
+        cvss: 7.5,
+        description:
+          'Tool "{{tool}}" reads `{{arg}}`, which its inputSchema does not declare — so the value either arrives unvalidated or never arrives at all',
+        severity: 'HIGH',
+        compliance: ['SOC2'],
+        fix: 'Declare `{{arg}}` in the inputSchema with the type and constraints it needs, or stop reading it. A key the schema does not mention is one nothing validated.',
+        documentationLink: 'https://modelcontextprotocol.io/docs/concepts/tools',
+      }),
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    let importsMcpSdk = false;
+    const candidates: Array<{ node: TSESTree.Node; tool: string; arg: string }> = [];
+
+    function toolNameOf(node: TSESTree.CallExpression): string {
+      const first = node.arguments[0];
+      if (first?.type === 'Literal' && typeof first.value === 'string') return first.value;
+      return 'unknown';
+    }
+
+    return {
+      ImportDeclaration(node: TSESTree.ImportDeclaration) {
+        if (node.source.value.startsWith(MCP_MODULE_PREFIX)) importsMcpSdk = true;
+      },
+
+      CallExpression(node: TSESTree.CallExpression) {
+        if (
+          node.callee.type === 'Identifier' &&
+          node.callee.name === 'require' &&
+          node.arguments[0]?.type === 'Literal' &&
+          typeof node.arguments[0].value === 'string' &&
+          node.arguments[0].value.startsWith(MCP_MODULE_PREFIX)
+        ) {
+          importsMcpSdk = true;
+          return;
+        }
+
+        if (node.callee.type !== 'MemberExpression' || node.callee.computed) return;
+        if (node.callee.property.type !== 'Identifier') return;
+        const method = node.callee.property.name;
+        if (method !== REGISTER_TOOL && method !== LEGACY_TOOL) return;
+
+        const config = node.arguments[1];
+        if (config?.type !== 'ObjectExpression') return;
+
+        const declared = declaredSchemaKeys(config);
+        // No readable schema means no contract to check against. That is
+        // require-tool-input-schema's question, not this rule's.
+        if (declared === undefined) return;
+
+        const handler = node.arguments[node.arguments.length - 1];
+        if (handler === undefined) return;
+
+        for (const read of destructuredArgNames(handler)) {
+          if (declared.has(read.name)) continue;
+          candidates.push({ node: read.node, tool: toolNameOf(node), arg: read.name });
+        }
+      },
+
+      'Program:exit'() {
+        if (!importsMcpSdk) return;
+        for (const { node, tool, arg } of candidates) {
+          context.report({ node, messageId: 'undeclaredArg', data: { tool, arg } });
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin-mcp-sdk-security/src/rules/no-unvalidated-tool-args/index.ts
+++ b/packages/eslint-plugin-mcp-sdk-security/src/rules/no-unvalidated-tool-args/index.ts
@@ -64,23 +64,30 @@ export function propertyKey(prop: TSESTree.ObjectLiteralElement): string | undef
 export function declaredSchemaKeys(
   config: TSESTree.ObjectExpression,
 ): Set<string> | undefined {
-  for (const prop of config.properties) {
-    if (propertyKey(prop) !== 'inputSchema') continue;
-    const value = (prop as TSESTree.Property).value;
-    if (value.type !== 'ObjectExpression') return undefined;
+  const index = config.properties.findIndex((prop) => propertyKey(prop) === 'inputSchema');
+  if (index === -1) return undefined;
 
-    const keys = new Set<string>();
-    for (const entry of value.properties) {
-      // A spread could contribute any key, so the whole schema becomes
-      // unreadable rather than partially known.
-      if (entry.type === 'SpreadElement') return undefined;
-      const key = propertyKey(entry);
-      if (key === undefined) return undefined;
-      keys.add(key);
-    }
-    return keys;
+  // A spread *after* `inputSchema` replaces it wholesale at runtime —
+  // `{ inputSchema: { path: z.string() }, ...options }` declares whatever
+  // `options.inputSchema` holds, which this file cannot see. A spread before it
+  // is harmless: the explicit key wins, so it is not a reason to go silent.
+  for (let i = index + 1; i < config.properties.length; i++) {
+    if (config.properties[i]!.type === 'SpreadElement') return undefined;
   }
-  return undefined;
+
+  const value = (config.properties[index] as TSESTree.Property).value;
+  if (value.type !== 'ObjectExpression') return undefined;
+
+  const keys = new Set<string>();
+  for (const entry of value.properties) {
+    // A spread could contribute any key, so the whole schema becomes
+    // unreadable rather than partially known.
+    if (entry.type === 'SpreadElement') return undefined;
+    const key = propertyKey(entry);
+    if (key === undefined) return undefined;
+    keys.add(key);
+  }
+  return keys;
 }
 
 /**

--- a/packages/eslint-plugin-mcp-sdk-security/src/rules/no-unvalidated-tool-args/no-unvalidated-tool-args.test.ts
+++ b/packages/eslint-plugin-mcp-sdk-security/src/rules/no-unvalidated-tool-args/no-unvalidated-tool-args.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Tests for mcp-sdk-security/no-unvalidated-tool-args
+ * CWE-20 — a handler reading a key its input schema does not declare.
+ *
+ * The `valid` half carries the weight: this rule compares two statically-read
+ * shapes, and every way of writing a schema it *cannot* read has to stay
+ * silent. Judging a handler against a shape the file does not contain would
+ * report correct code.
+ */
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { describe, it, afterAll, expect } from 'vitest';
+import * as parser from '@typescript-eslint/parser';
+import {
+  noUnvalidatedToolArgs,
+  declaredSchemaKeys,
+  destructuredArgNames,
+  propertyKey,
+} from './index';
+import type { TSESTree } from '@typescript-eslint/utils';
+
+RuleTester.afterAll = afterAll;
+RuleTester.it = it;
+RuleTester.itOnly = it.only;
+RuleTester.describe = describe;
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser,
+    parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+  },
+});
+
+const SDK = "import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';\n";
+
+describe('no-unvalidated-tool-args', () => {
+  describe('Valid', () => {
+    ruleTester.run('valid', noUnvalidatedToolArgs, {
+      valid: [
+        {
+          name: 'every read key is declared',
+          code:
+            SDK +
+            'server.registerTool("read", { inputSchema: { path: z.string() } }, async ({ path }) => read(path));',
+        },
+        {
+          name: 'reading a subset of the schema',
+          code:
+            SDK +
+            'server.registerTool("read", { inputSchema: { path: z.string(), mode: z.string() } }, async ({ path }) => read(path));',
+        },
+        {
+          name: 'reading nothing at all',
+          code:
+            SDK +
+            'server.registerTool("ping", { inputSchema: { path: z.string() } }, async () => "pong");',
+        },
+        {
+          // Not this rule's question — require-tool-input-schema owns it.
+          name: 'no inputSchema declared',
+          code: SDK + 'server.registerTool("read", { title: "Read" }, async ({ path }) => read(path));',
+        },
+        {
+          // Every shape the rule cannot read must be silent, or it judges a
+          // handler against a schema this file does not contain.
+          name: 'a schema built by a call',
+          code:
+            SDK +
+            'server.registerTool("read", { inputSchema: z.object({ path: z.string() }) }, async ({ path, extra }) => read(path));',
+        },
+        {
+          name: 'a schema spread from elsewhere',
+          code:
+            SDK +
+            'server.registerTool("read", { inputSchema: { ...base, path: z.string() } }, async ({ path, extra }) => read(path));',
+        },
+        {
+          name: 'a schema with a computed key',
+          code:
+            SDK +
+            'server.registerTool("read", { inputSchema: { [k]: z.string() } }, async ({ path }) => read(path));',
+        },
+        {
+          name: 'a schema referenced by name',
+          code:
+            SDK +
+            'server.registerTool("read", { inputSchema: ReadSchema }, async ({ path, extra }) => read(path));',
+        },
+        {
+          // Following every `args.x` through a body is the data-flow analysis
+          // this rule is built to avoid.
+          name: 'the whole-args form is out of scope',
+          code:
+            SDK +
+            'server.registerTool("read", { inputSchema: { path: z.string() } }, async (args) => read(args.extra));',
+        },
+        {
+          name: 'a rest element names no specific key',
+          code:
+            SDK +
+            'server.registerTool("read", { inputSchema: { path: z.string() } }, async ({ path, ...rest }) => read(path, rest));',
+        },
+        {
+          name: 'a computed key in the handler pattern',
+          code:
+            SDK +
+            'server.registerTool("read", { inputSchema: { path: z.string() } }, async ({ [k]: v }) => read(v));',
+        },
+        {
+          name: 'a handler passed by reference',
+          code:
+            SDK +
+            'server.registerTool("read", { inputSchema: { path: z.string() } }, handleRead);',
+        },
+        {
+          name: 'a config passed by reference',
+          code: SDK + 'server.registerTool("read", cfg, async ({ path }) => read(path));',
+        },
+        {
+          name: 'a file that never imports the MCP SDK',
+          code:
+            'server.registerTool("read", { inputSchema: { path: z.string() } }, async ({ extra }) => read(extra));',
+        },
+        {
+          name: 'a quoted schema key matches a plain read',
+          code:
+            SDK +
+            'server.registerTool("read", { inputSchema: { "path": z.string() } }, async ({ path }) => read(path));',
+        },
+      ],
+      invalid: [],
+    });
+  });
+
+  describe('Invalid — read but never declared', () => {
+    ruleTester.run('invalid', noUnvalidatedToolArgs, {
+      valid: [],
+      invalid: [
+        {
+          name: 'one undeclared key',
+          code:
+            SDK +
+            'server.registerTool("read", { inputSchema: { path: z.string() } }, async ({ path, encoding }) => read(path, encoding));',
+          errors: [
+            { messageId: 'undeclaredArg', data: { tool: 'read', arg: 'encoding' } },
+          ],
+        },
+        {
+          name: 'two undeclared keys report separately',
+          code:
+            SDK +
+            'server.registerTool("read", { inputSchema: { path: z.string() } }, async ({ path, encoding, flags }) => read(path));',
+          errors: [{ messageId: 'undeclaredArg' }, { messageId: 'undeclaredArg' }],
+        },
+        {
+          name: 'an empty schema declares nothing',
+          code:
+            SDK +
+            'server.registerTool("read", { inputSchema: {} }, async ({ path }) => read(path));',
+          errors: [{ messageId: 'undeclaredArg', data: { tool: 'read', arg: 'path' } }],
+        },
+        {
+          name: 'a renamed destructure is judged on the key, not the local name',
+          code:
+            SDK +
+            'server.registerTool("read", { inputSchema: { path: z.string() } }, async ({ encoding: enc }) => read(enc));',
+          errors: [{ messageId: 'undeclaredArg', data: { tool: 'read', arg: 'encoding' } }],
+        },
+        {
+          name: 'a defaulted destructure is still a read',
+          code:
+            SDK +
+            'server.registerTool("read", { inputSchema: { path: z.string() } }, async ({ encoding = "utf8" }) => encoding);',
+          errors: [{ messageId: 'undeclaredArg', data: { tool: 'read', arg: 'encoding' } }],
+        },
+        {
+          name: 'the legacy tool() arity',
+          code:
+            SDK +
+            'server.tool("read", { inputSchema: { path: z.string() } }, async ({ extra }) => read(extra));',
+          errors: [{ messageId: 'undeclaredArg' }],
+        },
+        {
+          name: 'a function expression handler',
+          code:
+            SDK +
+            'server.registerTool("read", { inputSchema: { path: z.string() } }, async function ({ extra }) { return read(extra); });',
+          errors: [{ messageId: 'undeclaredArg' }],
+        },
+        {
+          name: 'a non-literal tool name falls back to unknown',
+          code:
+            SDK +
+            'server.registerTool(toolName, { inputSchema: { path: z.string() } }, async ({ extra }) => read(extra));',
+          errors: [{ messageId: 'undeclaredArg', data: { tool: 'unknown', arg: 'extra' } }],
+        },
+        {
+          name: 'require() opens the same gate',
+          code:
+            "const { McpServer } = require('@modelcontextprotocol/sdk/server/mcp.js');\n" +
+            'server.registerTool("read", { inputSchema: { path: z.string() } }, async ({ extra }) => read(extra));',
+          errors: [{ messageId: 'undeclaredArg' }],
+        },
+        {
+          name: 'the import appearing after the registration',
+          code:
+            'server.registerTool("read", { inputSchema: { path: z.string() } }, async ({ extra }) => read(extra));\n' +
+            SDK,
+          errors: [{ messageId: 'undeclaredArg' }],
+        },
+      ],
+    });
+  });
+});
+
+const objOf = (code: string): TSESTree.ObjectExpression =>
+  (parser.parse(code, { range: true }).body[0] as TSESTree.ExpressionStatement)
+    .expression as TSESTree.ObjectExpression;
+
+describe('propertyKey', () => {
+  const firstProp = (code: string) => objOf(code).properties[0]!;
+
+  it('reads an identifier and a string-literal key', () => {
+    expect(propertyKey(firstProp('({ path: 1 })'))).toBe('path');
+    expect(propertyKey(firstProp('({ "path": 1 })'))).toBe('path');
+  });
+
+  it('returns undefined for a computed, numeric or spread member', () => {
+    expect(propertyKey(firstProp('({ [k]: 1 })'))).toBeUndefined();
+    expect(propertyKey(firstProp('({ 0: 1 })'))).toBeUndefined();
+    expect(propertyKey(firstProp('({ ...base })'))).toBeUndefined();
+  });
+});
+
+describe('declaredSchemaKeys', () => {
+  it('reads a plain object schema', () => {
+    const keys = declaredSchemaKeys(objOf('({ inputSchema: { a: 1, b: 2 } })'));
+    expect([...keys!].sort()).toEqual(['a', 'b']);
+  });
+
+  it('reads an empty schema as declaring nothing', () => {
+    expect([...declaredSchemaKeys(objOf('({ inputSchema: {} })'))!]).toEqual([]);
+  });
+
+  it('gives up rather than half-read a schema it cannot see', () => {
+    // Each of these could declare anything; a partial read would report
+    // correct handlers.
+    expect(declaredSchemaKeys(objOf('({ inputSchema: z.object({}) })'))).toBeUndefined();
+    expect(declaredSchemaKeys(objOf('({ inputSchema: Schema })'))).toBeUndefined();
+    expect(declaredSchemaKeys(objOf('({ inputSchema: { ...base } })'))).toBeUndefined();
+    expect(declaredSchemaKeys(objOf('({ inputSchema: { [k]: 1 } })'))).toBeUndefined();
+  });
+
+  it('returns undefined when there is no inputSchema at all', () => {
+    expect(declaredSchemaKeys(objOf('({ title: "t" })'))).toBeUndefined();
+  });
+});
+
+describe('destructuredArgNames', () => {
+  const fnOf = (code: string): TSESTree.Node =>
+    (parser.parse(code, { range: true }).body[0] as TSESTree.ExpressionStatement).expression;
+
+  it('reads the destructured keys', () => {
+    expect(destructuredArgNames(fnOf('({ a, b }) => {}')).map((r) => r.name)).toEqual(['a', 'b']);
+  });
+
+  it('reads the key, not the renamed local', () => {
+    expect(destructuredArgNames(fnOf('({ a: x }) => {}')).map((r) => r.name)).toEqual(['a']);
+  });
+
+  it('reads a defaulted key', () => {
+    expect(destructuredArgNames(fnOf('({ a = 1 }) => {}')).map((r) => r.name)).toEqual(['a']);
+  });
+
+  it('skips a rest element, which names no specific key', () => {
+    expect(destructuredArgNames(fnOf('({ a, ...rest }) => {}')).map((r) => r.name)).toEqual(['a']);
+  });
+
+  it('skips a computed key', () => {
+    expect(destructuredArgNames(fnOf('({ [k]: v }) => {}'))).toEqual([]);
+  });
+
+  it('returns nothing for the whole-args form', () => {
+    expect(destructuredArgNames(fnOf('(args) => {}'))).toEqual([]);
+  });
+
+  it('returns nothing for a non-function or a parameterless one', () => {
+    expect(destructuredArgNames(fnOf('handleRead'))).toEqual([]);
+    expect(destructuredArgNames(fnOf('() => {}'))).toEqual([]);
+  });
+});

--- a/packages/eslint-plugin-mcp-sdk-security/src/rules/no-unvalidated-tool-args/no-unvalidated-tool-args.test.ts
+++ b/packages/eslint-plugin-mcp-sdk-security/src/rules/no-unvalidated-tool-args/no-unvalidated-tool-args.test.ts
@@ -121,6 +121,20 @@ describe('no-unvalidated-tool-args', () => {
             'server.registerTool("read", { inputSchema: { path: z.string() } }, async ({ extra }) => read(extra));',
         },
         {
+          name: 'an unrelated import does not open the gate',
+          code:
+            "import { z } from 'zod';\n" +
+            'server.registerTool("read", { inputSchema: { path: z.string() } }, async ({ extra }) => read(extra));',
+        },
+        {
+          // A private method is the one non-computed property that is not an
+          // Identifier, so it is the only way to reach that guard.
+          name: 'a private method is not a registration',
+          code:
+            SDK +
+            'class S { #registerTool() {} m() { this.#registerTool("r", { inputSchema: {} }, ({ x }) => x); } }',
+        },
+        {
           name: 'a quoted schema key matches a plain read',
           code:
             SDK +

--- a/packages/eslint-plugin-mcp-sdk-security/src/rules/no-unvalidated-tool-args/no-unvalidated-tool-args.test.ts
+++ b/packages/eslint-plugin-mcp-sdk-security/src/rules/no-unvalidated-tool-args/no-unvalidated-tool-args.test.ts
@@ -55,6 +55,15 @@ describe('no-unvalidated-tool-args', () => {
             'server.registerTool("ping", { inputSchema: { path: z.string() } }, async () => "pong");',
         },
         {
+          // `options` can carry its own inputSchema, so the visible keys are
+          // not necessarily the declared ones. Reporting `extra` here would be
+          // judging the handler against a shape the file cannot see.
+          name: 'a spread after inputSchema can replace it',
+          code:
+            SDK +
+            'server.registerTool("read", { inputSchema: { path: z.string() }, ...options }, async ({ path, extra }) => read(path, extra));',
+        },
+        {
           // Not this rule's question — require-tool-input-schema owns it.
           name: 'no inputSchema declared',
           code: SDK + 'server.registerTool("read", { title: "Read" }, async ({ path }) => read(path));',
@@ -266,6 +275,23 @@ describe('declaredSchemaKeys', () => {
 
   it('returns undefined when there is no inputSchema at all', () => {
     expect(declaredSchemaKeys(objOf('({ title: "t" })'))).toBeUndefined();
+  });
+
+  it('gives up when a spread follows inputSchema and can replace it', () => {
+    // `options.inputSchema` wins at runtime, so the visible keys are not the
+    // declared ones — judging a handler against them would report correct code.
+    expect(declaredSchemaKeys(objOf('({ inputSchema: { a: 1 }, ...options })'))).toBeUndefined();
+  });
+
+  it('reads past an ordinary property that follows inputSchema', () => {
+    const keys = declaredSchemaKeys(objOf('({ inputSchema: { a: 1 }, title: "t" })'));
+    expect([...keys!]).toEqual(['a']);
+  });
+
+  it('still reads a schema when the spread comes first', () => {
+    // The explicit key wins over an earlier spread, so this one is readable.
+    const keys = declaredSchemaKeys(objOf('({ ...options, inputSchema: { a: 1 } })'));
+    expect([...keys!]).toEqual(['a']);
   });
 });
 


### PR DESCRIPTION
## Summary

W2 / M3. This is the rule that makes [`require-tool-input-schema`](https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-mcp-sdk-security/docs/rules/require-tool-input-schema.md) **mean something** rather than be decorative.

That rule ensures a schema *exists*. This one checks the handler only reads keys the schema *declares*.

## The security case

A schema is a contract with two sides, and only one is enforced at runtime. The SDK validates what arrives against the declared shape; nothing checks the handler confines itself to the same shape. When it doesn't, either:

- the value was **stripped** → the handler reads `undefined` and the tool is quietly broken in a way no test with a well-formed call catches, or
- it **wasn't** stripped — a passthrough schema, a hand-rolled validator, a server that skips validation — and the handler is reading raw model-controlled input that passed no check, while every reviewer assumes the schema covered it.

```ts
server.registerTool('read', { inputSchema: { path: z.string() } },
  async ({ path, encoding }) => readFile(path, encoding));   // `encoding` undeclared
```

It's invisible precisely because the schema *looks* like it covers the handler. Both sides are statically visible in the same expression, so this needs no inference.

## Silent by design

| Shape | Why |
|---|---|
| `inputSchema: z.object({…})`, a shared reference, a spread, a computed key | the schema can't be read; judging a handler against an invisible shape would report correct code |
| no `inputSchema` at all | that's `require-tool-input-schema`'s question |
| `async (args) => read(args.extra)` | would need the data-flow analysis this rule exists to avoid |
| `{ path, ...rest }` | a rest element names no specific key |

The whole registration is skipped rather than half-checked — a partial schema read is how a rule like this starts reporting correct code.

## Test plan

- [x] **100/100/100/100**, 110 tests across the plugin.
- [x] One unreachable guard **deleted** rather than covered: reaching `handler === undefined` requires `arguments[1]` to be an ObjectExpression, which guarantees a last argument exists.
- [x] Barrel lock, reference equality, strict membership, and an explicit assertion the rule is **absent** from `minimal`/`recommended` pending a measured FP profile (plan §1.6).
- [x] `turbo run build` 35/35; scope audit clean; shim manifest verified in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `no-unvalidated-tool-args` security rule to detect tool handlers accessing arguments not declared in readable input schemas.
  * Supports modern and legacy MCP tool registration patterns.
* **Documentation**
  * Added usage guidance, examples, exclusions, and security references for the new rule.
* **Chores**
  * Updated plugin catalogs and statistics to include the additional rule, increasing the total rule count to 457.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->