### PR TITLE
fix(browser-security): stop flagging inspected protocols and XML namespaces

### DIFF
--- a/.changeset/unencrypted-transmission-fps.md
+++ b/.changeset/unencrypted-transmission-fps.md
@@ -1,0 +1,31 @@
+---
+'eslint-plugin-browser-security': patch
+---
+
+`no-unencrypted-transmission` no longer flags protocol strings that are being
+inspected, or XML namespace identifiers.
+
+The rule reported **every** string literal containing `http://`, regardless of
+what the code did with it. Two false-positive classes followed, both measured by
+running the published ruleset over the Interlace monorepo:
+
+**The security check reported as the vulnerability.** The rule's own finding
+landed on this line:
+
+```js
+// Skip external links, anchors, and absolute paths
+if (url.startsWith('http://') || url.startsWith('https://') || …)
+```
+
+A protocol string passed to `startsWith` / `includes` / `replace` / `match`, or
+compared with `===`, is the thing being *looked for* — not an endpoint being
+called.
+
+**XML namespaces.** `xmlns="http://www.w3.org/2000/svg"` is the most common
+`http://` string in any React codebase — every inline SVG carries one. It is
+never fetched; namespaces are opaque identifiers and rewriting one to `https`
+breaks the document. Also covers the XSD/XSL/RDF and Inkscape/Adobe namespaces.
+
+Both are locked as `valid` cases, verified by reverting each guard and watching
+the rule report again. True positives are unaffected: `fetch('http://api…')`,
+`new WebSocket('ws://…')` and connection strings still report.

--- a/.changeset/unencrypted-transmission-fps.md
+++ b/.changeset/unencrypted-transmission-fps.md
@@ -17,9 +17,11 @@ landed on this line:
 if (url.startsWith('http://') || url.startsWith('https://') || …)
 ```
 
-A protocol string passed to `startsWith` / `includes` / `replace` / `match`, or
-compared with `===`, is the thing being *looked for* — not an endpoint being
-called.
+A protocol string passed to `startsWith` / `includes` / `match`, passed as the
+**first** argument to `replace` / `replaceAll`, or compared with `===`, is the
+thing being *looked for* — not an endpoint being called. The second argument to
+`replace` / `replaceAll` is content being written, so
+`url.replace(p, 'http://evil.test')` still reports.
 
 **XML namespaces.** `xmlns="http://www.w3.org/2000/svg"` is the most common
 `http://` string in any React codebase — every inline SVG carries one. It is

--- a/packages/eslint-plugin-browser-security/src/rules/no-unencrypted-transmission/index.ts
+++ b/packages/eslint-plugin-browser-security/src/rules/no-unencrypted-transmission/index.ts
@@ -8,12 +8,16 @@
  * ESLint Rule: no-unencrypted-transmission
  * Detects unencrypted data transmission (HTTP vs HTTPS, plain text protocols)
  * CWE-319: Cleartext Transmission of Sensitive Information
- * 
+ *
  * @see https://cwe.mitre.org/data/definitions/319.html
  * @see https://owasp.org/www-community/vulnerabilities/Insecure_Transport
  */
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
-import { AST_NODE_TYPES, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
+import {
+  AST_NODE_TYPES,
+  formatLLMMessage,
+  MessageIcons,
+} from '@interlace/eslint-devkit';
 import { createRule } from '@interlace/eslint-devkit';
 
 type MessageIds = 'unencryptedTransmission' | 'useHttps';
@@ -21,13 +25,13 @@ type MessageIds = 'unencryptedTransmission' | 'useHttps';
 export interface Options {
   /** Allow unencrypted transmission in test files. Default: false */
   allowInTests?: boolean;
-  
+
   /** Insecure protocol patterns. Default: ['http://', 'ws://', 'ftp://', 'tcp://', 'mongodb://', 'redis://', 'mysql://'] */
   insecureProtocols?: string[];
-  
+
   /** Secure protocol alternatives mapping. Default: { 'http://': 'https://', 'ws://': 'wss://', ... } */
   secureAlternatives?: Record<string, string>;
-  
+
   /** Additional safe patterns to ignore. Default: [] */
   ignorePatterns?: string[];
 }
@@ -66,10 +70,10 @@ const SECURE_ALTERNATIVES: Record<string, string> = {
 function containsInsecureProtocol(
   value: string,
   insecureProtocols: string[],
-  secureAlternatives: Record<string, string>
+  secureAlternatives: Record<string, string>,
 ): { isInsecure: boolean; protocol: string } {
   const lowerValue = value.toLowerCase();
-  
+
   for (const protocol of insecureProtocols) {
     const lowerProtocol = protocol.toLowerCase();
     // Check if the protocol appears in the value (as a URL scheme)
@@ -87,7 +91,7 @@ function containsInsecureProtocol(
       }
     }
   }
-  
+
   return { isInsecure: false, protocol: '' };
 }
 
@@ -95,7 +99,7 @@ function containsInsecureProtocol(
  * Check if a string matches any ignore pattern
  */
 function matchesIgnorePattern(text: string, patterns: string[]): boolean {
-  return patterns.some(pattern => {
+  return patterns.some((pattern) => {
     try {
       const regex = new RegExp(pattern, 'i');
       return regex.test(text);
@@ -116,7 +120,6 @@ function matchesIgnorePattern(text: string, patterns: string[]): boolean {
  */
 const NAMESPACE_URI_PREFIXES = [
   'http://www.w3.org/',
-  'http://www.w3.org/XML/',
   'http://schemas.xmlsoap.org/',
   'http://purl.org/',
   'http://xmlns.com/',
@@ -139,6 +142,9 @@ function isNamespaceUri(value: string): boolean {
  * Interlace repo, the rule's own finding landed inside an `if` that *skips*
  * insecure URLs.
  */
+/** Of the inspection methods, these write their second argument. */
+const WRITES_SECOND_ARGUMENT = new Set(['replace', 'replaceAll']);
+
 const INSPECTION_METHODS = new Set([
   'startsWith',
   'endsWith',
@@ -161,14 +167,26 @@ const INSPECTION_METHODS = new Set([
  * operand of an equality/comparison expression (`protocol === 'http://'`). Both
  * mean the code is reasoning *about* the protocol string.
  */
-function isProtocolInspection(node: TSESTree.Node, parent: TSESTree.Node): boolean {
+function isProtocolInspection(
+  node: TSESTree.Node,
+  parent: TSESTree.Node,
+): boolean {
   if (
     parent.type === AST_NODE_TYPES.CallExpression &&
-    parent.arguments.includes(node as TSESTree.CallExpressionArgument) &&
     parent.callee.type === AST_NODE_TYPES.MemberExpression &&
     parent.callee.property.type === AST_NODE_TYPES.Identifier &&
     INSPECTION_METHODS.has(parent.callee.property.name)
   ) {
+    // No -1 guard: `parent` is the call and the callee is a MemberExpression,
+    // so a Literal reaching here is necessarily one of the arguments.
+    const index = parent.arguments.indexOf(
+      node as TSESTree.CallExpressionArgument,
+    );
+    // `replace`/`replaceAll` take a *replacement* as their second argument, and
+    // that one is content being written — `url.replace(p, 'http://evil.test')`
+    // is a genuine insecure destination. Only the search operand is inspection.
+    if (WRITES_SECOND_ARGUMENT.has(parent.callee.property.name))
+      return index === 0;
     return true;
   }
 
@@ -178,8 +196,11 @@ function isProtocolInspection(node: TSESTree.Node, parent: TSESTree.Node): boole
   );
 }
 
-/** Operators that make their operands a comparison, not a destination. */
-const COMPARISON_OPERATORS = new Set(['===', '!==', '==', '!=', '<', '>', '<=', '>=']);
+/**
+ * Equality operators only. Nobody orders protocol strings with `<` / `>`, so
+ * including them widened the exemption past what the function promises.
+ */
+const COMPARISON_OPERATORS = new Set(['===', '!==', '==', '!=']);
 
 export const noUnencryptedTransmission = createRule<RuleOptions, MessageIds>({
   name: 'no-unencrypted-transmission',
@@ -187,7 +208,8 @@ export const noUnencryptedTransmission = createRule<RuleOptions, MessageIds>({
     type: 'problem',
     docs: {
       url: 'https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-browser-security/docs/rules/no-unencrypted-transmission.md',
-      description: 'Detects unencrypted data transmission (HTTP vs HTTPS, plain text protocols)',
+      description:
+        'Detects unencrypted data transmission (HTTP vs HTTPS, plain text protocols)',
       cwe: 'CWE-319',
       cvss: 7.5,
     },
@@ -208,7 +230,8 @@ export const noUnencryptedTransmission = createRule<RuleOptions, MessageIds>({
         description: 'Use secure protocol',
         severity: 'LOW',
         fix: 'Replace http:// with https://',
-        documentationLink: 'https://developer.mozilla.org/en-US/docs/Web/Security/Transport_Layer_Security',
+        documentationLink:
+          'https://developer.mozilla.org/en-US/docs/Web/Security/Transport_Layer_Security',
       }),
     },
     schema: [
@@ -230,7 +253,8 @@ export const noUnencryptedTransmission = createRule<RuleOptions, MessageIds>({
             type: 'object',
             additionalProperties: { type: 'string' },
             default: {},
-            description: 'Mapping of insecure protocols to their secure alternatives',
+            description:
+              'Mapping of insecure protocols to their secure alternatives',
           },
           ignorePatterns: {
             type: 'array',
@@ -253,7 +277,7 @@ export const noUnencryptedTransmission = createRule<RuleOptions, MessageIds>({
   ],
   create(
     context: TSESLint.RuleContext<MessageIds, RuleOptions>,
-    [options = {}]
+    [options = {}],
   ) {
     const {
       allowInTests = false,
@@ -262,17 +286,20 @@ export const noUnencryptedTransmission = createRule<RuleOptions, MessageIds>({
       ignorePatterns = [],
     } = options as Options;
 
-    const protocolsToCheck = insecureProtocols && insecureProtocols.length > 0
-      ? insecureProtocols
-      : DEFAULT_INSECURE_PROTOCOLS;
-    
+    const protocolsToCheck =
+      insecureProtocols && insecureProtocols.length > 0
+        ? insecureProtocols
+        : DEFAULT_INSECURE_PROTOCOLS;
+
     // Merge user-provided secure alternatives with defaults
-    const secureAlternativesToUse = secureAlternatives && Object.keys(secureAlternatives).length > 0
-      ? { ...SECURE_ALTERNATIVES, ...secureAlternatives }
-      : SECURE_ALTERNATIVES;
+    const secureAlternativesToUse =
+      secureAlternatives && Object.keys(secureAlternatives).length > 0
+        ? { ...SECURE_ALTERNATIVES, ...secureAlternatives }
+        : SECURE_ALTERNATIVES;
 
     const filename = context.filename;
-    const isTestFile = allowInTests && /\.(test|spec)\.(ts|tsx|js|jsx)$/.test(filename);
+    const isTestFile =
+      allowInTests && /\.(test|spec)\.(ts|tsx|js|jsx)$/.test(filename);
     const sourceCode = context.sourceCode;
 
     function checkLiteral(node: TSESTree.Literal) {
@@ -307,12 +334,17 @@ export const noUnencryptedTransmission = createRule<RuleOptions, MessageIds>({
         // For other URLs in test files, still check them
       }
 
-      const { isInsecure, protocol } = containsInsecureProtocol(value, protocolsToCheck, secureAlternativesToUse);
-      
+      const { isInsecure, protocol } = containsInsecureProtocol(
+        value,
+        protocolsToCheck,
+        secureAlternativesToUse,
+      );
+
       if (isInsecure) {
         // NOTE: localhost URLs in test files already returned above, so no
         // second `isTestFile && localhost` check is needed here.
-        const secureProtocol = secureAlternativesToUse[protocol.toLowerCase()] || 'secure protocol';
+        const secureProtocol =
+          secureAlternativesToUse[protocol.toLowerCase()] || 'secure protocol';
         const safeAlternative = `Use ${secureProtocol} instead of ${protocol}`;
 
         context.report({
@@ -323,20 +355,26 @@ export const noUnencryptedTransmission = createRule<RuleOptions, MessageIds>({
             safeAlternative,
           },
           suggest: [
-              {
-                messageId: 'useHttps',
-                data: {
-                  protocol,
-                  secureProtocol,
-                },
-                fix(fixer: TSESLint.RuleFixer) {
-                  if (secureProtocol && secureProtocol !== 'secure protocol') {
-                    // Replace the insecure protocol with secure one
-                    const newValue = value.replace(new RegExp(protocol.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi'), secureProtocol);
-                    return fixer.replaceText(node, JSON.stringify(newValue));
-                  }
-                  return null;
-                },
+            {
+              messageId: 'useHttps',
+              data: {
+                protocol,
+                secureProtocol,
+              },
+              fix(fixer: TSESLint.RuleFixer) {
+                if (secureProtocol && secureProtocol !== 'secure protocol') {
+                  // Replace the insecure protocol with secure one
+                  const newValue = value.replace(
+                    new RegExp(
+                      protocol.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
+                      'gi',
+                    ),
+                    secureProtocol,
+                  );
+                  return fixer.replaceText(node, JSON.stringify(newValue));
+                }
+                return null;
+              },
             },
           ],
         });
@@ -349,7 +387,7 @@ export const noUnencryptedTransmission = createRule<RuleOptions, MessageIds>({
       }
 
       const text = sourceCode.getText(node);
-      
+
       // Check if it matches any ignore pattern
       if (matchesIgnorePattern(text, ignorePatterns)) {
         return;
@@ -358,10 +396,16 @@ export const noUnencryptedTransmission = createRule<RuleOptions, MessageIds>({
       // Check each quasis (static parts) and expressions
       for (const quasi of node.quasis) {
         const value = quasi.value.raw;
-        const { isInsecure, protocol } = containsInsecureProtocol(value, protocolsToCheck, secureAlternativesToUse);
-        
+        const { isInsecure, protocol } = containsInsecureProtocol(
+          value,
+          protocolsToCheck,
+          secureAlternativesToUse,
+        );
+
         if (isInsecure) {
-          const secureProtocol = secureAlternativesToUse[protocol.toLowerCase()] || 'secure protocol';
+          const secureProtocol =
+            secureAlternativesToUse[protocol.toLowerCase()] ||
+            'secure protocol';
           const safeAlternative = `Use ${secureProtocol} instead of ${protocol}`;
 
           context.report({
@@ -383,4 +427,3 @@ export const noUnencryptedTransmission = createRule<RuleOptions, MessageIds>({
     };
   },
 });
-

--- a/packages/eslint-plugin-browser-security/src/rules/no-unencrypted-transmission/index.ts
+++ b/packages/eslint-plugin-browser-security/src/rules/no-unencrypted-transmission/index.ts
@@ -177,16 +177,16 @@ function isProtocolInspection(
     parent.callee.property.type === AST_NODE_TYPES.Identifier &&
     INSPECTION_METHODS.has(parent.callee.property.name)
   ) {
-    // No -1 guard: `parent` is the call and the callee is a MemberExpression,
-    // so a Literal reaching here is necessarily one of the arguments.
-    const index = parent.arguments.indexOf(
-      node as TSESTree.CallExpressionArgument,
-    );
     // `replace`/`replaceAll` take a *replacement* as their second argument, and
     // that one is content being written — `url.replace(p, 'http://evil.test')`
     // is a genuine insecure destination. Only the search operand is inspection.
-    if (WRITES_SECOND_ARGUMENT.has(parent.callee.property.name))
-      return index === 0;
+    //
+    // Compared by identity against argument 0 rather than scanned for with
+    // indexOf: the only question is whether this literal is the first argument,
+    // and scanning made a call with many literal arguments O(n²) over the pass.
+    if (WRITES_SECOND_ARGUMENT.has(parent.callee.property.name)) {
+      return parent.arguments[0] === node;
+    }
     return true;
   }
 

--- a/packages/eslint-plugin-browser-security/src/rules/no-unencrypted-transmission/index.ts
+++ b/packages/eslint-plugin-browser-security/src/rules/no-unencrypted-transmission/index.ts
@@ -13,7 +13,7 @@
  * @see https://owasp.org/www-community/vulnerabilities/Insecure_Transport
  */
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
-import { formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
+import { AST_NODE_TYPES, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
 import { createRule } from '@interlace/eslint-devkit';
 
 type MessageIds = 'unencryptedTransmission' | 'useHttps';
@@ -104,6 +104,82 @@ function matchesIgnorePattern(text: string, patterns: string[]): boolean {
     }
   });
 }
+
+/**
+ * URIs that are *identifiers*, not network destinations.
+ *
+ * `xmlns="http://www.w3.org/2000/svg"` is the single most common `http://`
+ * string in any React codebase — every inline SVG carries one. It is never
+ * fetched: XML namespaces are opaque identifiers, and changing it to https
+ * breaks the document. Same for the XSD/XSL/DTD namespaces and the XML
+ * specification URIs.
+ */
+const NAMESPACE_URI_PREFIXES = [
+  'http://www.w3.org/',
+  'http://www.w3.org/XML/',
+  'http://schemas.xmlsoap.org/',
+  'http://purl.org/',
+  'http://xmlns.com/',
+  'http://ns.adobe.com/',
+  'http://sodipodi.sourceforge.net/',
+  'http://www.inkscape.org/',
+];
+
+/** Is this string an XML/RDF namespace identifier rather than an endpoint? */
+function isNamespaceUri(value: string): boolean {
+  return NAMESPACE_URI_PREFIXES.some((prefix) => value.startsWith(prefix));
+}
+
+/**
+ * String methods that *inspect* a value rather than transmit it.
+ *
+ * `url.startsWith('http://')` is a guard — the literal is the thing being
+ * looked for, not an endpoint being called. Reporting it flags the security
+ * check as the vulnerability, which is exactly backwards: measured on the
+ * Interlace repo, the rule's own finding landed inside an `if` that *skips*
+ * insecure URLs.
+ */
+const INSPECTION_METHODS = new Set([
+  'startsWith',
+  'endsWith',
+  'includes',
+  'indexOf',
+  'lastIndexOf',
+  'search',
+  'match',
+  'matchAll',
+  'test',
+  'split',
+  'replace',
+  'replaceAll',
+]);
+
+/**
+ * Is this literal being examined rather than used as a destination?
+ *
+ * Two shapes count: an argument to one of the inspection methods above, and an
+ * operand of an equality/comparison expression (`protocol === 'http://'`). Both
+ * mean the code is reasoning *about* the protocol string.
+ */
+function isProtocolInspection(node: TSESTree.Node, parent: TSESTree.Node): boolean {
+  if (
+    parent.type === AST_NODE_TYPES.CallExpression &&
+    parent.arguments.includes(node as TSESTree.CallExpressionArgument) &&
+    parent.callee.type === AST_NODE_TYPES.MemberExpression &&
+    parent.callee.property.type === AST_NODE_TYPES.Identifier &&
+    INSPECTION_METHODS.has(parent.callee.property.name)
+  ) {
+    return true;
+  }
+
+  return (
+    parent.type === AST_NODE_TYPES.BinaryExpression &&
+    COMPARISON_OPERATORS.has(parent.operator)
+  );
+}
+
+/** Operators that make their operands a comparison, not a destination. */
+const COMPARISON_OPERATORS = new Set(['===', '!==', '==', '!=', '<', '>', '<=', '>=']);
 
 export const noUnencryptedTransmission = createRule<RuleOptions, MessageIds>({
   name: 'no-unencrypted-transmission',
@@ -206,7 +282,17 @@ export const noUnencryptedTransmission = createRule<RuleOptions, MessageIds>({
 
       const value = node.value;
       const text = sourceCode.getText(node);
-      
+
+      // A protocol string being tested against is not a transmission.
+      if (isProtocolInspection(node, node.parent as TSESTree.Node)) {
+        return;
+      }
+
+      // Nor is an XML namespace identifier, which is never fetched.
+      if (isNamespaceUri(value)) {
+        return;
+      }
+
       // Check if it matches any ignore pattern
       if (matchesIgnorePattern(text, ignorePatterns)) {
         return;

--- a/packages/eslint-plugin-browser-security/src/rules/no-unencrypted-transmission/no-unencrypted-transmission.test.ts
+++ b/packages/eslint-plugin-browser-security/src/rules/no-unencrypted-transmission/no-unencrypted-transmission.test.ts
@@ -33,11 +33,11 @@ describe('no-unencrypted-transmission', () => {
         // rule flagged the security check itself — measured on the Interlace
         // repo, the finding landed inside an `if` that skips insecure URLs.
         `if (url.startsWith('http://')) return;`,
-      // An XML namespace is an identifier, never fetched — and every inline
-      // SVG in every React codebase carries one. Changing it to https breaks
-      // the document.
-      `const svg = <svg xmlns="http://www.w3.org/2000/svg" />;`,
-      `el.setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:xlink', v);`,
+        // An XML namespace is an identifier, never fetched — and every inline
+        // SVG in every React codebase carries one. Changing it to https breaks
+        // the document.
+        `const svg = <svg xmlns="http://www.w3.org/2000/svg" />;`,
+        `el.setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:xlink', v);`,
         `if (url.includes('ws://')) reject();`,
         `const isPlain = protocol === 'http://';`,
         `const clean = raw.replace('http://', 'https://');`,
@@ -66,7 +66,21 @@ describe('no-unencrypted-transmission', () => {
           options: [{ allowInTests: true }],
         },
       ],
-      invalid: [],
+      invalid: [
+        {
+          // The literal is the RECEIVER, not an argument — an http:// URL written
+          // into source, which is the thing this rule is for.
+          code: `const ok = 'http://legacy.example.com'.startsWith(prefix);`,
+          errors: 1,
+        },
+
+        {
+          // The replacement argument is content being written, not a search
+          // operand — an insecure destination that must still report.
+          code: `const fixed = url.replace(/^https:/, 'http://legacy.example.com');`,
+          errors: 1,
+        },
+      ],
     });
   });
 
@@ -153,147 +167,171 @@ describe('no-unencrypted-transmission', () => {
   });
 
   describe('Invalid Code - Database Connections', () => {
-    ruleTester.run('invalid - unencrypted database', noUnencryptedTransmission, {
-      valid: [],
-      invalid: [
-        {
-          code: 'const db = "mongodb://user:pass@localhost:27017";',
-          errors: [
-            {
-              messageId: 'unencryptedTransmission',
-              data: {
-                issue: 'using insecure protocol mongodb://',
-                safeAlternative: 'Use mongodb+srv:// instead of mongodb://',
-              },
-              suggestions: [
-                {
-                  messageId: 'useHttps',
-                  data: {
-                    protocol: 'mongodb://',
-                    secureProtocol: 'mongodb+srv://',
-                  },
-                  output: 'const db = "mongodb+srv://user:pass@localhost:27017";',
+    ruleTester.run(
+      'invalid - unencrypted database',
+      noUnencryptedTransmission,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: 'const db = "mongodb://user:pass@localhost:27017";',
+            errors: [
+              {
+                messageId: 'unencryptedTransmission',
+                data: {
+                  issue: 'using insecure protocol mongodb://',
+                  safeAlternative: 'Use mongodb+srv:// instead of mongodb://',
                 },
-              ],
-            },
-          ],
-        },
-        {
-          code: 'const redis = "redis://localhost:6379";',
-          errors: [
-            {
-              messageId: 'unencryptedTransmission',
-              data: {
-                issue: 'using insecure protocol redis://',
-                safeAlternative: 'Use rediss:// instead of redis://',
-              },
-              suggestions: [
-                {
-                  messageId: 'useHttps',
-                  data: {
-                    protocol: 'redis://',
-                    secureProtocol: 'rediss://',
+                suggestions: [
+                  {
+                    messageId: 'useHttps',
+                    data: {
+                      protocol: 'mongodb://',
+                      secureProtocol: 'mongodb+srv://',
+                    },
+                    output:
+                      'const db = "mongodb+srv://user:pass@localhost:27017";',
                   },
-                  output: 'const redis = "rediss://localhost:6379";',
+                ],
+              },
+            ],
+          },
+          {
+            code: 'const redis = "redis://localhost:6379";',
+            errors: [
+              {
+                messageId: 'unencryptedTransmission',
+                data: {
+                  issue: 'using insecure protocol redis://',
+                  safeAlternative: 'Use rediss:// instead of redis://',
                 },
-              ],
-            },
-          ],
-        },
-      ],
-    });
+                suggestions: [
+                  {
+                    messageId: 'useHttps',
+                    data: {
+                      protocol: 'redis://',
+                      secureProtocol: 'rediss://',
+                    },
+                    output: 'const redis = "rediss://localhost:6379";',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    );
   });
 
   describe('Invalid Code - Template Literals', () => {
-    ruleTester.run('invalid - insecure protocol in template', noUnencryptedTransmission, {
-      valid: [],
-      invalid: [
-        {
-          code: 'const url = `http://${host}/api`;',
-          errors: [
-            {
-              messageId: 'unencryptedTransmission',
-              data: {
-                issue: 'using insecure protocol http:// in template literal',
-                safeAlternative: 'Use https:// instead of http://',
+    ruleTester.run(
+      'invalid - insecure protocol in template',
+      noUnencryptedTransmission,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: 'const url = `http://${host}/api`;',
+            errors: [
+              {
+                messageId: 'unencryptedTransmission',
+                data: {
+                  issue: 'using insecure protocol http:// in template literal',
+                  safeAlternative: 'Use https:// instead of http://',
+                },
+                suggestions: undefined,
               },
-              suggestions: undefined,
-            },
-          ],
-        },
-      ],
-    });
+            ],
+          },
+        ],
+      },
+    );
   });
 
   describe('Options Coverage', () => {
-    ruleTester.run('options - allowInTests still blocks non-localhost', noUnencryptedTransmission, {
-      valid: [],
-      invalid: [
-        {
-          code: 'const url = "http://staging.example.com";',
-          filename: 'example.spec.ts',
-          options: [{ allowInTests: true }],
-          errors: [
-            {
-              messageId: 'unencryptedTransmission',
-              suggestions: [
-                {
-                  messageId: 'useHttps',
-                  output: 'const url = "https://staging.example.com";',
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    });
+    ruleTester.run(
+      'options - allowInTests still blocks non-localhost',
+      noUnencryptedTransmission,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: 'const url = "http://staging.example.com";',
+            filename: 'example.spec.ts',
+            options: [{ allowInTests: true }],
+            errors: [
+              {
+                messageId: 'unencryptedTransmission',
+                suggestions: [
+                  {
+                    messageId: 'useHttps',
+                    output: 'const url = "https://staging.example.com";',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    );
 
-    ruleTester.run('options - ignorePatterns skip insecure literal', noUnencryptedTransmission, {
-      valid: [
-        {
-          code: 'const url = "http://internal.example.com";',
-          options: [{ ignorePatterns: ['internal'] }],
-        },
-      ],
-      invalid: [],
-    });
+    ruleTester.run(
+      'options - ignorePatterns skip insecure literal',
+      noUnencryptedTransmission,
+      {
+        valid: [
+          {
+            code: 'const url = "http://internal.example.com";',
+            options: [{ ignorePatterns: ['internal'] }],
+          },
+        ],
+        invalid: [],
+      },
+    );
 
-    ruleTester.run('options - custom insecure protocols', noUnencryptedTransmission, {
-      valid: [],
-      invalid: [
-        {
-          code: 'const smtp = "smtp://mail.example.com";',
-          options: [
-            {
-              insecureProtocols: ['smtp://'],
-              secureAlternatives: { 'smtp://': 'smtps://' },
-            },
-          ],
-          errors: [
-            {
-              messageId: 'unencryptedTransmission',
-              suggestions: [
-                {
-                  messageId: 'useHttps',
-                  output: 'const smtp = "smtps://mail.example.com";',
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    });
+    ruleTester.run(
+      'options - custom insecure protocols',
+      noUnencryptedTransmission,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: 'const smtp = "smtp://mail.example.com";',
+            options: [
+              {
+                insecureProtocols: ['smtp://'],
+                secureAlternatives: { 'smtp://': 'smtps://' },
+              },
+            ],
+            errors: [
+              {
+                messageId: 'unencryptedTransmission',
+                suggestions: [
+                  {
+                    messageId: 'useHttps',
+                    output: 'const smtp = "smtps://mail.example.com";',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    );
 
-    ruleTester.run('options - template literal in test file skipped', noUnencryptedTransmission, {
-      valid: [
-        {
-          code: 'const url = `http://${host}/api`;',
-          filename: 'transport.test.ts',
-          options: [{ allowInTests: true }],
-        },
-      ],
-      invalid: [],
-    });
+    ruleTester.run(
+      'options - template literal in test file skipped',
+      noUnencryptedTransmission,
+      {
+        valid: [
+          {
+            code: 'const url = `http://${host}/api`;',
+            filename: 'transport.test.ts',
+            options: [{ allowInTests: true }],
+          },
+        ],
+        invalid: [],
+      },
+    );
   });
 });
-

--- a/packages/eslint-plugin-browser-security/src/rules/no-unencrypted-transmission/no-unencrypted-transmission.test.ts
+++ b/packages/eslint-plugin-browser-security/src/rules/no-unencrypted-transmission/no-unencrypted-transmission.test.ts
@@ -29,6 +29,18 @@ describe('no-unencrypted-transmission', () => {
   describe('Valid Code', () => {
     ruleTester.run('valid - secure protocols', noUnencryptedTransmission, {
       valid: [
+        // A protocol string being TESTED is not a transmission. Ungated, this
+        // rule flagged the security check itself — measured on the Interlace
+        // repo, the finding landed inside an `if` that skips insecure URLs.
+        `if (url.startsWith('http://')) return;`,
+      // An XML namespace is an identifier, never fetched — and every inline
+      // SVG in every React codebase carries one. Changing it to https breaks
+      // the document.
+      `const svg = <svg xmlns="http://www.w3.org/2000/svg" />;`,
+      `el.setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:xlink', v);`,
+        `if (url.includes('ws://')) reject();`,
+        `const isPlain = protocol === 'http://';`,
+        `const clean = raw.replace('http://', 'https://');`,
         // HTTPS
         {
           code: 'const url = "https://api.example.com";',


### PR DESCRIPTION
## Two false-positive classes, both measured

`no-unencrypted-transmission` reported **every** string literal containing `http://`, regardless of what the code did with it.

### 1. The security check reported as the vulnerability

The rule's own finding landed on this line, inside an `if` that *skips* insecure URLs:

```js
// Skip external links, anchors, and absolute paths
if (url.startsWith('http://') || url.startsWith('https://') || …)
```

A protocol string passed to `startsWith` / `includes` / `replace` / `match`, or compared with `===`, is the thing being **looked for** — not an endpoint being called.

### 2. XML namespaces

```jsx
<svg xmlns="http://www.w3.org/2000/svg" />
```

The most common `http://` string in any React codebase — every inline SVG carries one. It is never fetched: namespaces are opaque identifiers, and rewriting one to `https` **breaks the document**. Also covers the XSD/XSL/RDF and Inkscape/Adobe namespaces.

## Test plan

- [x] Both classes locked as `valid` cases — **verified by reverting each guard** and watching the rule report again.
- [x] True positives unaffected: `fetch('http://api…')`, `new WebSocket('ws://…')`, connection strings.
- [x] 953 tests, 100% coverage held, typecheck clean.
- [x] Sweep over the monorepo, counting only non-test non-self code: **5 → 4**. The four remaining are *other rules' own `http://` constant lists* — detector source that necessarily contains the pattern it detects.

## Implementation note

`isProtocolInspection` takes the parent as a parameter rather than checking `node.parent` for `undefined` internally. ESLint always sets it, so that guard would have been unreachable code and coverage would have dropped below 100 — the same reordering discipline as #415.

## Scope

This is the second fix from the whole-ruleset dogfood sweep (after #415, MongoDB on `Array.prototype.find`). Two confirmed FPs remain queued: `node-security/no-timing-unsafe-compare` firing on `if (firstKey !== undefined)`, and `secure-coding/no-xxe-injection` firing on `JSON.parse(fs.readFileSync(…))`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved insecure-transmission detection to ignore protocol strings used for inspection, comparisons, replacements, and XML namespaces.
  * Continued reporting actual unencrypted transmission endpoints, including insecure replacement destinations.
  * Expanded handling for database URLs, templates, custom protocols, ignored patterns, and test-file options.

* **Documentation**
  * Updated plugin version information and generated statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->