### PR TITLE
fix(ci): make the Docker image build and stop Docs Data Sync pushing to main

### DIFF
--- a/.github/workflows/docs-data.yml
+++ b/.github/workflows/docs-data.yml
@@ -40,7 +40,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: write   # commits regenerated JSON back to main
+      contents: write        # push the sync branch
+      pull-requests: write   # open the rollup PR
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -69,15 +70,43 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: npx tsx apps/docs/scripts/update-coverage-stats.ts
 
-      - name: Commit changes (single rollup commit)
+      # Open a PR rather than pushing to main.
+      #
+      # This step used to `git push` straight to main and failed on EVERY run
+      # with `GH006: Protected branch update failed`. The sync itself always
+      # succeeded ("9 succeeded, 0 errors") — only the push was rejected — so
+      # the workflow reported red while doing its job correctly, and the data
+      # it generated was thrown away.
+      #
+      # main requires up-to-date branches, resolved conversations and linear
+      # history by deliberate policy, so the fix is to route the change through
+      # review like any other. A bot token that bypasses protection would clear
+      # the red X by punching a hole in the rule instead.
+      #
+      # Reuses one branch, so repeated runs update a single open PR rather than
+      # opening one per push to main.
+      - name: Open sync PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: automated/docs-data-sync
         run: |
           set -euo pipefail
-          git config --local user.name "github-actions[bot]"
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
           if git diff --quiet apps/docs/src/data/; then
-            echo "No changes to commit."
+            echo "No changes to sync — nothing to open."
             exit 0
           fi
+
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$BRANCH"
           git add apps/docs/src/data/
           git commit -m "chore(docs): sync data [automated]"
-          git push
+          git push --force-with-lease origin "$BRANCH"
+
+          if [ -n "$(gh pr list --head "$BRANCH" --state open --json number --jq '.[].number')" ]; then
+            echo "Existing PR updated with the new sync commit."
+          else
+            gh pr create --base main --head "$BRANCH" \
+              --title "chore(docs): sync generated data" \
+              --body "Regenerated apps/docs/src/data/ after a change under packages/**. Opened by the Docs Data Sync workflow; contents come entirely from the apps/docs/scripts/sync-* scripts, so review the diff rather than hand-editing."
+          fi

--- a/.github/workflows/docs-data.yml
+++ b/.github/workflows/docs-data.yml
@@ -89,6 +89,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           BRANCH: automated/docs-data-sync
+          # Passed through env rather than interpolated into the script body —
+          # `${{ }}` inside `run:` is substituted before the shell sees it, so
+          # keeping workflow context out of the command text is the habit worth
+          # having even when the value (push | workflow_dispatch) is safe.
+          TRIGGER: ${{ github.event_name }}
         run: |
           set -euo pipefail
           if git diff --quiet apps/docs/src/data/; then
@@ -108,5 +113,5 @@ jobs:
           else
             gh pr create --base main --head "$BRANCH" \
               --title "chore(docs): sync generated data" \
-              --body "Regenerated apps/docs/src/data/ after a change under packages/**. Opened by the Docs Data Sync workflow; contents come entirely from the apps/docs/scripts/sync-* scripts, so review the diff rather than hand-editing."
+              --body "Regenerated apps/docs/src/data/ (trigger: $TRIGGER). Opened by the Docs Data Sync workflow; contents come entirely from the apps/docs/scripts/sync-* scripts, so review the diff rather than hand-editing."
           fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,16 @@ FROM node:24-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526a
 RUN apk add --no-cache git
 
 # Install at the root so the tree is reachable from any mounted workspace.
+#
+# DO NOT change this to /app or /build. The install root must be an ANCESTOR of
+# the mounted workspace, or Node's upward node_modules walk never reaches it and
+# every user config fails with ERR_MODULE_NOT_FOUND — see HISTORY #2 above. The
+# image still builds green when this is wrong; only a real lint catches it,
+# which is what the selftest below is for.
+#
+# (Comment sits on its own line because Dockerfile has no trailing comments:
+# `WORKDIR /  # note` sets the directory to the literal string `/  # note`.
+# Verified — that is not a style preference.)
 WORKDIR /
 RUN printf '{"name":"interlace-image","private":true}' > /package.json
 RUN npm install --no-fund --no-audit --omit=dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,52 +1,71 @@
 # Interlace — official Docker image.
 #
-# Roadmap item 6.G — drops Interlace into any CI that can run a container
-# (GitLab, CircleCI, Jenkins, Drone, GitHub self-hosted, k8s Tekton…).
-# Single-arch image hosted at ghcr.io/ofri-peretz/interlace, multi-arch
-# (linux/amd64 + linux/arm64) via the publish workflow.
+# Roadmap item 6.G — drops the Interlace security plugins into any CI that can
+# run a container (GitLab, CircleCI, Jenkins, Drone, GitHub self-hosted, k8s
+# Tekton…). Multi-arch (linux/amd64 + linux/arm64) via the publish workflow,
+# hosted at ghcr.io/ofri-peretz/interlace.
 #
-# Usage in any CI:
+# Usage in any CI — mount the repo at /work and bring your own flat config:
 #
-#   docker run --rm -v "$PWD:/work" ghcr.io/ofri-peretz/interlace audit /work/src
-#   docker run --rm -v "$PWD:/work" ghcr.io/ofri-peretz/interlace audit --sarif /work/src > findings.sarif
+#   docker run --rm -v "$PWD:/work" ghcr.io/ofri-peretz/interlace .
+#   docker run --rm -v "$PWD:/work" ghcr.io/ofri-peretz/interlace --format json .
 #
-# What's pre-installed:
-#   - @interlace/cli (the `interlace` binary on PATH)
-#   - All 11 security plugins
-#   - SARIF formatter
-#   - eslint
+# The entrypoint is `eslint`, so every upstream flag works as documented.
 #
-# What's NOT pre-installed:
-#   - The 11 MCP servers (intended for editor / agent use, not CI)
-#   - tsx / typescript devDeps (the CLI shells `npx tsx` when needed)
+# Pre-installed: eslint + the 10 published security plugins.
+# NOT pre-installed: the MCP servers (editor/agent use, not CI), tsx/typescript.
 #
-# Image size target: < 250 MB compressed. Achieved via alpine + multi-stage.
+# ─────────────────────────────────────────────────────────────────────────────
+# HISTORY — two independent defects, both fixed here. Read before editing.
+#
+# 1. WRONG PACKAGE NAMES. As written at the Nx→Turborepo migration (#94) this
+#    image had never built once — 30 of 30 workflow runs failed. It installed
+#    `@interlace/cli` plus ten `@interlace/eslint-plugin-*` packages, and NONE
+#    of those names exist on npm: the plugins publish UNSCOPED
+#    (`eslint-plugin-node-security`), `@interlace/cli` was never written, and
+#    `@interlace/eslint-formatter-sarif` is `private: true` in this repo. The
+#    first `npm install -g` 404'd every build, and `ENTRYPOINT ["interlace"]`
+#    named a binary that does not exist.
+#
+#    Every name below was verified against the live registry before commit.
+#    Do not add one without doing the same.
+#
+# 2. GLOBAL INSTALL COULD NOT BE RESOLVED. Even with correct names, `npm
+#    install -g` would NOT have produced a working image. A flat config in the
+#    mounted workspace does `import plugin from 'eslint-plugin-x'`, and that
+#    resolves from the CONFIG's directory — Node never searches the global
+#    prefix, and ESM ignores NODE_PATH, so the import throws
+#    ERR_MODULE_NOT_FOUND. Verified in a container.
+#
+#    Hence the install lands at the filesystem ROOT (`/package.json` +
+#    `/node_modules`). Node resolves bare specifiers by walking parent
+#    directories, so a config at /work/eslint.config.mjs finds /node_modules on
+#    the way up. Keep it there, or the image silently stops resolving plugins
+#    for user configs while still building green.
+# ─────────────────────────────────────────────────────────────────────────────
 
 # ─── builder ────────────────────────────────────────────────────────────────
 # Pinned to the node:24-alpine digest for reproducible builds (Scorecard
 # Pinned-Dependencies). Bump the digest when refreshing the base image.
 FROM node:24-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14 AS builder
 
-WORKDIR /build
 RUN apk add --no-cache git
 
-# Install Interlace + plugins into a clean prefix that we'll copy out.
-ENV NPM_CONFIG_PREFIX=/build/prefix
-RUN mkdir -p $NPM_CONFIG_PREFIX
-RUN npm install -g --no-fund --no-audit \
-      @interlace/cli@latest \
-      @interlace/eslint-formatter-sarif@latest \
-      @interlace/eslint-plugin-secure-coding@latest \
-      @interlace/eslint-plugin-browser-security@latest \
-      @interlace/eslint-plugin-node-security@latest \
-      @interlace/eslint-plugin-jwt@latest \
-      @interlace/eslint-plugin-express-security@latest \
-      @interlace/eslint-plugin-lambda-security@latest \
-      @interlace/eslint-plugin-mongodb-security@latest \
-      @interlace/eslint-plugin-nestjs-security@latest \
-      @interlace/eslint-plugin-vercel-ai-security@latest \
-      @interlace/eslint-plugin-pg@latest \
-      eslint@latest
+# Install at the root so the tree is reachable from any mounted workspace.
+WORKDIR /
+RUN printf '{"name":"interlace-image","private":true}' > /package.json
+RUN npm install --no-fund --no-audit --omit=dev \
+      eslint@latest \
+      eslint-plugin-secure-coding@latest \
+      eslint-plugin-browser-security@latest \
+      eslint-plugin-node-security@latest \
+      eslint-plugin-jwt@latest \
+      eslint-plugin-express-security@latest \
+      eslint-plugin-lambda-security@latest \
+      eslint-plugin-mongodb-security@latest \
+      eslint-plugin-nestjs-security@latest \
+      eslint-plugin-vercel-ai-security@latest \
+      eslint-plugin-pg@latest
 
 # ─── runtime ────────────────────────────────────────────────────────────────
 FROM node:24-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14
@@ -59,15 +78,27 @@ LABEL org.opencontainers.image.documentation="https://github.com/ofri-peretz/esl
 # Non-root user for the lint process — workspace lint should never need root.
 RUN addgroup -S interlace && adduser -S interlace -G interlace
 
-# Copy the globally-installed prefix from the builder
-COPY --from=builder /build/prefix /usr/local
+COPY --from=builder /package.json /package.json
+COPY --from=builder /node_modules /node_modules
+RUN ln -s /node_modules/.bin/eslint /usr/local/bin/eslint
 
-# Working directory is /work; mount your repo here
+# Sanity checks — fail the BUILD rather than ship an image whose install half
+# succeeded. `--version` proves the binary resolves; the lint proves a plugin
+# both loads AND reports from a config outside the install root, which is the
+# property defect #2 above silently broke.
+RUN eslint --version \
+ && mkdir -p /tmp/selftest \
+ && printf 'import ns from "eslint-plugin-node-security";\nexport default [{files:["**/*.js"],plugins:{"node-security":ns},rules:{"node-security/detect-child-process":"error"}}];\n' > /tmp/selftest/eslint.config.mjs \
+ && printf 'const cp=require("child_process");cp.exec(userInput);\n' > /tmp/selftest/t.js \
+ && cd /tmp/selftest \
+ && ! eslint t.js > /tmp/selftest/out 2>&1 \
+ && grep -q 'node-security/detect-child-process' /tmp/selftest/out \
+ && echo 'selftest: plugin resolved and reported from a mounted-style config' \
+ && rm -rf /tmp/selftest
+
+# Mount the repo here.
 WORKDIR /work
 USER interlace
 
-# Sanity check — fail the build if interlace --version doesn't run
-RUN interlace --version
-
-ENTRYPOINT ["interlace"]
+ENTRYPOINT ["eslint"]
 CMD ["--help"]


### PR DESCRIPTION
Two workflows had been red on **every** push to main. Neither was flaky.

## Docker image — never built once (30/30 failures since #94)

Two independent defects, and fixing only the first would still have shipped a broken image.

**1. Every package name was a 404.** It installed `@interlace/cli` plus ten `@interlace/eslint-plugin-*` packages. None of those exist on npm — the plugins publish **unscoped**, `@interlace/cli` was never written, and `@interlace/eslint-formatter-sarif` is `private: true` in this repo. The first `npm install -g` 404'd every build, and `ENTRYPOINT ["interlace"]` named a binary that doesn't exist.

All 11 replacement names were checked against the live registry before commit.

**2. A global install can't be resolved by a user's config.** A flat config in the mounted workspace does `import plugin from 'eslint-plugin-x'`, which resolves from the *config's* directory. Node never searches the global prefix, and ESM ignores `NODE_PATH`, so the import throws `ERR_MODULE_NOT_FOUND`. Verified in a container.

The install now lands at the filesystem root (`/package.json` + `/node_modules`), which Node's upward `node_modules` walk reaches from anything under `/work`.

### Verified locally, not assumed

- image builds (`BUILD_EXIT=0`), 251 MB
- `docker run --rm -v "$PWD:/work" <img> .` against a user config importing **two** plugins by bare name reports both findings
- the build now **self-tests** both properties: `eslint --version` for the binary, plus a real lint from a config *outside* the install root that must report `node-security/detect-child-process`. A half-succeeded install fails the build instead of shipping.

## Docs Data Sync — the sync was correct, the push was not

Every run logged `Sync complete: 9 succeeded, 0 errors` and then died on `GH006: Protected branch update failed for refs/heads/main`. The workflow reported red while doing its job correctly, and threw the generated data away.

It now opens a PR against main, reusing one branch so repeated runs update a single open PR rather than one per push.

Deliberately **not** fixed with a bypass token: branch protection here is policy (up-to-date branches, resolved conversations, linear history). A token that punches through it would clear the red X by removing the rule.

Scope note: this touches only `.github/workflows/docs-data.yml`. #387 owns `apps/docs/scripts/**` and makes the generators idempotent — that handles the *no-change* case; this handles the case where data genuinely changes.

## Not fixed here — needs a repo admin

`Daily Impact Ingest` has failed **20+ consecutive runs** on:

```
##[error]GitHub returned 401 Bad credentials. Mint a new fine-grained PAT with
Contents:read on ofri-peretz/agents and update the AGENTS_REPO_PAT secret.
```

The secret expired. Only an admin can mint the replacement. Consequence: the scorecard has been serving numbers frozen since ~2026-07-17, because the workflow fails loudly in Actions but nothing downstream notices.

## Test plan

- [x] `docker build` succeeds; self-test step passes
- [x] end-to-end container run against a mounted workspace reports real findings from two plugins
- [x] every package name verified against the npm registry
- [x] `npm run lint:workflows` — 32 workflow files pass conventions
- [x] full pre-push battery green

🤖 Generated with [Claude Code](https://claude.com/claude-code)