### PR TITLE
fix(workspace): a benchmark config that cannot load must not score zero

### DIFF
--- a/.github/workflows/quality-full.yml
+++ b/.github/workflows/quality-full.yml
@@ -74,6 +74,7 @@ jobs:
       heavy: ${{ steps.matrix.outputs.heavy }}
       build_shards: ${{ steps.build_matrix.outputs.build_shards }}
       build_any: ${{ steps.build_matrix.outputs.build_any }}
+      bench_configs: ${{ steps.bench_configs.outputs.run }}
     steps:
       - id: decide
         env:
@@ -171,6 +172,33 @@ jobs:
           fi
           echo "Shard matrix: $SHARDS (heavy=$HEAVY)"
 
+      # The benchmark-config load check needs every plugin BUILT, so it cannot
+      # ride along in a lock job. A build is ~4 minutes of a scarce runner, so
+      # it fires only on a diff that can actually break a config: the config
+      # files themselves, the benchmark workspace's dependency list, or any
+      # package manifest (which is what a rename/removal shows up as — #414
+      # renamed eslint-plugin-pg/-jwt and every arena number silently went to
+      # zero for two days).
+      - id: bench_configs
+        if: steps.decide.outputs.run == 'true'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          if [ -z "${BASE_SHA:-}" ]; then
+            # Not a PR (main / cron / dispatch): always run, same backstop
+            # posture as the test shards.
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          CHANGED=$(git diff --name-only "$BASE_SHA"...HEAD)
+          if echo "$CHANGED" | grep -qE '^(benchmarks/suites/.*\.config\.(js|mjs)|benchmarks/package\.json|benchmarks/__tests__/configs-load\.test\.ts|benchmarks/vitest\.configs-load\.mts|packages/[^/]+/package\.json|\.github/workflows/quality-full\.yml)$'; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No benchmark config, benchmark dependency or package manifest touched — skipping the config-load check."
+          fi
+
   # `scripts/` is not an npm workspace (`workspaces` is apps/*, packages/*,
   # tools/*, benchmarks), so turbo has no task for it and `turbo run test` never
   # reaches scripts/__tests__. CI only ever executed the files pinned by name:
@@ -193,6 +221,28 @@ jobs:
       - uses: ./.github/actions/setup
       - name: Run scripts/__tests__
         run: npm run --silent test:scripts
+
+  # Executes every benchmark ESLint config on a built tree. A config that
+  # throws is scored as "found nothing" by four suites, so this is the gate
+  # between a package rename and a published F1 of 0%. Gated by the diff (see
+  # the `bench_configs` step) because it has to build to mean anything.
+  bench-configs:
+    name: Benchmark configs load
+    needs: gate
+    if: needs.gate.outputs.run == 'true' && needs.gate.outputs.bench_configs == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      # Same filter the weekly benchmark uses, for the same reason: the configs
+      # import plugins by package name and resolve through `exports` to dist/.
+      - name: Build plugins (dist/ is what the configs load)
+        run: npx turbo run build --filter='eslint-plugin-*' --filter=@interlace/eslint-devkit
+      - name: Load every benchmark config
+        run: npm run --silent -w @interlace/benchmarks test:configs-load
 
   # Sharded by package, not by `vitest --shard`: Turbo caches per package-task,
   # so splitting inside a package would make each shard an uncacheable slice of

--- a/benchmarks/__tests__/configs-load.test.ts
+++ b/benchmarks/__tests__/configs-load.test.ts
@@ -83,6 +83,14 @@ function loadFailure(absPath: string): string {
     execFileSync(process.execPath, ['--input-type=module', '-e', probe], {
       stdio: ['ignore', 'ignore', 'pipe'],
       encoding: 'utf-8',
+      // execFileSync blocks the event loop, so the per-case `timeout: 30_000`
+      // below cannot fire while it waits — a config whose import hangs (a
+      // top-level await on something unresolved, a plugin probing the network)
+      // would hang the whole run rather than fail it, which is the opposite of
+      // what a guard against silent failure should do. The child gets its own
+      // limit, and SIGKILL so a handler cannot ignore it.
+      timeout: 20_000,
+      killSignal: 'SIGKILL',
     });
     return '';
   } catch (error) {

--- a/benchmarks/__tests__/configs-load.test.ts
+++ b/benchmarks/__tests__/configs-load.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Every benchmark ESLint config must import successfully.
+ *
+ * This is not a tidiness check — it is the guard for a silent-zero defect.
+ *
+ * The configs under `suites/ilb-arena/configs/` are shared by three suites
+ * (ilb-arena, ilb-cwe-corpus, ilb-juliet) and `suites/ilb-ai/eslint.config.js`
+ * drives a fourth. Each of them used to catch a config-load failure per
+ * fixture and carry on: cwe-corpus and juliet returned `{error}` whose missing
+ * `findings` field scored as zero, and arena printed a warning and returned
+ * `[]`. In all of them, **a config that cannot load is scored identically to a
+ * plugin that detects nothing.**
+ *
+ * That is not hypothetical. #414 (2026-08-07) renamed `eslint-plugin-pg` and
+ * `eslint-plugin-jwt` to `-postgresql-security` / `-jwt-security`;
+ * `interlace.config.js` still imported the old names, so the entire config
+ * threw and ilb-cwe-corpus published `Interlace: TP=0 FP=0 FN=69, F1=0%` —
+ * dead last behind every competitor — while the real numbers were TP=51 FN=18,
+ * F1=75%, first place. Nobody noticed for two days, and the weekly badge
+ * generator (#449) was one cron away from rendering the 0% onto the site.
+ *
+ * The runners now exit non-zero on a load failure. This test is the earlier
+ * gate: it fails on the PR that renames a package, not on the next benchmark
+ * run. It deliberately covers the *competitor* configs too — the first thing
+ * it caught was `vue.config.js` failing on a missing `vue-eslint-parser`,
+ * meaning the arena had been publishing eslint-plugin-vue as detecting
+ * nothing. Scoring a competitor at zero because we broke their config is the
+ * same defect pointed the other way, and a far worse look.
+ *
+ * Each config is loaded in a real `node` subprocess rather than with a bare
+ * `await import()`. Vitest's SSR transform resolves these packages through its
+ * own interop, where `plugin.configs` reads back `undefined` for a plugin that
+ * loads perfectly under node — so an in-process import reports failures the
+ * benchmark will never hit and misses the resolution differences it will.
+ * The runners use plain node; so does this test.
+ *
+ * WHY THIS FILE IS NOT IN THE DEFAULT `vitest run`
+ * ------------------------------------------------
+ * The configs import our plugins by package name, and those packages resolve
+ * through `exports` to `dist/`. So this suite only means anything on a tree
+ * where the plugins are BUILT, and it is excluded from `test` (which the
+ * unsharded lock jobs and the test shards run without building) and pinned to
+ * its own `test:configs-load` script, run by the `Benchmark configs load` job
+ * after `turbo run build`.
+ *
+ * A resolve-only check needing no build was considered and rejected: it cannot
+ * see the failure mode that actually mattered here. `vue.config.js` imports
+ * exactly one specifier, `eslint-plugin-vue`, which resolves fine — the parser
+ * blew up *inside* `vue.configs['flat/recommended']`. Only executing the
+ * config finds that.
+ */
+import { describe, expect, it } from 'vitest';
+import { readdirSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+
+const SUITES = join(import.meta.dirname, '../suites');
+const ARENA_CONFIG_DIR = join(SUITES, 'ilb-arena/configs');
+
+/** Every scored config, as absolute paths. */
+const CONFIGS: string[] = [
+  ...readdirSync(ARENA_CONFIG_DIR)
+    .filter((f) => f.endsWith('.config.js'))
+    .sort()
+    .map((f) => join(ARENA_CONFIG_DIR, f)),
+  // Not in the arena directory, same defect exposure: ilb-ai scores whatever
+  // this config loads, and it imported the two renamed packages until now.
+  join(SUITES, 'ilb-ai/eslint.config.js'),
+];
+
+/** Import one config in a real node process; returns '' on success. */
+function loadFailure(absPath: string): string {
+  const probe = `
+    import(${JSON.stringify(absPath)})
+      .then((m) => {
+        const c = m.default;
+        if (!Array.isArray(c)) throw new Error('default export is not an array');
+        if (c.length === 0) throw new Error('exports an empty config — lints nothing');
+      })
+      .catch((e) => { console.error(e.message); process.exit(1); });
+  `;
+  try {
+    execFileSync(process.execPath, ['--input-type=module', '-e', probe], {
+      stdio: ['ignore', 'ignore', 'pipe'],
+      encoding: 'utf-8',
+    });
+    return '';
+  } catch (error) {
+    const e = error as { stderr?: string };
+    return (e.stderr ?? 'unknown failure').split('\n')[0]!.slice(0, 200);
+  }
+}
+
+describe('benchmark configs', () => {
+  it('finds the configs', () => {
+    // A moved or renamed directory would otherwise turn this whole suite into
+    // zero passing assertions, which reports green.
+    expect(CONFIGS.length).toBeGreaterThan(10);
+  });
+
+  it.each(CONFIGS.map((p) => [p.slice(SUITES.length + 1), p] as const))(
+    '%s loads under node',
+    { timeout: 30_000 },
+    (label, absPath) => {
+      expect(loadFailure(absPath), `${label} does not load`).toBe('');
+    },
+  );
+});

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "test": "vitest run",
+    "test:configs-load": "vitest run --config vitest.configs-load.mts",
     "ilb:perf-import": "tsx suites/ilb-perf-import/run.js",
     "ilb:perf-import-nestjs": "tsx suites/ilb-perf-import-nestjs/run.ts",
     "ilb:cwe-corpus": "tsx suites/ilb-cwe-corpus/run.ts",
@@ -46,7 +47,7 @@
     "eslint-plugin-conventions": "*",
     "eslint-plugin-express-security": "*",
     "eslint-plugin-import-next": "*",
-    "eslint-plugin-jwt": "*",
+    "eslint-plugin-jwt-security": "*",
     "eslint-plugin-lambda-security": "*",
     "eslint-plugin-maintainability": "*",
     "eslint-plugin-modernization": "*",
@@ -55,7 +56,7 @@
     "eslint-plugin-nestjs-security": "*",
     "eslint-plugin-node-security": "*",
     "eslint-plugin-operability": "*",
-    "eslint-plugin-pg": "*",
+    "eslint-plugin-postgresql-security": "*",
     "eslint-plugin-reliability": "*",
     "eslint-plugin-secure-coding": "*",
     "eslint-plugin-vercel-ai-security": "*"
@@ -83,6 +84,7 @@
     "eslint-plugin-unicorn": "^73.0.0",
     "eslint-plugin-vue": "^10.10.0",
     "tsx": "^4.23.9",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vue-eslint-parser": "^10.4.1"
   }
 }

--- a/benchmarks/results/ilb-cwe-corpus/2026-08-09.json
+++ b/benchmarks/results/ilb-cwe-corpus/2026-08-09.json
@@ -1,0 +1,8125 @@
+{
+  "bench": "ILB-CWE-Corpus",
+  "version": "1.0",
+  "timestamp": "2026-08-09T16:26:14.541Z",
+  "environment": {
+    "nodeVersion": "v24.12.0",
+    "eslintVersion": "10.7.0",
+    "platform": "darwin",
+    "arch": "arm64"
+  },
+  "corpus": [
+    {
+      "cwe": "CWE-020",
+      "name": "Improper Input Validation (validation-bypass cluster)",
+      "owasp": "A03:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-secure-coding"
+      ],
+      "counts": {
+        "vulnerable": 5,
+        "safe": 5
+      }
+    },
+    {
+      "cwe": "CWE-022",
+      "name": "Path Traversal",
+      "owasp": "A01:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-073",
+      "name": "External Control of File Name or Path (template object injection via res.render)",
+      "owasp": "A03:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-express-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 1
+      }
+    },
+    {
+      "cwe": "CWE-078",
+      "name": "OS Command Injection",
+      "owasp": "A03:2021",
+      "severity": "CRITICAL",
+      "expectedPlugins": [
+        "eslint-plugin-secure-coding",
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-079",
+      "name": "Cross-Site Scripting (XSS)",
+      "owasp": "A03:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-browser-security",
+        "eslint-plugin-secure-coding"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-088",
+      "name": "Argument Injection",
+      "owasp": "A03:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-089",
+      "name": "SQL Injection",
+      "owasp": "A03:2021",
+      "severity": "CRITICAL",
+      "expectedPlugins": [
+        "eslint-plugin-secure-coding",
+        "eslint-plugin-pg"
+      ],
+      "counts": {
+        "vulnerable": 3,
+        "safe": 3
+      }
+    },
+    {
+      "cwe": "CWE-094",
+      "name": "Improper Control of Generation of Code (Code Injection)",
+      "owasp": "A03:2021",
+      "severity": "CRITICAL",
+      "expectedPlugins": [
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-099",
+      "name": "Improper Control of Resource Identifiers (Environment Injection)",
+      "owasp": "A03:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 1,
+        "safe": 1
+      }
+    },
+    {
+      "cwe": "CWE-1007",
+      "name": "Insufficient Visual Distinction of Homoglyphs Presented to User",
+      "owasp": "A07:2021",
+      "severity": "MEDIUM",
+      "expectedPlugins": [
+        "eslint-plugin-secure-coding"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-116",
+      "name": "Improper Encoding or Escaping of Output (broken sanitizers)",
+      "owasp": "A03:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-secure-coding"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-117",
+      "name": "Improper Output Neutralization for Logs (log injection)",
+      "owasp": "A09:2021",
+      "severity": "MEDIUM",
+      "expectedPlugins": [
+        "eslint-plugin-secure-coding"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-1333",
+      "name": "Inefficient Regular Expression Complexity (ReDoS)",
+      "owasp": "A05:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-secure-coding"
+      ],
+      "counts": {
+        "vulnerable": 3,
+        "safe": 3
+      }
+    },
+    {
+      "cwe": "CWE-178",
+      "name": "Improper Handling of Case Sensitivity (auth-guard path bypass)",
+      "owasp": "A01:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-express-security"
+      ],
+      "counts": {
+        "vulnerable": 1,
+        "safe": 1
+      }
+    },
+    {
+      "cwe": "CWE-209",
+      "name": "Generation of Error Message Containing Sensitive Information (stack-trace exposure)",
+      "owasp": "A05:2021",
+      "severity": "MEDIUM",
+      "expectedPlugins": [
+        "eslint-plugin-express-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 1
+      }
+    },
+    {
+      "cwe": "CWE-248",
+      "name": "Uncaught Exception (Unhandled Stream Error)",
+      "owasp": "A04:2021",
+      "severity": "MEDIUM",
+      "expectedPlugins": [
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-295",
+      "name": "Improper Certificate Validation",
+      "owasp": "A07:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-327",
+      "name": "Use of a Broken or Risky Cryptographic Algorithm",
+      "owasp": "A02:2021",
+      "severity": "CRITICAL",
+      "expectedPlugins": [
+        "eslint-plugin-jwt",
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 4,
+        "safe": 4
+      }
+    },
+    {
+      "cwe": "CWE-346",
+      "name": "Origin Validation Error (postMessage wildcard)",
+      "owasp": "A01:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-browser-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-377",
+      "name": "Insecure Temporary File",
+      "owasp": "A04:2021",
+      "severity": "MEDIUM",
+      "expectedPlugins": [
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 1
+      }
+    },
+    {
+      "cwe": "CWE-409",
+      "name": "Improper Handling of Highly Compressed Data (Decompression Bomb)",
+      "owasp": "A05:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 1,
+        "safe": 1
+      }
+    },
+    {
+      "cwe": "CWE-444",
+      "name": "Inconsistent Interpretation of HTTP Requests (HTTP Request Smuggling)",
+      "owasp": "A03:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-548",
+      "name": "Exposure of Information Through Directory Listing",
+      "owasp": "A01:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-express-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 1
+      }
+    },
+    {
+      "cwe": "CWE-598",
+      "name": "Use of GET Request Method With Sensitive Query Strings",
+      "owasp": "A09:2021",
+      "severity": "MEDIUM",
+      "expectedPlugins": [
+        "eslint-plugin-express-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 1
+      }
+    },
+    {
+      "cwe": "CWE-636",
+      "name": "Not Failing Securely ('Failing Open')",
+      "owasp": "A07:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-secure-coding"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-640",
+      "name": "Weak Password Recovery Mechanism (host-header poisoning in reset links)",
+      "owasp": "A07:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-express-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 1
+      }
+    },
+    {
+      "cwe": "CWE-770",
+      "name": "Allocation of Resources Without Limits or Throttling",
+      "owasp": "A05:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 1
+      }
+    },
+    {
+      "cwe": "CWE-798",
+      "name": "Hardcoded Credentials",
+      "owasp": "A07:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-secure-coding",
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 5,
+        "safe": 4
+      }
+    },
+    {
+      "cwe": "CWE-843",
+      "name": "Access of Resource Using Incompatible Type (req.query type confusion)",
+      "owasp": "A03:2021",
+      "severity": "MEDIUM",
+      "expectedPlugins": [
+        "eslint-plugin-express-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 1
+      }
+    },
+    {
+      "cwe": "CWE-918",
+      "name": "Server-Side Request Forgery (SSRF)",
+      "owasp": "A10:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-943",
+      "name": "Improper Neutralization of Special Elements in Data Query Logic (NoSQL Injection)",
+      "owasp": "A03:2021",
+      "severity": "CRITICAL",
+      "expectedPlugins": [
+        "eslint-plugin-mongodb-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    }
+  ],
+  "plugins": {
+    "interlace": {
+      "displayName": "Interlace ESLint Ecosystem",
+      "perCwe": {
+        "CWE-020": {
+          "name": "Improper Input Validation (validation-bypass cluster)",
+          "owasp": "A03:2021",
+          "TP": 3,
+          "FP": 5,
+          "FN": 2,
+          "TN": 0,
+          "precision": 37.5,
+          "recall": 60,
+          "f1": 46.2,
+          "bas": -40,
+          "fixtures": [
+            {
+              "file": "incomplete-hostname-regexp.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "browser-security/no-insecure-redirects": 1
+              }
+            },
+            {
+              "file": "incomplete-url-scheme-check.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "incorrect-suffix-check.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "express-security/no-missing-security-headers": 1
+              }
+            },
+            {
+              "file": "missing-regexp-anchor.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "browser-security/require-postmessage-origin-check": 1
+              }
+            },
+            {
+              "file": "url-substring-sanitization.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "anchored-origin-regexp.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "browser-security/require-postmessage-origin-check": 1
+              }
+            },
+            {
+              "file": "endswith-boundary.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "express-security/no-missing-security-headers": 1
+              }
+            },
+            {
+              "file": "escaped-anchored-hostname.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "secure-coding/no-redos-vulnerable-regex": 1
+              }
+            },
+            {
+              "file": "scheme-allowlist.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "lambda-security/no-error-swallowing": 1
+              }
+            },
+            {
+              "file": "url-parse-hostname.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "lambda-security/no-error-swallowing": 1
+              }
+            }
+          ]
+        },
+        "CWE-022": {
+          "name": "Path Traversal",
+          "owasp": "A01:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 2,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "path-join-user.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "node-security/detect-non-literal-fs-filename": 1
+              }
+            },
+            {
+              "file": "readfile-concat.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "node-security/detect-non-literal-fs-filename": 1
+              }
+            },
+            {
+              "file": "dirname-path.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-path.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-073": {
+          "name": "External Control of File Name or Path (template object injection via res.render)",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 1,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "render-body-spread.js",
+              "expectedVulnerable": true,
+              "findings": 6,
+              "ruleHits": {
+                "express-security/require-helmet": 1,
+                "express-security/require-rate-limiting": 1,
+                "express-security/require-express-body-parser-limits": 1,
+                "express-security/require-csrf-protection": 1,
+                "express-security/no-missing-csrf-protection": 1,
+                "express-security/no-user-controlled-render-locals": 1
+              }
+            },
+            {
+              "file": "render-query-spread.js",
+              "expectedVulnerable": true,
+              "findings": 3,
+              "ruleHits": {
+                "express-security/require-helmet": 1,
+                "express-security/require-rate-limiting": 1,
+                "express-security/no-user-controlled-render-locals": 1
+              }
+            },
+            {
+              "file": "render-explicit-locals.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-078": {
+          "name": "OS Command Injection",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 2,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "exec-concat.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "node-security/detect-child-process": 1,
+                "node-security/no-shell-injection": 1
+              }
+            },
+            {
+              "file": "exec-template.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "node-security/detect-child-process": 1,
+                "node-security/no-shell-injection": 1
+              }
+            },
+            {
+              "file": "exec-static.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "execFile-array.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-079": {
+          "name": "Cross-Site Scripting (XSS)",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 2,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "document-write-dynamic.js",
+              "expectedVulnerable": true,
+              "findings": 3,
+              "ruleHits": {
+                "browser-security/no-innerhtml": 1,
+                "secure-coding/no-improper-sanitization": 2
+              }
+            },
+            {
+              "file": "innerhtml-user-input.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "browser-security/no-innerhtml": 1
+              }
+            },
+            {
+              "file": "static-innerhtml.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "textcontent-safe.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-088": {
+          "name": "Argument Injection",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 1,
+          "FN": 0,
+          "TN": 1,
+          "precision": 66.7,
+          "recall": 100,
+          "f1": 80,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "git-ls-remote-arg-injection.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "node-security/detect-child-process": 1,
+                "lambda-security/no-missing-authorization-check": 1
+              }
+            },
+            {
+              "file": "tar-user-args.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "node-security/detect-child-process": 1
+              }
+            },
+            {
+              "file": "literal-argv.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "separator-guard.js",
+              "expectedVulnerable": false,
+              "findings": 2,
+              "ruleHits": {
+                "node-security/detect-child-process": 1,
+                "lambda-security/no-missing-authorization-check": 1
+              }
+            }
+          ]
+        },
+        "CWE-089": {
+          "name": "SQL Injection",
+          "owasp": "A03:2021",
+          "TP": 3,
+          "FP": 0,
+          "FN": 0,
+          "TN": 3,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "dynamic-column.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "pg/no-floating-query": 1,
+                "pg/no-unsafe-query": 1
+              }
+            },
+            {
+              "file": "string-concat.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "pg/no-floating-query": 1,
+                "pg/no-unsafe-query": 1
+              }
+            },
+            {
+              "file": "template-literal.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "pg/no-floating-query": 1,
+                "pg/no-unsafe-query": 1
+              }
+            },
+            {
+              "file": "parameterized.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "prepared-statement.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-query.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-094": {
+          "name": "Improper Control of Generation of Code (Code Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "vm-run-user-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "vm2-run-user-code.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "vm-literal-script.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "worker-isolation.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-099": {
+          "name": "Improper Control of Resource Identifiers (Environment Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "env-key-from-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "env-allowlisted-key.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-1007": {
+          "name": "Insufficient Visual Distinction of Homoglyphs Presented to User",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "cyrillic-homoglyph-identifier.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "zero-width-in-auth-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "ascii-identifiers.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "i18n-ui-copy.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-116": {
+          "name": "Improper Encoding or Escaping of Output (broken sanitizers)",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 1,
+          "FN": 0,
+          "TN": 1,
+          "precision": 66.7,
+          "recall": 100,
+          "f1": 80,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "single-pass-replace.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "browser-security/no-innerhtml": 1,
+                "secure-coding/no-improper-sanitization": 1
+              }
+            },
+            {
+              "file": "tag-filter-regexp.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "secure-coding/no-redos-vulnerable-regex": 1,
+                "secure-coding/no-improper-sanitization": 1
+              }
+            },
+            {
+              "file": "dompurify-sanitize.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "replace-until-stable.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "secure-coding/no-unchecked-loop-condition": 1
+              }
+            }
+          ]
+        },
+        "CWE-117": {
+          "name": "Improper Output Neutralization for Logs (log injection)",
+          "owasp": "A09:2021",
+          "TP": 0,
+          "FP": 1,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": -50,
+          "fixtures": [
+            {
+              "file": "newline-in-log-message.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "template-literal-log.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "stripped-newlines.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "secure-coding/no-improper-sanitization": 1
+              }
+            },
+            {
+              "file": "structured-logging.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-1333": {
+          "name": "Inefficient Regular Expression Complexity (ReDoS)",
+          "owasp": "A05:2021",
+          "TP": 3,
+          "FP": 0,
+          "FN": 0,
+          "TN": 3,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "real-cve.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "secure-coding/no-redos-vulnerable-regex": 1
+              }
+            },
+            {
+              "file": "self-loop.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "secure-coding/detect-non-literal-regexp": 1,
+                "secure-coding/no-redos-vulnerable-regex": 1
+              }
+            },
+            {
+              "file": "trade-off.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "secure-coding/no-redos-vulnerable-regex": 1
+              }
+            },
+            {
+              "file": "atomic-equivalent.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "literal-match.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "simple-anchored.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-178": {
+          "name": "Improper Handling of Case Sensitivity (auth-guard path bypass)",
+          "owasp": "A01:2021",
+          "TP": 1,
+          "FP": 0,
+          "FN": 0,
+          "TN": 1,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "case-sensitive-admin-guard.js",
+              "expectedVulnerable": true,
+              "findings": 4,
+              "ruleHits": {
+                "express-security/require-helmet": 1,
+                "express-security/require-rate-limiting": 1,
+                "express-security/require-case-insensitive-path-guard": 1,
+                "lambda-security/no-exposed-debug-endpoints": 1
+              }
+            },
+            {
+              "file": "normalized-path-guard.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-209": {
+          "name": "Generation of Error Message Containing Sensitive Information (stack-trace exposure)",
+          "owasp": "A05:2021",
+          "TP": 2,
+          "FP": 1,
+          "FN": 0,
+          "TN": 0,
+          "precision": 66.7,
+          "recall": 100,
+          "f1": 80,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "error-object-in-json.js",
+              "expectedVulnerable": true,
+              "findings": 8,
+              "ruleHits": {
+                "express-security/require-helmet": 1,
+                "express-security/require-rate-limiting": 1,
+                "express-security/require-csrf-protection": 1,
+                "express-security/no-missing-csrf-protection": 1,
+                "express-security/require-route-authentication": 1,
+                "lambda-security/no-error-swallowing": 1,
+                "express-security/no-error-details-in-response": 2
+              }
+            },
+            {
+              "file": "stack-in-response.js",
+              "expectedVulnerable": true,
+              "findings": 7,
+              "ruleHits": {
+                "express-security/require-helmet": 1,
+                "express-security/require-rate-limiting": 1,
+                "lambda-security/no-missing-authorization-check": 2,
+                "express-security/no-error-details-in-response": 2,
+                "lambda-security/no-error-swallowing": 1
+              }
+            },
+            {
+              "file": "generic-error-response.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "lambda-security/no-error-swallowing": 1
+              }
+            }
+          ]
+        },
+        "CWE-248": {
+          "name": "Uncaught Exception (Unhandled Stream Error)",
+          "owasp": "A04:2021",
+          "TP": 2,
+          "FP": 2,
+          "FN": 0,
+          "TN": 0,
+          "precision": 50,
+          "recall": 100,
+          "f1": 66.7,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "multipart-pipe-no-handler.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "node-security/detect-non-literal-fs-filename": 1
+              }
+            },
+            {
+              "file": "pipe-no-error-listener.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "node-security/detect-non-literal-fs-filename": 1
+              }
+            },
+            {
+              "file": "pipe-with-error-listener.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "node-security/detect-non-literal-fs-filename": 1
+              }
+            },
+            {
+              "file": "pipeline-promises.js",
+              "expectedVulnerable": false,
+              "findings": 2,
+              "ruleHits": {
+                "node-security/detect-non-literal-fs-filename": 1,
+                "lambda-security/no-error-swallowing": 1
+              }
+            }
+          ]
+        },
+        "CWE-295": {
+          "name": "Improper Certificate Validation",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "reject-unauthorized-false.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-checkserveridentity-noop.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-checkserveridentity-validates.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-default-verification.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-327": {
+          "name": "Use of a Broken or Risky Cryptographic Algorithm",
+          "owasp": "A02:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 2,
+          "TN": 4,
+          "precision": 100,
+          "recall": 50,
+          "f1": 66.7,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "gcm-decipher-no-final.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-decrypt-no-authtag.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "sign-alg-none.js",
+              "expectedVulnerable": true,
+              "findings": 4,
+              "ruleHits": {
+                "jwt/require-expiration": 1,
+                "jwt/no-weak-secret": 1,
+                "jwt/no-hardcoded-secret": 1,
+                "jwt/no-algorithm-none": 1
+              }
+            },
+            {
+              "file": "verify-allows-none.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "jwt/no-algorithm-none": 1
+              }
+            },
+            {
+              "file": "gcm-decrypt-verified.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-encrypt-authtag.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "sign-rs256.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "verify-allowlist.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-346": {
+          "name": "Origin Validation Error (postMessage wildcard)",
+          "owasp": "A01:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 2,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "iframe-wildcard.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "browser-security/no-postmessage-wildcard-origin": 1
+              }
+            },
+            {
+              "file": "window-parent-wildcard.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "browser-security/no-postmessage-wildcard-origin": 1
+              }
+            },
+            {
+              "file": "explicit-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "self-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-377": {
+          "name": "Insecure Temporary File",
+          "owasp": "A04:2021",
+          "TP": 2,
+          "FP": 1,
+          "FN": 0,
+          "TN": 0,
+          "precision": 66.7,
+          "recall": 100,
+          "f1": 80,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "static-tmp-write.js",
+              "expectedVulnerable": true,
+              "findings": 3,
+              "ruleHits": {
+                "node-security/no-data-in-temp-storage": 1,
+                "node-security/no-arbitrary-file-access": 1,
+                "node-security/detect-non-literal-fs-filename": 1
+              }
+            },
+            {
+              "file": "tmpdir-static-name.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "node-security/no-arbitrary-file-access": 1,
+                "node-security/detect-non-literal-fs-filename": 1
+              }
+            },
+            {
+              "file": "mkdtemp-write.js",
+              "expectedVulnerable": false,
+              "findings": 2,
+              "ruleHits": {
+                "node-security/no-arbitrary-file-access": 1,
+                "node-security/detect-non-literal-fs-filename": 1
+              }
+            }
+          ]
+        },
+        "CWE-409": {
+          "name": "Improper Handling of Highly Compressed Data (Decompression Bomb)",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "gunzip-no-limit.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gunzip-limited.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-444": {
+          "name": "Inconsistent Interpretation of HTTP Requests (HTTP Request Smuggling)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "request-insecure-parser.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "server-insecure-parser.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "request-default-parser.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "server-default-parser.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-548": {
+          "name": "Exposure of Information Through Directory Listing",
+          "owasp": "A01:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 1,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "serve-index-root.js",
+              "expectedVulnerable": true,
+              "findings": 4,
+              "ruleHits": {
+                "express-security/require-helmet": 1,
+                "express-security/require-rate-limiting": 1,
+                "express-security/no-static-root-exposure": 2
+              }
+            },
+            {
+              "file": "static-root-dirname.js",
+              "expectedVulnerable": true,
+              "findings": 6,
+              "ruleHits": {
+                "express-security/require-helmet": 1,
+                "express-security/require-rate-limiting": 1,
+                "express-security/no-static-root-exposure": 1,
+                "express-security/no-exposed-debug-endpoints": 1,
+                "lambda-security/no-exposed-debug-endpoints": 1,
+                "lambda-security/no-missing-authorization-check": 1
+              }
+            },
+            {
+              "file": "static-public-dir.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-598": {
+          "name": "Use of GET Request Method With Sensitive Query Strings",
+          "owasp": "A09:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 1,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "login-via-query.js",
+              "expectedVulnerable": true,
+              "findings": 3,
+              "ruleHits": {
+                "express-security/require-helmet": 1,
+                "express-security/require-rate-limiting": 1,
+                "express-security/no-sensitive-data-in-query": 1
+              }
+            },
+            {
+              "file": "token-in-query.js",
+              "expectedVulnerable": true,
+              "findings": 4,
+              "ruleHits": {
+                "express-security/require-helmet": 1,
+                "express-security/require-rate-limiting": 1,
+                "express-security/require-route-authentication": 1,
+                "express-security/no-sensitive-data-in-query": 1
+              }
+            },
+            {
+              "file": "login-via-body-post.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-636": {
+          "name": "Not Failing Securely ('Failing Open')",
+          "owasp": "A07:2021",
+          "TP": 1,
+          "FP": 0,
+          "FN": 1,
+          "TN": 2,
+          "precision": 100,
+          "recall": 50,
+          "f1": 66.7,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "catch-returns-true.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "lambda-security/no-error-swallowing": 1
+              }
+            },
+            {
+              "file": "empty-catch-continues.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "catch-denies.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "catch-rethrows.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-640": {
+          "name": "Weak Password Recovery Mechanism (host-header poisoning in reset links)",
+          "owasp": "A07:2021",
+          "TP": 2,
+          "FP": 1,
+          "FN": 0,
+          "TN": 0,
+          "precision": 66.7,
+          "recall": 100,
+          "f1": 80,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "reset-link-forwarded-host.js",
+              "expectedVulnerable": true,
+              "findings": 6,
+              "ruleHits": {
+                "express-security/require-helmet": 1,
+                "express-security/require-rate-limiting": 1,
+                "express-security/require-csrf-protection": 1,
+                "express-security/no-missing-csrf-protection": 1,
+                "express-security/require-route-authentication": 1,
+                "express-security/no-host-header-in-links": 1
+              }
+            },
+            {
+              "file": "reset-link-host-header.js",
+              "expectedVulnerable": true,
+              "findings": 6,
+              "ruleHits": {
+                "express-security/require-helmet": 1,
+                "express-security/require-rate-limiting": 1,
+                "express-security/require-csrf-protection": 1,
+                "express-security/no-missing-csrf-protection": 1,
+                "express-security/no-host-header-in-links": 1,
+                "browser-security/no-credentials-in-query-params": 1
+              }
+            },
+            {
+              "file": "reset-link-config-origin.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "browser-security/no-credentials-in-query-params": 1
+              }
+            }
+          ]
+        },
+        "CWE-770": {
+          "name": "Allocation of Resources Without Limits or Throttling",
+          "owasp": "A05:2021",
+          "TP": 1,
+          "FP": 1,
+          "FN": 1,
+          "TN": 0,
+          "precision": 50,
+          "recall": 50,
+          "f1": 50,
+          "bas": -50,
+          "fixtures": [
+            {
+              "file": "array-length-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "buffer-alloc-user.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "browser-security/detect-mixed-content": 1
+              }
+            },
+            {
+              "file": "buffer-alloc-clamped.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "browser-security/detect-mixed-content": 1
+              }
+            }
+          ]
+        },
+        "CWE-798": {
+          "name": "Hardcoded Credentials",
+          "owasp": "A07:2021",
+          "TP": 5,
+          "FP": 1,
+          "FN": 0,
+          "TN": 3,
+          "precision": 83.3,
+          "recall": 100,
+          "f1": 90.9,
+          "bas": 75,
+          "fixtures": [
+            {
+              "file": "api-key-in-source.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "secure-coding/no-hardcoded-credentials": 1
+              }
+            },
+            {
+              "file": "aws-access-key-literal.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "secure-coding/no-hardcoded-credentials": 1
+              }
+            },
+            {
+              "file": "github-token-literal.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "secure-coding/no-hardcoded-credentials": 1
+              }
+            },
+            {
+              "file": "jwt-signing-secret-literal.js",
+              "expectedVulnerable": true,
+              "findings": 3,
+              "ruleHits": {
+                "secure-coding/no-hardcoded-credentials": 2,
+                "jwt/no-hardcoded-secret": 1
+              }
+            },
+            {
+              "file": "password-in-config.js",
+              "expectedVulnerable": true,
+              "findings": 4,
+              "ruleHits": {
+                "mongodb-security/no-hardcoded-credentials": 2,
+                "lambda-security/no-secrets-in-env": 1,
+                "secure-coding/no-hardcoded-credentials": 1
+              }
+            },
+            {
+              "file": "env-credentials.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "password-label.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "provider-env-credentials.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "test-placeholder-values.js",
+              "expectedVulnerable": false,
+              "findings": 2,
+              "ruleHits": {
+                "mongodb-security/no-hardcoded-credentials": 1,
+                "browser-security/detect-mixed-content": 1
+              }
+            }
+          ]
+        },
+        "CWE-843": {
+          "name": "Access of Resource Using Incompatible Type (req.query type confusion)",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 1,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "query-object-spread.js",
+              "expectedVulnerable": true,
+              "findings": 5,
+              "ruleHits": {
+                "express-security/require-helmet": 1,
+                "express-security/require-rate-limiting": 1,
+                "mongodb-security/no-unbounded-find": 1,
+                "mongodb-security/no-unsafe-query": 1,
+                "express-security/require-query-type-guard": 1
+              }
+            },
+            {
+              "file": "query-string-methods.js",
+              "expectedVulnerable": true,
+              "findings": 4,
+              "ruleHits": {
+                "express-security/require-helmet": 1,
+                "express-security/require-rate-limiting": 1,
+                "browser-security/no-insecure-redirects": 1,
+                "express-security/require-query-type-guard": 1
+              }
+            },
+            {
+              "file": "guarded-query-type.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-918": {
+          "name": "Server-Side Request Forgery (SSRF)",
+          "owasp": "A10:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 2,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "axios-user-url.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "node-security/no-ssrf": 1
+              }
+            },
+            {
+              "file": "fetch-user-url.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "node-security/no-ssrf": 1
+              }
+            },
+            {
+              "file": "fetch-static-url.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-validated-url.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-943": {
+          "name": "Improper Neutralization of Special Elements in Data Query Logic (NoSQL Injection)",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 1,
+          "FN": 0,
+          "TN": 1,
+          "precision": 66.7,
+          "recall": 100,
+          "f1": 80,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "user-input-in-find.js",
+              "expectedVulnerable": true,
+              "findings": 4,
+              "ruleHits": {
+                "mongodb-security/no-select-sensitive-fields": 1,
+                "express-security/no-idor-resource-access": 1,
+                "mongodb-security/no-unsafe-query": 2
+              }
+            },
+            {
+              "file": "where-string.js",
+              "expectedVulnerable": true,
+              "findings": 3,
+              "ruleHits": {
+                "mongodb-security/no-unbounded-find": 1,
+                "mongodb-security/no-unsafe-query": 1,
+                "mongodb-security/no-unsafe-where": 1
+              }
+            },
+            {
+              "file": "explicit-eq.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "express-security/no-idor-resource-access": 1
+              }
+            },
+            {
+              "file": "static-filter.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        }
+      },
+      "aggregate": {
+        "TP": 51,
+        "FP": 16,
+        "FN": 18,
+        "TN": 44,
+        "precision": 76.1,
+        "recall": 73.9,
+        "f1": 75,
+        "bas": 47.2
+      }
+    },
+    "eslint-plugin-security": {
+      "displayName": "eslint-plugin-security",
+      "perCwe": {
+        "CWE-020": {
+          "name": "Improper Input Validation (validation-bypass cluster)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 1,
+          "FN": 5,
+          "TN": 4,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": -20,
+          "fixtures": [
+            {
+              "file": "incomplete-hostname-regexp.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "incomplete-url-scheme-check.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "incorrect-suffix-check.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "missing-regexp-anchor.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "url-substring-sanitization.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "anchored-origin-regexp.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "endswith-boundary.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "escaped-anchored-hostname.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-unsafe-regex": 1
+              }
+            },
+            {
+              "file": "scheme-allowlist.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "url-parse-hostname.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-022": {
+          "name": "Path Traversal",
+          "owasp": "A01:2021",
+          "TP": 2,
+          "FP": 1,
+          "FN": 0,
+          "TN": 1,
+          "precision": 66.7,
+          "recall": 100,
+          "f1": 80,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "path-join-user.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-non-literal-fs-filename": 1
+              }
+            },
+            {
+              "file": "readfile-concat.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-non-literal-fs-filename": 1
+              }
+            },
+            {
+              "file": "dirname-path.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-non-literal-fs-filename": 1
+              }
+            },
+            {
+              "file": "static-path.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-073": {
+          "name": "External Control of File Name or Path (template object injection via res.render)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "render-body-spread.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "render-query-spread.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "render-explicit-locals.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-078": {
+          "name": "OS Command Injection",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 2,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "exec-concat.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-child-process": 1
+              }
+            },
+            {
+              "file": "exec-template.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-child-process": 1
+              }
+            },
+            {
+              "file": "exec-static.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "execFile-array.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-079": {
+          "name": "Cross-Site Scripting (XSS)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "document-write-dynamic.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "innerhtml-user-input.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-innerhtml.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "textcontent-safe.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-088": {
+          "name": "Argument Injection",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "git-ls-remote-arg-injection.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tar-user-args.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "literal-argv.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "separator-guard.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-089": {
+          "name": "SQL Injection",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 3,
+          "TN": 3,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "dynamic-column.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "string-concat.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "template-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "parameterized.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "prepared-statement.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-query.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-094": {
+          "name": "Improper Control of Generation of Code (Code Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "vm-run-user-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "vm2-run-user-code.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "vm-literal-script.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "worker-isolation.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-099": {
+          "name": "Improper Control of Resource Identifiers (Environment Injection)",
+          "owasp": "A03:2021",
+          "TP": 1,
+          "FP": 1,
+          "FN": 0,
+          "TN": 0,
+          "precision": 50,
+          "recall": 100,
+          "f1": 66.7,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "env-key-from-user.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-object-injection": 1
+              }
+            },
+            {
+              "file": "env-allowlisted-key.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-object-injection": 1
+              }
+            }
+          ]
+        },
+        "CWE-1007": {
+          "name": "Insufficient Visual Distinction of Homoglyphs Presented to User",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 1,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": -50,
+          "fixtures": [
+            {
+              "file": "cyrillic-homoglyph-identifier.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "zero-width-in-auth-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "ascii-identifiers.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "i18n-ui-copy.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-object-injection": 1
+              }
+            }
+          ]
+        },
+        "CWE-116": {
+          "name": "Improper Encoding or Escaping of Output (broken sanitizers)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "single-pass-replace.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tag-filter-regexp.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "dompurify-sanitize.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "replace-until-stable.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-117": {
+          "name": "Improper Output Neutralization for Logs (log injection)",
+          "owasp": "A09:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "newline-in-log-message.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "template-literal-log.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "stripped-newlines.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "structured-logging.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-1333": {
+          "name": "Inefficient Regular Expression Complexity (ReDoS)",
+          "owasp": "A05:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 1,
+          "TN": 3,
+          "precision": 100,
+          "recall": 66.7,
+          "f1": 80,
+          "bas": 66.7,
+          "fixtures": [
+            {
+              "file": "real-cve.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-unsafe-regex": 1
+              }
+            },
+            {
+              "file": "self-loop.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-unsafe-regex": 1
+              }
+            },
+            {
+              "file": "trade-off.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "atomic-equivalent.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "literal-match.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "simple-anchored.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-178": {
+          "name": "Improper Handling of Case Sensitivity (auth-guard path bypass)",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "case-sensitive-admin-guard.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "normalized-path-guard.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-209": {
+          "name": "Generation of Error Message Containing Sensitive Information (stack-trace exposure)",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "error-object-in-json.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "stack-in-response.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "generic-error-response.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-248": {
+          "name": "Uncaught Exception (Unhandled Stream Error)",
+          "owasp": "A04:2021",
+          "TP": 2,
+          "FP": 2,
+          "FN": 0,
+          "TN": 0,
+          "precision": 50,
+          "recall": 100,
+          "f1": 66.7,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "multipart-pipe-no-handler.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-non-literal-fs-filename": 1
+              }
+            },
+            {
+              "file": "pipe-no-error-listener.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-non-literal-fs-filename": 1
+              }
+            },
+            {
+              "file": "pipe-with-error-listener.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-non-literal-fs-filename": 1
+              }
+            },
+            {
+              "file": "pipeline-promises.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-non-literal-fs-filename": 1
+              }
+            }
+          ]
+        },
+        "CWE-295": {
+          "name": "Improper Certificate Validation",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "reject-unauthorized-false.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-checkserveridentity-noop.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-checkserveridentity-validates.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-default-verification.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-327": {
+          "name": "Use of a Broken or Risky Cryptographic Algorithm",
+          "owasp": "A02:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 4,
+          "TN": 4,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "gcm-decipher-no-final.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-decrypt-no-authtag.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "sign-alg-none.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "verify-allows-none.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-decrypt-verified.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-encrypt-authtag.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "sign-rs256.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "verify-allowlist.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-346": {
+          "name": "Origin Validation Error (postMessage wildcard)",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "iframe-wildcard.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "window-parent-wildcard.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "explicit-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "self-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-377": {
+          "name": "Insecure Temporary File",
+          "owasp": "A04:2021",
+          "TP": 1,
+          "FP": 1,
+          "FN": 1,
+          "TN": 0,
+          "precision": 50,
+          "recall": 50,
+          "f1": 50,
+          "bas": -50,
+          "fixtures": [
+            {
+              "file": "static-tmp-write.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tmpdir-static-name.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-non-literal-fs-filename": 1
+              }
+            },
+            {
+              "file": "mkdtemp-write.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-non-literal-fs-filename": 1
+              }
+            }
+          ]
+        },
+        "CWE-409": {
+          "name": "Improper Handling of Highly Compressed Data (Decompression Bomb)",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "gunzip-no-limit.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gunzip-limited.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-444": {
+          "name": "Inconsistent Interpretation of HTTP Requests (HTTP Request Smuggling)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "request-insecure-parser.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "server-insecure-parser.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "request-default-parser.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "server-default-parser.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-548": {
+          "name": "Exposure of Information Through Directory Listing",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "serve-index-root.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-root-dirname.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-public-dir.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-598": {
+          "name": "Use of GET Request Method With Sensitive Query Strings",
+          "owasp": "A09:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "login-via-query.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "token-in-query.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "login-via-body-post.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-636": {
+          "name": "Not Failing Securely ('Failing Open')",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "catch-returns-true.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "empty-catch-continues.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "catch-denies.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "catch-rethrows.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-640": {
+          "name": "Weak Password Recovery Mechanism (host-header poisoning in reset links)",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "reset-link-forwarded-host.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "reset-link-host-header.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "reset-link-config-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-770": {
+          "name": "Allocation of Resources Without Limits or Throttling",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "array-length-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "buffer-alloc-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "buffer-alloc-clamped.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-798": {
+          "name": "Hardcoded Credentials",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 5,
+          "TN": 4,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "api-key-in-source.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "aws-access-key-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "github-token-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "jwt-signing-secret-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "password-in-config.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "env-credentials.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "password-label.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "provider-env-credentials.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "test-placeholder-values.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-843": {
+          "name": "Access of Resource Using Incompatible Type (req.query type confusion)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "query-object-spread.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "query-string-methods.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "guarded-query-type.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-918": {
+          "name": "Server-Side Request Forgery (SSRF)",
+          "owasp": "A10:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "axios-user-url.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-user-url.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-static-url.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-validated-url.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-943": {
+          "name": "Improper Neutralization of Special Elements in Data Query Logic (NoSQL Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "user-input-in-find.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "where-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "explicit-eq.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-filter.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        }
+      },
+      "aggregate": {
+        "TP": 10,
+        "FP": 7,
+        "FN": 59,
+        "TN": 53,
+        "precision": 58.8,
+        "recall": 14.5,
+        "f1": 23.3,
+        "bas": 2.8
+      }
+    },
+    "security-node": {
+      "displayName": "eslint-plugin-security-node",
+      "perCwe": {
+        "CWE-020": {
+          "name": "Improper Input Validation (validation-bypass cluster)",
+          "owasp": "A03:2021",
+          "TP": 1,
+          "FP": 1,
+          "FN": 4,
+          "TN": 4,
+          "precision": 50,
+          "recall": 20,
+          "f1": 28.6,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "incomplete-hostname-regexp.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security-node/detect-dangerous-redirects": 1
+              }
+            },
+            {
+              "file": "incomplete-url-scheme-check.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "incorrect-suffix-check.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "missing-regexp-anchor.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "url-substring-sanitization.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "anchored-origin-regexp.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "endswith-boundary.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "escaped-anchored-hostname.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "security-node/detect-dangerous-redirects": 1
+              }
+            },
+            {
+              "file": "scheme-allowlist.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "url-parse-hostname.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-022": {
+          "name": "Path Traversal",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "path-join-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "readfile-concat.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "dirname-path.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-path.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-073": {
+          "name": "External Control of File Name or Path (template object injection via res.render)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "render-body-spread.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "render-query-spread.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "render-explicit-locals.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-078": {
+          "name": "OS Command Injection",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 1,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": -50,
+          "fixtures": [
+            {
+              "file": "exec-concat.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "exec-template.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "exec-static.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "execFile-array.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "security-node/detect-crlf": 1
+              }
+            }
+          ]
+        },
+        "CWE-079": {
+          "name": "Cross-Site Scripting (XSS)",
+          "owasp": "A03:2021",
+          "TP": 1,
+          "FP": 0,
+          "FN": 1,
+          "TN": 2,
+          "precision": 100,
+          "recall": 50,
+          "f1": 66.7,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "document-write-dynamic.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security-node/detect-html-injection": 1
+              }
+            },
+            {
+              "file": "innerhtml-user-input.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-innerhtml.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "textcontent-safe.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-088": {
+          "name": "Argument Injection",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "git-ls-remote-arg-injection.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tar-user-args.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "literal-argv.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "separator-guard.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-089": {
+          "name": "SQL Injection",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 3,
+          "TN": 3,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "dynamic-column.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "string-concat.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "template-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "parameterized.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "prepared-statement.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-query.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-094": {
+          "name": "Improper Control of Generation of Code (Code Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "vm-run-user-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "vm2-run-user-code.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "vm-literal-script.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "worker-isolation.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-099": {
+          "name": "Improper Control of Resource Identifiers (Environment Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "env-key-from-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "env-allowlisted-key.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-1007": {
+          "name": "Insufficient Visual Distinction of Homoglyphs Presented to User",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "cyrillic-homoglyph-identifier.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "zero-width-in-auth-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "ascii-identifiers.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "i18n-ui-copy.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-116": {
+          "name": "Improper Encoding or Escaping of Output (broken sanitizers)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "single-pass-replace.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tag-filter-regexp.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "dompurify-sanitize.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "replace-until-stable.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-117": {
+          "name": "Improper Output Neutralization for Logs (log injection)",
+          "owasp": "A09:2021",
+          "TP": 1,
+          "FP": 0,
+          "FN": 1,
+          "TN": 2,
+          "precision": 100,
+          "recall": 50,
+          "f1": 66.7,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "newline-in-log-message.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "template-literal-log.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security-node/detect-crlf": 1
+              }
+            },
+            {
+              "file": "stripped-newlines.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "structured-logging.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-1333": {
+          "name": "Inefficient Regular Expression Complexity (ReDoS)",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 3,
+          "TN": 3,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "real-cve.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "self-loop.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "trade-off.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "atomic-equivalent.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "literal-match.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "simple-anchored.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-178": {
+          "name": "Improper Handling of Case Sensitivity (auth-guard path bypass)",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "case-sensitive-admin-guard.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "normalized-path-guard.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-209": {
+          "name": "Generation of Error Message Containing Sensitive Information (stack-trace exposure)",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "error-object-in-json.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "stack-in-response.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "generic-error-response.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-248": {
+          "name": "Uncaught Exception (Unhandled Stream Error)",
+          "owasp": "A04:2021",
+          "TP": 0,
+          "FP": 1,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": -50,
+          "fixtures": [
+            {
+              "file": "multipart-pipe-no-handler.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "pipe-no-error-listener.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "pipe-with-error-listener.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "pipeline-promises.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "security-node/detect-unhandled-async-errors": 1
+              }
+            }
+          ]
+        },
+        "CWE-295": {
+          "name": "Improper Certificate Validation",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "reject-unauthorized-false.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-checkserveridentity-noop.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-checkserveridentity-validates.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-default-verification.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-327": {
+          "name": "Use of a Broken or Risky Cryptographic Algorithm",
+          "owasp": "A02:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 4,
+          "TN": 4,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "gcm-decipher-no-final.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-decrypt-no-authtag.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "sign-alg-none.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "verify-allows-none.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-decrypt-verified.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-encrypt-authtag.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "sign-rs256.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "verify-allowlist.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-346": {
+          "name": "Origin Validation Error (postMessage wildcard)",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "iframe-wildcard.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "window-parent-wildcard.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "explicit-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "self-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-377": {
+          "name": "Insecure Temporary File",
+          "owasp": "A04:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "static-tmp-write.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tmpdir-static-name.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "mkdtemp-write.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-409": {
+          "name": "Improper Handling of Highly Compressed Data (Decompression Bomb)",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "gunzip-no-limit.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gunzip-limited.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-444": {
+          "name": "Inconsistent Interpretation of HTTP Requests (HTTP Request Smuggling)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "request-insecure-parser.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "server-insecure-parser.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "request-default-parser.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "server-default-parser.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-548": {
+          "name": "Exposure of Information Through Directory Listing",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "serve-index-root.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-root-dirname.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-public-dir.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-598": {
+          "name": "Use of GET Request Method With Sensitive Query Strings",
+          "owasp": "A09:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "login-via-query.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "token-in-query.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "login-via-body-post.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-636": {
+          "name": "Not Failing Securely ('Failing Open')",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "catch-returns-true.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "empty-catch-continues.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "catch-denies.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "catch-rethrows.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-640": {
+          "name": "Weak Password Recovery Mechanism (host-header poisoning in reset links)",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "reset-link-forwarded-host.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "reset-link-host-header.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "reset-link-config-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-770": {
+          "name": "Allocation of Resources Without Limits or Throttling",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "array-length-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "buffer-alloc-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "buffer-alloc-clamped.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-798": {
+          "name": "Hardcoded Credentials",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 5,
+          "TN": 4,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "api-key-in-source.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "aws-access-key-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "github-token-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "jwt-signing-secret-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "password-in-config.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "env-credentials.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "password-label.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "provider-env-credentials.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "test-placeholder-values.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-843": {
+          "name": "Access of Resource Using Incompatible Type (req.query type confusion)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "query-object-spread.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "query-string-methods.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "guarded-query-type.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-918": {
+          "name": "Server-Side Request Forgery (SSRF)",
+          "owasp": "A10:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "axios-user-url.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-user-url.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-static-url.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-validated-url.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-943": {
+          "name": "Improper Neutralization of Special Elements in Data Query Logic (NoSQL Injection)",
+          "owasp": "A03:2021",
+          "TP": 1,
+          "FP": 0,
+          "FN": 1,
+          "TN": 2,
+          "precision": 100,
+          "recall": 50,
+          "f1": 66.7,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "user-input-in-find.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "where-string.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security-node/detect-nosql-injection": 1
+              }
+            },
+            {
+              "file": "explicit-eq.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-filter.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        }
+      },
+      "aggregate": {
+        "TP": 4,
+        "FP": 3,
+        "FN": 65,
+        "TN": 57,
+        "precision": 57.1,
+        "recall": 5.8,
+        "f1": 10.5,
+        "bas": 0.8
+      }
+    },
+    "sonarjs": {
+      "displayName": "eslint-plugin-sonarjs",
+      "perCwe": {
+        "CWE-020": {
+          "name": "Improper Input Validation (validation-bypass cluster)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 1,
+          "FN": 5,
+          "TN": 4,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": -20,
+          "fixtures": [
+            {
+              "file": "incomplete-hostname-regexp.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "incomplete-url-scheme-check.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "incorrect-suffix-check.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "missing-regexp-anchor.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "url-substring-sanitization.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "anchored-origin-regexp.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "endswith-boundary.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "escaped-anchored-hostname.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "scheme-allowlist.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/no-ignored-exceptions": 1
+              }
+            },
+            {
+              "file": "url-parse-hostname.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-022": {
+          "name": "Path Traversal",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "path-join-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "readfile-concat.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "dirname-path.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-path.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-073": {
+          "name": "External Control of File Name or Path (template object injection via res.render)",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 1,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "render-body-spread.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/x-powered-by": 1
+              }
+            },
+            {
+              "file": "render-query-spread.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/x-powered-by": 1
+              }
+            },
+            {
+              "file": "render-explicit-locals.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-078": {
+          "name": "OS Command Injection",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 2,
+          "FN": 2,
+          "TN": 0,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": -100,
+          "fixtures": [
+            {
+              "file": "exec-concat.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "exec-template.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "exec-static.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/no-os-command-from-path": 1
+              }
+            },
+            {
+              "file": "execFile-array.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/no-os-command-from-path": 1
+              }
+            }
+          ]
+        },
+        "CWE-079": {
+          "name": "Cross-Site Scripting (XSS)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "document-write-dynamic.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "innerhtml-user-input.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-innerhtml.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "textcontent-safe.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-088": {
+          "name": "Argument Injection",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 2,
+          "FN": 0,
+          "TN": 0,
+          "precision": 50,
+          "recall": 100,
+          "f1": 66.7,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "git-ls-remote-arg-injection.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/no-os-command-from-path": 1
+              }
+            },
+            {
+              "file": "tar-user-args.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/no-os-command-from-path": 1
+              }
+            },
+            {
+              "file": "literal-argv.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/no-os-command-from-path": 1
+              }
+            },
+            {
+              "file": "separator-guard.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/no-os-command-from-path": 1
+              }
+            }
+          ]
+        },
+        "CWE-089": {
+          "name": "SQL Injection",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 3,
+          "TN": 3,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "dynamic-column.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "string-concat.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "template-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "parameterized.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "prepared-statement.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-query.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-094": {
+          "name": "Improper Control of Generation of Code (Code Injection)",
+          "owasp": "A03:2021",
+          "TP": 1,
+          "FP": 1,
+          "FN": 1,
+          "TN": 1,
+          "precision": 50,
+          "recall": 50,
+          "f1": 50,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "vm-run-user-string.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/code-eval": 1
+              }
+            },
+            {
+              "file": "vm2-run-user-code.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "vm-literal-script.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/code-eval": 1
+              }
+            },
+            {
+              "file": "worker-isolation.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-099": {
+          "name": "Improper Control of Resource Identifiers (Environment Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "env-key-from-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "env-allowlisted-key.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-1007": {
+          "name": "Insufficient Visual Distinction of Homoglyphs Presented to User",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "cyrillic-homoglyph-identifier.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "zero-width-in-auth-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "ascii-identifiers.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "i18n-ui-copy.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-116": {
+          "name": "Improper Encoding or Escaping of Output (broken sanitizers)",
+          "owasp": "A03:2021",
+          "TP": 1,
+          "FP": 1,
+          "FN": 1,
+          "TN": 1,
+          "precision": 50,
+          "recall": 50,
+          "f1": 50,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "single-pass-replace.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tag-filter-regexp.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/super-linear-regex": 1
+              }
+            },
+            {
+              "file": "dompurify-sanitize.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "replace-until-stable.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/super-linear-regex": 1
+              }
+            }
+          ]
+        },
+        "CWE-117": {
+          "name": "Improper Output Neutralization for Logs (log injection)",
+          "owasp": "A09:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "newline-in-log-message.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "template-literal-log.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "stripped-newlines.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "structured-logging.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-1333": {
+          "name": "Inefficient Regular Expression Complexity (ReDoS)",
+          "owasp": "A05:2021",
+          "TP": 3,
+          "FP": 0,
+          "FN": 0,
+          "TN": 3,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "real-cve.js",
+              "expectedVulnerable": true,
+              "findings": 6,
+              "ruleHits": {
+                "sonarjs/slow-regex": 1,
+                "sonarjs/regex-complexity": 1,
+                "sonarjs/single-char-in-character-classes": 1,
+                "sonarjs/concise-regex": 3
+              }
+            },
+            {
+              "file": "self-loop.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/slow-regex": 1
+              }
+            },
+            {
+              "file": "trade-off.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/super-linear-regex": 1
+              }
+            },
+            {
+              "file": "atomic-equivalent.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "literal-match.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "simple-anchored.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-178": {
+          "name": "Improper Handling of Case Sensitivity (auth-guard path bypass)",
+          "owasp": "A01:2021",
+          "TP": 1,
+          "FP": 0,
+          "FN": 0,
+          "TN": 1,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "case-sensitive-admin-guard.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/x-powered-by": 1
+              }
+            },
+            {
+              "file": "normalized-path-guard.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-209": {
+          "name": "Generation of Error Message Containing Sensitive Information (stack-trace exposure)",
+          "owasp": "A05:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 1,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "error-object-in-json.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/x-powered-by": 1
+              }
+            },
+            {
+              "file": "stack-in-response.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/x-powered-by": 1
+              }
+            },
+            {
+              "file": "generic-error-response.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-248": {
+          "name": "Uncaught Exception (Unhandled Stream Error)",
+          "owasp": "A04:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "multipart-pipe-no-handler.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "pipe-no-error-listener.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "pipe-with-error-listener.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "pipeline-promises.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-295": {
+          "name": "Improper Certificate Validation",
+          "owasp": "A07:2021",
+          "TP": 1,
+          "FP": 0,
+          "FN": 1,
+          "TN": 2,
+          "precision": 100,
+          "recall": 50,
+          "f1": 66.7,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "reject-unauthorized-false.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "sonarjs/unverified-certificate": 1,
+                "sonarjs/unverified-hostname": 1
+              }
+            },
+            {
+              "file": "tls-checkserveridentity-noop.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-checkserveridentity-validates.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-default-verification.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-327": {
+          "name": "Use of a Broken or Risky Cryptographic Algorithm",
+          "owasp": "A02:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 2,
+          "TN": 4,
+          "precision": 100,
+          "recall": 50,
+          "f1": 66.7,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "gcm-decipher-no-final.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-decrypt-no-authtag.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "sign-alg-none.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "sonarjs/insecure-jwt-token": 1,
+                "sonarjs/hardcoded-secret-signatures": 1
+              }
+            },
+            {
+              "file": "verify-allows-none.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/insecure-jwt-token": 1
+              }
+            },
+            {
+              "file": "gcm-decrypt-verified.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-encrypt-authtag.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "sign-rs256.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "verify-allowlist.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-346": {
+          "name": "Origin Validation Error (postMessage wildcard)",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "iframe-wildcard.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "window-parent-wildcard.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "explicit-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "self-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-377": {
+          "name": "Insecure Temporary File",
+          "owasp": "A04:2021",
+          "TP": 1,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 100,
+          "recall": 50,
+          "f1": 66.7,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "static-tmp-write.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/publicly-writable-directories": 1
+              }
+            },
+            {
+              "file": "tmpdir-static-name.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "mkdtemp-write.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-409": {
+          "name": "Improper Handling of Highly Compressed Data (Decompression Bomb)",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "gunzip-no-limit.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gunzip-limited.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-444": {
+          "name": "Inconsistent Interpretation of HTTP Requests (HTTP Request Smuggling)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "request-insecure-parser.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "server-insecure-parser.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "request-default-parser.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "server-default-parser.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-548": {
+          "name": "Exposure of Information Through Directory Listing",
+          "owasp": "A01:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 1,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "serve-index-root.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/x-powered-by": 1
+              }
+            },
+            {
+              "file": "static-root-dirname.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/x-powered-by": 1
+              }
+            },
+            {
+              "file": "static-public-dir.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-598": {
+          "name": "Use of GET Request Method With Sensitive Query Strings",
+          "owasp": "A09:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 1,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "login-via-query.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/x-powered-by": 1
+              }
+            },
+            {
+              "file": "token-in-query.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/x-powered-by": 1
+              }
+            },
+            {
+              "file": "login-via-body-post.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-636": {
+          "name": "Not Failing Securely ('Failing Open')",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "catch-returns-true.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "empty-catch-continues.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "catch-denies.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "catch-rethrows.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-640": {
+          "name": "Weak Password Recovery Mechanism (host-header poisoning in reset links)",
+          "owasp": "A07:2021",
+          "TP": 2,
+          "FP": 1,
+          "FN": 0,
+          "TN": 0,
+          "precision": 66.7,
+          "recall": 100,
+          "f1": 80,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "reset-link-forwarded-host.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "sonarjs/x-powered-by": 1,
+                "sonarjs/no-clear-text-protocols": 1
+              }
+            },
+            {
+              "file": "reset-link-host-header.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "sonarjs/x-powered-by": 1,
+                "sonarjs/no-clear-text-protocols": 1
+              }
+            },
+            {
+              "file": "reset-link-config-origin.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/no-clear-text-protocols": 1
+              }
+            }
+          ]
+        },
+        "CWE-770": {
+          "name": "Allocation of Resources Without Limits or Throttling",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "array-length-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "buffer-alloc-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "buffer-alloc-clamped.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-798": {
+          "name": "Hardcoded Credentials",
+          "owasp": "A07:2021",
+          "TP": 3,
+          "FP": 0,
+          "FN": 2,
+          "TN": 4,
+          "precision": 100,
+          "recall": 60,
+          "f1": 75,
+          "bas": 60,
+          "fixtures": [
+            {
+              "file": "api-key-in-source.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/no-hardcoded-secrets": 1
+              }
+            },
+            {
+              "file": "aws-access-key-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "github-token-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "jwt-signing-secret-literal.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/no-hardcoded-secrets": 1
+              }
+            },
+            {
+              "file": "password-in-config.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/no-hardcoded-passwords": 1
+              }
+            },
+            {
+              "file": "env-credentials.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "password-label.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "provider-env-credentials.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "test-placeholder-values.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-843": {
+          "name": "Access of Resource Using Incompatible Type (req.query type confusion)",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 1,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "query-object-spread.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/x-powered-by": 1
+              }
+            },
+            {
+              "file": "query-string-methods.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/x-powered-by": 1
+              }
+            },
+            {
+              "file": "guarded-query-type.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-918": {
+          "name": "Server-Side Request Forgery (SSRF)",
+          "owasp": "A10:2021",
+          "TP": 0,
+          "FP": 1,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": -50,
+          "fixtures": [
+            {
+              "file": "axios-user-url.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-user-url.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-static-url.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-validated-url.js",
+              "expectedVulnerable": false,
+              "findings": 2,
+              "ruleHits": {
+                "sonarjs/no-unused-vars": 1,
+                "sonarjs/no-dead-store": 1
+              }
+            }
+          ]
+        },
+        "CWE-943": {
+          "name": "Improper Neutralization of Special Elements in Data Query Logic (NoSQL Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "user-input-in-find.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "where-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "explicit-eq.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-filter.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        }
+      },
+      "aggregate": {
+        "TP": 27,
+        "FP": 9,
+        "FN": 42,
+        "TN": 51,
+        "precision": 75,
+        "recall": 39.1,
+        "f1": 51.4,
+        "bas": 24.1
+      }
+    },
+    "microsoft-sdl": {
+      "displayName": "@microsoft/eslint-plugin-sdl",
+      "perCwe": {
+        "CWE-020": {
+          "name": "Improper Input Validation (validation-bypass cluster)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 5,
+          "TN": 5,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "incomplete-hostname-regexp.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "incomplete-url-scheme-check.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "incorrect-suffix-check.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "missing-regexp-anchor.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "url-substring-sanitization.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "anchored-origin-regexp.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "endswith-boundary.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "escaped-anchored-hostname.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "scheme-allowlist.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "url-parse-hostname.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-022": {
+          "name": "Path Traversal",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "path-join-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "readfile-concat.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "dirname-path.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-path.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-073": {
+          "name": "External Control of File Name or Path (template object injection via res.render)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "render-body-spread.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "render-query-spread.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "render-explicit-locals.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-078": {
+          "name": "OS Command Injection",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "exec-concat.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "exec-template.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "exec-static.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "execFile-array.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-079": {
+          "name": "Cross-Site Scripting (XSS)",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 1,
+          "FN": 0,
+          "TN": 1,
+          "precision": 66.7,
+          "recall": 100,
+          "f1": 80,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "document-write-dynamic.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "@microsoft/sdl/no-document-write": 1
+              }
+            },
+            {
+              "file": "innerhtml-user-input.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "@microsoft/sdl/no-inner-html": 1
+              }
+            },
+            {
+              "file": "static-innerhtml.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "@microsoft/sdl/no-inner-html": 1
+              }
+            },
+            {
+              "file": "textcontent-safe.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-088": {
+          "name": "Argument Injection",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "git-ls-remote-arg-injection.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tar-user-args.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "literal-argv.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "separator-guard.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-089": {
+          "name": "SQL Injection",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 3,
+          "TN": 3,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "dynamic-column.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "string-concat.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "template-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "parameterized.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "prepared-statement.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-query.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-094": {
+          "name": "Improper Control of Generation of Code (Code Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "vm-run-user-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "vm2-run-user-code.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "vm-literal-script.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "worker-isolation.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-099": {
+          "name": "Improper Control of Resource Identifiers (Environment Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "env-key-from-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "env-allowlisted-key.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-1007": {
+          "name": "Insufficient Visual Distinction of Homoglyphs Presented to User",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "cyrillic-homoglyph-identifier.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "zero-width-in-auth-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "ascii-identifiers.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "i18n-ui-copy.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-116": {
+          "name": "Improper Encoding or Escaping of Output (broken sanitizers)",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 1,
+          "FN": 0,
+          "TN": 1,
+          "precision": 66.7,
+          "recall": 100,
+          "f1": 80,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "single-pass-replace.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "@microsoft/sdl/no-inner-html": 1
+              }
+            },
+            {
+              "file": "tag-filter-regexp.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "@microsoft/sdl/no-inner-html": 1
+              }
+            },
+            {
+              "file": "dompurify-sanitize.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "@microsoft/sdl/no-inner-html": 1
+              }
+            },
+            {
+              "file": "replace-until-stable.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-117": {
+          "name": "Improper Output Neutralization for Logs (log injection)",
+          "owasp": "A09:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "newline-in-log-message.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "template-literal-log.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "stripped-newlines.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "structured-logging.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-1333": {
+          "name": "Inefficient Regular Expression Complexity (ReDoS)",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 3,
+          "TN": 3,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "real-cve.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "self-loop.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "trade-off.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "atomic-equivalent.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "literal-match.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "simple-anchored.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-178": {
+          "name": "Improper Handling of Case Sensitivity (auth-guard path bypass)",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "case-sensitive-admin-guard.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "normalized-path-guard.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-209": {
+          "name": "Generation of Error Message Containing Sensitive Information (stack-trace exposure)",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "error-object-in-json.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "stack-in-response.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "generic-error-response.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-248": {
+          "name": "Uncaught Exception (Unhandled Stream Error)",
+          "owasp": "A04:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "multipart-pipe-no-handler.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "pipe-no-error-listener.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "pipe-with-error-listener.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "pipeline-promises.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-295": {
+          "name": "Improper Certificate Validation",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "reject-unauthorized-false.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-checkserveridentity-noop.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-checkserveridentity-validates.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-default-verification.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-327": {
+          "name": "Use of a Broken or Risky Cryptographic Algorithm",
+          "owasp": "A02:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 4,
+          "TN": 4,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "gcm-decipher-no-final.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-decrypt-no-authtag.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "sign-alg-none.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "verify-allows-none.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-decrypt-verified.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-encrypt-authtag.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "sign-rs256.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "verify-allowlist.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-346": {
+          "name": "Origin Validation Error (postMessage wildcard)",
+          "owasp": "A01:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 2,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "iframe-wildcard.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "@microsoft/sdl/no-postmessage-star-origin": 1
+              }
+            },
+            {
+              "file": "window-parent-wildcard.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "@microsoft/sdl/no-postmessage-star-origin": 1
+              }
+            },
+            {
+              "file": "explicit-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "self-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-377": {
+          "name": "Insecure Temporary File",
+          "owasp": "A04:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "static-tmp-write.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tmpdir-static-name.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "mkdtemp-write.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-409": {
+          "name": "Improper Handling of Highly Compressed Data (Decompression Bomb)",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "gunzip-no-limit.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gunzip-limited.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-444": {
+          "name": "Inconsistent Interpretation of HTTP Requests (HTTP Request Smuggling)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "request-insecure-parser.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "server-insecure-parser.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "request-default-parser.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "server-default-parser.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-548": {
+          "name": "Exposure of Information Through Directory Listing",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "serve-index-root.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-root-dirname.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-public-dir.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-598": {
+          "name": "Use of GET Request Method With Sensitive Query Strings",
+          "owasp": "A09:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "login-via-query.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "token-in-query.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "login-via-body-post.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-636": {
+          "name": "Not Failing Securely ('Failing Open')",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "catch-returns-true.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "empty-catch-continues.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "catch-denies.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "catch-rethrows.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-640": {
+          "name": "Weak Password Recovery Mechanism (host-header poisoning in reset links)",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "reset-link-forwarded-host.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "reset-link-host-header.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "reset-link-config-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-770": {
+          "name": "Allocation of Resources Without Limits or Throttling",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "array-length-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "buffer-alloc-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "buffer-alloc-clamped.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-798": {
+          "name": "Hardcoded Credentials",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 5,
+          "TN": 4,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "api-key-in-source.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "aws-access-key-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "github-token-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "jwt-signing-secret-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "password-in-config.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "env-credentials.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "password-label.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "provider-env-credentials.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "test-placeholder-values.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-843": {
+          "name": "Access of Resource Using Incompatible Type (req.query type confusion)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "query-object-spread.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "query-string-methods.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "guarded-query-type.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-918": {
+          "name": "Server-Side Request Forgery (SSRF)",
+          "owasp": "A10:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "axios-user-url.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-user-url.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-static-url.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-validated-url.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-943": {
+          "name": "Improper Neutralization of Special Elements in Data Query Logic (NoSQL Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "user-input-in-find.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "where-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "explicit-eq.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-filter.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        }
+      },
+      "aggregate": {
+        "TP": 6,
+        "FP": 2,
+        "FN": 63,
+        "TN": 58,
+        "precision": 75,
+        "recall": 8.7,
+        "f1": 15.6,
+        "bas": 5.4
+      }
+    },
+    "no-unsanitized": {
+      "displayName": "eslint-plugin-no-unsanitized",
+      "perCwe": {
+        "CWE-020": {
+          "name": "Improper Input Validation (validation-bypass cluster)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 5,
+          "TN": 5,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "incomplete-hostname-regexp.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "incomplete-url-scheme-check.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "incorrect-suffix-check.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "missing-regexp-anchor.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "url-substring-sanitization.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "anchored-origin-regexp.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "endswith-boundary.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "escaped-anchored-hostname.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "scheme-allowlist.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "url-parse-hostname.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-022": {
+          "name": "Path Traversal",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "path-join-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "readfile-concat.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "dirname-path.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-path.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-073": {
+          "name": "External Control of File Name or Path (template object injection via res.render)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "render-body-spread.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "render-query-spread.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "render-explicit-locals.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-078": {
+          "name": "OS Command Injection",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "exec-concat.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "exec-template.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "exec-static.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "execFile-array.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-079": {
+          "name": "Cross-Site Scripting (XSS)",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 2,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "document-write-dynamic.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "no-unsanitized/method": 1
+              }
+            },
+            {
+              "file": "innerhtml-user-input.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "no-unsanitized/property": 1
+              }
+            },
+            {
+              "file": "static-innerhtml.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "textcontent-safe.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-088": {
+          "name": "Argument Injection",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "git-ls-remote-arg-injection.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tar-user-args.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "literal-argv.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "separator-guard.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-089": {
+          "name": "SQL Injection",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 3,
+          "TN": 3,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "dynamic-column.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "string-concat.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "template-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "parameterized.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "prepared-statement.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-query.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-094": {
+          "name": "Improper Control of Generation of Code (Code Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "vm-run-user-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "vm2-run-user-code.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "vm-literal-script.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "worker-isolation.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-099": {
+          "name": "Improper Control of Resource Identifiers (Environment Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "env-key-from-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "env-allowlisted-key.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-1007": {
+          "name": "Insufficient Visual Distinction of Homoglyphs Presented to User",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "cyrillic-homoglyph-identifier.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "zero-width-in-auth-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "ascii-identifiers.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "i18n-ui-copy.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-116": {
+          "name": "Improper Encoding or Escaping of Output (broken sanitizers)",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 1,
+          "FN": 0,
+          "TN": 1,
+          "precision": 66.7,
+          "recall": 100,
+          "f1": 80,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "single-pass-replace.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "no-unsanitized/property": 1
+              }
+            },
+            {
+              "file": "tag-filter-regexp.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "no-unsanitized/property": 1
+              }
+            },
+            {
+              "file": "dompurify-sanitize.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "no-unsanitized/property": 1
+              }
+            },
+            {
+              "file": "replace-until-stable.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-117": {
+          "name": "Improper Output Neutralization for Logs (log injection)",
+          "owasp": "A09:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "newline-in-log-message.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "template-literal-log.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "stripped-newlines.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "structured-logging.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-1333": {
+          "name": "Inefficient Regular Expression Complexity (ReDoS)",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 3,
+          "TN": 3,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "real-cve.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "self-loop.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "trade-off.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "atomic-equivalent.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "literal-match.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "simple-anchored.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-178": {
+          "name": "Improper Handling of Case Sensitivity (auth-guard path bypass)",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "case-sensitive-admin-guard.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "normalized-path-guard.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-209": {
+          "name": "Generation of Error Message Containing Sensitive Information (stack-trace exposure)",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "error-object-in-json.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "stack-in-response.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "generic-error-response.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-248": {
+          "name": "Uncaught Exception (Unhandled Stream Error)",
+          "owasp": "A04:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "multipart-pipe-no-handler.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "pipe-no-error-listener.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "pipe-with-error-listener.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "pipeline-promises.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-295": {
+          "name": "Improper Certificate Validation",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "reject-unauthorized-false.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-checkserveridentity-noop.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-checkserveridentity-validates.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-default-verification.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-327": {
+          "name": "Use of a Broken or Risky Cryptographic Algorithm",
+          "owasp": "A02:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 4,
+          "TN": 4,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "gcm-decipher-no-final.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-decrypt-no-authtag.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "sign-alg-none.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "verify-allows-none.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-decrypt-verified.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-encrypt-authtag.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "sign-rs256.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "verify-allowlist.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-346": {
+          "name": "Origin Validation Error (postMessage wildcard)",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "iframe-wildcard.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "window-parent-wildcard.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "explicit-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "self-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-377": {
+          "name": "Insecure Temporary File",
+          "owasp": "A04:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "static-tmp-write.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tmpdir-static-name.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "mkdtemp-write.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-409": {
+          "name": "Improper Handling of Highly Compressed Data (Decompression Bomb)",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "gunzip-no-limit.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gunzip-limited.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-444": {
+          "name": "Inconsistent Interpretation of HTTP Requests (HTTP Request Smuggling)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "request-insecure-parser.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "server-insecure-parser.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "request-default-parser.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "server-default-parser.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-548": {
+          "name": "Exposure of Information Through Directory Listing",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "serve-index-root.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-root-dirname.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-public-dir.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-598": {
+          "name": "Use of GET Request Method With Sensitive Query Strings",
+          "owasp": "A09:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "login-via-query.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "token-in-query.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "login-via-body-post.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-636": {
+          "name": "Not Failing Securely ('Failing Open')",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "catch-returns-true.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "empty-catch-continues.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "catch-denies.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "catch-rethrows.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-640": {
+          "name": "Weak Password Recovery Mechanism (host-header poisoning in reset links)",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "reset-link-forwarded-host.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "reset-link-host-header.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "reset-link-config-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-770": {
+          "name": "Allocation of Resources Without Limits or Throttling",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "array-length-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "buffer-alloc-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "buffer-alloc-clamped.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-798": {
+          "name": "Hardcoded Credentials",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 5,
+          "TN": 4,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "api-key-in-source.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "aws-access-key-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "github-token-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "jwt-signing-secret-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "password-in-config.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "env-credentials.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "password-label.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "provider-env-credentials.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "test-placeholder-values.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-843": {
+          "name": "Access of Resource Using Incompatible Type (req.query type confusion)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "query-object-spread.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "query-string-methods.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "guarded-query-type.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-918": {
+          "name": "Server-Side Request Forgery (SSRF)",
+          "owasp": "A10:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "axios-user-url.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-user-url.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-static-url.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-validated-url.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-943": {
+          "name": "Improper Neutralization of Special Elements in Data Query Logic (NoSQL Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "user-input-in-find.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "where-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "explicit-eq.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-filter.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        }
+      },
+      "aggregate": {
+        "TP": 4,
+        "FP": 1,
+        "FN": 65,
+        "TN": 59,
+        "precision": 80,
+        "recall": 5.8,
+        "f1": 10.8,
+        "bas": 4.1
+      }
+    }
+  }
+}

--- a/benchmarks/suites/ilb-ai/eslint.config.js
+++ b/benchmarks/suites/ilb-ai/eslint.config.js
@@ -6,9 +6,9 @@
  */
 
 import secureCoding from 'eslint-plugin-secure-coding';
-import pg from 'eslint-plugin-pg';
+import pg from 'eslint-plugin-postgresql-security';
 import nodeSecurity from 'eslint-plugin-node-security';
-import jwt from 'eslint-plugin-jwt';
+import jwt from 'eslint-plugin-jwt-security';
 
 export default [
   {

--- a/benchmarks/suites/ilb-ai/run-antigravity.js
+++ b/benchmarks/suites/ilb-ai/run-antigravity.js
@@ -701,9 +701,9 @@ async function runBenchmark(config) {
       iterationsPerPrompt,
       analysisTools: [
         "eslint-plugin-secure-coding",
-        "eslint-plugin-pg",
+        "eslint-plugin-postgresql-security",
         "eslint-plugin-node-security",
-        "eslint-plugin-jwt",
+        "eslint-plugin-jwt-security",
       ],
       classification: "CWE, CVSS 3.1, OWASP Top 10 2021",
     },

--- a/benchmarks/suites/ilb-ai/run.js
+++ b/benchmarks/suites/ilb-ai/run.js
@@ -426,9 +426,9 @@ async function runBenchmark(config = DEFAULT_CONFIG) {
       iterationsPerPrompt: config.iterationsPerPrompt,
       analysisTools: [
         "eslint-plugin-secure-coding",
-        "eslint-plugin-pg",
+        "eslint-plugin-postgresql-security",
         "eslint-plugin-node-security",
-        "eslint-plugin-jwt",
+        "eslint-plugin-jwt-security",
       ],
       classification: "CWE, CVSS 3.1, OWASP Top 10 2021",
     },

--- a/benchmarks/suites/ilb-arena/configs/interlace.config.js
+++ b/benchmarks/suites/ilb-arena/configs/interlace.config.js
@@ -5,8 +5,8 @@
 
 import secureCoding from "eslint-plugin-secure-coding";
 import nodeSecurity from "eslint-plugin-node-security";
-import pg from "eslint-plugin-pg";
-import jwt from "eslint-plugin-jwt";
+import pg from "eslint-plugin-postgresql-security";
+import jwt from "eslint-plugin-jwt-security";
 import browserSecurity from "eslint-plugin-browser-security";
 import mongodbSecurity from "eslint-plugin-mongodb-security";
 import expressSecurity from "eslint-plugin-express-security";

--- a/benchmarks/suites/ilb-arena/run.js
+++ b/benchmarks/suites/ilb-arena/run.js
@@ -276,8 +276,12 @@ async function runEslint(configPath, targetFile) {
   try {
     config = await loadConfig(configPath);
   } catch (e) {
-    console.error(`  ⚠️  Config load failed for ${configPath}: ${e.message?.slice(0, 200)}`);
-    return [];
+    // Not a warning. Returning [] here scores the plugin as "found nothing",
+    // which is indistinguishable from a plugin that genuinely detects nothing
+    // — that is how a stale import in interlace.config.js put Interlace last
+    // in ilb-cwe-corpus at F1 0% for two days after #414.
+    console.error(`\n❌ Config failed to load: ${configPath}\n   ${e.message}\n\nRefusing to score.`);
+    process.exit(3);
   }
 
   try {
@@ -545,8 +549,8 @@ async function runBenchmark() {
       "eslint-plugin-node-security": getInstalledVersion(
         "eslint-plugin-node-security",
       ),
-      "eslint-plugin-pg": getInstalledVersion("eslint-plugin-pg"),
-      "eslint-plugin-jwt": getInstalledVersion("eslint-plugin-jwt"),
+      "eslint-plugin-postgresql-security": getInstalledVersion("eslint-plugin-postgresql-security"),
+      "eslint-plugin-jwt-security": getInstalledVersion("eslint-plugin-jwt-security"),
       "eslint-plugin-browser-security": getInstalledVersion(
         "eslint-plugin-browser-security",
       ),

--- a/benchmarks/suites/ilb-cwe-corpus/run.ts
+++ b/benchmarks/suites/ilb-cwe-corpus/run.ts
@@ -208,6 +208,27 @@ async function main() {
     process.exit(1);
   }
 
+  // Load every config before scoring anything. A config that throws on import
+  // used to be caught per-fixture and returned as `{error}`; the scorer read
+  // the missing `findings` field as zero, so a plugin that could not load and
+  // a plugin that found nothing produced identical numbers. That is exactly
+  // what happened when #414 renamed eslint-plugin-pg/-jwt out from under
+  // interlace.config.js: this suite reported Interlace at F1 0%, FN 69, last
+  // place, for two days. Fail the run instead — a benchmark that cannot load a
+  // competitor must not publish a score for it.
+  for (const plugin of plugins) {
+    try {
+      await loadConfig(plugin.config);
+    } catch (e) {
+      console.error(
+        `\n❌ Config failed to load for "${plugin.displayName}" (${plugin.config})\n   ${(e as Error).message}\n\n` +
+          `Refusing to score. A config that does not load would otherwise be\n` +
+          `indistinguishable from a plugin that detects nothing.`,
+      );
+      process.exit(3);
+    }
+  }
+
   if (!EMIT_JSON) {
     console.log(`\n🧪 ILB-CWE-Corpus v1.0 — ${corpus.length} CWE${corpus.length === 1 ? "" : "s"} × ${plugins.length} plugin${plugins.length === 1 ? "" : "s"}\n`);
     for (const c of corpus) {

--- a/benchmarks/suites/ilb-juliet/run.ts
+++ b/benchmarks/suites/ilb-juliet/run.ts
@@ -201,6 +201,21 @@ async function main() {
     process.exit(1);
   }
 
+  // See the same preflight in ilb-cwe-corpus/run.ts — this suite shares both
+  // the arena configs and the swallow-the-error-and-score-zero defect.
+  for (const plugin of plugins) {
+    try {
+      await loadConfig(plugin.config);
+    } catch (e) {
+      console.error(
+        `\n❌ Config failed to load for "${plugin.displayName}" (${plugin.config})\n   ${(e as Error).message}\n\n` +
+          `Refusing to score. A config that does not load would otherwise be\n` +
+          `indistinguishable from a plugin that detects nothing.`,
+      );
+      process.exit(3);
+    }
+  }
+
   if (!EMIT_JSON) {
     console.log(`\n🧪 ILB-Juliet v1.0 — ${corpus.length} CWE${corpus.length === 1 ? "" : "s"} × ${plugins.length} plugin${plugins.length === 1 ? "" : "s"}\n`);
     for (const c of corpus) {

--- a/benchmarks/suites/ilb-oxlint-parity/run.ts
+++ b/benchmarks/suites/ilb-oxlint-parity/run.ts
@@ -315,7 +315,7 @@ function main() {
     console.log('');
   }
 
-  const distOk = fs.existsSync(path.join(REPO_ROOT, 'packages', 'eslint-plugin-pg', 'dist', 'src', 'index.js'));
+  const distOk = fs.existsSync(path.join(REPO_ROOT, 'packages', 'eslint-plugin-postgresql-security', 'dist', 'src', 'index.js'));
   if (!distOk) {
     if (CACHED && !CI) {
       // Soft-skip in --cached mode (typically wired into `quality` for local

--- a/benchmarks/suites/ilb-remediation/run.mjs
+++ b/benchmarks/suites/ilb-remediation/run.mjs
@@ -53,8 +53,8 @@ const OUR_PLUGINS = [
   'eslint-plugin-nestjs-security',
   'eslint-plugin-lambda-security',
   'eslint-plugin-mongodb-security',
-  'eslint-plugin-pg',
-  'eslint-plugin-jwt',
+  'eslint-plugin-postgresql-security',
+  'eslint-plugin-jwt-security',
   'eslint-plugin-vercel-ai-security',
 ];
 

--- a/benchmarks/suites/landscape-data/harvest.mjs
+++ b/benchmarks/suites/landscape-data/harvest.mjs
@@ -102,8 +102,8 @@ const TOOLS = [
     "eslint-plugin-mongodb-security",
     "eslint-plugin-nestjs-security",
     "eslint-plugin-vercel-ai-security",
-    "eslint-plugin-jwt",
-    "eslint-plugin-pg",
+    "eslint-plugin-jwt-security",
+    "eslint-plugin-postgresql-security",
   ].map((npm) => ({ id: npm, group: "interlace", class: "eslint-plugin", npm, repo: "ofri-peretz/eslint", repoLevel: true })),
 ];
 

--- a/benchmarks/vitest.config.mts
+++ b/benchmarks/vitest.config.mts
@@ -22,5 +22,12 @@ export default defineConfig({
     environment: 'node',
     watch: false,
     include: ['__tests__/**/*.test.ts'],
+    // configs-load executes the benchmark configs, which import our plugins by
+    // package name and therefore resolve through `exports` into `dist/`. The
+    // jobs that run this `test` task (the lock jobs and the test shards) do not
+    // build, so here it would only ever report a missing dist/ as a broken
+    // config. It is pinned to `test:configs-load` and run by the `Benchmark
+    // configs load` job, which builds first.
+    exclude: ['__tests__/configs-load.test.ts'],
   },
 });

--- a/benchmarks/vitest.configs-load.mts
+++ b/benchmarks/vitest.configs-load.mts
@@ -1,0 +1,30 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * The one suite the default `test` task excludes, because it only means
+ * anything on a BUILT tree. See the header of `__tests__/configs-load.test.ts`.
+ *
+ * Standalone, NOT `mergeConfig(base, ...)`. mergeConfig concatenates arrays
+ * rather than replacing them, so a base `exclude` survives every attempt to
+ * override it: `include` became both globs, `exclude` kept
+ * `configs-load.test.ts`, and this suite silently ran zero of its assertions
+ * while the job reported "41 passed" — those 41 were `methodology-lock`. A
+ * config-load gate that never loads a config is the same silent pass the suite
+ * it guards was written to stop.
+ *
+ * A CLI filter (`vitest run __tests__/configs-load.test.ts`) has the same
+ * problem from the other direction: the base `exclude` is applied on top of
+ * positional filters, so that form matches zero files and exits reporting
+ * "No test files found".
+ */
+export default defineConfig({
+  test: {
+    // Same rationale as the base config: pre-push runs dozens of turbo tasks
+    // concurrently and vitest's 5s default mis-reports contention as failure.
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+    environment: 'node',
+    watch: false,
+    include: ['__tests__/configs-load.test.ts'],
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -491,7 +491,7 @@
         "eslint-plugin-conventions": "*",
         "eslint-plugin-express-security": "*",
         "eslint-plugin-import-next": "*",
-        "eslint-plugin-jwt": "*",
+        "eslint-plugin-jwt-security": "*",
         "eslint-plugin-lambda-security": "*",
         "eslint-plugin-maintainability": "*",
         "eslint-plugin-modernization": "*",
@@ -500,7 +500,7 @@
         "eslint-plugin-nestjs-security": "*",
         "eslint-plugin-node-security": "*",
         "eslint-plugin-operability": "*",
-        "eslint-plugin-pg": "*",
+        "eslint-plugin-postgresql-security": "*",
         "eslint-plugin-reliability": "*",
         "eslint-plugin-secure-coding": "*",
         "eslint-plugin-vercel-ai-security": "*"
@@ -528,7 +528,8 @@
         "eslint-plugin-unicorn": "^73.0.0",
         "eslint-plugin-vue": "^10.10.0",
         "tsx": "^4.23.9",
-        "typescript": "^6.0.3"
+        "typescript": "^6.0.3",
+        "vue-eslint-parser": "^10.4.1"
       }
     },
     "benchmarks/node_modules/dotenv": {
@@ -16142,10 +16143,6 @@
         "node": "*"
       }
     },
-    "node_modules/eslint-plugin-jwt": {
-      "resolved": "packages/eslint-plugin-jwt",
-      "link": true
-    },
     "node_modules/eslint-plugin-jwt-security": {
       "resolved": "packages/eslint-plugin-jwt-security",
       "link": true
@@ -16264,10 +16261,6 @@
       "peerDependencies": {
         "oxlint": "~1.77.0"
       }
-    },
-    "node_modules/eslint-plugin-pg": {
-      "resolved": "packages/eslint-plugin-pg",
-      "link": true
     },
     "node_modules/eslint-plugin-postgresql-security": {
       "resolved": "packages/eslint-plugin-postgresql-security",
@@ -29935,6 +29928,43 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/vue-eslint-parser": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-10.4.1.tgz",
+      "integrity": "sha512-Gk6gRDj0n/fkRa3C3l0bBheoBckUq/Rs0F/TvMWIS6nzzx67amAViMe9CkNgsP2tXyQONvGiHQESHwFtZ3aYDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "eslint-scope": "^8.2.0 || ^9.0.0",
+        "eslint-visitor-keys": "^4.2.0 || ^5.0.0",
+        "espree": "^10.3.0 || ^11.0.0",
+        "esquery": "^1.6.0",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/vue-eslint-parser/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
       "dev": true,
@@ -31689,53 +31719,6 @@
         "@oxc-resolver/binding-win32-x64-msvc": "11.24.2"
       }
     },
-    "packages/eslint-plugin-jwt": {
-      "version": "2.2.14",
-      "license": "MIT",
-      "dependencies": {
-        "@interlace/eslint-devkit": "^1.10.0"
-      },
-      "devDependencies": {
-        "@typescript-eslint/parser": "^8.46.2",
-        "@typescript-eslint/rule-tester": "^8.46.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "git+https://github.com/ofri-peretz/eslint.git"
-      },
-      "peerDependencies": {
-        "@nestjs/jwt": "^9.0.0 || ^10.0.0 || ^11.0.0",
-        "eslint": "^8.40.0 || ^9.0.0 || ^10.0.0",
-        "express-jwt": "^7.0.0 || ^8.0.0",
-        "jose": "^4.0.0 || ^5.0.0 || ^6.0.0",
-        "jsonwebtoken": "^8.0.0 || ^9.0.0",
-        "jwks-rsa": "^3.0.0 || ^4.0.0",
-        "jwt-decode": "^3.0.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@nestjs/jwt": {
-          "optional": true
-        },
-        "express-jwt": {
-          "optional": true
-        },
-        "jose": {
-          "optional": true
-        },
-        "jsonwebtoken": {
-          "optional": true
-        },
-        "jwks-rsa": {
-          "optional": true
-        },
-        "jwt-decode": {
-          "optional": true
-        }
-      }
-    },
     "packages/eslint-plugin-jwt-security": {
       "version": "2.3.2",
       "license": "MIT",
@@ -32111,34 +32094,6 @@
       },
       "peerDependencies": {
         "eslint": "^8.40.0 || ^9.0.0 || ^10.0.0"
-      }
-    },
-    "packages/eslint-plugin-pg": {
-      "version": "1.4.14",
-      "license": "MIT",
-      "dependencies": {
-        "@interlace/eslint-devkit": "^1.10.0"
-      },
-      "devDependencies": {
-        "@typescript-eslint/parser": "^8.46.2",
-        "@typescript-eslint/rule-tester": "^8.46.2",
-        "pg": "^8.22.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "git+https://github.com/ofri-peretz/eslint.git"
-      },
-      "peerDependencies": {
-        "eslint": "^8.40.0 || ^9.0.0 || ^10.0.0",
-        "pg": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "pg": {
-          "optional": true
-        }
       }
     },
     "packages/eslint-plugin-postgresql-security": {


### PR DESCRIPTION
## The defect

`benchmarks/suites/ilb-arena/configs/interlace.config.js` still imported `eslint-plugin-pg` and `eslint-plugin-jwt`, deleted by #414 on 2026-08-07 when they were renamed to `postgresql-security` / `jwt-security`. The whole config threw on import.

All three suites that share these configs treated that as *"found nothing"*:

| Suite | Behaviour on config-load failure |
|---|---|
| `ilb-cwe-corpus` | caught it, returned `{error}` — missing `findings` field scored as `0` |
| `ilb-juliet` | identical code, identical defect |
| `ilb-arena` | logged `⚠️ Config load failed`, returned `[]`, carried on |

**A plugin that cannot load and a plugin that detects nothing produce identical numbers.**

## What it published

`ilb:cwe-corpus` reported `Interlace: TP=0 FP=0 FN=69, F1=0%` — dead last behind every competitor — for two days. Real numbers, same corpus, imports fixed:

| Plugin | TP | FP | FN | Precision | Recall | F1 |
|---|---|---|---|---|---|---|
| **Interlace** | **51** | 16 | 18 | 76.1% | 73.9% | **75%** |
| eslint-plugin-sonarjs | 27 | 9 | 42 | 75% | 39.1% | 51.4% |
| eslint-plugin-security | 10 | 7 | 59 | 58.8% | 14.5% | 23.3% |
| @microsoft/eslint-plugin-sdl | 6 | 2 | 63 | 75% | 8.7% | 15.6% |
| eslint-plugin-no-unsanitized | 4 | 1 | 65 | 80% | 5.8% | 10.8% |
| eslint-plugin-security-node | 4 | 3 | 65 | 57.1% | 5.8% | 10.5% |

The weekly badge generator added in #449 had not fired yet. The 0% was one cron away from being rendered onto the site.

## The fix

- Correct the two renamed imports.
- All three runners now **exit non-zero** on a config-load failure instead of scoring the plugin.
- New `scripts/__tests__/benchmark-configs-load.test.ts` — the earlier gate. It fails on the PR that renames a package, not on the next benchmark run.

Each config is loaded in a real `node` subprocess rather than with a bare `await import()`. Vitest's SSR interop reads `plugin.configs` back as `undefined` for plugins that load perfectly under node, so an in-process import invents failures the benchmark will never hit and misses the resolution differences it will. The runners use plain node; so does the test.

## It caught a second one immediately, pointed the other way

`vue.config.js` failed on a missing `vue-eslint-parser` (a peer of `eslint-plugin-vue`, never declared). **The arena had been publishing eslint-plugin-vue as detecting nothing.** Scoring a competitor at zero because we broke their config is the same defect in the opposite direction, and a considerably worse look. Added as a devDependency.

## Verification

Mutation-verified, four states:

| Mutation | Expected | Result |
|---|---|---|
| baseline | 19 pass | ✅ 19 passed |
| reintroduce the `pg` rename | only `interlace.config.js` fails | ✅ 1 failed / 18 passed |
| `export default []` in `sonarjs.config.js` | only `sonarjs.config.js` fails | ✅ 1 failed / 18 passed |
| restored | 19 pass | ✅ 19 passed |

Runner preflight, end to end: broken config → `EXIT=3`, no leaderboard printed. Restored → `EXIT=0`, real table.

## Follow-up

The 16 FPs and 18 FNs this now exposes are real and tracked separately — see the worklist in `DISTRIBUTION-PLAN.md`. This PR only makes the number honest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Benchmark runs now fail clearly when plugin configurations cannot be loaded, preventing invalid zero-finding scores.
  * Configuration errors identify the affected plugin and provide detailed error output.
  * ESLint execution failures continue to be handled without stopping benchmark processing.

* **Tests**
  * Added automated validation to ensure benchmark configurations load successfully and export valid results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->