### PR TITLE
fix(ci): point sdk-compatibility at the renamed plugins

### DIFF
--- a/.github/workflows/sdk-compatibility.yml
+++ b/.github/workflows/sdk-compatibility.yml
@@ -87,10 +87,10 @@ jobs:
             {
               "key": "jwt",
               "label": "JWT Ecosystem",
-              "plugin": "eslint-plugin-jwt",
+              "plugin": "eslint-plugin-jwt-security",
               "issue_label": "jwt",
               "packages": "jose@latest jsonwebtoken@latest express-jwt@latest",
-              "rules": "| jose / jsonwebtoken | no-weak-algorithm, require-expiration, no-hardcoded-secret |\n| express-jwt | require-issuer, require-audience |\n"
+              "rules": "| jose / jsonwebtoken | no-algorithm-none, no-weak-secret, require-expiration, no-hardcoded-secret |\n| express-jwt | require-issuer-validation, require-audience-validation |\n"
             },
             {
               "key": "lambda",
@@ -119,10 +119,10 @@ jobs:
             {
               "key": "pg",
               "label": "PostgreSQL Ecosystem (pg)",
-              "plugin": "eslint-plugin-pg",
+              "plugin": "eslint-plugin-postgresql-security",
               "issue_label": "pg",
               "packages": "pg@latest",
-              "rules": "| pg | no-unsafe-query, require-parameterized-query |\n"
+              "rules": "| pg | no-unsafe-query, check-query-params, no-missing-client-release |\n"
             },
             {
               "key": "vercel-ai",


### PR DESCRIPTION
Answers "ensure no GH workflow will try to publish to them ever again" — with one real finding.

## The publish path is already safe

`release.yml` enumerates `packages/*/package.json` from the filesystem — **no hardcoded list**. `packages/eslint-plugin-jwt` and `-pg` were deleted in the rename, so the loop cannot see them. There is no path by which the pipeline republishes those names, and nothing to change there.

## But one workflow still targeted them

`sdk-compatibility.yml` carried both retired names in its SDK matrix, and each row resolves `packages/${{ matrix.plugin }}` — directories that no longer exist. Two guaranteed-failing jobs. Worse, the workflow **files a GitHub issue on failure**, so dispatching it would have opened two bogus "breaking change detected" reports against packages that were merely renamed.

Dormant, not harmless: it's `workflow_dispatch`-only and its last four runs (2026-05-11) all failed, so nobody had tripped it yet.

## Also fixed: the rule names were wrong

Stale independently of the rename. The matrix cited `require-parameterized-query`, `no-weak-algorithm`, `require-issuer`, `require-audience` — **none of which exist** in either package. Replaced with rules actually shipped, checked against `src/rules/`:

| row | now cites |
|---|---|
| jwt | `no-algorithm-none`, `no-weak-secret`, `require-expiration`, `no-hardcoded-secret`, `require-issuer-validation`, `require-audience-validation` |
| pg | `no-unsafe-query`, `check-query-params`, `no-missing-client-release` |

## Verified

- All **7** matrix plugins resolve to real package directories
- `lint-workflows.ts` — ✅ 34 workflow files pass conventions
- Zero remaining `"eslint-plugin-jwt"` / `"eslint-plugin-pg"` references in the file

## Remaining references elsewhere — deliberately left

Nine other hits, all inert prose: an issue-template example, two docs examples, a `codecov.yml` input description, and the explanatory comments in `Dockerfile` and `release-hygiene.yml` that describe *why* those packages were retired. Rewriting those would erase the history that explains the rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)