### PR TITLE
fix(release): drop removed packages from two changesets

### DIFF
--- a/.changeset/eslint-peer-floor-8-40.md
+++ b/.changeset/eslint-peer-floor-8-40.md
@@ -7,7 +7,6 @@
 'eslint-plugin-express-security': patch
 'eslint-plugin-gemini-security': patch
 'eslint-plugin-import-next': patch
-'eslint-plugin-jwt': patch
 'eslint-plugin-jwt-security': patch
 'eslint-plugin-knex-security': patch
 'eslint-plugin-lambda-security': patch
@@ -21,7 +20,6 @@
 'eslint-plugin-node-security': patch
 'eslint-plugin-openai-security': patch
 'eslint-plugin-operability': patch
-'eslint-plugin-pg': patch
 'eslint-plugin-postgresql-security': patch
 'eslint-plugin-prisma-security': patch
 'eslint-plugin-react-a11y': patch

--- a/.changeset/readme-eslint-floor-sync.md
+++ b/.changeset/readme-eslint-floor-sync.md
@@ -5,7 +5,6 @@
 'eslint-plugin-drizzle-security': patch
 'eslint-plugin-express-security': patch
 'eslint-plugin-import-next': patch
-'eslint-plugin-jwt': patch
 'eslint-plugin-jwt-security': patch
 'eslint-plugin-knex-security': patch
 'eslint-plugin-lambda-security': patch
@@ -17,7 +16,6 @@
 'eslint-plugin-nestjs-security': patch
 'eslint-plugin-node-security': patch
 'eslint-plugin-operability': patch
-'eslint-plugin-pg': patch
 'eslint-plugin-postgresql-security': patch
 'eslint-plugin-prisma-security': patch
 'eslint-plugin-react-a11y': patch


### PR DESCRIPTION
## The release pipeline has been failing since 2026-08-07

Every push to `main` fails the **Changesets** workflow:

```
🦋  error Error: Found changeset eslint-peer-floor-8-40 for package
    eslint-plugin-jwt which is not in the workspace
```

`eslint-plugin-jwt` and `eslint-plugin-pg` were removed from `packages/` after being renamed to `eslint-plugin-jwt-security` / `eslint-plugin-postgresql-security`. Two changesets still list the old names, and changesets aborts the **entire** release plan on a single unknown package.

That is why #424 (Version Packages) is stale and conflicting — the bot has not been able to refresh it for two days. This is the actual blocker, not the conflict.

## The fix

Four lines removed across two files. Both already list the `-security` replacement on the very next line:

```diff
-'eslint-plugin-jwt': patch
 'eslint-plugin-jwt-security': patch
-'eslint-plugin-pg': patch
 'eslint-plugin-postgresql-security': patch
```

So no package loses its version bump.

## Verification

Audited **all 21** pending changesets against the real workspace (36 packages) — these were the only 4 stale references. `changeset status` goes from throwing to assembling a full plan:

- 31 packages at `patch`
- 5 at `minor` (`@interlace/eslint-devkit`, `browser-security`, `secure-coding`, `mongodb-security`, `nestjs-security`)
- 0 at `major`

Once this lands, the Changesets workflow should regenerate #424 on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)