### PR TITLE
fix(secure-coding): no-improper-sanitization fired on static response HTML

### DIFF
--- a/.changeset/no-improper-sanitization-static-output.md
+++ b/.changeset/no-improper-sanitization-static-output.md
@@ -1,0 +1,17 @@
+---
+'eslint-plugin-secure-coding': patch
+---
+
+Stop `no-improper-sanitization` reporting static developer-authored HTML
+
+A bare string literal reaching `res.send()` / `res.write()` / `res.json()` was
+reported as CWE-116 whenever it contained `<` or `>`, with no requirement of
+interpolation or user input. Express's own `examples/auth/index.js:89` —
+`res.send('… <a href="/logout">logout</a>')` — was one of 188 findings the
+recommended preset produced on Express's reference code (#398).
+
+The rule already applied the opposite reasoning on the `innerHTML` path
+("static developer-authored HTML normally has no taint source"); that
+exemption now covers the response-output sinks too. Dangerous markup
+(`<script>`, inline `on*=` handlers, `javascript:`) still reports even when
+hardcoded, because there the literal is itself the vector.

--- a/packages/eslint-plugin-secure-coding/src/rules/no-improper-sanitization/index.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/no-improper-sanitization/index.ts
@@ -517,9 +517,20 @@ export const noImproperSanitization = createRule<RuleOptions, MessageIds>({
           //
           // Dangerous markup still reports even when hardcoded, because there
           // the literal *is* the vector regardless of who wrote it.
-          const isBareLiteral =
-            directParent?.type !== 'TemplateLiteral' &&
-            directParent?.type !== 'BinaryExpression';
+          //
+          // Allowlist, not blacklist. Excluding TemplateLiteral/BinaryExpression
+          // silenced `res.send(req.query.name || '<p>fallback</p>')` and the
+          // ternary form, where tainted input still reaches the sink — a false
+          // negative is a worse outcome than the false positive being fixed.
+          // The literal only earns the exemption when it IS the argument, so
+          // any wrapper (`||`, `?:`, a call, a member access) falls through to
+          // the normal checks below.
+          const isDirectResponseArgument =
+            directParent?.type === 'CallExpression' &&
+            (directParent as TSESTree.CallExpression).arguments.includes(
+              node as TSESTree.CallExpressionArgument,
+            );
+          const isBareLiteral = isDirectResponseArgument;
           const hasDangerousMarkup =
             /<script[\s>]|<\/script>|\son\w+\s*=|javascript:/i.test(text);
           if (isBareLiteral && !hasDangerousMarkup) {

--- a/packages/eslint-plugin-secure-coding/src/rules/no-improper-sanitization/index.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/no-improper-sanitization/index.ts
@@ -504,6 +504,28 @@ export const noImproperSanitization = createRule<RuleOptions, MessageIds>({
         }
 
         if (isInDangerousContext) {
+          // A bare literal is developer-authored and carries no taint: nothing
+          // an attacker controls reaches it, so `<` in it is markup the author
+          // typed, not injection. Same reasoning the innerHTML branch above
+          // already applies — extended here because the response-output path
+          // (`res.send`/`write`/`json`) was reporting static HTML.
+          //
+          // Express's own examples/auth/index.js:89 is the case that surfaced
+          // it (#398): `res.send('… <a href="/logout">logout</a>')` reported
+          // CWE-116 with a message about `replace()`, where the statement has
+          // no `replace()` and no interpolation at all.
+          //
+          // Dangerous markup still reports even when hardcoded, because there
+          // the literal *is* the vector regardless of who wrote it.
+          const isBareLiteral =
+            directParent?.type !== 'TemplateLiteral' &&
+            directParent?.type !== 'BinaryExpression';
+          const hasDangerousMarkup =
+            /<script[\s>]|<\/script>|\son\w+\s*=|javascript:/i.test(text);
+          if (isBareLiteral && !hasDangerousMarkup) {
+            return;
+          }
+
           // Check if string contains dangerous characters without proper escaping
           const hasDangerousChars = dangerousChars.some(char => text.includes(char));
           const hasEscaping = text.includes('&lt;') || text.includes('&gt;') ||

--- a/packages/eslint-plugin-secure-coding/src/rules/no-improper-sanitization/no-improper-sanitization.test.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/no-improper-sanitization/no-improper-sanitization.test.ts
@@ -83,6 +83,20 @@ describe('no-improper-sanitization', () => {
             { messageId: 'unsafeReplaceSanitization' },
           ],
         },
+        // The literal is a fallback, not the argument — tainted input still
+        // reaches the sink. An earlier version of this exemption excluded
+        // TemplateLiteral/BinaryExpression by name and silenced both of these,
+        // turning a false-positive fix into a false negative. The exemption is
+        // now an allowlist (literal IS the argument), so any wrapper falls
+        // through to the normal checks.
+        {
+          code: `res.send(req.query.name || '<p>fallback</p>');`,
+          errors: [{ messageId: 'unsafeReplaceSanitization' }],
+        },
+        {
+          code: `res.send(flag ? req.query.name : '<p>x</p>');`,
+          errors: [{ messageId: 'unsafeReplaceSanitization' }],
+        },
       ],
     });
   });

--- a/packages/eslint-plugin-secure-coding/src/rules/no-improper-sanitization/no-improper-sanitization.test.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/no-improper-sanitization/no-improper-sanitization.test.ts
@@ -70,9 +70,18 @@ describe('no-improper-sanitization', () => {
         },
         // User input concatenated into the response — the actual CWE-116 shape
         // the rule exists for.
+        //
+        // Two errors, not one: the Literal visitor fires per string literal, so
+        // the opening `'<div>'` and closing `'</div>'` each report. That
+        // duplicate is pre-existing behaviour on this branch and is asserted
+        // here as-is rather than silently accepted by a looser matcher — if it
+        // is ever deduplicated, this test should fail and be updated.
         {
           code: `res.send('<div>' + req.query.name + '</div>');`,
-          errors: [{ messageId: 'unsafeReplaceSanitization' }],
+          errors: [
+            { messageId: 'unsafeReplaceSanitization' },
+            { messageId: 'unsafeReplaceSanitization' },
+          ],
         },
       ],
     });

--- a/packages/eslint-plugin-secure-coding/src/rules/no-improper-sanitization/no-improper-sanitization.test.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/no-improper-sanitization/no-improper-sanitization.test.ts
@@ -43,8 +43,38 @@ describe('no-improper-sanitization', () => {
         `,
         // Proper HTML entity escaping
 
+        // #398: Express's own examples/auth/index.js:89. A bare string literal
+        // reaching res.send() is developer-authored — nothing an attacker
+        // controls flows into it, so the `<` is markup the author typed. This
+        // reported CWE-116 with a message about `replace()` on a statement that
+        // has no replace() and no interpolation, one of 188 findings on
+        // Express's own reference code.
+        `res.send('Wahoo! restricted area, click to <a href="/logout">logout</a>');`,
+        // Same shape on the other response sinks the rule watches.
+        `res.write('<p>static</p>');`,
+        `res.json('<b>ok</b>');`,
       ],
       invalid: [],
+    });
+  });
+
+  describe('#398 regression: static output stays silent, real sinks do not', () => {
+    ruleTester.run('static vs tainted response output', noImproperSanitization, {
+      valid: [],
+      invalid: [
+        // Hardcoded but genuinely dangerous: the literal IS the vector, so
+        // author-controlled is not a defence. Must still report.
+        {
+          code: `res.send('<script>alert(1)</script>');`,
+          errors: [{ messageId: 'unsafeReplaceSanitization' }],
+        },
+        // User input concatenated into the response — the actual CWE-116 shape
+        // the rule exists for.
+        {
+          code: `res.send('<div>' + req.query.name + '</div>');`,
+          errors: [{ messageId: 'unsafeReplaceSanitization' }],
+        },
+      ],
     });
   });
 


### PR DESCRIPTION
Closes one of the two confirmed defects in #398.

## The defect

A **bare string literal** passed to `res.send()` / `res.write()` / `res.json()` was reported as CWE-116 whenever it contained `<` or `>` — no interpolation, no user input, nothing attacker-controlled:

```js
res.send('Wahoo! restricted area, click to <a href="/logout">logout</a>');
//        ^ reported: "Simple replace() calls are insufficient for sanitization"
```

The message made it worse — it describes a `replace()` call the statement does not contain. This is Express's own `examples/auth/index.js:89`, part of the **188 findings on 50 files** of Express reference code that #398 documented.

Same class as the unconditioned-impact work: the rule asserted an impact whose precondition (a taint source) it never checked.

## The fix

The rule **already** reasons correctly about this on the `innerHTML` path, in its own words:

> Static developer-authored HTML normally has no taint source … flagging it would force every static UI template into the noise floor — BUT a literal like `<script>alert(1)</script>` is unsafe even when developer-authored, because the markup itself is the vector.

That exemption simply never covered the response-output sinks. This extends it, with the identical escape hatch.

## Verified against the rule, not assumed

| Case | Expected | Result |
|---|---|---|
| `res.send('… <a href="/logout">logout</a>')` | silent | ✅ silent |
| `res.write('<p>static</p>')` | silent | ✅ silent |
| `res.json('<b>ok</b>')` | silent | ✅ silent |
| `res.send('<script>alert(1)</script>')` | **reports** | ✅ reports |
| `res.send('<div>' + req.query.name + '</div>')` | **reports** | ✅ reports |

Confirmed by diffing against the unmodified rule: my change removes **exactly one** finding — the false positive — and preserves every true positive. All five shapes are locked with regression tests.

## Status of the rest of #398

- **Defect 1 (`no-xpath-injection` on Express routes) — already fixed on main.** The ungated `includes('/')` branch is gone, replaced by `XPATH_SYNTAX.test(literalTextOf(node))` plus an untrusted-input requirement. I reproduced the issue's exact case (`'/' + name + '/:' + name + '_id'`) and it no longer reports.
- **`detect-object-injection` (42 findings) — resolved by #372**, which dropped it from `recommended`.
- Still open: adding `expressjs/express` to the ILB-Wild corpus, and the `require-helmet` / `require-rate-limiting` judgement call on single-purpose demo apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced false-positive security warnings for safe, developer-authored static HTML sent in responses.
  * Continued detecting dangerous hardcoded markup, including scripts, inline event handlers, and `javascript:` URLs.
  * Preserved warnings when response content includes user-controlled input.

* **Tests**
  * Added coverage for safe static responses and unsafe or tainted response content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->