### PR TITLE
fix(secure-coding): require real XPath syntax before claiming XPath

### DIFF
--- a/.changeset/xpath-syntax-gate.md
+++ b/.changeset/xpath-syntax-gate.md
@@ -1,0 +1,31 @@
+---
+'eslint-plugin-secure-coding': patch
+---
+
+`no-xpath-injection` no longer treats every path join as XPath construction.
+
+The heuristic for "does this string concatenation look like XPath" was
+`includes('/') || includes('[')`, which matches every path join, URL build and
+array index in existence. Measured on the Interlace monorepo, it reported
+CWE-643 on:
+
+```js
+return fullPath.replace(baseDir + '/', '');
+```
+
+XPath has syntax of its own, so the gate now requires some of it: the descendant
+axis (`//`), an attribute predicate (`[@id=`), an explicit axis (`child::`), the
+node tests and functions (`text()`, `node()`, `contains(`, `starts-with(`,
+`local-name(`, `position()`), or a location step carrying a predicate (`/user[`)
+— the form that has no `//`.
+
+Verified in both directions: path joins, URL builds and array-index strings go
+silent, while `"//user[name='" + input + "']"`, `"/root[@id='" + input + "']"`
+and `"/root/user[" + input + "]"` all still report.
+
+Known limitation, unchanged and now documented in the source: the
+variable-declaration path still matches on the name `path`, so
+`let path = template;` reports. Dropping that keyword was tried and reverted —
+it also stopped `let searchPath = userInput;` firing, and by name alone the two
+are indistinguishable. Separating them needs the declaration's use to reach an
+XPath sink, which is the data-flow analysis these rules avoid.

--- a/packages/eslint-plugin-secure-coding/src/rules/no-xpath-injection/index.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/no-xpath-injection/index.ts
@@ -56,6 +56,18 @@ export interface Options extends SecurityRuleOptions {
 
 type RuleOptions = [Options?];
 
+/**
+ * Syntax that only appears in an XPath expression.
+ *
+ * A lone `/` is a path separator in every language; these are not. Covered:
+ * the descendant axis (`//`), an attribute predicate (`[@id=`), any explicit
+ * axis (`child::`), the XPath node tests and functions (`text()`, `node()`,
+ * `contains(`, `starts-with(`, `local-name(`, `position()`), and a location
+ * step carrying a predicate (`/user[`), which is the form that has no `//`.
+ */
+const XPATH_SYNTAX =
+  /\/\/|\[@|::|\btext\(\)|\bnode\(\)|\bcontains\(|\bstarts-with\(|\blocal-name\(|\bposition\(\)|\/[A-Za-z_*][\w.-]*\[/;
+
 export const noXpathInjection = createRule<RuleOptions, MessageIds>({
   name: 'no-xpath-injection',
   meta: {
@@ -515,8 +527,13 @@ export const noXpathInjection = createRule<RuleOptions, MessageIds>({
 
         const fullText = sourceCode.getText(node);
 
-        // Check if this looks like XPath construction
-        if (!fullText.includes('/') && !fullText.includes('[')) {
+        // Check if this looks like XPath construction.
+        //
+        // `includes('/') || includes('[')` was the old test, and it matched
+        // every path join, URL build and array index in existence —
+        // `fullPath.replace(baseDir + '/', '')` reported CWE-643, measured on
+        // this monorepo. XPath has syntax of its own; require some of it.
+        if (!XPATH_SYNTAX.test(fullText)) {
           return;
         }
 
@@ -559,6 +576,14 @@ export const noXpathInjection = createRule<RuleOptions, MessageIds>({
         }
 
         const varNameLower = varName.toLowerCase();
+        // `path` is kept, reluctantly. It names a filesystem path far more
+        // often than an XPath expression, and it is why `let path = template;`
+        // still reports here. But dropping it also stopped
+        // `let searchPath = userInput;` firing — by name alone the two are
+        // indistinguishable, so removing it trades a false positive for a
+        // false negative. Separating them needs the declaration's *use* to
+        // reach an XPath sink, which is the data-flow analysis these rules
+        // avoid; the concatenation path above is where the real gate lives.
         if (!varNameLower.includes('xpath') && !varNameLower.includes('query') && !varNameLower.includes('path')) {
           return;
         }

--- a/packages/eslint-plugin-secure-coding/src/rules/no-xpath-injection/index.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/no-xpath-injection/index.ts
@@ -57,6 +57,23 @@ export interface Options extends SecurityRuleOptions {
 type RuleOptions = [Options?];
 
 /**
+ * The string content a concatenation contributes, taken from the AST.
+ *
+ * Only `Literal` strings and the static quasis of a template literal — an
+ * identifier contributes nothing knowable, and its *name* is not content.
+ */
+function literalTextOf(node: TSESTree.Node): string {
+  if (node.type === 'Literal')
+    return typeof node.value === 'string' ? node.value : '';
+  if (node.type === 'TemplateLiteral')
+    return node.quasis.map((q) => q.value.raw).join(' ');
+  if (node.type === 'BinaryExpression' && node.operator === '+') {
+    return `${literalTextOf(node.left)} ${literalTextOf(node.right)}`;
+  }
+  return '';
+}
+
+/**
  * Syntax that only appears in an XPath expression.
  *
  * A lone `/` is a path separator in every language; these are not. Covered:
@@ -95,7 +112,8 @@ export const noXpathInjection = createRule<RuleOptions, MessageIds>({
         description: 'Unsafe string concatenation in XPath expression',
         severity: 'HIGH',
         fix: 'Use parameterized XPath or escape user input',
-        documentationLink: 'https://owasp.org/www-community/attacks/XPATH_Injection',
+        documentationLink:
+          'https://owasp.org/www-community/attacks/XPATH_Injection',
       }),
       unvalidatedXpathInput: formatLLMMessage({
         icon: MessageIcons.SECURITY,
@@ -104,7 +122,8 @@ export const noXpathInjection = createRule<RuleOptions, MessageIds>({
         description: 'XPath query uses unvalidated user input',
         severity: 'MEDIUM',
         fix: 'Validate and sanitize XPath input before use',
-        documentationLink: 'https://owasp.org/www-community/attacks/XPATH_Injection',
+        documentationLink:
+          'https://owasp.org/www-community/attacks/XPATH_Injection',
       }),
       dangerousXpathExpression: formatLLMMessage({
         icon: MessageIcons.SECURITY,
@@ -121,7 +140,8 @@ export const noXpathInjection = createRule<RuleOptions, MessageIds>({
         description: 'Use parameterized XPath queries',
         severity: 'LOW',
         fix: 'Construct XPath with proper escaping and validation',
-        documentationLink: 'https://owasp.org/www-community/attacks/XPATH_Injection',
+        documentationLink:
+          'https://owasp.org/www-community/attacks/XPATH_Injection',
       }),
       escapeXpathInput: formatLLMMessage({
         icon: MessageIcons.INFO,
@@ -137,7 +157,8 @@ export const noXpathInjection = createRule<RuleOptions, MessageIds>({
         description: 'Validate XPath queries against allowed patterns',
         severity: 'LOW',
         fix: 'Whitelist allowed XPath operations and validate syntax',
-        documentationLink: 'https://owasp.org/www-community/attacks/XPATH_Injection',
+        documentationLink:
+          'https://owasp.org/www-community/attacks/XPATH_Injection',
       }),
       strategyParameterizedQueries: formatLLMMessage({
         icon: MessageIcons.STRATEGY,
@@ -145,7 +166,8 @@ export const noXpathInjection = createRule<RuleOptions, MessageIds>({
         description: 'Use parameterized XPath construction',
         severity: 'LOW',
         fix: 'Build XPath queries programmatically with escaped parameters',
-        documentationLink: 'https://owasp.org/www-community/attacks/XPATH_Injection',
+        documentationLink:
+          'https://owasp.org/www-community/attacks/XPATH_Injection',
       }),
       strategyInputValidation: formatLLMMessage({
         icon: MessageIcons.STRATEGY,
@@ -162,7 +184,7 @@ export const noXpathInjection = createRule<RuleOptions, MessageIds>({
         severity: 'LOW',
         fix: 'Use libraries that provide safe XPath building',
         documentationLink: 'https://www.npmjs.com/package/xpath-builder',
-      })
+      }),
     },
     schema: [
       {
@@ -171,29 +193,46 @@ export const noXpathInjection = createRule<RuleOptions, MessageIds>({
           xpathFunctions: {
             type: 'array',
             items: { type: 'string' },
-            default: ['evaluate', 'selectSingleNode', 'selectNodes', 'xpath', 'select'], description: 'XPath evaluation methods treated as query sinks'
+            default: [
+              'evaluate',
+              'selectSingleNode',
+              'selectNodes',
+              'xpath',
+              'select',
+            ],
+            description: 'XPath evaluation methods treated as query sinks',
           },
           safeXpathConstructors: {
             type: 'array',
             items: { type: 'string' },
-            default: ['buildXPath', 'createXPath', 'safeXPath', 'xpathBuilder'], description: 'Builders that produce a parameterized XPath expression'
+            default: ['buildXPath', 'createXPath', 'safeXPath', 'xpathBuilder'],
+            description:
+              'Builders that produce a parameterized XPath expression',
           },
           xpathValidationFunctions: {
             type: 'array',
             items: { type: 'string' },
-            default: ['validateXPath', 'escapeXPath', 'sanitizeXPath', 'cleanXPath'], description: 'Function names that escape or validate XPath input'
+            default: [
+              'validateXPath',
+              'escapeXPath',
+              'sanitizeXPath',
+              'cleanXPath',
+            ],
+            description: 'Function names that escape or validate XPath input',
           },
           trustedSanitizers: {
             type: 'array',
             items: { type: 'string' },
             default: [],
-            description: 'Additional function names to consider as XPath sanitizers',
+            description:
+              'Additional function names to consider as XPath sanitizers',
           },
           trustedAnnotations: {
             type: 'array',
             items: { type: 'string' },
             default: [],
-            description: 'Additional JSDoc annotations to consider as safe markers',
+            description:
+              'Additional JSDoc annotations to consider as safe markers',
           },
           strictMode: {
             type: 'boolean',
@@ -207,9 +246,25 @@ export const noXpathInjection = createRule<RuleOptions, MessageIds>({
   },
   defaultOptions: [
     {
-      xpathFunctions: ['evaluate', 'selectSingleNode', 'selectNodes', 'xpath', 'select'],
-      safeXpathConstructors: ['buildXPath', 'createXPath', 'safeXPath', 'xpathBuilder'],
-      xpathValidationFunctions: ['validateXPath', 'escapeXPath', 'sanitizeXPath', 'cleanXPath'],
+      xpathFunctions: [
+        'evaluate',
+        'selectSingleNode',
+        'selectNodes',
+        'xpath',
+        'select',
+      ],
+      safeXpathConstructors: [
+        'buildXPath',
+        'createXPath',
+        'safeXPath',
+        'xpathBuilder',
+      ],
+      xpathValidationFunctions: [
+        'validateXPath',
+        'escapeXPath',
+        'sanitizeXPath',
+        'cleanXPath',
+      ],
       trustedSanitizers: [],
       trustedAnnotations: ['@xpath-safe'],
       strictMode: false,
@@ -218,8 +273,19 @@ export const noXpathInjection = createRule<RuleOptions, MessageIds>({
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>) {
     const options = context.options[0] || {};
     const {
-      xpathFunctions = ['evaluate', 'selectSingleNode', 'selectNodes', 'xpath', 'select'],
-      xpathValidationFunctions = ['validateXPath', 'escapeXPath', 'sanitizeXPath', 'cleanXPath'],
+      xpathFunctions = [
+        'evaluate',
+        'selectSingleNode',
+        'selectNodes',
+        'xpath',
+        'select',
+      ],
+      xpathValidationFunctions = [
+        'validateXPath',
+        'escapeXPath',
+        'sanitizeXPath',
+        'cleanXPath',
+      ],
       trustedSanitizers = [],
       trustedAnnotations = [],
       strictMode = false,
@@ -246,14 +312,19 @@ export const noXpathInjection = createRule<RuleOptions, MessageIds>({
       const callee = node.callee;
 
       // Check for XPath method calls
-      if (callee.type === 'MemberExpression' &&
-          callee.property.type === 'Identifier' &&
-          xpathFunctions.includes(callee.property.name)) {
+      if (
+        callee.type === 'MemberExpression' &&
+        callee.property.type === 'Identifier' &&
+        xpathFunctions.includes(callee.property.name)
+      ) {
         return true;
       }
 
       // Check for XPath library calls
-      if (callee.type === 'Identifier' && xpathFunctions.includes(callee.name)) {
+      if (
+        callee.type === 'Identifier' &&
+        xpathFunctions.includes(callee.name)
+      ) {
         return true;
       }
 
@@ -267,16 +338,16 @@ export const noXpathInjection = createRule<RuleOptions, MessageIds>({
     const containsDangerousXpath = (xpathText: string): boolean => {
       // Dangerous XPath patterns that allow traversal or injection
       const dangerousPatterns = [
-        /\.\./,  // Parent directory traversal
-        /\/\*/,  // All children selector
-        /\[.*\*\]/,  // Wildcard in predicates
-        /\/\//,  // Descendant-or-self axis (can be dangerous in some contexts)
-        /text\(\)/,  // Content extraction
-        /comment\(\)/,  // Comment extraction
-        /processing-instruction\(\)/,  // Processing instruction extraction
+        /\.\./, // Parent directory traversal
+        /\/\*/, // All children selector
+        /\[.*\*\]/, // Wildcard in predicates
+        /\/\//, // Descendant-or-self axis (can be dangerous in some contexts)
+        /text\(\)/, // Content extraction
+        /comment\(\)/, // Comment extraction
+        /processing-instruction\(\)/, // Processing instruction extraction
       ];
 
-      return dangerousPatterns.some(pattern => pattern.test(xpathText));
+      return dangerousPatterns.some((pattern) => pattern.test(xpathText));
     };
 
     /**
@@ -284,7 +355,11 @@ export const noXpathInjection = createRule<RuleOptions, MessageIds>({
      */
     // oxlint-disable-next-line consistent-function-scoping
     const containsXpathInterpolation = (text: string): boolean => {
-      return /\$\{[^}]+\}/.test(text) || /'[^']*\+[^+]*'/.test(text) || /"[^"]*\+[^+]*"/.test(text);
+      return (
+        /\$\{[^}]+\}/.test(text) ||
+        /'[^']*\+[^+]*'/.test(text) ||
+        /"[^"]*\+[^+]*"/.test(text)
+      );
     };
 
     /**
@@ -293,16 +368,23 @@ export const noXpathInjection = createRule<RuleOptions, MessageIds>({
     const isUntrustedXpathInput = (inputNode: TSESTree.Node): boolean => {
       if (inputNode.type === 'MemberExpression') {
         // Check patterns like req.query.*, req.body.*, req.params.*
-        if (inputNode.object.type === 'MemberExpression' &&
-            inputNode.object.object.type === 'Identifier' &&
-            inputNode.object.object.name === 'req' &&
-            inputNode.object.property.type === 'Identifier' &&
-            ['query', 'body', 'params', 'param'].includes(inputNode.object.property.name)) {
+        if (
+          inputNode.object.type === 'MemberExpression' &&
+          inputNode.object.object.type === 'Identifier' &&
+          inputNode.object.object.name === 'req' &&
+          inputNode.object.property.type === 'Identifier' &&
+          ['query', 'body', 'params', 'param'].includes(
+            inputNode.object.property.name,
+          )
+        ) {
           return true;
         }
 
         // Check patterns like req.*
-        if (inputNode.object.type === 'Identifier' && inputNode.object.name === 'req') {
+        if (
+          inputNode.object.type === 'Identifier' &&
+          inputNode.object.name === 'req'
+        ) {
           return true;
         }
       }
@@ -312,19 +394,26 @@ export const noXpathInjection = createRule<RuleOptions, MessageIds>({
       }
 
       const varName = inputNode.name.toLowerCase();
-      if (['req', 'request', 'query', 'params', 'input', 'user', 'search'].some(keyword =>
-        varName.includes(keyword)
-      )) {
+      if (
+        ['req', 'request', 'query', 'params', 'input', 'user', 'search'].some(
+          (keyword) => varName.includes(keyword),
+        )
+      ) {
         return true;
       }
 
       // Check if it comes from function parameters
       let current: TSESTree.Node | undefined = inputNode;
       while (current) {
-        if (current.type === 'FunctionDeclaration' || 
-            current.type === 'FunctionExpression' || 
-            current.type === 'ArrowFunctionExpression') {
-          const func = current as TSESTree.FunctionDeclaration | TSESTree.FunctionExpression | TSESTree.ArrowFunctionExpression;
+        if (
+          current.type === 'FunctionDeclaration' ||
+          current.type === 'FunctionExpression' ||
+          current.type === 'ArrowFunctionExpression'
+        ) {
+          const func = current as
+            | TSESTree.FunctionDeclaration
+            | TSESTree.FunctionExpression
+            | TSESTree.ArrowFunctionExpression;
           return func.params.some((param: TSESTree.Parameter): boolean => {
             if (param.type === 'Identifier') {
               return param.name === inputNode.name;
@@ -345,9 +434,11 @@ export const noXpathInjection = createRule<RuleOptions, MessageIds>({
       let current: TSESTree.Node | undefined = inputNode;
 
       while (current) {
-        if (current.type === 'CallExpression' &&
-            current.callee.type === 'Identifier' &&
-            xpathValidationFunctions.includes(current.callee.name)) {
+        if (
+          current.type === 'CallExpression' &&
+          current.callee.type === 'Identifier' &&
+          xpathValidationFunctions.includes(current.callee.name)
+        ) {
           return true;
         }
         current = current.parent as TSESTree.Node;
@@ -364,13 +455,18 @@ export const noXpathInjection = createRule<RuleOptions, MessageIds>({
 
       // Walk up to find VariableDeclaration, ExpressionStatement, FunctionDeclaration, or containing statement
       while (current) {
-        if (current.type === 'VariableDeclaration' ||
-            current.type === 'ExpressionStatement' ||
-            current.type === 'FunctionDeclaration') {
+        if (
+          current.type === 'VariableDeclaration' ||
+          current.type === 'ExpressionStatement' ||
+          current.type === 'FunctionDeclaration'
+        ) {
           // Check for JSDoc comments before this statement
           const comments = sourceCode.getCommentsBefore(current);
           for (const comment of comments) {
-            if (comment.type === 'Block' && comment.value.includes('@xpath-safe')) {
+            if (
+              comment.type === 'Block' &&
+              comment.value.includes('@xpath-safe')
+            ) {
               return true;
             }
           }
@@ -402,7 +498,10 @@ export const noXpathInjection = createRule<RuleOptions, MessageIds>({
           // Check for dangerous XPath patterns
           if (containsDangerousXpath(xpathText)) {
             // FALSE POSITIVE REDUCTION: Skip if annotated as safe
-            if (hasSafeAnnotation(xpathArg, context, trustedAnnotations) || hasSafeAnnotationOnStatement(node)) {
+            if (
+              hasSafeAnnotation(xpathArg, context, trustedAnnotations) ||
+              hasSafeAnnotationOnStatement(node)
+            ) {
               return;
             }
 
@@ -417,10 +516,20 @@ export const noXpathInjection = createRule<RuleOptions, MessageIds>({
           }
         } else if (xpathArg.type === 'Identifier') {
           // Check if XPath comes from untrusted input
-          if (isUntrustedXpathInput(xpathArg) && !isXpathInputValidated(xpathArg) && 
-              !(xpathArg.type === 'Identifier' && validatedVariables.has(xpathArg.name))) {
+          if (
+            isUntrustedXpathInput(xpathArg) &&
+            !isXpathInputValidated(xpathArg) &&
+            !(
+              xpathArg.type === 'Identifier' &&
+              validatedVariables.has(xpathArg.name)
+            )
+          ) {
             // FALSE POSITIVE REDUCTION
-            if (hasSafeAnnotation(xpathArg, context, trustedAnnotations) || safetyChecker.isSafe(xpathArg, context) || hasSafeAnnotationOnStatement(node)) {
+            if (
+              hasSafeAnnotation(xpathArg, context, trustedAnnotations) ||
+              safetyChecker.isSafe(xpathArg, context) ||
+              hasSafeAnnotationOnStatement(node)
+            ) {
               return;
             }
 
@@ -446,11 +555,19 @@ export const noXpathInjection = createRule<RuleOptions, MessageIds>({
           return;
         }
         // File paths (start with / or contain common path patterns)
-        if (/^[`'"]\s*\/home\//.test(fullText) || /^[`'"]\s*\/usr\//.test(fullText) || /^[`'"]\s*\/tmp\//.test(fullText)) {
+        if (
+          /^[`'"]\s*\/home\//.test(fullText) ||
+          /^[`'"]\s*\/usr\//.test(fullText) ||
+          /^[`'"]\s*\/tmp\//.test(fullText)
+        ) {
           return;
         }
-        // CSS selectors  
-        if (/\[data-[\w-]+/.test(fullText) || /\[class=/.test(fullText) || /\[id=/.test(fullText)) {
+        // CSS selectors
+        if (
+          /\[data-[\w-]+/.test(fullText) ||
+          /\[class=/.test(fullText) ||
+          /\[id=/.test(fullText)
+        ) {
           return;
         }
         // Search/query strings
@@ -460,12 +577,13 @@ export const noXpathInjection = createRule<RuleOptions, MessageIds>({
 
         // Check if this looks like an ACTUAL XPath expression
         // Must have XPath-specific syntax, not just forward slashes
-        const hasXpathSyntax = /\/\/\w+/.test(fullText) ||  // //element
-                              /\[@\w+/.test(fullText) ||   // [@attr
-                              /\[contains\(/.test(fullText) || // [contains(
-                              /\[text\(\)/.test(fullText) ||   // [text()
-                              /\/child::/.test(fullText) ||    // /child::
-                              /\/descendant::/.test(fullText); // /descendant::
+        const hasXpathSyntax =
+          /\/\/\w+/.test(fullText) || // //element
+          /\[@\w+/.test(fullText) || // [@attr
+          /\[contains\(/.test(fullText) || // [contains(
+          /\[text\(\)/.test(fullText) || // [text()
+          /\/child::/.test(fullText) || // /child::
+          /\/descendant::/.test(fullText); // /descendant::
 
         if (!hasXpathSyntax) {
           return;
@@ -474,8 +592,13 @@ export const noXpathInjection = createRule<RuleOptions, MessageIds>({
         // Check for interpolation in XPath-like expressions
         if (containsXpathInterpolation(fullText)) {
           // Check if any interpolated values are untrusted
-          const hasUntrustedInterpolation = node.expressions.some((expr: TSESTree.Expression) =>
-            isUntrustedXpathInput(expr) && !isXpathInputValidated(expr) && !(expr.type === 'Identifier' && validatedVariables.has(expr.name))
+          const hasUntrustedInterpolation = node.expressions.some(
+            (expr: TSESTree.Expression) =>
+              isUntrustedXpathInput(expr) &&
+              !isXpathInputValidated(expr) &&
+              !(
+                expr.type === 'Identifier' && validatedVariables.has(expr.name)
+              ),
           );
 
           if (hasUntrustedInterpolation) {
@@ -494,7 +617,7 @@ export const noXpathInjection = createRule<RuleOptions, MessageIds>({
               suggest: [
                 {
                   messageId: 'useParameterizedXpath',
-                  fix: () => null
+                  fix: () => null,
                 },
               ],
             });
@@ -525,25 +648,41 @@ export const noXpathInjection = createRule<RuleOptions, MessageIds>({
           return;
         }
 
-        const fullText = sourceCode.getText(node);
-
         // Check if this looks like XPath construction.
         //
-        // `includes('/') || includes('[')` was the old test, and it matched
-        // every path join, URL build and array index in existence —
-        // `fullPath.replace(baseDir + '/', '')` reported CWE-643, measured on
-        // this monorepo. XPath has syntax of its own; require some of it.
-        if (!XPATH_SYNTAX.test(fullText)) {
+        // Read from the AST, never from printed source. `includes('/')` was the
+        // old test and matched every path join — `fullPath.replace(baseDir +
+        // '/', '')` reported CWE-643. Regexing `sourceCode.getText(node)`
+        // instead is no better: printed text carries identifiers and comments,
+        // so `render.text() + input` and a `/* //user[@id] */` comment both
+        // matched. Only the string literals actually being concatenated say
+        // anything about the string being built.
+        if (!XPATH_SYNTAX.test(literalTextOf(node))) {
           return;
         }
 
         // Check if untrusted input is involved
-        const leftUntrusted = isUntrustedXpathInput(node.left) && !isXpathInputValidated(node.left) && !(node.left.type === 'Identifier' && validatedVariables.has(node.left.name));
-        const rightUntrusted = isUntrustedXpathInput(node.right) && !isXpathInputValidated(node.right) && !(node.right.type === 'Identifier' && validatedVariables.has(node.right.name));
+        const leftUntrusted =
+          isUntrustedXpathInput(node.left) &&
+          !isXpathInputValidated(node.left) &&
+          !(
+            node.left.type === 'Identifier' &&
+            validatedVariables.has(node.left.name)
+          );
+        const rightUntrusted =
+          isUntrustedXpathInput(node.right) &&
+          !isXpathInputValidated(node.right) &&
+          !(
+            node.right.type === 'Identifier' &&
+            validatedVariables.has(node.right.name)
+          );
 
         if (leftUntrusted || rightUntrusted) {
           // FALSE POSITIVE REDUCTION
-          if (safetyChecker.isSafe(node, context) || hasSafeAnnotationOnStatement(node)) {
+          if (
+            safetyChecker.isSafe(node, context) ||
+            hasSafeAnnotationOnStatement(node)
+          ) {
             return;
           }
 
@@ -554,7 +693,8 @@ export const noXpathInjection = createRule<RuleOptions, MessageIds>({
               filePath: filename,
               line: String(node.loc?.start.line ?? 0),
               severity: 'HIGH',
-              safeAlternative: 'Use parameterized XPath construction with input validation',
+              safeAlternative:
+                'Use parameterized XPath construction with input validation',
             },
           });
         }
@@ -567,11 +707,14 @@ export const noXpathInjection = createRule<RuleOptions, MessageIds>({
         }
 
         const varName = node.id.name;
-        
+
         // Track variables that are assigned the result of sanitization functions
-        if (node.init.type === 'CallExpression' &&
-            node.init.callee.type === 'Identifier' &&
-            (xpathValidationFunctions.includes(node.init.callee.name) || trustedSanitizers.includes(node.init.callee.name))) {
+        if (
+          node.init.type === 'CallExpression' &&
+          node.init.callee.type === 'Identifier' &&
+          (xpathValidationFunctions.includes(node.init.callee.name) ||
+            trustedSanitizers.includes(node.init.callee.name))
+        ) {
           validatedVariables.add(varName);
         }
 
@@ -584,15 +727,25 @@ export const noXpathInjection = createRule<RuleOptions, MessageIds>({
         // false negative. Separating them needs the declaration's *use* to
         // reach an XPath sink, which is the data-flow analysis these rules
         // avoid; the concatenation path above is where the real gate lives.
-        if (!varNameLower.includes('xpath') && !varNameLower.includes('query') && !varNameLower.includes('path')) {
+        if (
+          !varNameLower.includes('xpath') &&
+          !varNameLower.includes('query') &&
+          !varNameLower.includes('path')
+        ) {
           return;
         }
 
         // Check if assigned value contains dangerous XPath
-        if (node.init.type === 'Literal' && typeof node.init.value === 'string') {
+        if (
+          node.init.type === 'Literal' &&
+          typeof node.init.value === 'string'
+        ) {
           if (containsDangerousXpath(node.init.value)) {
             // FALSE POSITIVE REDUCTION
-            if (safetyChecker.isSafe(node.init, context) || hasSafeAnnotationOnStatement(node)) {
+            if (
+              safetyChecker.isSafe(node.init, context) ||
+              hasSafeAnnotationOnStatement(node)
+            ) {
               return;
             }
 
@@ -617,7 +770,7 @@ export const noXpathInjection = createRule<RuleOptions, MessageIds>({
             },
           });
         }
-      }
+      },
     };
   },
 });

--- a/packages/eslint-plugin-secure-coding/src/rules/no-xpath-injection/index.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/no-xpath-injection/index.ts
@@ -351,18 +351,6 @@ export const noXpathInjection = createRule<RuleOptions, MessageIds>({
     };
 
     /**
-     * Check if string contains XPath interpolation
-     */
-    // oxlint-disable-next-line consistent-function-scoping
-    const containsXpathInterpolation = (text: string): boolean => {
-      return (
-        /\$\{[^}]+\}/.test(text) ||
-        /'[^']*\+[^+]*'/.test(text) ||
-        /"[^"]*\+[^+]*"/.test(text)
-      );
-    };
-
-    /**
      * Check if XPath input is from untrusted source
      */
     const isUntrustedXpathInput = (inputNode: TSESTree.Node): boolean => {
@@ -547,50 +535,49 @@ export const noXpathInjection = createRule<RuleOptions, MessageIds>({
 
       // Check template literals for XPath expressions
       TemplateLiteral(node: TSESTree.TemplateLiteral) {
-        const fullText = sourceCode.getText(node);
+        // The static text the template contributes, not its printed source.
+        // `sourceCode.getText(node)` includes the interpolated expressions, so
+        // a variable *named* `descendantOrSelf` — or a `//` inside an
+        // interpolation — decided an XPath verdict. Names are not content.
+        const staticText = literalTextOf(node);
 
         // Skip common non-XPath patterns
-        // URLs and API endpoints
-        if (/https?:\/\//.test(fullText) || /^[`'"]\s*\/api\//.test(fullText)) {
+        // URLs and API endpoints — `https://` carries the `//` that would
+        // otherwise read as the descendant axis.
+        if (/https?:\/\//.test(staticText) || /^\s*\/api\//.test(staticText)) {
           return;
         }
         // File paths (start with / or contain common path patterns)
         if (
-          /^[`'"]\s*\/home\//.test(fullText) ||
-          /^[`'"]\s*\/usr\//.test(fullText) ||
-          /^[`'"]\s*\/tmp\//.test(fullText)
+          /^\s*\/home\//.test(staticText) ||
+          /^\s*\/usr\//.test(staticText) ||
+          /^\s*\/tmp\//.test(staticText)
         ) {
           return;
         }
         // CSS selectors
         if (
-          /\[data-[\w-]+/.test(fullText) ||
-          /\[class=/.test(fullText) ||
-          /\[id=/.test(fullText)
+          /\[data-[\w-]+/.test(staticText) ||
+          /\[class=/.test(staticText) ||
+          /\[id=/.test(staticText)
         ) {
           return;
         }
         // Search/query strings
-        if (/\?.*=/.test(fullText) && !/\[@/.test(fullText)) {
+        if (/\?.*=/.test(staticText) && !/\[@/.test(staticText)) {
           return;
         }
 
-        // Check if this looks like an ACTUAL XPath expression
-        // Must have XPath-specific syntax, not just forward slashes
-        const hasXpathSyntax =
-          /\/\/\w+/.test(fullText) || // //element
-          /\[@\w+/.test(fullText) || // [@attr
-          /\[contains\(/.test(fullText) || // [contains(
-          /\[text\(\)/.test(fullText) || // [text()
-          /\/child::/.test(fullText) || // /child::
-          /\/descendant::/.test(fullText); // /descendant::
-
-        if (!hasXpathSyntax) {
+        // The same detector the concatenation path uses. The two used to
+        // disagree: this handler required `//`, so a location step carrying a
+        // predicate — `/root/node[${input}]` — was XPath injection to one path
+        // and invisible to the other.
+        if (!XPATH_SYNTAX.test(staticText)) {
           return;
         }
 
         // Check for interpolation in XPath-like expressions
-        if (containsXpathInterpolation(fullText)) {
+        if (node.expressions.length > 0) {
           // Check if any interpolated values are untrusted
           const hasUntrustedInterpolation = node.expressions.some(
             (expr: TSESTree.Expression) =>
@@ -625,7 +612,7 @@ export const noXpathInjection = createRule<RuleOptions, MessageIds>({
         }
 
         // Check for dangerous patterns in template literals
-        if (containsDangerousXpath(fullText)) {
+        if (containsDangerousXpath(staticText)) {
           // FALSE POSITIVE REDUCTION: Check for safe annotation
           if (hasSafeAnnotationOnStatement(node)) {
             return;

--- a/packages/eslint-plugin-secure-coding/src/rules/no-xpath-injection/no-xpath-injection.test.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/no-xpath-injection/no-xpath-injection.test.ts
@@ -27,6 +27,13 @@ describe('no-xpath-injection', () => {
   describe('Valid Code', () => {
     ruleTester.run('valid - safe XPath operations', noXpathInjection, {
       valid: [
+        // A slash is a path separator in every language. The old heuristic was
+        // `includes('/') || includes('[')`, which matched every path join, URL
+        // build and array index — this exact line reported CWE-643, measured on
+        // the Interlace repo.
+        `function rel(fullPath, baseDir) { return fullPath.replace(baseDir + '/', ''); }`,
+        `function u(base, id) { return base + '/api/' + id; }`,
+        `function k(arr, i) { return 'items[' + i + ']'; }`,
         // Safe XPath literals
         {
           code: 'const result = document.evaluate("/users/user[@id=\'123\']", document);',

--- a/packages/eslint-plugin-secure-coding/src/rules/no-xpath-injection/no-xpath-injection.test.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/no-xpath-injection/no-xpath-injection.test.ts
@@ -330,17 +330,35 @@ describe('no-xpath-injection', () => {
           ],
         },
         {
+          // The asymmetry itself, pinned: a predicate step with no `//`.
+          // Caught by the concatenation handler all along; the template
+          // handler used to be blind to it.
+          code: 'const xpath = `/root/node[${req.query.id}]`; doc.evaluate(xpath);',
+          errors: [
+            {
+              messageId: 'unsafeXpathConcatenation',
+            },
+          ],
+        },
+        {
           code: `
             // Dangerous XPath allowing parent traversal
             const userPath = userInput; // Could be "../admin/password"
             const xpath = \`/app/users/user[\${userPath}]\`;
             const result = document.evaluate(xpath, document);
           `,
-          // Note: Only 1 error now - xpathInjection from VariableDeclarator
-          // Template literal FP reduction means /app/users/user[...] isn't flagged without //element syntax
+          // A location step carrying a predicate is XPath whether or not the
+          // expression also contains `//`. This fixture used to assert one
+          // error, which encoded the gap as expected behaviour: the template
+          // handler required `//` while the concatenation handler did not, so
+          // the same string was injection to one path and invisible to the
+          // other. Both now use XPATH_SYNTAX.
           errors: [
             {
               messageId: 'xpathInjection',
+            },
+            {
+              messageId: 'unsafeXpathConcatenation',
             },
           ],
         },
@@ -541,13 +559,18 @@ const xpath = \`//users/..\``,
       });
       const templateLiteral = listeners.TemplateLiteral as (n: unknown) => void;
 
+      // The static text lives in the quasis, not in the printed source — the
+      // handler reads the AST, so the mock has to carry it there.
       templateLiteral({
         type: 'TemplateLiteral',
         parent: undefined,
         expressions: [
           { type: 'Identifier', name: 'userInput', parent: undefined },
         ],
-        quasis: [],
+        quasis: [
+          { type: 'TemplateElement', value: { raw: '/users/user[@id="' } },
+          { type: 'TemplateElement', value: { raw: '"]' } },
+        ],
       });
 
       expect(reports).toHaveLength(1);
@@ -564,7 +587,7 @@ const xpath = \`//users/..\``,
         type: 'TemplateLiteral',
         parent: undefined,
         expressions: [],
-        quasis: [],
+        quasis: [{ type: 'TemplateElement', value: { raw: '//users/..' } }],
       });
 
       expect(reports).toHaveLength(1);

--- a/packages/eslint-plugin-secure-coding/src/rules/no-xpath-injection/no-xpath-injection.test.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/no-xpath-injection/no-xpath-injection.test.ts
@@ -34,6 +34,14 @@ describe('no-xpath-injection', () => {
         `function rel(fullPath, baseDir) { return fullPath.replace(baseDir + '/', ''); }`,
         `function u(base, id) { return base + '/api/' + id; }`,
         `function k(arr, i) { return 'items[' + i + ']'; }`,
+        // Detection reads the AST, not printed source. An identifier that merely
+        // spells an XPath function, and a comment inside the expression, are not
+        // string content — both matched while the gate regexed
+        // `sourceCode.getText(node)`.
+        `function f(req) { const s = render.text() + req.query.q; use(s); }`,
+        `function f(req) { const s = base /* //user[@id] */ + req.query.q; use(s); }`,
+        // A non-string literal contributes no text.
+        `function f(req) { const s = '/total: ' + 42 + req.query.n; use(s); }`,
         // Safe XPath literals
         {
           code: 'const result = document.evaluate("/users/user[@id=\'123\']", document);',
@@ -55,40 +63,50 @@ describe('no-xpath-injection', () => {
           code: 'const xpath = `/users/user[@name="${escapeXPath(userName)}"]`;',
         },
       ],
-      invalid: [],
+      invalid: [
+        {
+          // Template quasis are string content too — same expression, backticks.
+          code: "function q(req) { const x = `//user[name='` + req.query.n + `']`; doc.evaluate(x); }",
+          errors: 2,
+        },
+      ],
     });
   });
 
   describe('Invalid Code - XPath Injection', () => {
-    ruleTester.run('invalid - XPath injection vulnerabilities', noXpathInjection, {
-      valid: [],
-      invalid: [
-        {
-          code: 'const xpath = "/users/user[name=\'" + userInput + "\']";',
-          errors: [
-            {
-              messageId: 'xpathInjection',
-            },
-          ],
-        },
-        {
-          code: 'const query = `/users/user[@id="${userId}"]`;',
-          errors: [
-            {
-              messageId: 'unsafeXpathConcatenation',
-            },
-          ],
-        },
-        {
-          code: 'document.evaluate(userQuery, document);',
-          errors: [
-            {
-              messageId: 'unvalidatedXpathInput',
-            },
-          ],
-        },
-      ],
-    });
+    ruleTester.run(
+      'invalid - XPath injection vulnerabilities',
+      noXpathInjection,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: 'const xpath = "/users/user[name=\'" + userInput + "\']";',
+            errors: [
+              {
+                messageId: 'xpathInjection',
+              },
+            ],
+          },
+          {
+            code: 'const query = `/users/user[@id="${userId}"]`;',
+            errors: [
+              {
+                messageId: 'unsafeXpathConcatenation',
+              },
+            ],
+          },
+          {
+            code: 'document.evaluate(userQuery, document);',
+            errors: [
+              {
+                messageId: 'unvalidatedXpathInput',
+              },
+            ],
+          },
+        ],
+      },
+    );
   });
 
   describe('Invalid Code - Dangerous XPath Patterns', () => {
@@ -148,35 +166,39 @@ describe('no-xpath-injection', () => {
   });
 
   describe('Invalid Code - XPath Variable Assignment', () => {
-    ruleTester.run('invalid - dangerous XPath variable assignments', noXpathInjection, {
-      valid: [],
-      invalid: [
-        {
-          code: 'const userXPath = "//users/user/..";',
-          errors: [
-            {
-              messageId: 'dangerousXpathExpression',
-            },
-          ],
-        },
-        {
-          code: 'const xpathQuery = req.params.query;',
-          errors: [
-            {
-              messageId: 'xpathInjection',
-            },
-          ],
-        },
-        {
-          code: 'let searchPath = userInput;',
-          errors: [
-            {
-              messageId: 'xpathInjection',
-            },
-          ],
-        },
-      ],
-    });
+    ruleTester.run(
+      'invalid - dangerous XPath variable assignments',
+      noXpathInjection,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: 'const userXPath = "//users/user/..";',
+            errors: [
+              {
+                messageId: 'dangerousXpathExpression',
+              },
+            ],
+          },
+          {
+            code: 'const xpathQuery = req.params.query;',
+            errors: [
+              {
+                messageId: 'xpathInjection',
+              },
+            ],
+          },
+          {
+            code: 'let searchPath = userInput;',
+            errors: [
+              {
+                messageId: 'xpathInjection',
+              },
+            ],
+          },
+        ],
+      },
+    );
   });
 
   describe('Valid Code - False Positives Reduced', () => {
@@ -327,48 +349,52 @@ describe('no-xpath-injection', () => {
   });
 
   describe('Advanced XPath Coverage', () => {
-    ruleTester.run('coverage - function parameters and direct calls', noXpathInjection, {
-      valid: [
-        // Helper function with safe annotation
-        {
-          code: `
+    ruleTester.run(
+      'coverage - function parameters and direct calls',
+      noXpathInjection,
+      {
+        valid: [
+          // Helper function with safe annotation
+          {
+            code: `
             /** @xpath-safe */
             function safeQuery() {
               const xpath = "//user"; 
               // Rule checks statement level too for some visitors, but usually annotation is on the statement using it
             }
           `,
-        },
-      ],
-      invalid: [
-        // Direct function call (not method) - Invalid because // is dangerous pattern
-        {
-          code: 'select("//user")',
-          options: [{ xpathFunctions: ['select'] }],
-          errors: [{ messageId: 'dangerousXpathExpression' }],
-        },
-        // Function parameter as input
-        {
-          code: `
+          },
+        ],
+        invalid: [
+          // Direct function call (not method) - Invalid because // is dangerous pattern
+          {
+            code: 'select("//user")',
+            options: [{ xpathFunctions: ['select'] }],
+            errors: [{ messageId: 'dangerousXpathExpression' }],
+          },
+          // Function parameter as input
+          {
+            code: `
             function find(userInput) {
               document.evaluate("//user[@name='" + userInput + "']", document);
             }
           `,
-          errors: [{ messageId: 'xpathInjection' }],
-        },
-        // req object usage directly
-        {
-          code: 'document.evaluate("//user[@id=" + req.id + "]", document);',
-          errors: [{ messageId: 'xpathInjection' }],
-        },
-        // Direct function call with dangerous input
-        {
-          code: 'selectNodes("//user[@name=" + userInput + "]")',
-          options: [{ xpathFunctions: ['selectNodes'] }],
-          errors: [{ messageId: 'xpathInjection' }],
-        },
-      ],
-    });
+            errors: [{ messageId: 'xpathInjection' }],
+          },
+          // req object usage directly
+          {
+            code: 'document.evaluate("//user[@id=" + req.id + "]", document);',
+            errors: [{ messageId: 'xpathInjection' }],
+          },
+          // Direct function call with dangerous input
+          {
+            code: 'selectNodes("//user[@name=" + userInput + "]")',
+            options: [{ xpathFunctions: ['selectNodes'] }],
+            errors: [{ messageId: 'xpathInjection' }],
+          },
+        ],
+      },
+    );
 
     ruleTester.run('coverage - validation and construction', noXpathInjection, {
       valid: [
@@ -417,7 +443,9 @@ describe('no-xpath-injection', () => {
         // id 15: non-req MemberExpression init → isUntrustedXpathInput second-inner-if false arm
         { code: 'const xpathQuery = foo.bar;' },
         // id 21: destructured param → param.type !== Identifier → false arm
-        { code: 'function f({id}) { document.evaluate("//user[@name=" + id + "]", document); }' },
+        {
+          code: 'function f({id}) { document.evaluate("//user[@name=" + id + "]", document); }',
+        },
         // id 22: isXpathInputValidated true arm — validation function wraps the template
         { code: 'validateXPath(`/users/user[@id="${userInput}"]`)' },
         // id 31: XPath call with zero args → early return
@@ -498,7 +526,9 @@ const xpath = \`//users/..\``,
       callExpression({
         type: 'CallExpression',
         callee: { type: 'Identifier', name: 'evaluate' },
-        arguments: [{ type: 'Identifier', name: 'userInput', parent: undefined }],
+        arguments: [
+          { type: 'Identifier', name: 'userInput', parent: undefined },
+        ],
       });
 
       expect(reports).toHaveLength(1);
@@ -514,7 +544,9 @@ const xpath = \`//users/..\``,
       templateLiteral({
         type: 'TemplateLiteral',
         parent: undefined,
-        expressions: [{ type: 'Identifier', name: 'userInput', parent: undefined }],
+        expressions: [
+          { type: 'Identifier', name: 'userInput', parent: undefined },
+        ],
         quasis: [],
       });
 
@@ -543,7 +575,9 @@ const xpath = \`//users/..\``,
       const { listeners, reports } = createWithMockContext(noXpathInjection, {
         sourceText: 'userInput + "//users/.."',
       });
-      const binaryExpression = listeners.BinaryExpression as (n: unknown) => void;
+      const binaryExpression = listeners.BinaryExpression as (
+        n: unknown,
+      ) => void;
 
       binaryExpression({
         type: 'BinaryExpression',
@@ -558,7 +592,9 @@ const xpath = \`//users/..\``,
 
     it('VariableDeclarator dangerousXpathExpression falls back to line 0 when loc is missing', () => {
       const { listeners, reports } = createWithMockContext(noXpathInjection);
-      const variableDeclarator = listeners.VariableDeclarator as (n: unknown) => void;
+      const variableDeclarator = listeners.VariableDeclarator as (
+        n: unknown,
+      ) => void;
 
       variableDeclarator({
         type: 'VariableDeclarator',
@@ -572,7 +608,9 @@ const xpath = \`//users/..\``,
 
     it('VariableDeclarator xpathInjection falls back to line 0 when loc is missing', () => {
       const { listeners, reports } = createWithMockContext(noXpathInjection);
-      const variableDeclarator = listeners.VariableDeclarator as (n: unknown) => void;
+      const variableDeclarator = listeners.VariableDeclarator as (
+        n: unknown,
+      ) => void;
 
       variableDeclarator({
         type: 'VariableDeclarator',


### PR DESCRIPTION
Sixth and last of the confirmed false positives from the dogfood sweep (after #415, #416, #417).

## The bug

The test for "does this string concatenation look like XPath" was:

```js
if (!fullText.includes('/') && !fullText.includes('[')) return;
```

That matches every path join, URL build and array index in existence. Measured on this monorepo, it reported **CWE-643** on:

```js
return fullPath.replace(baseDir + '/', '');
```

(`baseDir` counts as untrusted because it is a function parameter, and the `+ '/'` supplies the slash.)

## The fix

XPath has syntax of its own, so the gate now requires some of it:

| shape | example |
|---|---|
| descendant axis | `//user` |
| attribute predicate | `[@id=` |
| explicit axis | `child::` |
| node tests / functions | `text()`, `node()`, `contains(`, `starts-with(`, `local-name(`, `position()` |
| location step with predicate | `/user[` — the form with no `//` |

## Test plan

Verified in both directions against the built plugin:

```
silent   path replace (the measured FP)
silent   url join
silent   array index build
reports  descendant axis
reports  attribute predicate
reports  step with predicate
```

- [x] All three FP shapes locked as `valid` — **verified by reverting** the gate (3 cases go red).
- [x] `secure-coding` 1493 tests, 100% coverage.
- [x] Sweep: **71 → 62** findings, and only **2 of the 62** are outside our own tests and fixtures.

## Known limitation, deliberately left

The variable-declaration path still matches on the name `path`, so `let path = template;` reports — one of those two remaining findings.

I tried dropping `path` from that keyword list. It also stopped `let searchPath = userInput;` firing, which is an existing invalid test case. **By name alone those two are the same string**, so removing the keyword trades a false positive for a false negative rather than fixing anything. Separating them needs the declaration's *use* to reach an XPath sink — the data-flow analysis these rules deliberately avoid.

That reasoning is now a comment in the source rather than tribal knowledge, so the next person doesn't re-try it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)