### PR TITLE
fix(nestjs-security): require-guards sees in-handler credential comparison

### DIFF
--- a/.changeset/require-guards-in-handler-secret.md
+++ b/.changeset/require-guards-in-handler-secret.md
@@ -1,0 +1,23 @@
+---
+'eslint-plugin-nestjs-security': patch
+---
+
+`require-guards` recognises an in-handler check against a configured secret
+
+The sibling of the existing `@Headers('…secret')` webhook exemption, one step
+further in: some handlers take the credential as a query or route parameter and
+compare it against the environment themselves.
+
+```ts
+if (this.configService.get<string>('FEATURE_TOKEN') !== token) {
+  return false;
+}
+```
+
+That is amplication's `user.controller.ts:19`, reported as an unguarded route
+while it authenticates on its first statement.
+
+Only equality against a secret *source* — `process.env.X` or a `.get()` on a
+config object — clears a route. Comparing already-trusted data
+(`req.user.role !== 'admin'`) is authorization, not authentication, and still
+reports; so does reading config without comparing it.

--- a/packages/eslint-plugin-nestjs-security/src/rules/require-guards/index.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/require-guards/index.ts
@@ -680,6 +680,80 @@ export const requireGuards = createRule<RuleOptions, MessageIds>({
       );
     }
 
+    /**
+     * Whether the handler compares something against a configured secret.
+     *
+     * The sibling of `verifiesCredentialHeader`, one step further in: instead of
+     * declaring the credential as a `@Headers()` parameter, these handlers take
+     * it as a query or route parameter and check it against the environment
+     * themselves.
+     *
+     *     if (this.configService.get<string>('FEATURE_TOKEN') !== token) {
+     *       this.logger.error('InvalidToken, process aborted');
+     *       return false;
+     *     }
+     *
+     * That is amplication's `user.controller.ts:19`, reported as an unguarded
+     * route while it authenticates on its first statement. A secret read from
+     * `process.env` or a config service, on either side of an equality
+     * comparison, is not a value an unauthenticated caller can supply.
+     *
+     * Narrow on purpose. Only equality against a *secret source* counts —
+     * `if (user.role === 'admin')` is authorization on already-trusted data and
+     * says nothing about whether the caller was authenticated. Requiring the
+     * comparison, rather than a bare `process.env` read, keeps a handler that
+     * merely logs `process.env.NODE_ENV` from silencing the rule.
+     */
+    function comparesAgainstConfiguredSecret(
+      node: TSESTree.MethodDefinition,
+    ): boolean {
+      // Non-null here for the same reason as elsewhere in this file: TypeScript
+      // forbids decorators on an overload or abstract signature, so a body-less
+      // method is never a route handler.
+      const body = node.value.body as TSESTree.BlockStatement;
+
+      /** `process.env.X` or a `.get(...)` call on a config-ish receiver. */
+      const isSecretSource = (expr: TSESTree.Node): boolean => {
+        if (expr.type === AST_NODE_TYPES.MemberExpression) {
+          return expressionName(expr.object) === 'env';
+        }
+        if (expr.type !== AST_NODE_TYPES.CallExpression) return false;
+        if (expressionName(expr.callee) !== 'get') return false;
+        if (expr.callee.type !== AST_NODE_TYPES.MemberExpression) return false;
+        // The receiver is usually `this.configService`, a member expression
+        // rather than a bare identifier, so match on its property name.
+        return /config/i.test(expressionName(expr.callee.object));
+      };
+
+      let found = false;
+      const visit = (current: TSESTree.Node): void => {
+        if (found) return;
+        if (
+          current.type === AST_NODE_TYPES.BinaryExpression &&
+          ['===', '!==', '==', '!='].includes(current.operator) &&
+          (isSecretSource(current.left) || isSecretSource(current.right))
+        ) {
+          found = true;
+          return;
+        }
+        for (const key of Object.keys(current) as (keyof TSESTree.Node)[]) {
+          if (key === 'parent') continue;
+          const value = current[key] as unknown;
+          if (Array.isArray(value)) {
+            for (const child of value) {
+              if (child && typeof child === 'object' && 'type' in child) {
+                visit(child as TSESTree.Node);
+              }
+            }
+          } else if (value && typeof value === 'object' && 'type' in value) {
+            visit(value as TSESTree.Node);
+          }
+        }
+      };
+      visit(body);
+      return found;
+    }
+
     function registerClass(node: ClassNode): void {
       if (node.id?.name) {
         classesByName.set(node.id.name, node);
@@ -698,6 +772,7 @@ export const requireGuards = createRule<RuleOptions, MessageIds>({
         if (hasPublicDecorator(cls.decorators)) return;
         if (middlewareProtected(node, cls)) return;
         if (verifiesCredentialHeader(node)) return;
+        if (comparesAgainstConfiguredSecret(node)) return;
 
         pending.push({ node, cls, name: memberName(node) ?? '<anonymous>' });
       },

--- a/packages/eslint-plugin-nestjs-security/src/rules/require-guards/require-guards.test.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/require-guards/require-guards.test.ts
@@ -123,6 +123,34 @@ ruleTester.run('require-guards', requireGuards, {
         async updateStatus(@Headers('stigg-webhooks-secret') secret, @Body() dto) {}
       }
     `,
+    // amplication/.../user.controller.ts:19 — the same authentication, one step
+    // further in: the credential arrives as a route parameter and the handler
+    // checks it against config itself. Reported as unguarded while it
+    // authenticates on its first statement.
+    `
+      @Controller('user')
+      class UserController {
+        @Post(':token/announcement')
+        async announce(@Param('token') token: string) {
+          if (this.configService.get<string>('FEATURE_TOKEN') !== token) {
+            this.logger.error('InvalidToken, process aborted');
+            return false;
+          }
+          return this.userService.announce();
+        }
+      }
+    `,
+    // The same shape read straight from the environment.
+    `
+      @Controller('cron')
+      class CronController {
+        @Post('run')
+        async run(@Query('key') key: string) {
+          if (key !== process.env.CRON_SECRET) throw new UnauthorizedException();
+          return this.jobs.run();
+        }
+      }
+    `,
     `
       @Controller('hooks')
       class HooksController {
@@ -415,6 +443,58 @@ ruleTester.run('require-guards', requireGuards, {
     },
   ],
   invalid: [
+    // The configured-secret exemption is bounded on both sides. Comparing
+    // already-trusted data is authorization, not authentication — it says
+    // nothing about whether the caller proved who they are.
+    {
+      code: `
+        @Controller('admin')
+        class AdminController {
+          @Get('users')
+          list(@Req() req) {
+            if (req.user.role !== 'admin') throw new ForbiddenException();
+            return this.users.findAll();
+          }
+        }
+      `,
+      errors: [{ messageId: 'missingGuards' }],
+    },
+    // Only a *secret source* clears a route. Comparing against an ordinary
+    // call, a bare function named `get`, or a `.get()` whose receiver is not a
+    // config object leaves all three of these reported.
+    {
+      code: `
+        @Controller('admin')
+        class AdminController {
+          @Get('a')
+          a(@Query('x') x) { if (this.compute(x) !== 'y') throw new Error(); return 1; }
+          @Get('b')
+          b(@Query('x') x) { if (get(x) !== 'y') throw new Error(); return 1; }
+          @Get('c')
+          c(@Query('x') x) { if (this.get('K') !== x) throw new Error(); return 1; }
+        }
+      `,
+      errors: [
+        { messageId: 'missingGuards' },
+        { messageId: 'missingGuards' },
+        { messageId: 'missingGuards' },
+      ],
+    },
+    // Reading config without comparing it is not an authentication check —
+    // otherwise any handler that logs process.env.NODE_ENV would go quiet.
+    {
+      code: `
+        @Controller('admin')
+        class AdminController {
+          @Get('users')
+          list() {
+            this.logger.debug(process.env.NODE_ENV);
+            return this.users.findAll();
+          }
+        }
+      `,
+      errors: [{ messageId: 'missingGuards' }],
+    },
     // Each narrowing above is bounded. A public term in the middle of a name
     // is a resource listing, not an entry point.
     {


### PR DESCRIPTION
## Summary

Stacked on #410 (same rule). Third of the fixes coming out of the 128-finding
sweep across eight NestJS codebases — see #419 for the other two.

`require-guards` already exempts the webhook shape that declares its credential
as `@Headers('…secret')`. Some handlers take it as a query or route parameter
and check it against config themselves:

```ts
if (this.configService.get<string>('FEATURE_TOKEN') !== token) {
  this.logger.error('InvalidToken, process aborted');
  return false;
}
```

That is amplication's `user.controller.ts:19` — reported as an unguarded route
while it authenticates on its first statement.

## Bounded on both sides

Only equality against a *secret source* clears a route: `process.env.X`, or a
`.get()` whose receiver names a config object. Locked as still-reporting:

- `req.user.role !== 'admin'` — authorization on already-trusted data, which
  says nothing about whether the caller was authenticated
- `this.logger.debug(process.env.NODE_ENV)` — reading config without comparing
  it, or any handler that logs an env var would go quiet
- `this.compute(x) !== y`, `get(x) !== y`, `this.get('K') !== x` — a call that
  is not a config read

## Not fixed here

Amplication's OIDC callback (`auth.controller.ts:138`) still reports. Its path
is an imported constant — `@Get(AUTH_AFTER_CALLBACK_PATH)` — and `'callback'` is
already in the default public-route list, but the rule cannot read a
non-literal. Abstaining on a path we cannot resolve would silence on *absent*
evidence, the self-suppression failure this plugin avoids elsewhere. A real fix
needs cross-file constant resolution.

## Test plan

- [x] `vitest run --coverage` — **707 passed**, 100% statements / branches /
      lines (repo threshold).
- [x] Re-scanned the corpus with the built plugin: `require-guards` **13 → 12**
      across twenty/novu/ghostfolio/amplication, `user.controller.ts:19` gone,
      no other rule moved.

## After merge

Retarget to `main` once #410 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)