### PR TITLE
chore(deps): pin dependabot off the TypeScript major until TS7 is viable

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,6 +52,26 @@ updates:
           - "@vitejs/*"
           - "tslib"
           - "@swc/*"
+    ignore:
+      # TypeScript 7 is the Go port (tsgo). Its package exports map `"."` to
+      # `./lib/version.cjs` — a version string — and moves the compiler API
+      # under `./unstable/*`, where `TypeChecker` and `ParserServices` do not
+      # exist at all. Every `import * as ts from 'typescript'` in this repo
+      # breaks, which took every check on #436 red.
+      #
+      # The blocker is not our code: no published typescript-eslint supports
+      # TS 7. Stable 8.54 declares `typescript: >=4.8.4 <6.0.0`; even
+      # 8.66.1-alpha.10 only reaches `<6.1.0`. Type-aware rules get their
+      # checker through typescript-eslint, so adopting TS 7 today would
+      # disable type-aware linting rather than upgrade it.
+      #
+      # TS 7 work already proceeds through `@typescript/native-preview`, which
+      # provides the `tsgo` binary used by `typecheck:graph` — the two live
+      # side by side. This pin is only for the copy typescript-eslint resolves.
+      #
+      # Lift this when typescript-eslint ships a TS7-capable release.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   # Maintain GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Unblocks the recurring Dependabot PR (currently #436), which has taken **all 18 heavy checks red** on every regeneration.

## One dependency is failing the whole group

#436 bumps 47 packages. Exactly one breaks it: `typescript` `^6.0.3` → `^7.0.2`.

TypeScript 7 is the Go port. Its package `exports` map sends `"."` to `./lib/version.cjs` — a module exporting a version string — and relocates the compiler API under `./unstable/*`, where `TypeChecker` and `ParserServices` do not exist at all. Every `import * as ts from 'typescript'` in this repo stops resolving:

```
packages/eslint-devkit/src/types/type-utils.ts(101,7): error TS2694:
Namespace '…/node_modules/typescript/lib/version' has no exported member 'Type'.
```

`eslint-devkit` is a dependency of every plugin, which is why 10 test shards, 4 builds and typecheck fail together.

## The blocker is upstream

| Package | TS peer range |
|---|---|
| `@typescript-eslint/utils` 8.54.0 (current) | `>=4.8.4 <6.0.0` |
| `@typescript-eslint/utils` 8.66.1-alpha.10 (newest prerelease) | `>=4.8.4 <6.1.0` |

**No published typescript-eslint — stable or alpha — supports TS 7.** Type-aware rules obtain their checker through typescript-eslint's `ParserServices`, not from `typescript` directly, so adopting TS 7 today would *disable* type-aware linting rather than upgrade it.

## Why config, not a PR comment

I tried `@dependabot ignore typescript major` on #436 first. Dependabot did not act — the PR is `DIRTY`, and a conflicted grouped PR generally cannot be rebuilt in place. A comment also only records a transient preference; a config entry survives regeneration and documents the reason where the next person will look.

Scoped to `version-update:semver-major`, so **6.x minors and patches keep flowing**.

## TS 7 is not being abandoned

The repo already runs both side by side: `@typescript/native-preview` (`7.0.0-dev`) provides the `tsgo` binary behind `typecheck:graph`, while `typescript@6.x` serves typescript-eslint. `.npmrc` carries `legacy-peer-deps=true`, which is how TS 6.0.3 already coexists with a `<6.0.0` peer. This pin touches only the copy typescript-eslint resolves.

Lift it when typescript-eslint ships a TS7-capable release.

## Verified

- `dependabot.yml` parses; all six npm groups and both ecosystems intact
- The ignore rule applies to the major only

Note: the file is Prettier-dirty on `main` already (double vs single quotes) — I left that alone rather than bury a 20-line change under a 37-line reformat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)