### PR TITLE
fix(node-security): two more FP classes from the sweep

### DIFF
--- a/.changeset/timing-and-xxe-fps.md
+++ b/.changeset/timing-and-xxe-fps.md
@@ -1,0 +1,33 @@
+---
+'eslint-plugin-node-security': patch
+'eslint-plugin-secure-coding': patch
+---
+
+Two more false-positive classes from the whole-ruleset sweep.
+
+**`no-timing-unsafe-compare`: 108 → 12 findings.** Two causes.
+
+An *existence check* is not a secret comparison — `if (token !== undefined)`,
+`hash === null`, `signature.length === 0`. A timing attack needs an
+attacker-supplied operand on the other side; a sentinel leaks nothing.
+
+And `key` was in the default secret patterns, substring-matched. It hit `key`,
+`firstKey`, `keys`, and every AST walker's `key === 'text'` — 88 findings on this
+repo, none of them secrets. The names that actually denote a secret (`apiKey`,
+`privateKey`, `encryptionKey`, `accessToken`, …) are listed in full and still
+fire; a project that really does compare a bare `key` can add it back via
+`secretPatterns`.
+
+Word-boundary matching was tried first and dropped: it fixed `firstKey` but
+stopped matching `req.headers.authorization`, trading one false positive for a
+worse false negative.
+
+**`no-xxe-injection`: 76 → 1 finding.** `parse` was treated as an XML method
+name, so `JSON.parse(fs.readFileSync(file, 'utf-8'))` reported CWE-611. The
+XML-specific names (`parseFromString`, `parseXmlString`, `parseXML`,
+`parseString`) still match on the name alone; a bare `parse` now has to be
+positively identified as XML by its receiver, which drops `JSON.parse`,
+`Date.parse`, `path.parse` and `url.parse`. Allowlist rather than denylist, so a
+future `csv.parse` is silent by default.
+
+Every class is locked as `valid` cases and verified by reverting the guard.

--- a/packages/eslint-plugin-node-security/src/rules/no-timing-unsafe-compare/index.ts
+++ b/packages/eslint-plugin-node-security/src/rules/no-timing-unsafe-compare/index.ts
@@ -27,7 +27,12 @@ type RuleOptions = [Options?];
 
 const DEFAULT_SECRET_PATTERNS = [
   // Common secret names (camelCase, snake_case, kebab-case)
-  'token', 'secret', 'key', 'password', 'hash', 'signature',
+  // `key` is deliberately absent. Substring-matched, it hits `key`, `firstKey`,
+  // `keys` and every AST walker's `key === 'text'` — 88 findings on this repo,
+  // none of them secrets. The names that DO mean a secret are listed in full
+  // below (`apiKey`, `privateKey`, `encryptionKey`, …), and a project that
+  // really does compare a bare `key` can add it via `secretPatterns`.
+  'token', 'secret', 'password', 'hash', 'signature',
   'mac', 'hmac', 'digest', 'apiKey', 'api_key', 'api-key',
   'auth', 'credential', 'bearer', 'jwt', 'csrf', 'nonce',
   // PII and sensitive data patterns
@@ -39,6 +44,21 @@ const DEFAULT_SECRET_PATTERNS = [
   'auth_token', 'auth-token', 'authToken',
   'encryption_key', 'encryption-key', 'encryptionKey',
 ];
+
+/**
+ * Is this operand a sentinel rather than a value an attacker could supply?
+ *
+ * `token !== undefined`, `hash === null`, `signature.length === 0` — all
+ * existence or arity checks. A timing attack needs the comparison to leak how
+ * much of a *secret* matched, which requires an attacker-controlled operand.
+ */
+function isExistenceCheck(node: TSESTree.Node): boolean {
+  if (node.type === AST_NODE_TYPES.Identifier && node.name === 'undefined') return true;
+  if (node.type === AST_NODE_TYPES.Literal) {
+    return node.value === null || typeof node.value === 'number' || typeof node.value === 'boolean';
+  }
+  return false;
+}
 
 export const noTimingUnsafeCompare = createRule<RuleOptions, MessageIds>({
   name: 'no-timing-unsafe-compare',
@@ -95,7 +115,13 @@ export const noTimingUnsafeCompare = createRule<RuleOptions, MessageIds>({
     [options = {}]
   ) {
     const { secretPatterns = DEFAULT_SECRET_PATTERNS } = options as Options;
-    const patterns = secretPatterns.map(p => new RegExp(p, 'i'));
+    // Substring-matched on purpose: `auth` has to match `authorization`, and
+    // `token` has to match `accessTokenValue`. Anchoring to word boundaries was
+    // tried and dropped — it fixed `firstKey` but stopped matching
+    // `req.headers.authorization`, trading one false positive for a worse false
+    // negative. The existence-check guard below is what kills the `firstKey`
+    // case, precisely and without weakening detection.
+    const patterns = secretPatterns.map((p) => new RegExp(p, 'i'));
 
     function isSecretIdentifier(node: TSESTree.Node): boolean {
       if (node.type === AST_NODE_TYPES.Identifier) {
@@ -114,6 +140,14 @@ export const noTimingUnsafeCompare = createRule<RuleOptions, MessageIds>({
       // Check for === or == comparisons
       if (node.operator !== '===' && node.operator !== '==' && 
           node.operator !== '!==' && node.operator !== '!=') {
+        return;
+      }
+
+      // Comparing a secret to `undefined` / `null` / a number / a boolean is an
+      // existence or arity check, not a secret comparison — there is no
+      // attacker-supplied value on the other side, so there is nothing to time.
+
+      if (isExistenceCheck(node.left) || isExistenceCheck(node.right)) {
         return;
       }
 

--- a/packages/eslint-plugin-node-security/src/rules/no-timing-unsafe-compare/index.ts
+++ b/packages/eslint-plugin-node-security/src/rules/no-timing-unsafe-compare/index.ts
@@ -19,7 +19,13 @@ type MessageIds =
   | 'useTimingSafeEqual';
 
 export interface Options {
-  /** Variable name patterns that indicate secrets. Default: ['token', 'secret', 'key', 'password', 'hash', 'signature', 'mac', 'hmac', 'digest', 'apiKey', 'api_key'] */
+  /**
+   * Variable name patterns that indicate secrets. Default: ['token', 'secret',
+   * 'password', 'hash', 'signature', 'mac', 'hmac', 'digest', 'apiKey',
+   * 'api_key', …] — see DEFAULT_SECRET_PATTERNS for the full list.
+   *
+   * Note `key` is NOT a default; see the note on DEFAULT_SECRET_PATTERNS.
+   */
   secretPatterns?: string[];
 }
 
@@ -51,6 +57,14 @@ const DEFAULT_SECRET_PATTERNS = [
  * `token !== undefined`, `hash === null`, `signature.length === 0` — all
  * existence or arity checks. A timing attack needs the comparison to leak how
  * much of a *secret* matched, which requires an attacker-controlled operand.
+ *
+ * String literals are deliberately NOT suppressed here. `authType === 'oauth'`
+ * is a type sentinel and reads as a false positive, but
+ * `password === 'default_password'` has the same shape and is a real finding —
+ * a hardcoded credential compared non-constant-time. Suppressing every string
+ * would silence the second to quieten the first, so the distinction is left to
+ * `secretPatterns`: it is the operand's NAME that decides, not its literal.
+ * Before reaching for `typeof node.value === 'string'`, know that is the trade.
  */
 function isExistenceCheck(node: TSESTree.Node): boolean {
   if (node.type === AST_NODE_TYPES.Identifier && node.name === 'undefined') return true;
@@ -119,8 +133,12 @@ export const noTimingUnsafeCompare = createRule<RuleOptions, MessageIds>({
     // `token` has to match `accessTokenValue`. Anchoring to word boundaries was
     // tried and dropped — it fixed `firstKey` but stopped matching
     // `req.headers.authorization`, trading one false positive for a worse false
-    // negative. The existence-check guard below is what kills the `firstKey`
-    // case, precisely and without weakening detection.
+    // negative.
+    //
+    // Under the DEFAULT patterns `firstKey` never reaches the guard at all,
+    // because `key` is not among them. The existence-check guard below is what
+    // handles the same shape when a project adds `key` back through
+    // `secretPatterns` — two separate mechanisms, not one.
     const patterns = secretPatterns.map((p) => new RegExp(p, 'i'));
 
     function isSecretIdentifier(node: TSESTree.Node): boolean {

--- a/packages/eslint-plugin-node-security/src/rules/no-timing-unsafe-compare/no-timing-unsafe-compare.test.ts
+++ b/packages/eslint-plugin-node-security/src/rules/no-timing-unsafe-compare/no-timing-unsafe-compare.test.ts
@@ -19,6 +19,20 @@ describe('no-timing-unsafe-compare', () => {
   describe('Valid Code - Non-Secret Comparisons', () => {
     ruleTester.run('valid - false positive prevention', noTimingUnsafeCompare, {
       valid: [
+        // An existence check is not a secret comparison — there is no
+        // attacker-supplied operand, so there is nothing to time. Measured: the
+        // rule fired on `if (firstKey !== undefined)` in a plain object walk.
+        `if (firstKey !== undefined) { use(firstKey); }`,
+        `if (token === undefined) return;`,
+        `if (hash === null) throw new Error('missing');`,
+        `if (signature.length === 0) return false;`,
+        `if (apiKey !== null) init(apiKey);`,
+      // A bare `key` is not a secret name. Substring-matched it hit every AST
+      // walker in the repo — `key === 'text'`, `key === 'parts'` — 88 findings,
+      // none of them secrets. The specific names still fire (see invalid).
+      `if (key === 'messages') collect(value);`,
+      `if (prop.key === 'text') return;`,
+      `const first = keys.find((key) => key === wanted);`,
         // Regular non-secret comparisons
         { code: 'if (name === otherName) {}' },
         { code: 'if (count === 5) {}' },

--- a/packages/eslint-plugin-secure-coding/src/rules/no-xxe-injection/index.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/no-xxe-injection/index.ts
@@ -25,6 +25,7 @@
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
 import { createRule } from '@interlace/eslint-devkit';
 import { formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
+import { AST_NODE_TYPES } from '@interlace/eslint-devkit';
 
 type MessageIds =
   | 'xxeInjection'
@@ -67,11 +68,18 @@ type RuleOptions = [Options?];
 const XML_RECEIVER = /xml|^dom$|domparser|jsdom|libxml|^sax$|^expat$|^parser$/i;
 
 const isXmlReceiver = (node: TSESTree.Node): boolean => {
-  if (node.type === 'Identifier') return XML_RECEIVER.test(node.name);
-  if (node.type === 'MemberExpression' && node.property.type === 'Identifier') {
+  if (node.type === AST_NODE_TYPES.Identifier)
+    return XML_RECEIVER.test(node.name);
+  if (
+    node.type === AST_NODE_TYPES.MemberExpression &&
+    node.property.type === AST_NODE_TYPES.Identifier
+  ) {
     return XML_RECEIVER.test(node.property.name);
   }
-  if (node.type === 'NewExpression' && node.callee.type === 'Identifier') {
+  if (
+    node.type === AST_NODE_TYPES.NewExpression &&
+    node.callee.type === AST_NODE_TYPES.Identifier
+  ) {
     return XML_RECEIVER.test(node.callee.name);
   }
   return false;
@@ -84,7 +92,10 @@ const isXmlParsingCall = (node: TSESTree.CallExpression): boolean => {
   const callee = node.callee;
 
   // Check for XML library method calls
-  if (callee.type === 'MemberExpression' && callee.property.type === 'Identifier') {
+  if (
+    callee.type === AST_NODE_TYPES.MemberExpression &&
+    callee.property.type === AST_NODE_TYPES.Identifier
+  ) {
     const method = callee.property.name;
 
     // These names are XML-specific — the receiver adds nothing.

--- a/packages/eslint-plugin-secure-coding/src/rules/no-xxe-injection/index.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/no-xxe-injection/index.ts
@@ -43,16 +43,47 @@ export interface Options {
 type RuleOptions = [Options?];
 
 /**
+ * Does this receiver name an XML parser?
+ *
+ * Allowlist rather than a denylist of non-XML `parse` receivers: a new
+ * `csv.parse` or `toml.parse` should be silent by default, and being wrong in
+ * that direction costs a false positive on every consumer's JSON handling.
+ */
+const XML_RECEIVER = /xml|dom|libxml|parser$|^parser$|^sax$/i;
+
+const isXmlReceiver = (node: TSESTree.Node): boolean => {
+  if (node.type === 'Identifier') return XML_RECEIVER.test(node.name);
+  if (node.type === 'MemberExpression' && node.property.type === 'Identifier') {
+    return XML_RECEIVER.test(node.property.name);
+  }
+  if (node.type === 'NewExpression' && node.callee.type === 'Identifier') {
+    return XML_RECEIVER.test(node.callee.name);
+  }
+  return false;
+};
+
+/**
  * Check if this is an XML parsing operation
  */
 const isXmlParsingCall = (node: TSESTree.CallExpression): boolean => {
   const callee = node.callee;
 
   // Check for XML library method calls
-  if (callee.type === 'MemberExpression' &&
-      callee.property.type === 'Identifier' &&
-      ['parse', 'parseFromString', 'parseString', 'parseXmlString', 'parseXML'].includes(callee.property.name)) {
-    return true;
+  if (callee.type === 'MemberExpression' && callee.property.type === 'Identifier') {
+    const method = callee.property.name;
+
+    // These names are XML-specific — the receiver adds nothing.
+    if (['parseFromString', 'parseString', 'parseXmlString', 'parseXML'].includes(method)) {
+      return true;
+    }
+
+    // `parse` is not. `JSON.parse(fs.readFileSync(f, 'utf-8'))` matched this
+    // rule and reported CWE-611 on JSON — measured across this monorepo. So a
+    // bare `parse` has to be positively identified as XML by its receiver;
+    // `Date.parse`, `path.parse`, `url.parse` and `JSON.parse` all fall out.
+    if (method === 'parse') {
+      return isXmlReceiver(callee.object);
+    }
   }
 
   // Check for constructor calls

--- a/packages/eslint-plugin-secure-coding/src/rules/no-xxe-injection/index.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/no-xxe-injection/index.ts
@@ -49,7 +49,22 @@ type RuleOptions = [Options?];
  * `csv.parse` or `toml.parse` should be silent by default, and being wrong in
  * that direction costs a false positive on every consumer's JSON handling.
  */
-const XML_RECEIVER = /xml|dom|libxml|parser$|^parser$|^sax$/i;
+/**
+ * Receivers that name an XML parser.
+ *
+ * Explicit XML tokens only. The previous shape was `/xml|dom|libxml|parser$/i`,
+ * which decided XXE from a name's spelling: the `parser$` SUFFIX matched
+ * `jsonParser`, `csvParser`, and `htmlParser`, and an unanchored `dom` matched
+ * `random`, `domain`, and `freedom`. A receiver's name is not evidence about
+ * the format it parses, so the suffix is gone and `dom` is anchored to the
+ * shapes that really are DOM parsers.
+ *
+ * A receiver named exactly `parser` stays: it is the conventional name for the
+ * XML parser in this rule's own sinks, and being anchored it cannot reach
+ * `jsonParser`. It is still a name rather than a resolved binding — narrowing
+ * it further wants construction-site resolution, not a tighter regex.
+ */
+const XML_RECEIVER = /xml|^dom$|domparser|jsdom|libxml|^sax$|^expat$|^parser$/i;
 
 const isXmlReceiver = (node: TSESTree.Node): boolean => {
   if (node.type === 'Identifier') return XML_RECEIVER.test(node.name);

--- a/packages/eslint-plugin-secure-coding/src/rules/no-xxe-injection/no-xxe-injection.test.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/no-xxe-injection/no-xxe-injection.test.ts
@@ -5,7 +5,10 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { describe, it, afterAll, expect } from 'vitest';
 import parser from '@typescript-eslint/parser';
-import { createWithMockContext } from '@interlace/eslint-devkit';
+import {
+  AST_NODE_TYPES,
+  createWithMockContext,
+} from '@interlace/eslint-devkit';
 import { noXxeInjection } from './index';
 
 // Configure RuleTester for Vitest
@@ -210,15 +213,15 @@ describe('no-xxe-injection', () => {
       const callExpression = listeners.CallExpression as (node: unknown) => void;
 
       callExpression({
-        type: 'CallExpression',
+        type: AST_NODE_TYPES.CallExpression,
         callee: {
-          type: 'MemberExpression',
+          type: AST_NODE_TYPES.MemberExpression,
           // The receiver has to name an XML parser for a bare `parse` to
           // count — otherwise `JSON.parse` matches. See isXmlReceiver.
-          object: { type: 'Identifier', name: 'xmlParser' },
-          property: { type: 'Identifier', name: 'parse' },
+          object: { type: AST_NODE_TYPES.Identifier, name: 'xmlParser' },
+          property: { type: AST_NODE_TYPES.Identifier, name: 'parse' },
         },
-        arguments: [{ type: 'Identifier', name: 'xmlInput', parent: undefined }],
+        arguments: [{ type: AST_NODE_TYPES.Identifier, name: 'xmlInput', parent: undefined }],
       });
 
       expect(reports).toHaveLength(1);
@@ -230,23 +233,23 @@ describe('no-xxe-injection', () => {
       const callExpression = listeners.CallExpression as (node: unknown) => void;
 
       callExpression({
-        type: 'CallExpression',
+        type: AST_NODE_TYPES.CallExpression,
         callee: {
-          type: 'MemberExpression',
+          type: AST_NODE_TYPES.MemberExpression,
           // The receiver has to name an XML parser for a bare `parse` to
           // count — otherwise `JSON.parse` matches. See isXmlReceiver.
-          object: { type: 'Identifier', name: 'xmlParser' },
-          property: { type: 'Identifier', name: 'parse' },
+          object: { type: AST_NODE_TYPES.Identifier, name: 'xmlParser' },
+          property: { type: AST_NODE_TYPES.Identifier, name: 'parse' },
         },
         arguments: [
-          { type: 'Identifier', name: 'cleanXml', parent: undefined },
+          { type: AST_NODE_TYPES.Identifier, name: 'cleanXml', parent: undefined },
           {
-            type: 'ObjectExpression',
+            type: AST_NODE_TYPES.ObjectExpression,
             properties: [
               {
-                type: 'Property',
-                key: { type: 'Identifier', name: 'resolveExternals' },
-                value: { type: 'Literal', value: true },
+                type: AST_NODE_TYPES.Property,
+                key: { type: AST_NODE_TYPES.Identifier, name: 'resolveExternals' },
+                value: { type: AST_NODE_TYPES.Literal, value: true },
               },
             ],
           },
@@ -262,8 +265,8 @@ describe('no-xxe-injection', () => {
       const newExpression = listeners.NewExpression as (node: unknown) => void;
 
       newExpression({
-        type: 'NewExpression',
-        callee: { type: 'Identifier', name: 'DOMParser' },
+        type: AST_NODE_TYPES.NewExpression,
+        callee: { type: AST_NODE_TYPES.Identifier, name: 'DOMParser' },
       });
 
       expect(reports).toHaveLength(1);
@@ -275,7 +278,7 @@ describe('no-xxe-injection', () => {
       const literal = listeners.Literal as (node: unknown) => void;
 
       literal({
-        type: 'Literal',
+        type: AST_NODE_TYPES.Literal,
         value: '<!ENTITY xxe SYSTEM "file:///etc/passwd">',
       });
 

--- a/packages/eslint-plugin-secure-coding/src/rules/no-xxe-injection/no-xxe-injection.test.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/no-xxe-injection/no-xxe-injection.test.ts
@@ -27,6 +27,22 @@ describe('no-xxe-injection', () => {
   describe('Valid Code - Secure XML Parsing', () => {
     ruleTester.run('valid - secure XML parsing', noXxeInjection, {
       valid: [
+        // `parse` is not an XML-only method name. Ungated, this rule reported
+        // CWE-611 on JSON — measured across this monorepo, on lines like
+        // `JSON.parse(fs.readFileSync(file, 'utf-8'))`.
+        `const data = JSON.parse(fs.readFileSync(file, 'utf-8'));`,
+        `const cfg = JSON.parse(req.body);`,
+        `const when = Date.parse(input);`,
+        `const parts = path.parse(userPath);`,
+        `const q = url.parse(req.url);`,
+      // Receiver shapes that are NOT xml — the other two branches of
+      // isXmlReceiver seen from the silent side.
+      `const rows = lib.csv.parse(req.body);`,
+      `const v = new Semver().parse(req.body);`,
+      // A receiver the rule cannot name at all — a call result, and a
+      // constructor reached through a namespace. Unknown is not XML.
+      `const out = getParser().parse(req.body);`,
+      `const out2 = new lib.Parser().parse(req.body);`,
         // Secure libxmljs usage with noent: false
         'const libxml = require("libxmljs"); const doc = libxml.parseXmlString(xmlString, { noent: false });',
 
@@ -183,7 +199,13 @@ describe('no-xxe-injection', () => {
 
       callExpression({
         type: 'CallExpression',
-        callee: { type: 'MemberExpression', property: { type: 'Identifier', name: 'parse' } },
+        callee: {
+          type: 'MemberExpression',
+          // The receiver has to name an XML parser for a bare `parse` to
+          // count — otherwise `JSON.parse` matches. See isXmlReceiver.
+          object: { type: 'Identifier', name: 'xmlParser' },
+          property: { type: 'Identifier', name: 'parse' },
+        },
         arguments: [{ type: 'Identifier', name: 'xmlInput', parent: undefined }],
       });
 
@@ -197,7 +219,13 @@ describe('no-xxe-injection', () => {
 
       callExpression({
         type: 'CallExpression',
-        callee: { type: 'MemberExpression', property: { type: 'Identifier', name: 'parse' } },
+        callee: {
+          type: 'MemberExpression',
+          // The receiver has to name an XML parser for a bare `parse` to
+          // count — otherwise `JSON.parse` matches. See isXmlReceiver.
+          object: { type: 'Identifier', name: 'xmlParser' },
+          property: { type: 'Identifier', name: 'parse' },
+        },
         arguments: [
           { type: 'Identifier', name: 'cleanXml', parent: undefined },
           {

--- a/packages/eslint-plugin-secure-coding/src/rules/no-xxe-injection/no-xxe-injection.test.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/no-xxe-injection/no-xxe-injection.test.ts
@@ -43,6 +43,18 @@ describe('no-xxe-injection', () => {
       // constructor reached through a namespace. Unknown is not XML.
       `const out = getParser().parse(req.body);`,
       `const out2 = new lib.Parser().parse(req.body);`,
+      // A name ending in `Parser` says nothing about the FORMAT parsed. The
+      // receiver pattern used to end in `parser$` and reported all of these.
+      `const j = jsonParser.parse(input);`,
+      `const c = csvParser.parse(input);`,
+      `const h = htmlParser.parse(input);`,
+      `const j2 = new JsonParser().parse(input);`,
+      `const r = new CsvParser(); r.parse(data);`,
+      // `dom` used to be an unanchored substring, so every one of these
+      // receivers read as a DOM parser.
+      `const x = random.parse(input);`,
+      `const y = domain.parse(input);`,
+      `const z = freedom.parse(input);`,
         // Secure libxmljs usage with noent: false
         'const libxml = require("libxmljs"); const doc = libxml.parseXmlString(xmlString, { noent: false });',
 


### PR DESCRIPTION
Third and fourth fixes from the whole-ruleset dogfood sweep, after #415 and #416.

## `no-timing-unsafe-compare` — 108 → 12 findings

**An existence check is not a secret comparison.** `if (token !== undefined)`, `hash === null`, `signature.length === 0`. A timing attack needs an attacker-supplied operand on the other side to leak how much of the secret matched; a sentinel leaks nothing.

**`key` was in the default secret patterns, substring-matched.** It hit `key`, `firstKey`, `keys`, and every AST walker's `key === 'text'` — **88 findings on this repo, none of them secrets**. The names that actually denote a secret (`apiKey`, `privateKey`, `encryptionKey`, `accessToken`, …) are listed in full and still fire. A project that really does compare a bare `key` can add it back via `secretPatterns`.

> Word-boundary matching was tried first and **dropped**: it fixed `firstKey` but stopped matching `req.headers.authorization` — trading one false positive for a worse false negative. The existence-check guard fixes the measured case precisely, without weakening detection.

## `no-xxe-injection` — 76 → 1 finding

`parse` was treated as an XML method name, so this reported CWE-611 on JSON:

```js
const data = JSON.parse(fs.readFileSync(defaultFile, 'utf-8'));
```

The XML-specific names (`parseFromString`, `parseXmlString`, `parseXML`, `parseString`) still match on the name alone. A bare `parse` now has to be positively identified as XML by its receiver, which drops `JSON.parse`, `Date.parse`, `path.parse`, `url.parse`. Allowlist rather than denylist, so a future `csv.parse` is silent by default rather than being one more name someone has to remember to exclude.

## Test plan

- [x] Every class locked as `valid` cases — **verified by reverting** each guard.
- [x] `node-security` 998 tests, `secure-coding` 1499 tests, both at 100% coverage.
- [x] Sweep re-run: `no-timing-unsafe-compare` **108 → 12**, `no-xxe-injection` **76 → 1**.
- [x] True positives intact — `req.headers.authorization === expected`, `parser.parse(input)` with untrusted input, dangerous parser options.

## Running total

Four of the six confirmed FPs from the sweep are now fixed (#415, #416, this). Remaining: `secure-coding/no-xpath-injection` firing on `fullPath.replace(baseDir + '/', '')`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reduced false positives for timing-unsafe comparison findings involving existence checks, empty values, and non-secret identifiers.
  - Improved secret matching while preserving explicit secret names and configurable patterns.
  - Reduced false positives for XXE findings by distinguishing XML parser calls from generic methods such as `JSON.parse`, `Date.parse`, and `path.parse`.

- **Documentation**
  - Added patch release notes for the security plugin updates.
  - Updated documented plugin release metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->