### PR TITLE
fix(node-security): resolve the fs binding instead of matching one spelling

### DIFF
--- a/.changeset/fs-binding-resolution.md
+++ b/.changeset/fs-binding-resolution.md
@@ -1,0 +1,23 @@
+---
+'eslint-plugin-node-security': minor
+---
+
+`detect-non-literal-fs-filename` now resolves the fs binding instead of matching
+one spelling of it.
+
+The gate required the receiver be literally the identifier `fs`, so a named
+import from `node:fs/promises`, a renamed default import, a namespace import,
+`fs.promises.*` and a destructured `require` were all silently unchecked — the
+rule's own documentation used `const { readFile } = require('fs')` as its first
+incorrect example, a shape it never reported. All of those are now checked, and
+bindings are resolved across the whole file before any call is judged, so a
+`require` below its call site counts too.
+
+Detection is strictly wider, so expect more findings. Because of that,
+`detect-non-literal-fs-filename` drops from `error` to `warn` in the
+`recommended` preset: measured on the ecosystem repo the widened rule reports
+854 findings (555 outside test files), and it has no notion of a trust
+boundary — a build script reading its own repo reports identically to a request
+handler reading user input. Set it back to `error` explicitly if you want the
+old severity; it will be reconsidered once the corpus run measures its
+false-positive profile.

--- a/apps/docs/content/docs/security/plugin-node-security/rules/detect-non-literal-fs-filename.mdx
+++ b/apps/docs/content/docs/security/plugin-node-security/rules/detect-non-literal-fs-filename.mdx
@@ -21,7 +21,7 @@ import { FalseNegativeCTA, WhenNotToUse, RuleBadges } from "@/components/RuleCom
 
 Detects variable in filename argument of fs calls, which might allow an attacker to access anything on your system. This rule is part of [`eslint-plugin-node-security`](https://www.npmjs.com/package/eslint-plugin-node-security) and provides LLM-optimized error messages with fix suggestions.
 
-**🚨 Security rule** | **💡 Provides LLM-optimized guidance** | **⚠️ Set to error in `recommended`**
+**🚨 Security rule** | **💡 Provides LLM-optimized guidance** | **⚠️ Set to warn in `recommended`**
 
 ## Quick Summary
 

--- a/packages/eslint-plugin-node-security/docs/rules/detect-non-literal-fs-filename.md
+++ b/packages/eslint-plugin-node-security/docs/rules/detect-non-literal-fs-filename.md
@@ -19,7 +19,7 @@ Detects variable in filename argument of fs calls, which might allow an attacker
 
 Detects variable in filename argument of fs calls, which might allow an attacker to access anything on your system. This rule is part of [`eslint-plugin-node-security`](https://www.npmjs.com/package/eslint-plugin-node-security) and provides LLM-optimized error messages with fix suggestions.
 
-**🚨 Security rule** | **💡 Provides LLM-optimized guidance** | **⚠️ Set to error in `recommended`**
+**🚨 Security rule** | **💡 Provides LLM-optimized guidance** | **⚠️ Set to warn in `recommended`**
 
 ## Quick Summary
 

--- a/packages/eslint-plugin-node-security/docs/rules/detect-non-literal-fs-filename.md
+++ b/packages/eslint-plugin-node-security/docs/rules/detect-non-literal-fs-filename.md
@@ -111,6 +111,26 @@ The rule provides **LLM-optimized error messages** (Compact 2-line format) with 
 | `allowLiterals`     | `boolean`  | `false` | Allow literal string paths     |
 | `additionalMethods` | `string[]` | `[]`    | Additional fs methods to check |
 
+## How the fs module is recognised
+
+The rule resolves the binding rather than matching one spelling of it, so all
+of these are checked — `fs`, `node:fs`, `fs/promises` and `node:fs/promises`:
+
+```typescript
+import fs from 'fs';                         // default import, any local name
+import * as fileSystem from 'node:fs';       // namespace import
+import { readFile } from 'fs/promises';      // named import, renamed or not
+const { readdir } = require('node:fs');      // destructured require
+fs.promises.readFile(p);                     // the promises sub-object
+```
+
+A bare `fs.readFile(...)` in a file that imports nothing is still reported, on
+the assumption that `fs` names the module.
+
+Bindings are resolved across the whole file before any call is judged, so a
+`require` placed below its call site still counts — statement order is not a
+security property.
+
 ## Examples
 
 ### ❌ Incorrect

--- a/packages/eslint-plugin-node-security/src/index.test.ts
+++ b/packages/eslint-plugin-node-security/src/index.test.ts
@@ -86,6 +86,22 @@ describe('eslint-plugin-node-security plugin interface', () => {
       ).toBeDefined();
     });
 
+    // Demoted 2026-08-05 alongside the binding-resolution fix, which widened
+    // detection from the single `fs.x` spelling to every way the module can be
+    // bound. Measured 854 findings on this repo (555 outside test files); the
+    // rule has no trust-boundary notion, so a build script reading its own repo
+    // reports like a handler reading user input. Re-promoting to 'error' is a
+    // deliberate act gated on W6's corpus FP measurement, not something a later
+    // refactor should do by accident.
+    it('keeps detect-non-literal-fs-filename at warn in recommended', () => {
+      const recommendedRules = configs['recommended'].rules || {};
+      expect(
+        recommendedRules['node-security/detect-non-literal-fs-filename'],
+        'the widened binding resolution multiplies findings; promote to error ' +
+          'only after the corpus run measures its FP profile',
+      ).toBe('warn');
+    });
+
     it('should provide strict configuration', () => {
       expect(configs['strict']).toBeDefined();
       expect(configs['strict'].plugins?.['node-security']).toBeDefined();

--- a/packages/eslint-plugin-node-security/src/index.ts
+++ b/packages/eslint-plugin-node-security/src/index.ts
@@ -106,7 +106,17 @@ export const plugin: TSESLint.FlatConfig.Plugin = {
 const recommendedRules: Record<string, TSESLint.FlatConfig.RuleEntry> = {
   'node-security/detect-child-process': 'error',
   'node-security/detect-eval-with-expression': 'error',
-  'node-security/detect-non-literal-fs-filename': 'error',
+  // Demoted 2026-08-05, in the same change that widened its detection. The
+  // rule used to gate on the receiver being literally `fs`, so a named import
+  // from `node:fs/promises`, a renamed default, a namespace import and
+  // `fs.promises.*` were all silently unchecked. Resolving the binding is the
+  // correct fix, but it multiplies findings: measured on this repo, 854 (555
+  // outside test files) where the old gate saw a fraction of that. The rule
+  // has no notion of a trust boundary, so a build script reading its own repo
+  // reports identically to a request handler reading user input. Shipping
+  // that at 'error' would break every adopter's CI on a minor.
+  // Promote back to 'error' once W6's corpus run measures the FP profile.
+  'node-security/detect-non-literal-fs-filename': 'warn',
   'node-security/no-unsafe-dynamic-require': 'error',
   // no-buffer-overread demoted 2026-05-09 — 95% of Wild hits on adversarial
   // Edge corpus + insufficient fixture coverage for the README §1 promotion

--- a/packages/eslint-plugin-node-security/src/rules/detect-non-literal-fs-filename/fs-binding-resolution.test.ts
+++ b/packages/eslint-plugin-node-security/src/rules/detect-non-literal-fs-filename/fs-binding-resolution.test.ts
@@ -131,6 +131,19 @@ describe('fs binding resolution', () => {
         errors: [{ messageId: 'fsPathTraversal' }],
       },
       {
+        // `promises` is the one fs export that is itself a module object.
+        // Filed under methods it was unresolvable, so the whole promise API
+        // reached through this idiom was silently unchecked.
+        name: 'a destructured promises object binds a namespace, not a method',
+        code: "const { promises } = require('fs');\npromises.readFile(userPath);",
+        errors: [{ messageId: 'fsPathTraversal' }],
+      },
+      {
+        name: 'the same through a named import',
+        code: "import { promises as fsp } from 'node:fs';\nfsp.writeFile(userPath, data);",
+        errors: [{ messageId: 'fsPathTraversal' }],
+      },
+      {
         name: 'the bare fs identifier still reports with no import at all',
         code: 'fs.readFile(userPath);',
         errors: [{ messageId: 'fsPathTraversal' }],

--- a/packages/eslint-plugin-node-security/src/rules/detect-non-literal-fs-filename/fs-binding-resolution.test.ts
+++ b/packages/eslint-plugin-node-security/src/rules/detect-non-literal-fs-filename/fs-binding-resolution.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Binding-resolution tests for detect-non-literal-fs-filename.
+ *
+ * The rule used to gate on the receiver being literally the identifier `fs`,
+ * so every other way of binding the module was unchecked. Each invalid case
+ * below is a shape that reported *nothing* before this change — revert
+ * `fsMethodName` to the old `object.name !== 'fs'` check and they all go
+ * silent, which is what makes this file a lock rather than a restatement.
+ *
+ * Layer 1: the rule through RuleTester.
+ * Layer 2: fsMethodName / isFsModule / isFsRequire directly, for the arms no
+ * source shape can reach through the rule.
+ */
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { describe, it, expect, afterAll } from 'vitest';
+import parser from '@typescript-eslint/parser';
+import type { TSESTree } from '@interlace/eslint-devkit';
+import { detectNonLiteralFsFilename, fsMethodName, isFsModule, isFsRequire } from './index';
+
+RuleTester.afterAll = afterAll;
+RuleTester.it = it;
+RuleTester.itOnly = it.only;
+RuleTester.describe = describe;
+
+const ruleTester = new RuleTester({
+  languageOptions: { parser, ecmaVersion: 2022, sourceType: 'module' },
+});
+
+describe('fs binding resolution', () => {
+  ruleTester.run('detect-non-literal-fs-filename', detectNonLiteralFsFilename, {
+    valid: [
+      {
+        name: 'a same-named binding from an unrelated module is not fs',
+        code: "import { readFile } from './my-utils';\nreadFile(userPath);",
+      },
+      {
+        name: 'a bare call with no fs binding in the file',
+        code: 'readFile(userPath);',
+      },
+      {
+        name: 'a require of something else does not bind fs',
+        code: "const fsx = require('path');\nfsx.readFile(userPath);",
+      },
+      {
+        name: 'a non-dangerous method on a resolved namespace',
+        code: "import fsp from 'node:fs/promises';\nfsp.realpath(userPath);",
+      },
+      {
+        name: 'a literal path through a resolved named import',
+        code: "import { readFile } from 'node:fs/promises';\nreadFile('./config.json');",
+      },
+      {
+        name: 'a computed member on the module object is not resolved',
+        code: "import fs2 from 'fs';\nfs2[method](userPath);",
+      },
+      {
+        name: 'a non-promises member chain is not an fs sink',
+        code: "import fs2 from 'fs';\nfs2.constants.readFile(userPath);",
+      },
+      {
+        name: 'require with no arguments is not an fs require',
+        code: 'const fs3 = require();\nfs3.readFile(userPath);',
+      },
+      {
+        name: 'a destructured require of a non-fs module',
+        code: "const { readFile } = require('./local');\nreadFile(userPath);",
+      },
+      {
+        name: 'a computed destructuring key binds no method name',
+        code: "const { [k]: readFile } = require('fs');\nreadFile(userPath);",
+      },
+      {
+        name: 'a nested destructuring pattern is not a method binding',
+        code: "const { promises: { readFile } } = require('fs');\nreadFile(userPath);",
+      },
+      {
+        name: 'a declarator with no initialiser',
+        code: 'let fsLater;\nreadFile(userPath);',
+      },
+      {
+        // fs has no array shape, so an array pattern binds nothing this rule
+        // can name — better silent than guessing which element is which.
+        name: 'an array-pattern require binds no fs name',
+        code: "const [readFile] = require('fs');\nreadFile(userPath);",
+      },
+    ],
+    invalid: [
+      {
+        name: 'a named import from node:fs/promises',
+        code: "import { readFile } from 'node:fs/promises';\nreadFile(userPath);",
+        errors: [{ messageId: 'fsPathTraversal' }],
+      },
+      {
+        name: 'a renamed named import still resolves to its fs method',
+        code: "import { readFile as read } from 'fs/promises';\nread(userPath);",
+        errors: [{ messageId: 'fsPathTraversal' }],
+      },
+      {
+        name: 'the string-literal import name resolves the same method',
+        code: "import { 'readFile' as read } from 'fs/promises';\nread(userPath);",
+        errors: [{ messageId: 'fsPathTraversal' }],
+      },
+      {
+        name: 'a renamed default import',
+        code: "import nodeFs from 'node:fs';\nnodeFs.readFileSync(userPath);",
+        errors: [{ messageId: 'fsPathTraversal' }],
+      },
+      {
+        name: 'a namespace import',
+        code: "import * as fileSystem from 'fs';\nfileSystem.writeFile(userPath, data);",
+        errors: [{ messageId: 'fsPathTraversal' }],
+      },
+      {
+        name: 'fs.promises off a renamed binding',
+        code: "import nodeFs from 'fs';\nnodeFs.promises.readFile(userPath);",
+        errors: [{ messageId: 'fsPathTraversal' }],
+      },
+      {
+        name: 'a renamed require',
+        code: "const nodeFs = require('node:fs');\nnodeFs.unlink(userPath);",
+        errors: [{ messageId: 'fsPathTraversal' }],
+      },
+      {
+        name: 'a destructured require',
+        code: "const { readdir } = require('fs');\nreaddir(userDir);",
+        errors: [{ messageId: 'fsPathTraversal' }],
+      },
+      {
+        name: 'a renamed destructured require keeps the fs method name',
+        code: "const { readFile: rf } = require('node:fs/promises');\nrf(userPath);",
+        errors: [{ messageId: 'fsPathTraversal' }],
+      },
+      {
+        name: 'the bare fs identifier still reports with no import at all',
+        code: 'fs.readFile(userPath);',
+        errors: [{ messageId: 'fsPathTraversal' }],
+      },
+      {
+        // Judging in visit order would miss this: the binding is established
+        // after the call site. Statement order is not a security property.
+        name: 'a require below the call site still binds',
+        code: "function read(p) { return nodeFs.readFileSync(p); }\nconst nodeFs = require('fs');",
+        errors: [{ messageId: 'fsPathTraversal' }],
+      },
+    ],
+  });
+});
+
+describe('isFsModule', () => {
+  it('accepts the four fs specifiers', () => {
+    for (const m of ['fs', 'node:fs', 'fs/promises', 'node:fs/promises']) {
+      expect(isFsModule(m)).toBe(true);
+    }
+  });
+
+  it('rejects anything else, including a non-string source', () => {
+    expect(isFsModule('fs-extra')).toBe(false);
+    expect(isFsModule('./fs')).toBe(false);
+    // A `require(0)` parses fine; the source is then not a string.
+    expect(isFsModule(0)).toBe(false);
+  });
+});
+
+describe('fsMethodName', () => {
+  const calleeOf = (code: string): TSESTree.Node => {
+    const stmt = parser.parse(code, { range: true }).body[0] as TSESTree.ExpressionStatement;
+    return (stmt.expression as TSESTree.CallExpression).callee;
+  };
+
+  it('returns undefined for a callee that is neither identifier nor member', () => {
+    expect(fsMethodName(calleeOf('getFs()(p)'), new Set(['fs']), new Map())).toBeUndefined();
+  });
+
+  it('returns undefined for a member whose property is not an identifier', () => {
+    expect(fsMethodName(calleeOf('fs["readFile"](p)'), new Set(['fs']), new Map())).toBeUndefined();
+  });
+
+  it('resolves a namespace member', () => {
+    expect(fsMethodName(calleeOf('fs.readFile(p)'), new Set(['fs']), new Map())).toBe('readFile');
+  });
+
+  it('resolves a promises member', () => {
+    expect(fsMethodName(calleeOf('fs.promises.readFile(p)'), new Set(['fs']), new Map())).toBe(
+      'readFile',
+    );
+  });
+
+  it('rejects a promises chain rooted in an unknown binding', () => {
+    expect(fsMethodName(calleeOf('other.promises.readFile(p)'), new Set(['fs']), new Map()))
+      .toBeUndefined();
+  });
+
+  it('rejects a computed promises member', () => {
+    expect(
+      fsMethodName(calleeOf('fs[key].readFile(p)'), new Set(['fs']), new Map()),
+    ).toBeUndefined();
+  });
+
+  it('rejects a member chain deeper than fs.promises', () => {
+    expect(
+      fsMethodName(calleeOf('a.b.c.readFile(p)'), new Set(['fs']), new Map()),
+    ).toBeUndefined();
+  });
+
+  it('maps a named binding to its fs method', () => {
+    expect(fsMethodName(calleeOf('read(p)'), new Set(), new Map([['read', 'readFile']]))).toBe(
+      'readFile',
+    );
+  });
+});
+
+describe('isFsRequire', () => {
+  const exprOf = (code: string): TSESTree.Node =>
+    (parser.parse(code, { range: true }).body[0] as TSESTree.ExpressionStatement).expression;
+
+  it('is true for require of any fs specifier', () => {
+    expect(isFsRequire(exprOf("require('fs')"))).toBe(true);
+    expect(isFsRequire(exprOf("require('node:fs/promises')"))).toBe(true);
+  });
+
+  it('is false for a non-call, a non-require call, and a non-literal argument', () => {
+    expect(isFsRequire(exprOf('someValue'))).toBe(false);
+    expect(isFsRequire(exprOf("imports('fs')"))).toBe(false);
+    expect(isFsRequire(exprOf('require(moduleName)'))).toBe(false);
+    expect(isFsRequire(exprOf('require()'))).toBe(false);
+  });
+});

--- a/packages/eslint-plugin-node-security/src/rules/detect-non-literal-fs-filename/fs-binding-resolution.test.ts
+++ b/packages/eslint-plugin-node-security/src/rules/detect-non-literal-fs-filename/fs-binding-resolution.test.ts
@@ -66,6 +66,11 @@ describe('fs binding resolution', () => {
         code: "const { readFile } = require('./local');\nreadFile(userPath);",
       },
       {
+        // A numeric key is not an fs method name; better silent than guessing.
+        name: 'a numeric destructuring key binds no method name',
+        code: "const { 0: readFile } = require('fs');\nreadFile(userPath);",
+      },
+      {
         name: 'a computed destructuring key binds no method name',
         code: "const { [k]: readFile } = require('fs');\nreadFile(userPath);",
       },
@@ -93,6 +98,12 @@ describe('fs binding resolution', () => {
       {
         name: 'a renamed named import still resolves to its fs method',
         code: "import { readFile as read } from 'fs/promises';\nread(userPath);",
+        errors: [{ messageId: 'fsPathTraversal' }],
+      },
+      {
+        // Parity with the import path, which already reads the string form.
+        name: 'a string-literal destructuring key resolves the same method',
+        code: "const { 'readFile': read } = require('fs');\nread(userPath);",
         errors: [{ messageId: 'fsPathTraversal' }],
       },
       {

--- a/packages/eslint-plugin-node-security/src/rules/detect-non-literal-fs-filename/index.ts
+++ b/packages/eslint-plugin-node-security/src/rules/detect-non-literal-fs-filename/index.ts
@@ -733,14 +733,20 @@ allowLiterals = false,
         }
         if (node.id.type !== AST_NODE_TYPES.ObjectPattern) return;
         for (const prop of node.id.properties) {
-          if (
-            prop.type === AST_NODE_TYPES.Property &&
-            !prop.computed &&
-            prop.key.type === AST_NODE_TYPES.Identifier &&
-            prop.value.type === AST_NODE_TYPES.Identifier
-          ) {
-            bindFsName(prop.value.name, prop.key.name);
-          }
+          if (prop.type !== AST_NODE_TYPES.Property || prop.computed) continue;
+          if (prop.value.type !== AST_NODE_TYPES.Identifier) continue;
+          // `const { 'readFile': read } = require('fs')` names the same method
+          // as the bare form. The import path already reads the string spelling
+          // (`import { 'readFile' as read }`), so gating it out here would be an
+          // asymmetry, not a narrower gate.
+          const key =
+            prop.key.type === AST_NODE_TYPES.Identifier
+              ? prop.key.name
+              : prop.key.type === AST_NODE_TYPES.Literal && typeof prop.key.value === 'string'
+                ? prop.key.value
+                : undefined;
+          if (key === undefined) continue;
+          bindFsName(prop.value.name, key);
         }
       },
 

--- a/packages/eslint-plugin-node-security/src/rules/detect-non-literal-fs-filename/index.ts
+++ b/packages/eslint-plugin-node-security/src/rules/detect-non-literal-fs-filename/index.ts
@@ -148,6 +148,83 @@ export const generateRefactoringSteps = (operation: FSOperation): string => {
 };
 
 /**
+ * The four specifiers that resolve to Node's filesystem module.
+ *
+ * `fs/promises` is included because the promise API is the same set of sinks
+ * under a different import path — `readFile(userPath)` there is exactly as
+ * exploitable as `fs.readFile(userPath)`.
+ */
+const FS_MODULES = new Set(['fs', 'node:fs', 'fs/promises', 'node:fs/promises']);
+
+export const isFsModule = (source: unknown): boolean =>
+  typeof source === 'string' && FS_MODULES.has(source);
+
+/**
+ * The fs method this callee invokes, if any.
+ *
+ * The rule used to require the receiver be literally the identifier `fs`, so
+ * every other way of binding the module was silently unchecked — a named
+ * import, a renamed default, `fs.promises`, a namespace import. A path
+ * traversal is not less exploitable because the author wrote
+ * `import { readFile } from 'node:fs/promises'`, so the gate now resolves the
+ * binding instead of pattern-matching one spelling of it.
+ *
+ * Module-scope so each shape is directly unit-testable (Layer-2).
+ */
+export function fsMethodName(
+  callee: TSESTree.Node,
+  namespaces: ReadonlySet<string>,
+  named: ReadonlyMap<string, string>,
+): string | undefined {
+  // `readFile(userPath)` — named import or destructured require.
+  if (callee.type === AST_NODE_TYPES.Identifier) return named.get(callee.name);
+
+  if (
+    callee.type !== AST_NODE_TYPES.MemberExpression ||
+    callee.computed ||
+    callee.property.type !== AST_NODE_TYPES.Identifier
+  ) {
+    return undefined;
+  }
+
+  const object = callee.object;
+
+  // `fs.readFile(userPath)` — under whatever name the module was bound to.
+  if (object.type === AST_NODE_TYPES.Identifier && namespaces.has(object.name)) {
+    return callee.property.name;
+  }
+
+  // `fs.promises.readFile(userPath)`.
+  if (
+    object.type === AST_NODE_TYPES.MemberExpression &&
+    !object.computed &&
+    object.object.type === AST_NODE_TYPES.Identifier &&
+    namespaces.has(object.object.name) &&
+    object.property.type === AST_NODE_TYPES.Identifier &&
+    object.property.name === 'promises'
+  ) {
+    return callee.property.name;
+  }
+
+  return undefined;
+}
+
+/**
+ * Is this expression `require('fs')` (or any of the four fs specifiers)?
+ * Module-scope so it is directly unit-testable (Layer-2).
+ */
+export function isFsRequire(node: TSESTree.Node): boolean {
+  return (
+    node.type === AST_NODE_TYPES.CallExpression &&
+    node.callee.type === AST_NODE_TYPES.Identifier &&
+    node.callee.name === 'require' &&
+    node.arguments.length > 0 &&
+    node.arguments[0].type === AST_NODE_TYPES.Literal &&
+    isFsModule(node.arguments[0].value)
+  );
+}
+
+/**
  * Determine risk level based on the operation and path.
  * Module-scope so the non-dangerous fallback (no FS_OPERATIONS entry sets
  * dangerous: false today) is directly unit-testable (Layer-2).
@@ -539,18 +616,26 @@ allowLiterals = false,
     };
 
     /**
+     * Names bound to the fs module itself.
+     *
+     * Seeded with `fs`, so a file that never imports it — the shape the rule
+     * has always reported — keeps being reported. Anything else has to be
+     * traced to an import or a require.
+     */
+    const fsNamespaces = new Set<string>(['fs']);
+    /** Local name → fs method, for named imports and destructured requires. */
+    const fsNamedMethods = new Map<string, string>();
+    /** Calls to judge at Program:exit, once every binding in the file is known. */
+    const pendingCalls: TSESTree.CallExpression[] = [];
+
+    /**
      * Check fs method calls for path traversal vulnerabilities
      */
     const checkFsCall = (node: TSESTree.CallExpression) => {
-      // Check if it's an fs method call
-      if (node.callee.type !== 'MemberExpression' ||
-          node.callee.object.type !== 'Identifier' ||
-          node.callee.object.name !== 'fs' ||
-          node.callee.property.type !== 'Identifier') {
+      const methodName = fsMethodName(node.callee, fsNamespaces, fsNamedMethods);
+      if (methodName === undefined) {
         return;
       }
-
-      const methodName = node.callee.property.name;
 
       // Skip if not a dangerous method
       if (!dangerousMethods.has(methodName)) {
@@ -607,7 +692,56 @@ allowLiterals = false,
     };
 
     return {
-      CallExpression: checkFsCall
+      ImportDeclaration(node: TSESTree.ImportDeclaration) {
+        if (!isFsModule(node.source.value)) return;
+        for (const spec of node.specifiers) {
+          if (spec.type === AST_NODE_TYPES.ImportSpecifier) {
+            // `import { readFile as read }` — the *imported* name is the fs
+            // method, the local name is what the call site writes. The string
+            // form (`import { 'readFile' as read }`) names the same method, so
+            // skipping it would be a false negative, not a narrower gate.
+            fsNamedMethods.set(
+              spec.local.name,
+              spec.imported.type === AST_NODE_TYPES.Identifier
+                ? spec.imported.name
+                : spec.imported.value,
+            );
+            continue;
+          }
+          // Default and namespace specifiers both bind the module object.
+          fsNamespaces.add(spec.local.name);
+        }
+      },
+
+      VariableDeclarator(node: TSESTree.VariableDeclarator) {
+        if (node.init === null || !isFsRequire(node.init)) return;
+        if (node.id.type === AST_NODE_TYPES.Identifier) {
+          fsNamespaces.add(node.id.name);
+          return;
+        }
+        if (node.id.type !== AST_NODE_TYPES.ObjectPattern) return;
+        for (const prop of node.id.properties) {
+          if (
+            prop.type === AST_NODE_TYPES.Property &&
+            !prop.computed &&
+            prop.key.type === AST_NODE_TYPES.Identifier &&
+            prop.value.type === AST_NODE_TYPES.Identifier
+          ) {
+            fsNamedMethods.set(prop.value.name, prop.key.name);
+          }
+        }
+      },
+
+      // Collected, not judged: a `const fs = require('fs')` below the call
+      // site still binds it, and a rule that missed those would be reporting
+      // on statement order rather than on risk.
+      CallExpression(node: TSESTree.CallExpression) {
+        pendingCalls.push(node);
+      },
+
+      'Program:exit'() {
+        for (const call of pendingCalls) checkFsCall(call);
+      },
     };
   },
 });

--- a/packages/eslint-plugin-node-security/src/rules/detect-non-literal-fs-filename/index.ts
+++ b/packages/eslint-plugin-node-security/src/rules/detect-non-literal-fs-filename/index.ts
@@ -629,6 +629,19 @@ allowLiterals = false,
     const pendingCalls: TSESTree.CallExpression[] = [];
 
     /**
+     * Record what a destructured / named binding refers to.
+     *
+     * `promises` is the one member of the fs module that is itself a module
+     * object, so `const { promises } = require('fs')` binds a *namespace*, not
+     * a method — filing it under methods left `promises.readFile(userPath)`
+     * unresolvable and therefore silently unchecked.
+     */
+    function bindFsName(local: string, imported: string): void {
+      if (imported === 'promises') fsNamespaces.add(local);
+      else fsNamedMethods.set(local, imported);
+    }
+
+    /**
      * Check fs method calls for path traversal vulnerabilities
      */
     const checkFsCall = (node: TSESTree.CallExpression) => {
@@ -700,12 +713,11 @@ allowLiterals = false,
             // method, the local name is what the call site writes. The string
             // form (`import { 'readFile' as read }`) names the same method, so
             // skipping it would be a false negative, not a narrower gate.
-            fsNamedMethods.set(
-              spec.local.name,
+            const imported =
               spec.imported.type === AST_NODE_TYPES.Identifier
                 ? spec.imported.name
-                : spec.imported.value,
-            );
+                : spec.imported.value;
+            bindFsName(spec.local.name, imported);
             continue;
           }
           // Default and namespace specifiers both bind the module object.
@@ -727,7 +739,7 @@ allowLiterals = false,
             prop.key.type === AST_NODE_TYPES.Identifier &&
             prop.value.type === AST_NODE_TYPES.Identifier
           ) {
-            fsNamedMethods.set(prop.value.name, prop.key.name);
+            bindFsName(prop.value.name, prop.key.name);
           }
         }
       },


### PR DESCRIPTION
## Summary

`detect-non-literal-fs-filename` gated on the receiver being literally the identifier `fs`:

```ts
node.callee.object.name !== 'fs'
```

so every other way of binding the module was silently unchecked. Measured against real shapes before this change:

```
✅ reports | fs.readFile(userPath)
❌ MISSED  | import { readFile } from 'node:fs/promises'
❌ MISSED  | renamed default import
❌ MISSED  | renamed require
❌ MISSED  | fs.promises.readFile
❌ MISSED  | namespace import
```

The rule's own docs used `const { readFile } = require('fs')` as their **first incorrect example** — a shape it never reported. This is the self-suppression class: a security rule that switches itself off scores a perfect FP rate while protecting nothing.

- New `fsMethodName` resolves the binding from imports and requires across `fs`, `node:fs`, `fs/promises`, `node:fs/promises`. Named, renamed, default, namespace, destructured-require and `fs.promises.*` all resolve.
- Calls are collected and judged at `Program:exit`, so a `require` below its call site still binds — statement order is not a security property.
- A bare `fs.x` with no import still reports, so no existing detection is lost.
- `import { 'readFile' as read }` (string-literal import name) resolves too, rather than being skipped.

## Blast radius, and why the preset severity drops

Detection is strictly wider. Measured on this repo with the widened rule: **854 findings, 555 outside test files** — build scripts, sync scripts, and rule sources reading their own repo. The rule has no notion of a trust boundary, so a script reading its own directory reports identically to a request handler reading user input.

`node-security/detect-non-literal-fs-filename` therefore drops from `'error'` to `'warn'` in `recommended`, following the `no-buffer-overread` / `no-unsafe-buffer-alloc` precedent already in that file. Shipping the widened rule at `error` would break every adopter's CI on a minor. Promotion back to `error` is gated on the corpus FP measurement, and the severity is locked by a test so a later refactor cannot flip it silently.

## Test plan

- [x] `vitest --root packages/eslint-plugin-node-security` — 985 tests pass, **100/100/100/100**, no coverage-ignore pragmas.
- [x] New lock `src/rules/detect-non-literal-fs-filename/fs-binding-resolution.test.ts` — 36 cases, dual-layer (RuleTester + direct `fsMethodName` / `isFsModule` / `isFsRequire`).
- [x] **Verified by reverting**: restoring the `object.name === 'fs'` gate fails **10 of the 36**. The lock fails on unfixed code.
- [x] Preset severity locked in `src/index.test.ts`.
- [x] Rule doc gains a "How the fs module is recognised" section, so the documented behaviour and the real gate now agree.

## After merge

Adopters on `recommended` see new `warn`-level findings from fs call sites that were previously invisible. Changeset is `minor` and says so. Anyone who wants the old severity sets the rule to `error` explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)