### PR TITLE
fix(docs): restore 2-decimal ESLint shares the version lock requires

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,14 +278,14 @@ are in [`benchmarks/README.md`](./benchmarks/README.md).
 
 > **Last refresh:** 2026-08-02 (source: npm registry — `npm run stats:eslint-versions`)
 
-| ESLint major    | Weekly downloads | Share | Status                         |
-| :-------------- | ---------------: | ----: | :----------------------------- |
-| **v10**         |            23.6M | 11.1% | ✅ Supported (forward-looking) |
-| **v9**          |           109.1M | 51.1% | ✅ Supported (current default) |
-| **v8** (≥ 8.40) |            60.3M | 28.3% | ✅ Supported (legacy active)   |
-| v7 and older    |            19.9M |  9.4% | ❌ Unsupported (EOL)           |
+| ESLint major    | Weekly downloads |  Share | Status                         |
+| :-------------- | ---------------: | -----: | :----------------------------- |
+| **v10**         |            23.6M | 11.08% | ✅ Supported (forward-looking) |
+| **v9**          |           109.1M | 51.13% | ✅ Supported (current default) |
+| **v8** (≥ 8.40) |            60.3M | 28.29% | ✅ Supported (legacy active)   |
+| v7 and older    |            20.3M |  9.51% | ❌ Unsupported (EOL)           |
 
-Supported majors cover **90.5%** of weekly ESLint downloads. Every published package
+Supported majors cover **90.49%** of weekly ESLint downloads. Every published package
 declares `"eslint": "^8.40.0 || ^9.0.0 || ^10.0.0"`.
 
 **Why the floor is 8.40 and not 8.0:** releases before 8.40 predate


### PR DESCRIPTION
## What

#432 rewrote the compatibility table with 1-decimal shares (`11.1%` / `51.1%` / `28.3%`), but `eslint-version-share-lock.test.ts` asserts the exact 2-decimal values from `benchmark-results/eslint-version-stats.json`.

**Every open PR has been failing `Unit Tests + Coverage (1/10)` since #432 merged.** Confirmed on #435, #259 and #251 — three unrelated branches, identical failure.

Main's own Quality Gate went green on that commit because affected-file filtering skipped the docs shard there, so the break only surfaced on branches that touch enough to run it. Same "green means nothing" class #361 was about.

## Also fixed

Three figures were wrong rather than merely rounded — recomputed from the stats file:

| Field | #432 said | Actual |
|---|---|---|
| v7-and-older downloads | 19.9M | **20.3M** |
| v7-and-older share | 9.4% | **9.51%** |
| Supported-majors total | 90.5% | **90.49%** |

The pre-#432 README had `20.3M / 9.51%` right; the rewrite introduced the drift.

## Verification

- `eslint-version-share-lock.test.ts` — **38/38 pass** (was 2 failing)
- `sync-root-readme.ts --check` — ✅ in sync
- No content changes beyond the numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)