### PR TITLE
fix(ci): gate release-hygiene on missing tags, not orphan tags

### DIFF
--- a/.github/workflows/release-hygiene.yml
+++ b/.github/workflows/release-hygiene.yml
@@ -143,8 +143,20 @@ jobs:
             process.exit(0);
           }
           const { summary, findings } = report;
-          const drift = (summary.orphanTags ?? 0) + (summary.missingTags ?? 0);
-          const header = drift === 0 ? '✅ No drift detected' : `🧹 Drift: ${summary.orphanTags} orphan / ${summary.missingTags} missing`;
+          // Only `missing` is actionable drift. An orphan tag means the git tag
+          // exists and the npm version does not — which is the expected state
+          // for every version we have unpublished or deprecated off the
+          // registry (the renamed eslint-plugin-jwt / -pg lines, and the 2.x–7.x
+          // history of several plugins). Those tags are the only surviving
+          // record that the release happened; deleting them to satisfy a
+          // counter would destroy history, so they are reported, not gated on.
+          //
+          // A `missing` tag is the reverse and always a real defect: a version
+          // is on npm with no tag pointing at the commit that produced it.
+          const drift = summary.missingTags ?? 0;
+          const header = drift === 0
+            ? `✅ No actionable drift (${summary.orphanTags ?? 0} orphan tag(s) — informational)`
+            : `🧹 Drift: ${summary.missingTags} missing tag(s) · ${summary.orphanTags} orphan (informational)`;
           console.log(`# ${header}`);
           console.log('');
           console.log(`| Field | Value |`);
@@ -193,7 +205,10 @@ jobs:
               return;
             }
             const { summary, findings } = report;
-            const drift = (summary?.orphanTags ?? 0) + (summary?.missingTags ?? 0);
+            // Gate on `missing` only — see the rationale in the summary step
+            // above. Orphan tags are expected for unpublished/deprecated
+            // versions and are reported in the body, not treated as drift.
+            const drift = summary?.missingTags ?? 0;
 
             const marker = '<!-- release-hygiene -->';
             const { data: existing } = await github.rest.issues.listForRepo({
@@ -231,11 +246,21 @@ jobs:
               if (f.orphan.length === 0 && f.missing.length === 0) continue;
               lines.push(`| \`${f.name}\` | ${f.orphan.join(', ') || '—'} | ${f.missing.join(', ') || '—'} |`);
             }
+            lines.push('');
+            lines.push(`**This issue is open because ${summary.missingTags} tag(s) are missing.** A missing tag`);
+            lines.push('means a version is published on npm with no git tag pointing at the commit that');
+            lines.push('produced it — always a real defect, fixed with `backfill-missing`.');
+            lines.push('');
+            lines.push(`The ${summary.orphanTags} orphan tag(s) above are **informational** and do not open this`);
+            lines.push('issue on their own. An orphan means the tag exists and the npm version does not,');
+            lines.push('which is the expected state for anything unpublished or deprecated off the');
+            lines.push('registry. Those tags are the only surviving record that the release happened —');
+            lines.push('`cleanup-orphans` would delete real history to make a counter read zero.');
             lines.push('', '### Recovery commands');
             lines.push('```bash');
             lines.push('# Re-run from the workflow_dispatch UI:');
-            lines.push('#   action=backfill-missing  → create the missing tags + push');
-            lines.push('#   action=cleanup-orphans   → DELETE orphan tags (destructive)');
+            lines.push('#   action=backfill-missing  → create the missing tags + push   ← the fix for THIS issue');
+            lines.push('#   action=cleanup-orphans   → DELETE orphan tags (destructive; read the note above first)');
             lines.push('#   action=full              → backfill + create-releases');
             lines.push('# Or locally:');
             lines.push('npm run release:reconcile               # report');


### PR DESCRIPTION
Closes #393.

## The problem

The drift gate is `orphanTags + missingTags`, so **30 expected orphans keep the issue permanently open with zero actionable problems**. Current state: `30 orphan · 0 missing`.

## Why orphans are not drift

An orphan tag means *the git tag exists and the npm version does not*. I checked what these actually are before touching them — every one points at a genuine release commit:

| Tag | Commit |
|---|---|
| `eslint-plugin-mongodb-security@7.0.0` | `861dd1e3` `chore(release): …@7.0.0` (2026-01-05) |
| `eslint-plugin-secure-coding@2.0.0` | real release commit (2025-12-08) |
| `eslint-plugin-react-a11y@3.0.0` | real release commit (2025-12-30) |

And npm confirms the versions were **removed after publication**, not never-published — `secure-coding` has `1.0.0` but not `2.0.0`–`2.0.2`; `react-a11y`'s oldest is `2.1.0`; `mongodb-security` starts at `8.0.0` with tags for `2.0.0`–`7.0.0`.

So "orphan" here means *unpublished or deprecated off the registry* — the expected state for the renamed `eslint-plugin-jwt` / `-pg` lines (#439) and for old majors. **Those tags are the only surviving record that the release happened.** The issue's own recovery section offered `cleanup-orphans`, which would delete that history to make a counter read zero.

A **missing** tag is the reverse and always a real defect: a version is live on npm with no tag pointing at the commit that produced it. That is what this now gates on.

## What changes

- `drift = summary.missingTags` (was `orphan + missing`) at both decision sites
- Orphans still appear in the report **and** the issue body — nothing is hidden, they just don't file an issue
- The issue body now explains why orphans are informational and warns before `cleanup-orphans`, so the next reader doesn't reach for the destructive command

## Verified

```
{"orphanTags":30,"missingTags":0} -> drift = 0 (issue CLOSED)   ← today
{"orphanTags":30,"missingTags":2} -> drift = 2 (issue OPEN)     ← still catches real drift
{"orphanTags":0,"missingTags":0}  -> drift = 0 (issue CLOSED)
```

`node scripts/lint-workflows.ts` — ✅ 32 workflow file(s) pass conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release hygiene checks now distinguish missing tags from orphan tags.
  * Missing tags are treated as actionable defects, while orphan tags are reported for information only.
  * Tracking issues and success status are no longer affected by orphan tags.

* **Documentation**
  * Updated summaries and recovery guidance to clarify the distinction and explain that backfilling missing tags resolves the issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->