### PR TITLE
fix(lambda-security): no-error-swallowing fired on four correct patterns

### DIFF
--- a/.changeset/no-error-swallowing-fail-closed.md
+++ b/.changeset/no-error-swallowing-fail-closed.md
@@ -1,0 +1,23 @@
+---
+"eslint-plugin-lambda-security": patch
+---
+
+`no-error-swallowing` no longer reports a catch that handles its error.
+
+The rule detected handling by regexing the block's printed source, so it
+missed `next(err)`, `reject(err)` and every response call, while matching any
+identifier that merely started with "log" — including inside comments and
+string literals. Its return check additionally demanded the returned
+expression match `/500|error|fail/`, so `return false` from a hostname
+validator read as swallowing.
+
+Detection is now AST-based. A catch handles its error when it logs, forwards
+to a callback (`next`, `reject`, `callback`, `done`), answers the request
+(`res.status(...)`, `res.end()`), or returns a **fail-closed** value.
+
+Fail-open returns still report, and that distinction is the point:
+`catch { return false }` denies, `catch { return true }` grants access on a
+malformed token. `true`, a 2xx `statusCode`, `null` and `undefined` are all
+excluded from the exemption.
+
+Fixes four false positives in ILB-CWE-Corpus with no loss of true positives.

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -83,6 +83,7 @@
     "eslint-plugin-unicorn": "^72.0.0",
     "eslint-plugin-vue": "^10.9.2",
     "tsx": "^4.23.1",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vue-eslint-parser": "^10.4.1"
   }
 }

--- a/benchmarks/results/ilb-cwe-corpus/2026-08-09.json
+++ b/benchmarks/results/ilb-cwe-corpus/2026-08-09.json
@@ -1,7 +1,7 @@
 {
   "bench": "ILB-CWE-Corpus",
   "version": "1.0",
-  "timestamp": "2026-08-09T16:26:14.541Z",
+  "timestamp": "2026-08-09T17:04:36.607Z",
   "environment": {
     "nodeVersion": "v24.12.0",
     "eslintVersion": "10.7.0",
@@ -426,13 +426,13 @@
           "name": "Improper Input Validation (validation-bypass cluster)",
           "owasp": "A03:2021",
           "TP": 3,
-          "FP": 5,
+          "FP": 3,
           "FN": 2,
-          "TN": 0,
-          "precision": 37.5,
+          "TN": 2,
+          "precision": 50,
           "recall": 60,
-          "f1": 46.2,
-          "bas": -40,
+          "f1": 54.5,
+          "bas": 0,
           "fixtures": [
             {
               "file": "incomplete-hostname-regexp.js",
@@ -497,18 +497,14 @@
             {
               "file": "scheme-allowlist.js",
               "expectedVulnerable": false,
-              "findings": 1,
-              "ruleHits": {
-                "lambda-security/no-error-swallowing": 1
-              }
+              "findings": 0,
+              "ruleHits": {}
             },
             {
               "file": "url-parse-hostname.js",
               "expectedVulnerable": false,
-              "findings": 1,
-              "ruleHits": {
-                "lambda-security/no-error-swallowing": 1
-              }
+              "findings": 0,
+              "ruleHits": {}
             }
           ]
         },
@@ -1069,47 +1065,43 @@
           "name": "Generation of Error Message Containing Sensitive Information (stack-trace exposure)",
           "owasp": "A05:2021",
           "TP": 2,
-          "FP": 1,
+          "FP": 0,
           "FN": 0,
-          "TN": 0,
-          "precision": 66.7,
+          "TN": 1,
+          "precision": 100,
           "recall": 100,
-          "f1": 80,
-          "bas": 0,
+          "f1": 100,
+          "bas": 100,
           "fixtures": [
             {
               "file": "error-object-in-json.js",
               "expectedVulnerable": true,
-              "findings": 8,
+              "findings": 7,
               "ruleHits": {
                 "express-security/require-helmet": 1,
                 "express-security/require-rate-limiting": 1,
                 "express-security/require-csrf-protection": 1,
                 "express-security/no-missing-csrf-protection": 1,
                 "express-security/require-route-authentication": 1,
-                "lambda-security/no-error-swallowing": 1,
                 "express-security/no-error-details-in-response": 2
               }
             },
             {
               "file": "stack-in-response.js",
               "expectedVulnerable": true,
-              "findings": 7,
+              "findings": 6,
               "ruleHits": {
                 "express-security/require-helmet": 1,
                 "express-security/require-rate-limiting": 1,
                 "lambda-security/no-missing-authorization-check": 2,
-                "express-security/no-error-details-in-response": 2,
-                "lambda-security/no-error-swallowing": 1
+                "express-security/no-error-details-in-response": 2
               }
             },
             {
               "file": "generic-error-response.js",
               "expectedVulnerable": false,
-              "findings": 1,
-              "ruleHits": {
-                "lambda-security/no-error-swallowing": 1
-              }
+              "findings": 0,
+              "ruleHits": {}
             }
           ]
         },
@@ -1152,10 +1144,9 @@
             {
               "file": "pipeline-promises.js",
               "expectedVulnerable": false,
-              "findings": 2,
+              "findings": 1,
               "ruleHits": {
-                "node-security/detect-non-literal-fs-filename": 1,
-                "lambda-security/no-error-swallowing": 1
+                "node-security/detect-non-literal-fs-filename": 1
               }
             }
           ]
@@ -1843,13 +1834,13 @@
       },
       "aggregate": {
         "TP": 51,
-        "FP": 16,
+        "FP": 13,
         "FN": 18,
-        "TN": 44,
-        "precision": 76.1,
+        "TN": 47,
+        "precision": 79.7,
         "recall": 73.9,
-        "f1": 75,
-        "bas": 47.2
+        "f1": 76.7,
+        "bas": 52.2
       }
     },
     "eslint-plugin-security": {

--- a/benchmarks/results/ilb-cwe-corpus/2026-08-09.json
+++ b/benchmarks/results/ilb-cwe-corpus/2026-08-09.json
@@ -1,0 +1,8125 @@
+{
+  "bench": "ILB-CWE-Corpus",
+  "version": "1.0",
+  "timestamp": "2026-08-09T16:26:14.541Z",
+  "environment": {
+    "nodeVersion": "v24.12.0",
+    "eslintVersion": "10.7.0",
+    "platform": "darwin",
+    "arch": "arm64"
+  },
+  "corpus": [
+    {
+      "cwe": "CWE-020",
+      "name": "Improper Input Validation (validation-bypass cluster)",
+      "owasp": "A03:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-secure-coding"
+      ],
+      "counts": {
+        "vulnerable": 5,
+        "safe": 5
+      }
+    },
+    {
+      "cwe": "CWE-022",
+      "name": "Path Traversal",
+      "owasp": "A01:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-073",
+      "name": "External Control of File Name or Path (template object injection via res.render)",
+      "owasp": "A03:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-express-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 1
+      }
+    },
+    {
+      "cwe": "CWE-078",
+      "name": "OS Command Injection",
+      "owasp": "A03:2021",
+      "severity": "CRITICAL",
+      "expectedPlugins": [
+        "eslint-plugin-secure-coding",
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-079",
+      "name": "Cross-Site Scripting (XSS)",
+      "owasp": "A03:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-browser-security",
+        "eslint-plugin-secure-coding"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-088",
+      "name": "Argument Injection",
+      "owasp": "A03:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-089",
+      "name": "SQL Injection",
+      "owasp": "A03:2021",
+      "severity": "CRITICAL",
+      "expectedPlugins": [
+        "eslint-plugin-secure-coding",
+        "eslint-plugin-pg"
+      ],
+      "counts": {
+        "vulnerable": 3,
+        "safe": 3
+      }
+    },
+    {
+      "cwe": "CWE-094",
+      "name": "Improper Control of Generation of Code (Code Injection)",
+      "owasp": "A03:2021",
+      "severity": "CRITICAL",
+      "expectedPlugins": [
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-099",
+      "name": "Improper Control of Resource Identifiers (Environment Injection)",
+      "owasp": "A03:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 1,
+        "safe": 1
+      }
+    },
+    {
+      "cwe": "CWE-1007",
+      "name": "Insufficient Visual Distinction of Homoglyphs Presented to User",
+      "owasp": "A07:2021",
+      "severity": "MEDIUM",
+      "expectedPlugins": [
+        "eslint-plugin-secure-coding"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-116",
+      "name": "Improper Encoding or Escaping of Output (broken sanitizers)",
+      "owasp": "A03:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-secure-coding"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-117",
+      "name": "Improper Output Neutralization for Logs (log injection)",
+      "owasp": "A09:2021",
+      "severity": "MEDIUM",
+      "expectedPlugins": [
+        "eslint-plugin-secure-coding"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-1333",
+      "name": "Inefficient Regular Expression Complexity (ReDoS)",
+      "owasp": "A05:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-secure-coding"
+      ],
+      "counts": {
+        "vulnerable": 3,
+        "safe": 3
+      }
+    },
+    {
+      "cwe": "CWE-178",
+      "name": "Improper Handling of Case Sensitivity (auth-guard path bypass)",
+      "owasp": "A01:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-express-security"
+      ],
+      "counts": {
+        "vulnerable": 1,
+        "safe": 1
+      }
+    },
+    {
+      "cwe": "CWE-209",
+      "name": "Generation of Error Message Containing Sensitive Information (stack-trace exposure)",
+      "owasp": "A05:2021",
+      "severity": "MEDIUM",
+      "expectedPlugins": [
+        "eslint-plugin-express-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 1
+      }
+    },
+    {
+      "cwe": "CWE-248",
+      "name": "Uncaught Exception (Unhandled Stream Error)",
+      "owasp": "A04:2021",
+      "severity": "MEDIUM",
+      "expectedPlugins": [
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-295",
+      "name": "Improper Certificate Validation",
+      "owasp": "A07:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-327",
+      "name": "Use of a Broken or Risky Cryptographic Algorithm",
+      "owasp": "A02:2021",
+      "severity": "CRITICAL",
+      "expectedPlugins": [
+        "eslint-plugin-jwt",
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 4,
+        "safe": 4
+      }
+    },
+    {
+      "cwe": "CWE-346",
+      "name": "Origin Validation Error (postMessage wildcard)",
+      "owasp": "A01:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-browser-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-377",
+      "name": "Insecure Temporary File",
+      "owasp": "A04:2021",
+      "severity": "MEDIUM",
+      "expectedPlugins": [
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 1
+      }
+    },
+    {
+      "cwe": "CWE-409",
+      "name": "Improper Handling of Highly Compressed Data (Decompression Bomb)",
+      "owasp": "A05:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 1,
+        "safe": 1
+      }
+    },
+    {
+      "cwe": "CWE-444",
+      "name": "Inconsistent Interpretation of HTTP Requests (HTTP Request Smuggling)",
+      "owasp": "A03:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-548",
+      "name": "Exposure of Information Through Directory Listing",
+      "owasp": "A01:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-express-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 1
+      }
+    },
+    {
+      "cwe": "CWE-598",
+      "name": "Use of GET Request Method With Sensitive Query Strings",
+      "owasp": "A09:2021",
+      "severity": "MEDIUM",
+      "expectedPlugins": [
+        "eslint-plugin-express-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 1
+      }
+    },
+    {
+      "cwe": "CWE-636",
+      "name": "Not Failing Securely ('Failing Open')",
+      "owasp": "A07:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-secure-coding"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-640",
+      "name": "Weak Password Recovery Mechanism (host-header poisoning in reset links)",
+      "owasp": "A07:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-express-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 1
+      }
+    },
+    {
+      "cwe": "CWE-770",
+      "name": "Allocation of Resources Without Limits or Throttling",
+      "owasp": "A05:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 1
+      }
+    },
+    {
+      "cwe": "CWE-798",
+      "name": "Hardcoded Credentials",
+      "owasp": "A07:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-secure-coding",
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 5,
+        "safe": 4
+      }
+    },
+    {
+      "cwe": "CWE-843",
+      "name": "Access of Resource Using Incompatible Type (req.query type confusion)",
+      "owasp": "A03:2021",
+      "severity": "MEDIUM",
+      "expectedPlugins": [
+        "eslint-plugin-express-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 1
+      }
+    },
+    {
+      "cwe": "CWE-918",
+      "name": "Server-Side Request Forgery (SSRF)",
+      "owasp": "A10:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-943",
+      "name": "Improper Neutralization of Special Elements in Data Query Logic (NoSQL Injection)",
+      "owasp": "A03:2021",
+      "severity": "CRITICAL",
+      "expectedPlugins": [
+        "eslint-plugin-mongodb-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    }
+  ],
+  "plugins": {
+    "interlace": {
+      "displayName": "Interlace ESLint Ecosystem",
+      "perCwe": {
+        "CWE-020": {
+          "name": "Improper Input Validation (validation-bypass cluster)",
+          "owasp": "A03:2021",
+          "TP": 3,
+          "FP": 5,
+          "FN": 2,
+          "TN": 0,
+          "precision": 37.5,
+          "recall": 60,
+          "f1": 46.2,
+          "bas": -40,
+          "fixtures": [
+            {
+              "file": "incomplete-hostname-regexp.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "browser-security/no-insecure-redirects": 1
+              }
+            },
+            {
+              "file": "incomplete-url-scheme-check.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "incorrect-suffix-check.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "express-security/no-missing-security-headers": 1
+              }
+            },
+            {
+              "file": "missing-regexp-anchor.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "browser-security/require-postmessage-origin-check": 1
+              }
+            },
+            {
+              "file": "url-substring-sanitization.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "anchored-origin-regexp.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "browser-security/require-postmessage-origin-check": 1
+              }
+            },
+            {
+              "file": "endswith-boundary.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "express-security/no-missing-security-headers": 1
+              }
+            },
+            {
+              "file": "escaped-anchored-hostname.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "secure-coding/no-redos-vulnerable-regex": 1
+              }
+            },
+            {
+              "file": "scheme-allowlist.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "lambda-security/no-error-swallowing": 1
+              }
+            },
+            {
+              "file": "url-parse-hostname.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "lambda-security/no-error-swallowing": 1
+              }
+            }
+          ]
+        },
+        "CWE-022": {
+          "name": "Path Traversal",
+          "owasp": "A01:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 2,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "path-join-user.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "node-security/detect-non-literal-fs-filename": 1
+              }
+            },
+            {
+              "file": "readfile-concat.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "node-security/detect-non-literal-fs-filename": 1
+              }
+            },
+            {
+              "file": "dirname-path.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-path.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-073": {
+          "name": "External Control of File Name or Path (template object injection via res.render)",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 1,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "render-body-spread.js",
+              "expectedVulnerable": true,
+              "findings": 6,
+              "ruleHits": {
+                "express-security/require-helmet": 1,
+                "express-security/require-rate-limiting": 1,
+                "express-security/require-express-body-parser-limits": 1,
+                "express-security/require-csrf-protection": 1,
+                "express-security/no-missing-csrf-protection": 1,
+                "express-security/no-user-controlled-render-locals": 1
+              }
+            },
+            {
+              "file": "render-query-spread.js",
+              "expectedVulnerable": true,
+              "findings": 3,
+              "ruleHits": {
+                "express-security/require-helmet": 1,
+                "express-security/require-rate-limiting": 1,
+                "express-security/no-user-controlled-render-locals": 1
+              }
+            },
+            {
+              "file": "render-explicit-locals.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-078": {
+          "name": "OS Command Injection",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 2,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "exec-concat.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "node-security/detect-child-process": 1,
+                "node-security/no-shell-injection": 1
+              }
+            },
+            {
+              "file": "exec-template.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "node-security/detect-child-process": 1,
+                "node-security/no-shell-injection": 1
+              }
+            },
+            {
+              "file": "exec-static.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "execFile-array.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-079": {
+          "name": "Cross-Site Scripting (XSS)",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 2,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "document-write-dynamic.js",
+              "expectedVulnerable": true,
+              "findings": 3,
+              "ruleHits": {
+                "browser-security/no-innerhtml": 1,
+                "secure-coding/no-improper-sanitization": 2
+              }
+            },
+            {
+              "file": "innerhtml-user-input.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "browser-security/no-innerhtml": 1
+              }
+            },
+            {
+              "file": "static-innerhtml.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "textcontent-safe.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-088": {
+          "name": "Argument Injection",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 1,
+          "FN": 0,
+          "TN": 1,
+          "precision": 66.7,
+          "recall": 100,
+          "f1": 80,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "git-ls-remote-arg-injection.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "node-security/detect-child-process": 1,
+                "lambda-security/no-missing-authorization-check": 1
+              }
+            },
+            {
+              "file": "tar-user-args.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "node-security/detect-child-process": 1
+              }
+            },
+            {
+              "file": "literal-argv.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "separator-guard.js",
+              "expectedVulnerable": false,
+              "findings": 2,
+              "ruleHits": {
+                "node-security/detect-child-process": 1,
+                "lambda-security/no-missing-authorization-check": 1
+              }
+            }
+          ]
+        },
+        "CWE-089": {
+          "name": "SQL Injection",
+          "owasp": "A03:2021",
+          "TP": 3,
+          "FP": 0,
+          "FN": 0,
+          "TN": 3,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "dynamic-column.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "pg/no-floating-query": 1,
+                "pg/no-unsafe-query": 1
+              }
+            },
+            {
+              "file": "string-concat.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "pg/no-floating-query": 1,
+                "pg/no-unsafe-query": 1
+              }
+            },
+            {
+              "file": "template-literal.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "pg/no-floating-query": 1,
+                "pg/no-unsafe-query": 1
+              }
+            },
+            {
+              "file": "parameterized.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "prepared-statement.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-query.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-094": {
+          "name": "Improper Control of Generation of Code (Code Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "vm-run-user-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "vm2-run-user-code.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "vm-literal-script.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "worker-isolation.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-099": {
+          "name": "Improper Control of Resource Identifiers (Environment Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "env-key-from-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "env-allowlisted-key.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-1007": {
+          "name": "Insufficient Visual Distinction of Homoglyphs Presented to User",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "cyrillic-homoglyph-identifier.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "zero-width-in-auth-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "ascii-identifiers.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "i18n-ui-copy.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-116": {
+          "name": "Improper Encoding or Escaping of Output (broken sanitizers)",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 1,
+          "FN": 0,
+          "TN": 1,
+          "precision": 66.7,
+          "recall": 100,
+          "f1": 80,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "single-pass-replace.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "browser-security/no-innerhtml": 1,
+                "secure-coding/no-improper-sanitization": 1
+              }
+            },
+            {
+              "file": "tag-filter-regexp.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "secure-coding/no-redos-vulnerable-regex": 1,
+                "secure-coding/no-improper-sanitization": 1
+              }
+            },
+            {
+              "file": "dompurify-sanitize.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "replace-until-stable.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "secure-coding/no-unchecked-loop-condition": 1
+              }
+            }
+          ]
+        },
+        "CWE-117": {
+          "name": "Improper Output Neutralization for Logs (log injection)",
+          "owasp": "A09:2021",
+          "TP": 0,
+          "FP": 1,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": -50,
+          "fixtures": [
+            {
+              "file": "newline-in-log-message.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "template-literal-log.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "stripped-newlines.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "secure-coding/no-improper-sanitization": 1
+              }
+            },
+            {
+              "file": "structured-logging.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-1333": {
+          "name": "Inefficient Regular Expression Complexity (ReDoS)",
+          "owasp": "A05:2021",
+          "TP": 3,
+          "FP": 0,
+          "FN": 0,
+          "TN": 3,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "real-cve.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "secure-coding/no-redos-vulnerable-regex": 1
+              }
+            },
+            {
+              "file": "self-loop.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "secure-coding/detect-non-literal-regexp": 1,
+                "secure-coding/no-redos-vulnerable-regex": 1
+              }
+            },
+            {
+              "file": "trade-off.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "secure-coding/no-redos-vulnerable-regex": 1
+              }
+            },
+            {
+              "file": "atomic-equivalent.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "literal-match.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "simple-anchored.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-178": {
+          "name": "Improper Handling of Case Sensitivity (auth-guard path bypass)",
+          "owasp": "A01:2021",
+          "TP": 1,
+          "FP": 0,
+          "FN": 0,
+          "TN": 1,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "case-sensitive-admin-guard.js",
+              "expectedVulnerable": true,
+              "findings": 4,
+              "ruleHits": {
+                "express-security/require-helmet": 1,
+                "express-security/require-rate-limiting": 1,
+                "express-security/require-case-insensitive-path-guard": 1,
+                "lambda-security/no-exposed-debug-endpoints": 1
+              }
+            },
+            {
+              "file": "normalized-path-guard.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-209": {
+          "name": "Generation of Error Message Containing Sensitive Information (stack-trace exposure)",
+          "owasp": "A05:2021",
+          "TP": 2,
+          "FP": 1,
+          "FN": 0,
+          "TN": 0,
+          "precision": 66.7,
+          "recall": 100,
+          "f1": 80,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "error-object-in-json.js",
+              "expectedVulnerable": true,
+              "findings": 8,
+              "ruleHits": {
+                "express-security/require-helmet": 1,
+                "express-security/require-rate-limiting": 1,
+                "express-security/require-csrf-protection": 1,
+                "express-security/no-missing-csrf-protection": 1,
+                "express-security/require-route-authentication": 1,
+                "lambda-security/no-error-swallowing": 1,
+                "express-security/no-error-details-in-response": 2
+              }
+            },
+            {
+              "file": "stack-in-response.js",
+              "expectedVulnerable": true,
+              "findings": 7,
+              "ruleHits": {
+                "express-security/require-helmet": 1,
+                "express-security/require-rate-limiting": 1,
+                "lambda-security/no-missing-authorization-check": 2,
+                "express-security/no-error-details-in-response": 2,
+                "lambda-security/no-error-swallowing": 1
+              }
+            },
+            {
+              "file": "generic-error-response.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "lambda-security/no-error-swallowing": 1
+              }
+            }
+          ]
+        },
+        "CWE-248": {
+          "name": "Uncaught Exception (Unhandled Stream Error)",
+          "owasp": "A04:2021",
+          "TP": 2,
+          "FP": 2,
+          "FN": 0,
+          "TN": 0,
+          "precision": 50,
+          "recall": 100,
+          "f1": 66.7,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "multipart-pipe-no-handler.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "node-security/detect-non-literal-fs-filename": 1
+              }
+            },
+            {
+              "file": "pipe-no-error-listener.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "node-security/detect-non-literal-fs-filename": 1
+              }
+            },
+            {
+              "file": "pipe-with-error-listener.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "node-security/detect-non-literal-fs-filename": 1
+              }
+            },
+            {
+              "file": "pipeline-promises.js",
+              "expectedVulnerable": false,
+              "findings": 2,
+              "ruleHits": {
+                "node-security/detect-non-literal-fs-filename": 1,
+                "lambda-security/no-error-swallowing": 1
+              }
+            }
+          ]
+        },
+        "CWE-295": {
+          "name": "Improper Certificate Validation",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "reject-unauthorized-false.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-checkserveridentity-noop.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-checkserveridentity-validates.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-default-verification.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-327": {
+          "name": "Use of a Broken or Risky Cryptographic Algorithm",
+          "owasp": "A02:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 2,
+          "TN": 4,
+          "precision": 100,
+          "recall": 50,
+          "f1": 66.7,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "gcm-decipher-no-final.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-decrypt-no-authtag.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "sign-alg-none.js",
+              "expectedVulnerable": true,
+              "findings": 4,
+              "ruleHits": {
+                "jwt/require-expiration": 1,
+                "jwt/no-weak-secret": 1,
+                "jwt/no-hardcoded-secret": 1,
+                "jwt/no-algorithm-none": 1
+              }
+            },
+            {
+              "file": "verify-allows-none.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "jwt/no-algorithm-none": 1
+              }
+            },
+            {
+              "file": "gcm-decrypt-verified.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-encrypt-authtag.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "sign-rs256.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "verify-allowlist.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-346": {
+          "name": "Origin Validation Error (postMessage wildcard)",
+          "owasp": "A01:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 2,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "iframe-wildcard.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "browser-security/no-postmessage-wildcard-origin": 1
+              }
+            },
+            {
+              "file": "window-parent-wildcard.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "browser-security/no-postmessage-wildcard-origin": 1
+              }
+            },
+            {
+              "file": "explicit-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "self-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-377": {
+          "name": "Insecure Temporary File",
+          "owasp": "A04:2021",
+          "TP": 2,
+          "FP": 1,
+          "FN": 0,
+          "TN": 0,
+          "precision": 66.7,
+          "recall": 100,
+          "f1": 80,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "static-tmp-write.js",
+              "expectedVulnerable": true,
+              "findings": 3,
+              "ruleHits": {
+                "node-security/no-data-in-temp-storage": 1,
+                "node-security/no-arbitrary-file-access": 1,
+                "node-security/detect-non-literal-fs-filename": 1
+              }
+            },
+            {
+              "file": "tmpdir-static-name.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "node-security/no-arbitrary-file-access": 1,
+                "node-security/detect-non-literal-fs-filename": 1
+              }
+            },
+            {
+              "file": "mkdtemp-write.js",
+              "expectedVulnerable": false,
+              "findings": 2,
+              "ruleHits": {
+                "node-security/no-arbitrary-file-access": 1,
+                "node-security/detect-non-literal-fs-filename": 1
+              }
+            }
+          ]
+        },
+        "CWE-409": {
+          "name": "Improper Handling of Highly Compressed Data (Decompression Bomb)",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "gunzip-no-limit.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gunzip-limited.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-444": {
+          "name": "Inconsistent Interpretation of HTTP Requests (HTTP Request Smuggling)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "request-insecure-parser.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "server-insecure-parser.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "request-default-parser.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "server-default-parser.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-548": {
+          "name": "Exposure of Information Through Directory Listing",
+          "owasp": "A01:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 1,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "serve-index-root.js",
+              "expectedVulnerable": true,
+              "findings": 4,
+              "ruleHits": {
+                "express-security/require-helmet": 1,
+                "express-security/require-rate-limiting": 1,
+                "express-security/no-static-root-exposure": 2
+              }
+            },
+            {
+              "file": "static-root-dirname.js",
+              "expectedVulnerable": true,
+              "findings": 6,
+              "ruleHits": {
+                "express-security/require-helmet": 1,
+                "express-security/require-rate-limiting": 1,
+                "express-security/no-static-root-exposure": 1,
+                "express-security/no-exposed-debug-endpoints": 1,
+                "lambda-security/no-exposed-debug-endpoints": 1,
+                "lambda-security/no-missing-authorization-check": 1
+              }
+            },
+            {
+              "file": "static-public-dir.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-598": {
+          "name": "Use of GET Request Method With Sensitive Query Strings",
+          "owasp": "A09:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 1,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "login-via-query.js",
+              "expectedVulnerable": true,
+              "findings": 3,
+              "ruleHits": {
+                "express-security/require-helmet": 1,
+                "express-security/require-rate-limiting": 1,
+                "express-security/no-sensitive-data-in-query": 1
+              }
+            },
+            {
+              "file": "token-in-query.js",
+              "expectedVulnerable": true,
+              "findings": 4,
+              "ruleHits": {
+                "express-security/require-helmet": 1,
+                "express-security/require-rate-limiting": 1,
+                "express-security/require-route-authentication": 1,
+                "express-security/no-sensitive-data-in-query": 1
+              }
+            },
+            {
+              "file": "login-via-body-post.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-636": {
+          "name": "Not Failing Securely ('Failing Open')",
+          "owasp": "A07:2021",
+          "TP": 1,
+          "FP": 0,
+          "FN": 1,
+          "TN": 2,
+          "precision": 100,
+          "recall": 50,
+          "f1": 66.7,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "catch-returns-true.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "lambda-security/no-error-swallowing": 1
+              }
+            },
+            {
+              "file": "empty-catch-continues.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "catch-denies.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "catch-rethrows.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-640": {
+          "name": "Weak Password Recovery Mechanism (host-header poisoning in reset links)",
+          "owasp": "A07:2021",
+          "TP": 2,
+          "FP": 1,
+          "FN": 0,
+          "TN": 0,
+          "precision": 66.7,
+          "recall": 100,
+          "f1": 80,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "reset-link-forwarded-host.js",
+              "expectedVulnerable": true,
+              "findings": 6,
+              "ruleHits": {
+                "express-security/require-helmet": 1,
+                "express-security/require-rate-limiting": 1,
+                "express-security/require-csrf-protection": 1,
+                "express-security/no-missing-csrf-protection": 1,
+                "express-security/require-route-authentication": 1,
+                "express-security/no-host-header-in-links": 1
+              }
+            },
+            {
+              "file": "reset-link-host-header.js",
+              "expectedVulnerable": true,
+              "findings": 6,
+              "ruleHits": {
+                "express-security/require-helmet": 1,
+                "express-security/require-rate-limiting": 1,
+                "express-security/require-csrf-protection": 1,
+                "express-security/no-missing-csrf-protection": 1,
+                "express-security/no-host-header-in-links": 1,
+                "browser-security/no-credentials-in-query-params": 1
+              }
+            },
+            {
+              "file": "reset-link-config-origin.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "browser-security/no-credentials-in-query-params": 1
+              }
+            }
+          ]
+        },
+        "CWE-770": {
+          "name": "Allocation of Resources Without Limits or Throttling",
+          "owasp": "A05:2021",
+          "TP": 1,
+          "FP": 1,
+          "FN": 1,
+          "TN": 0,
+          "precision": 50,
+          "recall": 50,
+          "f1": 50,
+          "bas": -50,
+          "fixtures": [
+            {
+              "file": "array-length-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "buffer-alloc-user.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "browser-security/detect-mixed-content": 1
+              }
+            },
+            {
+              "file": "buffer-alloc-clamped.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "browser-security/detect-mixed-content": 1
+              }
+            }
+          ]
+        },
+        "CWE-798": {
+          "name": "Hardcoded Credentials",
+          "owasp": "A07:2021",
+          "TP": 5,
+          "FP": 1,
+          "FN": 0,
+          "TN": 3,
+          "precision": 83.3,
+          "recall": 100,
+          "f1": 90.9,
+          "bas": 75,
+          "fixtures": [
+            {
+              "file": "api-key-in-source.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "secure-coding/no-hardcoded-credentials": 1
+              }
+            },
+            {
+              "file": "aws-access-key-literal.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "secure-coding/no-hardcoded-credentials": 1
+              }
+            },
+            {
+              "file": "github-token-literal.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "secure-coding/no-hardcoded-credentials": 1
+              }
+            },
+            {
+              "file": "jwt-signing-secret-literal.js",
+              "expectedVulnerable": true,
+              "findings": 3,
+              "ruleHits": {
+                "secure-coding/no-hardcoded-credentials": 2,
+                "jwt/no-hardcoded-secret": 1
+              }
+            },
+            {
+              "file": "password-in-config.js",
+              "expectedVulnerable": true,
+              "findings": 4,
+              "ruleHits": {
+                "mongodb-security/no-hardcoded-credentials": 2,
+                "lambda-security/no-secrets-in-env": 1,
+                "secure-coding/no-hardcoded-credentials": 1
+              }
+            },
+            {
+              "file": "env-credentials.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "password-label.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "provider-env-credentials.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "test-placeholder-values.js",
+              "expectedVulnerable": false,
+              "findings": 2,
+              "ruleHits": {
+                "mongodb-security/no-hardcoded-credentials": 1,
+                "browser-security/detect-mixed-content": 1
+              }
+            }
+          ]
+        },
+        "CWE-843": {
+          "name": "Access of Resource Using Incompatible Type (req.query type confusion)",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 1,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "query-object-spread.js",
+              "expectedVulnerable": true,
+              "findings": 5,
+              "ruleHits": {
+                "express-security/require-helmet": 1,
+                "express-security/require-rate-limiting": 1,
+                "mongodb-security/no-unbounded-find": 1,
+                "mongodb-security/no-unsafe-query": 1,
+                "express-security/require-query-type-guard": 1
+              }
+            },
+            {
+              "file": "query-string-methods.js",
+              "expectedVulnerable": true,
+              "findings": 4,
+              "ruleHits": {
+                "express-security/require-helmet": 1,
+                "express-security/require-rate-limiting": 1,
+                "browser-security/no-insecure-redirects": 1,
+                "express-security/require-query-type-guard": 1
+              }
+            },
+            {
+              "file": "guarded-query-type.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-918": {
+          "name": "Server-Side Request Forgery (SSRF)",
+          "owasp": "A10:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 2,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "axios-user-url.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "node-security/no-ssrf": 1
+              }
+            },
+            {
+              "file": "fetch-user-url.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "node-security/no-ssrf": 1
+              }
+            },
+            {
+              "file": "fetch-static-url.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-validated-url.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-943": {
+          "name": "Improper Neutralization of Special Elements in Data Query Logic (NoSQL Injection)",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 1,
+          "FN": 0,
+          "TN": 1,
+          "precision": 66.7,
+          "recall": 100,
+          "f1": 80,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "user-input-in-find.js",
+              "expectedVulnerable": true,
+              "findings": 4,
+              "ruleHits": {
+                "mongodb-security/no-select-sensitive-fields": 1,
+                "express-security/no-idor-resource-access": 1,
+                "mongodb-security/no-unsafe-query": 2
+              }
+            },
+            {
+              "file": "where-string.js",
+              "expectedVulnerable": true,
+              "findings": 3,
+              "ruleHits": {
+                "mongodb-security/no-unbounded-find": 1,
+                "mongodb-security/no-unsafe-query": 1,
+                "mongodb-security/no-unsafe-where": 1
+              }
+            },
+            {
+              "file": "explicit-eq.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "express-security/no-idor-resource-access": 1
+              }
+            },
+            {
+              "file": "static-filter.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        }
+      },
+      "aggregate": {
+        "TP": 51,
+        "FP": 16,
+        "FN": 18,
+        "TN": 44,
+        "precision": 76.1,
+        "recall": 73.9,
+        "f1": 75,
+        "bas": 47.2
+      }
+    },
+    "eslint-plugin-security": {
+      "displayName": "eslint-plugin-security",
+      "perCwe": {
+        "CWE-020": {
+          "name": "Improper Input Validation (validation-bypass cluster)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 1,
+          "FN": 5,
+          "TN": 4,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": -20,
+          "fixtures": [
+            {
+              "file": "incomplete-hostname-regexp.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "incomplete-url-scheme-check.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "incorrect-suffix-check.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "missing-regexp-anchor.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "url-substring-sanitization.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "anchored-origin-regexp.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "endswith-boundary.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "escaped-anchored-hostname.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-unsafe-regex": 1
+              }
+            },
+            {
+              "file": "scheme-allowlist.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "url-parse-hostname.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-022": {
+          "name": "Path Traversal",
+          "owasp": "A01:2021",
+          "TP": 2,
+          "FP": 1,
+          "FN": 0,
+          "TN": 1,
+          "precision": 66.7,
+          "recall": 100,
+          "f1": 80,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "path-join-user.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-non-literal-fs-filename": 1
+              }
+            },
+            {
+              "file": "readfile-concat.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-non-literal-fs-filename": 1
+              }
+            },
+            {
+              "file": "dirname-path.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-non-literal-fs-filename": 1
+              }
+            },
+            {
+              "file": "static-path.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-073": {
+          "name": "External Control of File Name or Path (template object injection via res.render)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "render-body-spread.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "render-query-spread.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "render-explicit-locals.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-078": {
+          "name": "OS Command Injection",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 2,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "exec-concat.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-child-process": 1
+              }
+            },
+            {
+              "file": "exec-template.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-child-process": 1
+              }
+            },
+            {
+              "file": "exec-static.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "execFile-array.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-079": {
+          "name": "Cross-Site Scripting (XSS)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "document-write-dynamic.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "innerhtml-user-input.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-innerhtml.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "textcontent-safe.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-088": {
+          "name": "Argument Injection",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "git-ls-remote-arg-injection.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tar-user-args.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "literal-argv.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "separator-guard.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-089": {
+          "name": "SQL Injection",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 3,
+          "TN": 3,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "dynamic-column.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "string-concat.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "template-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "parameterized.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "prepared-statement.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-query.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-094": {
+          "name": "Improper Control of Generation of Code (Code Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "vm-run-user-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "vm2-run-user-code.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "vm-literal-script.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "worker-isolation.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-099": {
+          "name": "Improper Control of Resource Identifiers (Environment Injection)",
+          "owasp": "A03:2021",
+          "TP": 1,
+          "FP": 1,
+          "FN": 0,
+          "TN": 0,
+          "precision": 50,
+          "recall": 100,
+          "f1": 66.7,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "env-key-from-user.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-object-injection": 1
+              }
+            },
+            {
+              "file": "env-allowlisted-key.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-object-injection": 1
+              }
+            }
+          ]
+        },
+        "CWE-1007": {
+          "name": "Insufficient Visual Distinction of Homoglyphs Presented to User",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 1,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": -50,
+          "fixtures": [
+            {
+              "file": "cyrillic-homoglyph-identifier.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "zero-width-in-auth-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "ascii-identifiers.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "i18n-ui-copy.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-object-injection": 1
+              }
+            }
+          ]
+        },
+        "CWE-116": {
+          "name": "Improper Encoding or Escaping of Output (broken sanitizers)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "single-pass-replace.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tag-filter-regexp.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "dompurify-sanitize.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "replace-until-stable.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-117": {
+          "name": "Improper Output Neutralization for Logs (log injection)",
+          "owasp": "A09:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "newline-in-log-message.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "template-literal-log.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "stripped-newlines.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "structured-logging.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-1333": {
+          "name": "Inefficient Regular Expression Complexity (ReDoS)",
+          "owasp": "A05:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 1,
+          "TN": 3,
+          "precision": 100,
+          "recall": 66.7,
+          "f1": 80,
+          "bas": 66.7,
+          "fixtures": [
+            {
+              "file": "real-cve.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-unsafe-regex": 1
+              }
+            },
+            {
+              "file": "self-loop.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-unsafe-regex": 1
+              }
+            },
+            {
+              "file": "trade-off.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "atomic-equivalent.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "literal-match.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "simple-anchored.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-178": {
+          "name": "Improper Handling of Case Sensitivity (auth-guard path bypass)",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "case-sensitive-admin-guard.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "normalized-path-guard.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-209": {
+          "name": "Generation of Error Message Containing Sensitive Information (stack-trace exposure)",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "error-object-in-json.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "stack-in-response.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "generic-error-response.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-248": {
+          "name": "Uncaught Exception (Unhandled Stream Error)",
+          "owasp": "A04:2021",
+          "TP": 2,
+          "FP": 2,
+          "FN": 0,
+          "TN": 0,
+          "precision": 50,
+          "recall": 100,
+          "f1": 66.7,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "multipart-pipe-no-handler.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-non-literal-fs-filename": 1
+              }
+            },
+            {
+              "file": "pipe-no-error-listener.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-non-literal-fs-filename": 1
+              }
+            },
+            {
+              "file": "pipe-with-error-listener.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-non-literal-fs-filename": 1
+              }
+            },
+            {
+              "file": "pipeline-promises.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-non-literal-fs-filename": 1
+              }
+            }
+          ]
+        },
+        "CWE-295": {
+          "name": "Improper Certificate Validation",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "reject-unauthorized-false.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-checkserveridentity-noop.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-checkserveridentity-validates.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-default-verification.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-327": {
+          "name": "Use of a Broken or Risky Cryptographic Algorithm",
+          "owasp": "A02:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 4,
+          "TN": 4,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "gcm-decipher-no-final.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-decrypt-no-authtag.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "sign-alg-none.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "verify-allows-none.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-decrypt-verified.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-encrypt-authtag.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "sign-rs256.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "verify-allowlist.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-346": {
+          "name": "Origin Validation Error (postMessage wildcard)",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "iframe-wildcard.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "window-parent-wildcard.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "explicit-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "self-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-377": {
+          "name": "Insecure Temporary File",
+          "owasp": "A04:2021",
+          "TP": 1,
+          "FP": 1,
+          "FN": 1,
+          "TN": 0,
+          "precision": 50,
+          "recall": 50,
+          "f1": 50,
+          "bas": -50,
+          "fixtures": [
+            {
+              "file": "static-tmp-write.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tmpdir-static-name.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-non-literal-fs-filename": 1
+              }
+            },
+            {
+              "file": "mkdtemp-write.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-non-literal-fs-filename": 1
+              }
+            }
+          ]
+        },
+        "CWE-409": {
+          "name": "Improper Handling of Highly Compressed Data (Decompression Bomb)",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "gunzip-no-limit.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gunzip-limited.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-444": {
+          "name": "Inconsistent Interpretation of HTTP Requests (HTTP Request Smuggling)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "request-insecure-parser.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "server-insecure-parser.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "request-default-parser.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "server-default-parser.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-548": {
+          "name": "Exposure of Information Through Directory Listing",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "serve-index-root.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-root-dirname.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-public-dir.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-598": {
+          "name": "Use of GET Request Method With Sensitive Query Strings",
+          "owasp": "A09:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "login-via-query.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "token-in-query.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "login-via-body-post.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-636": {
+          "name": "Not Failing Securely ('Failing Open')",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "catch-returns-true.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "empty-catch-continues.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "catch-denies.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "catch-rethrows.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-640": {
+          "name": "Weak Password Recovery Mechanism (host-header poisoning in reset links)",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "reset-link-forwarded-host.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "reset-link-host-header.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "reset-link-config-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-770": {
+          "name": "Allocation of Resources Without Limits or Throttling",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "array-length-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "buffer-alloc-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "buffer-alloc-clamped.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-798": {
+          "name": "Hardcoded Credentials",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 5,
+          "TN": 4,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "api-key-in-source.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "aws-access-key-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "github-token-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "jwt-signing-secret-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "password-in-config.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "env-credentials.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "password-label.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "provider-env-credentials.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "test-placeholder-values.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-843": {
+          "name": "Access of Resource Using Incompatible Type (req.query type confusion)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "query-object-spread.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "query-string-methods.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "guarded-query-type.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-918": {
+          "name": "Server-Side Request Forgery (SSRF)",
+          "owasp": "A10:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "axios-user-url.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-user-url.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-static-url.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-validated-url.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-943": {
+          "name": "Improper Neutralization of Special Elements in Data Query Logic (NoSQL Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "user-input-in-find.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "where-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "explicit-eq.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-filter.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        }
+      },
+      "aggregate": {
+        "TP": 10,
+        "FP": 7,
+        "FN": 59,
+        "TN": 53,
+        "precision": 58.8,
+        "recall": 14.5,
+        "f1": 23.3,
+        "bas": 2.8
+      }
+    },
+    "security-node": {
+      "displayName": "eslint-plugin-security-node",
+      "perCwe": {
+        "CWE-020": {
+          "name": "Improper Input Validation (validation-bypass cluster)",
+          "owasp": "A03:2021",
+          "TP": 1,
+          "FP": 1,
+          "FN": 4,
+          "TN": 4,
+          "precision": 50,
+          "recall": 20,
+          "f1": 28.6,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "incomplete-hostname-regexp.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security-node/detect-dangerous-redirects": 1
+              }
+            },
+            {
+              "file": "incomplete-url-scheme-check.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "incorrect-suffix-check.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "missing-regexp-anchor.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "url-substring-sanitization.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "anchored-origin-regexp.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "endswith-boundary.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "escaped-anchored-hostname.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "security-node/detect-dangerous-redirects": 1
+              }
+            },
+            {
+              "file": "scheme-allowlist.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "url-parse-hostname.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-022": {
+          "name": "Path Traversal",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "path-join-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "readfile-concat.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "dirname-path.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-path.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-073": {
+          "name": "External Control of File Name or Path (template object injection via res.render)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "render-body-spread.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "render-query-spread.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "render-explicit-locals.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-078": {
+          "name": "OS Command Injection",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 1,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": -50,
+          "fixtures": [
+            {
+              "file": "exec-concat.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "exec-template.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "exec-static.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "execFile-array.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "security-node/detect-crlf": 1
+              }
+            }
+          ]
+        },
+        "CWE-079": {
+          "name": "Cross-Site Scripting (XSS)",
+          "owasp": "A03:2021",
+          "TP": 1,
+          "FP": 0,
+          "FN": 1,
+          "TN": 2,
+          "precision": 100,
+          "recall": 50,
+          "f1": 66.7,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "document-write-dynamic.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security-node/detect-html-injection": 1
+              }
+            },
+            {
+              "file": "innerhtml-user-input.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-innerhtml.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "textcontent-safe.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-088": {
+          "name": "Argument Injection",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "git-ls-remote-arg-injection.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tar-user-args.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "literal-argv.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "separator-guard.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-089": {
+          "name": "SQL Injection",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 3,
+          "TN": 3,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "dynamic-column.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "string-concat.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "template-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "parameterized.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "prepared-statement.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-query.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-094": {
+          "name": "Improper Control of Generation of Code (Code Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "vm-run-user-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "vm2-run-user-code.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "vm-literal-script.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "worker-isolation.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-099": {
+          "name": "Improper Control of Resource Identifiers (Environment Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "env-key-from-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "env-allowlisted-key.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-1007": {
+          "name": "Insufficient Visual Distinction of Homoglyphs Presented to User",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "cyrillic-homoglyph-identifier.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "zero-width-in-auth-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "ascii-identifiers.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "i18n-ui-copy.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-116": {
+          "name": "Improper Encoding or Escaping of Output (broken sanitizers)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "single-pass-replace.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tag-filter-regexp.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "dompurify-sanitize.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "replace-until-stable.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-117": {
+          "name": "Improper Output Neutralization for Logs (log injection)",
+          "owasp": "A09:2021",
+          "TP": 1,
+          "FP": 0,
+          "FN": 1,
+          "TN": 2,
+          "precision": 100,
+          "recall": 50,
+          "f1": 66.7,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "newline-in-log-message.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "template-literal-log.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security-node/detect-crlf": 1
+              }
+            },
+            {
+              "file": "stripped-newlines.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "structured-logging.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-1333": {
+          "name": "Inefficient Regular Expression Complexity (ReDoS)",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 3,
+          "TN": 3,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "real-cve.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "self-loop.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "trade-off.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "atomic-equivalent.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "literal-match.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "simple-anchored.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-178": {
+          "name": "Improper Handling of Case Sensitivity (auth-guard path bypass)",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "case-sensitive-admin-guard.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "normalized-path-guard.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-209": {
+          "name": "Generation of Error Message Containing Sensitive Information (stack-trace exposure)",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "error-object-in-json.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "stack-in-response.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "generic-error-response.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-248": {
+          "name": "Uncaught Exception (Unhandled Stream Error)",
+          "owasp": "A04:2021",
+          "TP": 0,
+          "FP": 1,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": -50,
+          "fixtures": [
+            {
+              "file": "multipart-pipe-no-handler.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "pipe-no-error-listener.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "pipe-with-error-listener.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "pipeline-promises.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "security-node/detect-unhandled-async-errors": 1
+              }
+            }
+          ]
+        },
+        "CWE-295": {
+          "name": "Improper Certificate Validation",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "reject-unauthorized-false.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-checkserveridentity-noop.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-checkserveridentity-validates.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-default-verification.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-327": {
+          "name": "Use of a Broken or Risky Cryptographic Algorithm",
+          "owasp": "A02:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 4,
+          "TN": 4,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "gcm-decipher-no-final.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-decrypt-no-authtag.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "sign-alg-none.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "verify-allows-none.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-decrypt-verified.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-encrypt-authtag.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "sign-rs256.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "verify-allowlist.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-346": {
+          "name": "Origin Validation Error (postMessage wildcard)",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "iframe-wildcard.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "window-parent-wildcard.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "explicit-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "self-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-377": {
+          "name": "Insecure Temporary File",
+          "owasp": "A04:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "static-tmp-write.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tmpdir-static-name.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "mkdtemp-write.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-409": {
+          "name": "Improper Handling of Highly Compressed Data (Decompression Bomb)",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "gunzip-no-limit.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gunzip-limited.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-444": {
+          "name": "Inconsistent Interpretation of HTTP Requests (HTTP Request Smuggling)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "request-insecure-parser.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "server-insecure-parser.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "request-default-parser.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "server-default-parser.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-548": {
+          "name": "Exposure of Information Through Directory Listing",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "serve-index-root.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-root-dirname.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-public-dir.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-598": {
+          "name": "Use of GET Request Method With Sensitive Query Strings",
+          "owasp": "A09:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "login-via-query.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "token-in-query.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "login-via-body-post.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-636": {
+          "name": "Not Failing Securely ('Failing Open')",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "catch-returns-true.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "empty-catch-continues.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "catch-denies.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "catch-rethrows.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-640": {
+          "name": "Weak Password Recovery Mechanism (host-header poisoning in reset links)",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "reset-link-forwarded-host.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "reset-link-host-header.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "reset-link-config-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-770": {
+          "name": "Allocation of Resources Without Limits or Throttling",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "array-length-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "buffer-alloc-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "buffer-alloc-clamped.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-798": {
+          "name": "Hardcoded Credentials",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 5,
+          "TN": 4,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "api-key-in-source.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "aws-access-key-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "github-token-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "jwt-signing-secret-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "password-in-config.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "env-credentials.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "password-label.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "provider-env-credentials.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "test-placeholder-values.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-843": {
+          "name": "Access of Resource Using Incompatible Type (req.query type confusion)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "query-object-spread.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "query-string-methods.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "guarded-query-type.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-918": {
+          "name": "Server-Side Request Forgery (SSRF)",
+          "owasp": "A10:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "axios-user-url.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-user-url.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-static-url.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-validated-url.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-943": {
+          "name": "Improper Neutralization of Special Elements in Data Query Logic (NoSQL Injection)",
+          "owasp": "A03:2021",
+          "TP": 1,
+          "FP": 0,
+          "FN": 1,
+          "TN": 2,
+          "precision": 100,
+          "recall": 50,
+          "f1": 66.7,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "user-input-in-find.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "where-string.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security-node/detect-nosql-injection": 1
+              }
+            },
+            {
+              "file": "explicit-eq.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-filter.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        }
+      },
+      "aggregate": {
+        "TP": 4,
+        "FP": 3,
+        "FN": 65,
+        "TN": 57,
+        "precision": 57.1,
+        "recall": 5.8,
+        "f1": 10.5,
+        "bas": 0.8
+      }
+    },
+    "sonarjs": {
+      "displayName": "eslint-plugin-sonarjs",
+      "perCwe": {
+        "CWE-020": {
+          "name": "Improper Input Validation (validation-bypass cluster)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 1,
+          "FN": 5,
+          "TN": 4,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": -20,
+          "fixtures": [
+            {
+              "file": "incomplete-hostname-regexp.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "incomplete-url-scheme-check.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "incorrect-suffix-check.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "missing-regexp-anchor.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "url-substring-sanitization.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "anchored-origin-regexp.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "endswith-boundary.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "escaped-anchored-hostname.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "scheme-allowlist.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/no-ignored-exceptions": 1
+              }
+            },
+            {
+              "file": "url-parse-hostname.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-022": {
+          "name": "Path Traversal",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "path-join-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "readfile-concat.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "dirname-path.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-path.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-073": {
+          "name": "External Control of File Name or Path (template object injection via res.render)",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 1,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "render-body-spread.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/x-powered-by": 1
+              }
+            },
+            {
+              "file": "render-query-spread.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/x-powered-by": 1
+              }
+            },
+            {
+              "file": "render-explicit-locals.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-078": {
+          "name": "OS Command Injection",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 2,
+          "FN": 2,
+          "TN": 0,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": -100,
+          "fixtures": [
+            {
+              "file": "exec-concat.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "exec-template.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "exec-static.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/no-os-command-from-path": 1
+              }
+            },
+            {
+              "file": "execFile-array.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/no-os-command-from-path": 1
+              }
+            }
+          ]
+        },
+        "CWE-079": {
+          "name": "Cross-Site Scripting (XSS)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "document-write-dynamic.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "innerhtml-user-input.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-innerhtml.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "textcontent-safe.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-088": {
+          "name": "Argument Injection",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 2,
+          "FN": 0,
+          "TN": 0,
+          "precision": 50,
+          "recall": 100,
+          "f1": 66.7,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "git-ls-remote-arg-injection.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/no-os-command-from-path": 1
+              }
+            },
+            {
+              "file": "tar-user-args.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/no-os-command-from-path": 1
+              }
+            },
+            {
+              "file": "literal-argv.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/no-os-command-from-path": 1
+              }
+            },
+            {
+              "file": "separator-guard.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/no-os-command-from-path": 1
+              }
+            }
+          ]
+        },
+        "CWE-089": {
+          "name": "SQL Injection",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 3,
+          "TN": 3,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "dynamic-column.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "string-concat.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "template-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "parameterized.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "prepared-statement.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-query.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-094": {
+          "name": "Improper Control of Generation of Code (Code Injection)",
+          "owasp": "A03:2021",
+          "TP": 1,
+          "FP": 1,
+          "FN": 1,
+          "TN": 1,
+          "precision": 50,
+          "recall": 50,
+          "f1": 50,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "vm-run-user-string.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/code-eval": 1
+              }
+            },
+            {
+              "file": "vm2-run-user-code.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "vm-literal-script.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/code-eval": 1
+              }
+            },
+            {
+              "file": "worker-isolation.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-099": {
+          "name": "Improper Control of Resource Identifiers (Environment Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "env-key-from-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "env-allowlisted-key.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-1007": {
+          "name": "Insufficient Visual Distinction of Homoglyphs Presented to User",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "cyrillic-homoglyph-identifier.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "zero-width-in-auth-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "ascii-identifiers.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "i18n-ui-copy.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-116": {
+          "name": "Improper Encoding or Escaping of Output (broken sanitizers)",
+          "owasp": "A03:2021",
+          "TP": 1,
+          "FP": 1,
+          "FN": 1,
+          "TN": 1,
+          "precision": 50,
+          "recall": 50,
+          "f1": 50,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "single-pass-replace.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tag-filter-regexp.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/super-linear-regex": 1
+              }
+            },
+            {
+              "file": "dompurify-sanitize.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "replace-until-stable.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/super-linear-regex": 1
+              }
+            }
+          ]
+        },
+        "CWE-117": {
+          "name": "Improper Output Neutralization for Logs (log injection)",
+          "owasp": "A09:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "newline-in-log-message.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "template-literal-log.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "stripped-newlines.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "structured-logging.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-1333": {
+          "name": "Inefficient Regular Expression Complexity (ReDoS)",
+          "owasp": "A05:2021",
+          "TP": 3,
+          "FP": 0,
+          "FN": 0,
+          "TN": 3,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "real-cve.js",
+              "expectedVulnerable": true,
+              "findings": 6,
+              "ruleHits": {
+                "sonarjs/slow-regex": 1,
+                "sonarjs/regex-complexity": 1,
+                "sonarjs/single-char-in-character-classes": 1,
+                "sonarjs/concise-regex": 3
+              }
+            },
+            {
+              "file": "self-loop.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/slow-regex": 1
+              }
+            },
+            {
+              "file": "trade-off.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/super-linear-regex": 1
+              }
+            },
+            {
+              "file": "atomic-equivalent.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "literal-match.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "simple-anchored.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-178": {
+          "name": "Improper Handling of Case Sensitivity (auth-guard path bypass)",
+          "owasp": "A01:2021",
+          "TP": 1,
+          "FP": 0,
+          "FN": 0,
+          "TN": 1,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "case-sensitive-admin-guard.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/x-powered-by": 1
+              }
+            },
+            {
+              "file": "normalized-path-guard.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-209": {
+          "name": "Generation of Error Message Containing Sensitive Information (stack-trace exposure)",
+          "owasp": "A05:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 1,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "error-object-in-json.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/x-powered-by": 1
+              }
+            },
+            {
+              "file": "stack-in-response.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/x-powered-by": 1
+              }
+            },
+            {
+              "file": "generic-error-response.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-248": {
+          "name": "Uncaught Exception (Unhandled Stream Error)",
+          "owasp": "A04:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "multipart-pipe-no-handler.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "pipe-no-error-listener.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "pipe-with-error-listener.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "pipeline-promises.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-295": {
+          "name": "Improper Certificate Validation",
+          "owasp": "A07:2021",
+          "TP": 1,
+          "FP": 0,
+          "FN": 1,
+          "TN": 2,
+          "precision": 100,
+          "recall": 50,
+          "f1": 66.7,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "reject-unauthorized-false.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "sonarjs/unverified-certificate": 1,
+                "sonarjs/unverified-hostname": 1
+              }
+            },
+            {
+              "file": "tls-checkserveridentity-noop.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-checkserveridentity-validates.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-default-verification.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-327": {
+          "name": "Use of a Broken or Risky Cryptographic Algorithm",
+          "owasp": "A02:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 2,
+          "TN": 4,
+          "precision": 100,
+          "recall": 50,
+          "f1": 66.7,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "gcm-decipher-no-final.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-decrypt-no-authtag.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "sign-alg-none.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "sonarjs/insecure-jwt-token": 1,
+                "sonarjs/hardcoded-secret-signatures": 1
+              }
+            },
+            {
+              "file": "verify-allows-none.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/insecure-jwt-token": 1
+              }
+            },
+            {
+              "file": "gcm-decrypt-verified.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-encrypt-authtag.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "sign-rs256.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "verify-allowlist.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-346": {
+          "name": "Origin Validation Error (postMessage wildcard)",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "iframe-wildcard.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "window-parent-wildcard.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "explicit-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "self-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-377": {
+          "name": "Insecure Temporary File",
+          "owasp": "A04:2021",
+          "TP": 1,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 100,
+          "recall": 50,
+          "f1": 66.7,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "static-tmp-write.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/publicly-writable-directories": 1
+              }
+            },
+            {
+              "file": "tmpdir-static-name.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "mkdtemp-write.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-409": {
+          "name": "Improper Handling of Highly Compressed Data (Decompression Bomb)",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "gunzip-no-limit.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gunzip-limited.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-444": {
+          "name": "Inconsistent Interpretation of HTTP Requests (HTTP Request Smuggling)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "request-insecure-parser.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "server-insecure-parser.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "request-default-parser.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "server-default-parser.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-548": {
+          "name": "Exposure of Information Through Directory Listing",
+          "owasp": "A01:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 1,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "serve-index-root.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/x-powered-by": 1
+              }
+            },
+            {
+              "file": "static-root-dirname.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/x-powered-by": 1
+              }
+            },
+            {
+              "file": "static-public-dir.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-598": {
+          "name": "Use of GET Request Method With Sensitive Query Strings",
+          "owasp": "A09:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 1,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "login-via-query.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/x-powered-by": 1
+              }
+            },
+            {
+              "file": "token-in-query.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/x-powered-by": 1
+              }
+            },
+            {
+              "file": "login-via-body-post.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-636": {
+          "name": "Not Failing Securely ('Failing Open')",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "catch-returns-true.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "empty-catch-continues.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "catch-denies.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "catch-rethrows.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-640": {
+          "name": "Weak Password Recovery Mechanism (host-header poisoning in reset links)",
+          "owasp": "A07:2021",
+          "TP": 2,
+          "FP": 1,
+          "FN": 0,
+          "TN": 0,
+          "precision": 66.7,
+          "recall": 100,
+          "f1": 80,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "reset-link-forwarded-host.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "sonarjs/x-powered-by": 1,
+                "sonarjs/no-clear-text-protocols": 1
+              }
+            },
+            {
+              "file": "reset-link-host-header.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "sonarjs/x-powered-by": 1,
+                "sonarjs/no-clear-text-protocols": 1
+              }
+            },
+            {
+              "file": "reset-link-config-origin.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/no-clear-text-protocols": 1
+              }
+            }
+          ]
+        },
+        "CWE-770": {
+          "name": "Allocation of Resources Without Limits or Throttling",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "array-length-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "buffer-alloc-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "buffer-alloc-clamped.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-798": {
+          "name": "Hardcoded Credentials",
+          "owasp": "A07:2021",
+          "TP": 3,
+          "FP": 0,
+          "FN": 2,
+          "TN": 4,
+          "precision": 100,
+          "recall": 60,
+          "f1": 75,
+          "bas": 60,
+          "fixtures": [
+            {
+              "file": "api-key-in-source.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/no-hardcoded-secrets": 1
+              }
+            },
+            {
+              "file": "aws-access-key-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "github-token-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "jwt-signing-secret-literal.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/no-hardcoded-secrets": 1
+              }
+            },
+            {
+              "file": "password-in-config.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/no-hardcoded-passwords": 1
+              }
+            },
+            {
+              "file": "env-credentials.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "password-label.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "provider-env-credentials.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "test-placeholder-values.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-843": {
+          "name": "Access of Resource Using Incompatible Type (req.query type confusion)",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 1,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "query-object-spread.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/x-powered-by": 1
+              }
+            },
+            {
+              "file": "query-string-methods.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/x-powered-by": 1
+              }
+            },
+            {
+              "file": "guarded-query-type.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-918": {
+          "name": "Server-Side Request Forgery (SSRF)",
+          "owasp": "A10:2021",
+          "TP": 0,
+          "FP": 1,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": -50,
+          "fixtures": [
+            {
+              "file": "axios-user-url.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-user-url.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-static-url.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-validated-url.js",
+              "expectedVulnerable": false,
+              "findings": 2,
+              "ruleHits": {
+                "sonarjs/no-unused-vars": 1,
+                "sonarjs/no-dead-store": 1
+              }
+            }
+          ]
+        },
+        "CWE-943": {
+          "name": "Improper Neutralization of Special Elements in Data Query Logic (NoSQL Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "user-input-in-find.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "where-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "explicit-eq.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-filter.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        }
+      },
+      "aggregate": {
+        "TP": 27,
+        "FP": 9,
+        "FN": 42,
+        "TN": 51,
+        "precision": 75,
+        "recall": 39.1,
+        "f1": 51.4,
+        "bas": 24.1
+      }
+    },
+    "microsoft-sdl": {
+      "displayName": "@microsoft/eslint-plugin-sdl",
+      "perCwe": {
+        "CWE-020": {
+          "name": "Improper Input Validation (validation-bypass cluster)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 5,
+          "TN": 5,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "incomplete-hostname-regexp.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "incomplete-url-scheme-check.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "incorrect-suffix-check.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "missing-regexp-anchor.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "url-substring-sanitization.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "anchored-origin-regexp.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "endswith-boundary.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "escaped-anchored-hostname.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "scheme-allowlist.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "url-parse-hostname.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-022": {
+          "name": "Path Traversal",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "path-join-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "readfile-concat.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "dirname-path.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-path.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-073": {
+          "name": "External Control of File Name or Path (template object injection via res.render)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "render-body-spread.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "render-query-spread.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "render-explicit-locals.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-078": {
+          "name": "OS Command Injection",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "exec-concat.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "exec-template.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "exec-static.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "execFile-array.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-079": {
+          "name": "Cross-Site Scripting (XSS)",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 1,
+          "FN": 0,
+          "TN": 1,
+          "precision": 66.7,
+          "recall": 100,
+          "f1": 80,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "document-write-dynamic.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "@microsoft/sdl/no-document-write": 1
+              }
+            },
+            {
+              "file": "innerhtml-user-input.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "@microsoft/sdl/no-inner-html": 1
+              }
+            },
+            {
+              "file": "static-innerhtml.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "@microsoft/sdl/no-inner-html": 1
+              }
+            },
+            {
+              "file": "textcontent-safe.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-088": {
+          "name": "Argument Injection",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "git-ls-remote-arg-injection.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tar-user-args.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "literal-argv.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "separator-guard.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-089": {
+          "name": "SQL Injection",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 3,
+          "TN": 3,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "dynamic-column.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "string-concat.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "template-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "parameterized.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "prepared-statement.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-query.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-094": {
+          "name": "Improper Control of Generation of Code (Code Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "vm-run-user-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "vm2-run-user-code.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "vm-literal-script.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "worker-isolation.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-099": {
+          "name": "Improper Control of Resource Identifiers (Environment Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "env-key-from-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "env-allowlisted-key.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-1007": {
+          "name": "Insufficient Visual Distinction of Homoglyphs Presented to User",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "cyrillic-homoglyph-identifier.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "zero-width-in-auth-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "ascii-identifiers.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "i18n-ui-copy.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-116": {
+          "name": "Improper Encoding or Escaping of Output (broken sanitizers)",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 1,
+          "FN": 0,
+          "TN": 1,
+          "precision": 66.7,
+          "recall": 100,
+          "f1": 80,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "single-pass-replace.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "@microsoft/sdl/no-inner-html": 1
+              }
+            },
+            {
+              "file": "tag-filter-regexp.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "@microsoft/sdl/no-inner-html": 1
+              }
+            },
+            {
+              "file": "dompurify-sanitize.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "@microsoft/sdl/no-inner-html": 1
+              }
+            },
+            {
+              "file": "replace-until-stable.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-117": {
+          "name": "Improper Output Neutralization for Logs (log injection)",
+          "owasp": "A09:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "newline-in-log-message.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "template-literal-log.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "stripped-newlines.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "structured-logging.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-1333": {
+          "name": "Inefficient Regular Expression Complexity (ReDoS)",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 3,
+          "TN": 3,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "real-cve.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "self-loop.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "trade-off.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "atomic-equivalent.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "literal-match.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "simple-anchored.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-178": {
+          "name": "Improper Handling of Case Sensitivity (auth-guard path bypass)",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "case-sensitive-admin-guard.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "normalized-path-guard.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-209": {
+          "name": "Generation of Error Message Containing Sensitive Information (stack-trace exposure)",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "error-object-in-json.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "stack-in-response.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "generic-error-response.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-248": {
+          "name": "Uncaught Exception (Unhandled Stream Error)",
+          "owasp": "A04:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "multipart-pipe-no-handler.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "pipe-no-error-listener.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "pipe-with-error-listener.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "pipeline-promises.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-295": {
+          "name": "Improper Certificate Validation",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "reject-unauthorized-false.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-checkserveridentity-noop.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-checkserveridentity-validates.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-default-verification.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-327": {
+          "name": "Use of a Broken or Risky Cryptographic Algorithm",
+          "owasp": "A02:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 4,
+          "TN": 4,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "gcm-decipher-no-final.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-decrypt-no-authtag.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "sign-alg-none.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "verify-allows-none.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-decrypt-verified.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-encrypt-authtag.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "sign-rs256.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "verify-allowlist.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-346": {
+          "name": "Origin Validation Error (postMessage wildcard)",
+          "owasp": "A01:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 2,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "iframe-wildcard.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "@microsoft/sdl/no-postmessage-star-origin": 1
+              }
+            },
+            {
+              "file": "window-parent-wildcard.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "@microsoft/sdl/no-postmessage-star-origin": 1
+              }
+            },
+            {
+              "file": "explicit-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "self-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-377": {
+          "name": "Insecure Temporary File",
+          "owasp": "A04:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "static-tmp-write.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tmpdir-static-name.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "mkdtemp-write.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-409": {
+          "name": "Improper Handling of Highly Compressed Data (Decompression Bomb)",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "gunzip-no-limit.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gunzip-limited.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-444": {
+          "name": "Inconsistent Interpretation of HTTP Requests (HTTP Request Smuggling)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "request-insecure-parser.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "server-insecure-parser.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "request-default-parser.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "server-default-parser.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-548": {
+          "name": "Exposure of Information Through Directory Listing",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "serve-index-root.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-root-dirname.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-public-dir.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-598": {
+          "name": "Use of GET Request Method With Sensitive Query Strings",
+          "owasp": "A09:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "login-via-query.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "token-in-query.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "login-via-body-post.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-636": {
+          "name": "Not Failing Securely ('Failing Open')",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "catch-returns-true.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "empty-catch-continues.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "catch-denies.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "catch-rethrows.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-640": {
+          "name": "Weak Password Recovery Mechanism (host-header poisoning in reset links)",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "reset-link-forwarded-host.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "reset-link-host-header.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "reset-link-config-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-770": {
+          "name": "Allocation of Resources Without Limits or Throttling",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "array-length-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "buffer-alloc-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "buffer-alloc-clamped.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-798": {
+          "name": "Hardcoded Credentials",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 5,
+          "TN": 4,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "api-key-in-source.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "aws-access-key-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "github-token-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "jwt-signing-secret-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "password-in-config.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "env-credentials.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "password-label.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "provider-env-credentials.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "test-placeholder-values.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-843": {
+          "name": "Access of Resource Using Incompatible Type (req.query type confusion)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "query-object-spread.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "query-string-methods.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "guarded-query-type.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-918": {
+          "name": "Server-Side Request Forgery (SSRF)",
+          "owasp": "A10:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "axios-user-url.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-user-url.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-static-url.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-validated-url.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-943": {
+          "name": "Improper Neutralization of Special Elements in Data Query Logic (NoSQL Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "user-input-in-find.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "where-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "explicit-eq.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-filter.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        }
+      },
+      "aggregate": {
+        "TP": 6,
+        "FP": 2,
+        "FN": 63,
+        "TN": 58,
+        "precision": 75,
+        "recall": 8.7,
+        "f1": 15.6,
+        "bas": 5.4
+      }
+    },
+    "no-unsanitized": {
+      "displayName": "eslint-plugin-no-unsanitized",
+      "perCwe": {
+        "CWE-020": {
+          "name": "Improper Input Validation (validation-bypass cluster)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 5,
+          "TN": 5,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "incomplete-hostname-regexp.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "incomplete-url-scheme-check.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "incorrect-suffix-check.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "missing-regexp-anchor.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "url-substring-sanitization.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "anchored-origin-regexp.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "endswith-boundary.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "escaped-anchored-hostname.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "scheme-allowlist.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "url-parse-hostname.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-022": {
+          "name": "Path Traversal",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "path-join-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "readfile-concat.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "dirname-path.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-path.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-073": {
+          "name": "External Control of File Name or Path (template object injection via res.render)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "render-body-spread.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "render-query-spread.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "render-explicit-locals.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-078": {
+          "name": "OS Command Injection",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "exec-concat.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "exec-template.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "exec-static.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "execFile-array.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-079": {
+          "name": "Cross-Site Scripting (XSS)",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 2,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "document-write-dynamic.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "no-unsanitized/method": 1
+              }
+            },
+            {
+              "file": "innerhtml-user-input.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "no-unsanitized/property": 1
+              }
+            },
+            {
+              "file": "static-innerhtml.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "textcontent-safe.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-088": {
+          "name": "Argument Injection",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "git-ls-remote-arg-injection.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tar-user-args.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "literal-argv.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "separator-guard.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-089": {
+          "name": "SQL Injection",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 3,
+          "TN": 3,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "dynamic-column.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "string-concat.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "template-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "parameterized.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "prepared-statement.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-query.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-094": {
+          "name": "Improper Control of Generation of Code (Code Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "vm-run-user-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "vm2-run-user-code.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "vm-literal-script.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "worker-isolation.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-099": {
+          "name": "Improper Control of Resource Identifiers (Environment Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "env-key-from-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "env-allowlisted-key.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-1007": {
+          "name": "Insufficient Visual Distinction of Homoglyphs Presented to User",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "cyrillic-homoglyph-identifier.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "zero-width-in-auth-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "ascii-identifiers.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "i18n-ui-copy.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-116": {
+          "name": "Improper Encoding or Escaping of Output (broken sanitizers)",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 1,
+          "FN": 0,
+          "TN": 1,
+          "precision": 66.7,
+          "recall": 100,
+          "f1": 80,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "single-pass-replace.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "no-unsanitized/property": 1
+              }
+            },
+            {
+              "file": "tag-filter-regexp.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "no-unsanitized/property": 1
+              }
+            },
+            {
+              "file": "dompurify-sanitize.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "no-unsanitized/property": 1
+              }
+            },
+            {
+              "file": "replace-until-stable.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-117": {
+          "name": "Improper Output Neutralization for Logs (log injection)",
+          "owasp": "A09:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "newline-in-log-message.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "template-literal-log.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "stripped-newlines.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "structured-logging.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-1333": {
+          "name": "Inefficient Regular Expression Complexity (ReDoS)",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 3,
+          "TN": 3,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "real-cve.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "self-loop.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "trade-off.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "atomic-equivalent.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "literal-match.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "simple-anchored.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-178": {
+          "name": "Improper Handling of Case Sensitivity (auth-guard path bypass)",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "case-sensitive-admin-guard.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "normalized-path-guard.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-209": {
+          "name": "Generation of Error Message Containing Sensitive Information (stack-trace exposure)",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "error-object-in-json.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "stack-in-response.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "generic-error-response.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-248": {
+          "name": "Uncaught Exception (Unhandled Stream Error)",
+          "owasp": "A04:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "multipart-pipe-no-handler.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "pipe-no-error-listener.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "pipe-with-error-listener.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "pipeline-promises.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-295": {
+          "name": "Improper Certificate Validation",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "reject-unauthorized-false.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-checkserveridentity-noop.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-checkserveridentity-validates.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-default-verification.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-327": {
+          "name": "Use of a Broken or Risky Cryptographic Algorithm",
+          "owasp": "A02:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 4,
+          "TN": 4,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "gcm-decipher-no-final.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-decrypt-no-authtag.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "sign-alg-none.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "verify-allows-none.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-decrypt-verified.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-encrypt-authtag.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "sign-rs256.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "verify-allowlist.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-346": {
+          "name": "Origin Validation Error (postMessage wildcard)",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "iframe-wildcard.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "window-parent-wildcard.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "explicit-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "self-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-377": {
+          "name": "Insecure Temporary File",
+          "owasp": "A04:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "static-tmp-write.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tmpdir-static-name.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "mkdtemp-write.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-409": {
+          "name": "Improper Handling of Highly Compressed Data (Decompression Bomb)",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "gunzip-no-limit.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gunzip-limited.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-444": {
+          "name": "Inconsistent Interpretation of HTTP Requests (HTTP Request Smuggling)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "request-insecure-parser.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "server-insecure-parser.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "request-default-parser.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "server-default-parser.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-548": {
+          "name": "Exposure of Information Through Directory Listing",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "serve-index-root.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-root-dirname.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-public-dir.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-598": {
+          "name": "Use of GET Request Method With Sensitive Query Strings",
+          "owasp": "A09:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "login-via-query.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "token-in-query.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "login-via-body-post.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-636": {
+          "name": "Not Failing Securely ('Failing Open')",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "catch-returns-true.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "empty-catch-continues.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "catch-denies.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "catch-rethrows.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-640": {
+          "name": "Weak Password Recovery Mechanism (host-header poisoning in reset links)",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "reset-link-forwarded-host.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "reset-link-host-header.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "reset-link-config-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-770": {
+          "name": "Allocation of Resources Without Limits or Throttling",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "array-length-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "buffer-alloc-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "buffer-alloc-clamped.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-798": {
+          "name": "Hardcoded Credentials",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 5,
+          "TN": 4,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "api-key-in-source.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "aws-access-key-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "github-token-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "jwt-signing-secret-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "password-in-config.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "env-credentials.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "password-label.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "provider-env-credentials.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "test-placeholder-values.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-843": {
+          "name": "Access of Resource Using Incompatible Type (req.query type confusion)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "query-object-spread.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "query-string-methods.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "guarded-query-type.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-918": {
+          "name": "Server-Side Request Forgery (SSRF)",
+          "owasp": "A10:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "axios-user-url.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-user-url.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-static-url.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-validated-url.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-943": {
+          "name": "Improper Neutralization of Special Elements in Data Query Logic (NoSQL Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "user-input-in-find.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "where-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "explicit-eq.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-filter.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        }
+      },
+      "aggregate": {
+        "TP": 4,
+        "FP": 1,
+        "FN": 65,
+        "TN": 59,
+        "precision": 80,
+        "recall": 5.8,
+        "f1": 10.8,
+        "bas": 4.1
+      }
+    }
+  }
+}

--- a/benchmarks/suites/ilb-arena/configs/interlace.config.js
+++ b/benchmarks/suites/ilb-arena/configs/interlace.config.js
@@ -5,8 +5,8 @@
 
 import secureCoding from "eslint-plugin-secure-coding";
 import nodeSecurity from "eslint-plugin-node-security";
-import pg from "eslint-plugin-pg";
-import jwt from "eslint-plugin-jwt";
+import pg from "eslint-plugin-postgresql-security";
+import jwt from "eslint-plugin-jwt-security";
 import browserSecurity from "eslint-plugin-browser-security";
 import mongodbSecurity from "eslint-plugin-mongodb-security";
 import expressSecurity from "eslint-plugin-express-security";

--- a/benchmarks/suites/ilb-arena/run.js
+++ b/benchmarks/suites/ilb-arena/run.js
@@ -276,8 +276,12 @@ async function runEslint(configPath, targetFile) {
   try {
     config = await loadConfig(configPath);
   } catch (e) {
-    console.error(`  ⚠️  Config load failed for ${configPath}: ${e.message?.slice(0, 200)}`);
-    return [];
+    // Not a warning. Returning [] here scores the plugin as "found nothing",
+    // which is indistinguishable from a plugin that genuinely detects nothing
+    // — that is how a stale import in interlace.config.js put Interlace last
+    // in ilb-cwe-corpus at F1 0% for two days after #414.
+    console.error(`\n❌ Config failed to load: ${configPath}\n   ${e.message}\n\nRefusing to score.`);
+    process.exit(3);
   }
 
   try {

--- a/benchmarks/suites/ilb-cwe-corpus/run.ts
+++ b/benchmarks/suites/ilb-cwe-corpus/run.ts
@@ -208,6 +208,27 @@ async function main() {
     process.exit(1);
   }
 
+  // Load every config before scoring anything. A config that throws on import
+  // used to be caught per-fixture and returned as `{error}`; the scorer read
+  // the missing `findings` field as zero, so a plugin that could not load and
+  // a plugin that found nothing produced identical numbers. That is exactly
+  // what happened when #414 renamed eslint-plugin-pg/-jwt out from under
+  // interlace.config.js: this suite reported Interlace at F1 0%, FN 69, last
+  // place, for two days. Fail the run instead — a benchmark that cannot load a
+  // competitor must not publish a score for it.
+  for (const plugin of plugins) {
+    try {
+      await loadConfig(plugin.config);
+    } catch (e) {
+      console.error(
+        `\n❌ Config failed to load for "${plugin.displayName}" (${plugin.config})\n   ${(e as Error).message}\n\n` +
+          `Refusing to score. A config that does not load would otherwise be\n` +
+          `indistinguishable from a plugin that detects nothing.`,
+      );
+      process.exit(3);
+    }
+  }
+
   if (!EMIT_JSON) {
     console.log(`\n🧪 ILB-CWE-Corpus v1.0 — ${corpus.length} CWE${corpus.length === 1 ? "" : "s"} × ${plugins.length} plugin${plugins.length === 1 ? "" : "s"}\n`);
     for (const c of corpus) {

--- a/benchmarks/suites/ilb-juliet/run.ts
+++ b/benchmarks/suites/ilb-juliet/run.ts
@@ -201,6 +201,21 @@ async function main() {
     process.exit(1);
   }
 
+  // See the same preflight in ilb-cwe-corpus/run.ts — this suite shares both
+  // the arena configs and the swallow-the-error-and-score-zero defect.
+  for (const plugin of plugins) {
+    try {
+      await loadConfig(plugin.config);
+    } catch (e) {
+      console.error(
+        `\n❌ Config failed to load for "${plugin.displayName}" (${plugin.config})\n   ${(e as Error).message}\n\n` +
+          `Refusing to score. A config that does not load would otherwise be\n` +
+          `indistinguishable from a plugin that detects nothing.`,
+      );
+      process.exit(3);
+    }
+  }
+
   if (!EMIT_JSON) {
     console.log(`\n🧪 ILB-Juliet v1.0 — ${corpus.length} CWE${corpus.length === 1 ? "" : "s"} × ${plugins.length} plugin${plugins.length === 1 ? "" : "s"}\n`);
     for (const c of corpus) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1263,7 +1263,8 @@
         "eslint-plugin-unicorn": "^72.0.0",
         "eslint-plugin-vue": "^10.9.2",
         "tsx": "^4.23.1",
-        "typescript": "^6.0.3"
+        "typescript": "^6.0.3",
+        "vue-eslint-parser": "^10.4.1"
       }
     },
     "benchmarks/node_modules/dotenv": {
@@ -30781,6 +30782,43 @@
       "version": "3.1.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vue-eslint-parser": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-10.4.1.tgz",
+      "integrity": "sha512-Gk6gRDj0n/fkRa3C3l0bBheoBckUq/Rs0F/TvMWIS6nzzx67amAViMe9CkNgsP2tXyQONvGiHQESHwFtZ3aYDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "eslint-scope": "^8.2.0 || ^9.0.0",
+        "eslint-visitor-keys": "^4.2.0 || ^5.0.0",
+        "espree": "^10.3.0 || ^11.0.0",
+        "esquery": "^1.6.0",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/vue-eslint-parser/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/packages/eslint-plugin-lambda-security/src/rules/no-error-swallowing/index.ts
+++ b/packages/eslint-plugin-lambda-security/src/rules/no-error-swallowing/index.ts
@@ -95,29 +95,121 @@ export const noErrorSwallowing = createRule<RuleOptions, MessageIds>({
       return {};
     }
 
+    /** Loggers whose methods count as recording the error. */
+    const LOGGER_OBJECTS = /^(console|logger|log|winston|pino|bunyan|sentry|Sentry)$/;
+    const LOGGER_METHODS = /^(log|error|warn|info|debug|captureException|captureMessage)$/;
+    /** Bare calls that record: logError(), reportError(), captureError(), trackError(). */
+    const LOGGING_FUNCTIONS = /^(log|report|capture|track|record|notify)\w*$/i;
     /**
-     * Check if a catch block has any logging
+     * Callbacks that hand the error onward. Passing the error to one of these
+     * is propagation, not swallowing — it is `throw` spelled asynchronously,
+     * and Express's own error middleware is reached no other way.
      */
-    function hasLogging(block: TSESTree.BlockStatement): boolean {
-      const sourceCode = context.sourceCode;
-      const blockText = sourceCode.getText(block);
+    const FORWARDING_CALLBACKS = /^(next|reject|callback|cb|done|fail|emit)$/;
+    /** Response objects whose terminal methods answer the request. */
+    const RESPONSE_OBJECTS = /^(res|response|reply|ctx)$/;
+    const RESPONSE_METHODS =
+      /^(status|sendStatus|json|send|end|writeHead|render|redirect)$/;
 
-      // console.log/error/warn/info/debug
-      if (/console\.\s*(log|error|warn|info|debug)\s*\(/.test(blockText)) {
-        return true;
+    /** The root identifier of a member chain: `a.b.c()` → `a`. */
+    function rootName(node: TSESTree.Node): string | undefined {
+      let current: TSESTree.Node = node;
+      while (current.type === AST_NODE_TYPES.MemberExpression) current = current.object;
+      return current.type === AST_NODE_TYPES.Identifier ? current.name : undefined;
+    }
+
+    /** Every property name in a member chain: `a.b.c()` → ['b','c']. */
+    function memberNames(node: TSESTree.Node): string[] {
+      const names: string[] = [];
+      let current: TSESTree.Node = node;
+      while (current.type === AST_NODE_TYPES.MemberExpression) {
+        if (current.property.type === AST_NODE_TYPES.Identifier) {
+          names.unshift(current.property.name);
+        }
+        current = current.object;
+      }
+      return names;
+    }
+
+    /**
+     * Classify a single call. Read off the AST, never off printed source:
+     * the previous implementation regexed `sourceCode.getText(block)` for
+     * `/\b(log|error|warn)\w*\s*\(/`, which matched any identifier beginning
+     * with "log" — and matched inside comments and string literals too.
+     */
+    function classifyCall(call: TSESTree.CallExpression): 'log' | 'forward' | 'respond' | undefined {
+      const callee = call.callee;
+
+      if (callee.type === AST_NODE_TYPES.Identifier) {
+        if (FORWARDING_CALLBACKS.test(callee.name)) return 'forward';
+        if (LOGGING_FUNCTIONS.test(callee.name)) return 'log';
+        return undefined;
       }
 
-      // logger.error, winston.error, pino.error, bunyan.error, log.error
-      if (/(logger|log|winston|pino|bunyan)\.\s*(error|warn|info|debug|log)\s*\(/.test(blockText)) {
-        return true;
+      if (callee.type !== AST_NODE_TYPES.MemberExpression) return undefined;
+
+      const names = memberNames(callee);
+      const method = names.at(-1) ?? '';
+
+      // Nested loggers first, so `this.logger.error()` is recognised — its
+      // chain roots at a ThisExpression, which has no name at all.
+      if (
+        names.length > 1 &&
+        LOGGER_OBJECTS.test(names.at(-2) ?? '') &&
+        LOGGER_METHODS.test(method)
+      ) {
+        return 'log';
       }
 
-      // Direct function call: logError(), reportError(), warnUser()
-      if (/\b(log|error|warn)\w*\s*\(/.test(blockText)) {
-        return true;
-      }
+      const root = rootName(callee);
+      if (root === undefined) return undefined;
 
-      return false;
+      if (LOGGER_OBJECTS.test(root) && LOGGER_METHODS.test(method)) return 'log';
+      // res.status(500).json(...) — the terminal method is what answers, so
+      // check the whole chain rather than only its last link.
+      if (RESPONSE_OBJECTS.test(root) && names.some((n) => RESPONSE_METHODS.test(n))) {
+        return 'respond';
+      }
+      return undefined;
+    }
+
+    /**
+     * Walk every node under the catch body and report what the block does with
+     * the error. A nested function body is deliberately included: a `catch`
+     * that logs from inside a callback still records the error.
+     */
+    function analyze(block: TSESTree.BlockStatement): {
+      logs: boolean;
+      forwards: boolean;
+      responds: boolean;
+    } {
+      const result = { logs: false, forwards: false, responds: false };
+      const seen = new Set<TSESTree.Node>();
+
+      const visit = (node: TSESTree.Node | null | undefined): void => {
+        if (!node || typeof node.type !== 'string' || seen.has(node)) return;
+        seen.add(node);
+
+        if (node.type === AST_NODE_TYPES.CallExpression) {
+          const kind = classifyCall(node);
+          if (kind === 'log') result.logs = true;
+          else if (kind === 'forward') result.forwards = true;
+          else if (kind === 'respond') result.responds = true;
+        }
+
+        for (const key of Object.keys(node)) {
+          if (key === 'parent') continue;
+          const value = (node as unknown as Record<string, unknown>)[key];
+          if (Array.isArray(value)) {
+            for (const item of value) visit(item as TSESTree.Node);
+          } else if (value && typeof value === 'object') {
+            visit(value as TSESTree.Node);
+          }
+        }
+      };
+
+      visit(block);
+      return result;
     }
 
     /**
@@ -146,12 +238,65 @@ export const noErrorSwallowing = createRule<RuleOptions, MessageIds>({
     }
 
     /**
-     * Check if catch has return (might be valid in some contexts)
+     * A `return <value>` from a catch handles the error only when it **fails
+     * closed**. The distinction is not whether a value comes back — it is
+     * what that value grants:
+     *
+     *   return '#';                    fail closed  — the safe sentinel
+     *   return false;                  fail closed  — an explicit denial
+     *   return [];                     fail closed  — no results
+     *
+     *   return;                        swallowed    — records and produces nothing
+     *   return null; / undefined;      swallowed    — no signal a caller can
+     *                                                tell from "no data"
+     *   return true;                   FAIL OPEN    — `catch { return true }`
+     *                                                in an auth check grants
+     *                                                access on a malformed
+     *                                                token (CWE-636)
+     *   return { statusCode: 200 };    FAIL OPEN    — reports success on failure
+     *
+     * Getting this backwards is not a near-miss. `return false` and
+     * `return true` are one token apart and sit on opposite sides of the
+     * line: one is a hostname validator denying an untrusted host, the other
+     * is an authorization check letting an expired token through. An earlier
+     * revision of this fix treated every value-return as handled and turned
+     * the CWE-636 fixture into a false negative — it caught the fail-open
+     * auth bypass before, and stopped.
      */
-    function hasReturn(block: TSESTree.BlockStatement): boolean {
-      return block.body.some(
-        (stmt) => stmt.type === AST_NODE_TYPES.ReturnStatement,
-      );
+    function returnsFallback(block: TSESTree.BlockStatement): boolean {
+      return block.body.some((stmt) => {
+        if (stmt.type !== AST_NODE_TYPES.ReturnStatement) return false;
+        const value = stmt.argument;
+        if (value === null) return false;
+
+        // No signal at all.
+        if (value.type === AST_NODE_TYPES.Literal && value.value === null) return false;
+        if (value.type === AST_NODE_TYPES.Identifier && value.name === 'undefined') {
+          return false;
+        }
+
+        // Permissive: grants whatever the caller was asking permission for.
+        if (value.type === AST_NODE_TYPES.Literal && value.value === true) return false;
+
+        // An object literal claiming a 2xx status is failure dressed as success.
+        if (value.type === AST_NODE_TYPES.ObjectExpression) {
+          const status = value.properties.find(
+            (p): p is TSESTree.Property =>
+              p.type === AST_NODE_TYPES.Property &&
+              p.key.type === AST_NODE_TYPES.Identifier &&
+              /^(statusCode|status|ok|allowed|authorized)$/.test(p.key.name),
+          );
+          if (status) {
+            const literal =
+              status.value.type === AST_NODE_TYPES.Literal ? status.value.value : undefined;
+            if (literal === true) return false;
+            const code = Number(literal);
+            if (code >= 200 && code < 300) return false;
+          }
+        }
+
+        return true;
+      });
     }
 
     return {
@@ -189,31 +334,28 @@ export const noErrorSwallowing = createRule<RuleOptions, MessageIds>({
           return;
         }
 
-        // Check if there's logging
-        if (!hasLogging(body)) {
-          // If there's a return with error context, that's also OK
-          if (hasReturn(body)) {
-            // Check if return includes error info
-            const returnStmt = body.body.find(
-              (s) => s.type === AST_NODE_TYPES.ReturnStatement,
-            ) as TSESTree.ReturnStatement | undefined;
+        // Four ways a catch handles rather than swallows. The rule previously
+        // recognised only the first, and only by regexing the block's printed
+        // text — so it fired on the *correct* form of four separate patterns
+        // in the CWE corpus:
+        //
+        //   catch (err) { return '#'; }              a safe fallback value
+        //   catch (err) { next(err); }               forwarding to a handler
+        //   catch { res.status(404).end(); }         answering the request
+        //
+        // The old return check demanded the returned expression match
+        // /500|error|fail/, so `return false` from a hostname validator read
+        // as swallowing while `return errorish` did not.
+        const { logs, forwards, responds } = analyze(body);
+        if (logs || forwards || responds || returnsFallback(body)) {
+          return;
+        }
 
-            if (returnStmt?.argument) {
-              // Check if return includes status 500 or error body
-              const sourceCode = context.sourceCode;
-              const returnText = sourceCode.getText(returnStmt.argument);
-              if (/500|error|fail/i.test(returnText)) {
-                return; // Acceptable error handling
-              }
-            }
-          }
-
-          if (!hasIntentionalComment(node)) {
-            context.report({
-              node,
-              messageId: 'emptyCatchBlock',
-            });
-          }
+        if (!hasIntentionalComment(node)) {
+          context.report({
+            node,
+            messageId: 'emptyCatchBlock',
+          });
         }
       },
     };

--- a/packages/eslint-plugin-lambda-security/src/rules/no-error-swallowing/no-error-swallowing.test.ts
+++ b/packages/eslint-plugin-lambda-security/src/rules/no-error-swallowing/no-error-swallowing.test.ts
@@ -11,6 +11,107 @@ const ruleTester = new RuleTester();
 
 ruleTester.run('no-error-swallowing', noErrorSwallowing, {
   valid: [
+    // ── The four ILB-CWE-Corpus fixtures this rule used to report ────────
+    // Each is the *correct, secure* form of its pattern. Together they were
+    // 4 of the suite's 16 false positives — a quarter, from one rule.
+    //
+    // A safe fallback value. The old check demanded the returned expression
+    // match /500|error|fail/, so `return '#'` from a scheme allowlist and
+    // `return false` from a hostname validator both read as swallowing.
+    {
+      name: 'CWE-020/scheme-allowlist — catch returns a safe fallback',
+      code: `
+        function sanitizeHref(raw) {
+          try {
+            const parsed = new URL(raw, window.location.origin);
+            return ALLOWED_PROTOCOLS.includes(parsed.protocol) ? parsed.href : '#';
+          } catch (err) {
+            return '#';
+          }
+        }
+      `,
+    },
+    {
+      name: 'CWE-020/url-parse-hostname — catch returns false',
+      code: `
+        function isTrustedApi(url) {
+          try {
+            return new URL(url).hostname === 'trusted.com';
+          } catch (err) {
+            return false;
+          }
+        }
+      `,
+    },
+    // Forwarding to an error handler is `throw` spelled asynchronously —
+    // Express's error middleware is reached no other way.
+    {
+      name: 'CWE-209/generic-error-response — catch forwards via next(err)',
+      code: `
+        app.get('/reports/:id', async (req, res, next) => {
+          try {
+            res.json(await loadReport(req.params.id));
+          } catch (err) {
+            next(err);
+          }
+        });
+      `,
+    },
+    // Answering the request is handling it. No return statement here — the
+    // response happens inside an if — so the old return check never applied.
+    {
+      name: 'CWE-248/pipeline-promises — catch answers the request',
+      code: `
+        async function download(req, res) {
+          try {
+            await pipeline(fs.createReadStream('./uploads/report.json'), res);
+          } catch {
+            if (!res.headersSent) res.status(404).end();
+          }
+        }
+      `,
+    },
+    // Related shapes the AST rewrite must also accept.
+    {
+      name: 'promise rejection is propagation',
+      code: `
+        new Promise((resolve, reject) => {
+          try { risky(); } catch (error) { reject(error); }
+        });
+      `,
+    },
+    {
+      name: 'node-style callback is propagation',
+      code: `try { risky(); } catch (error) { callback(error); }`,
+    },
+    {
+      name: 'logger reached through a member chain',
+      code: `try { risky(); } catch (error) { this.logger.error('failed', error); }`,
+    },
+    {
+      name: 'sentry capture counts as recording',
+      code: `try { risky(); } catch (error) { Sentry.captureException(error); }`,
+    },
+    {
+      name: 'logging from inside a nested callback still records',
+      code: `
+        try { risky(); } catch (error) {
+          process.nextTick(() => { console.error('failed', error); });
+        }
+      `,
+    },
+    // Object returns that carry no success claim are fail-closed fallbacks:
+    // no status-like key at all, and a status whose value is computed rather
+    // than a literal (nothing to read, so nothing to treat as 2xx).
+    {
+      name: 'object fallback with no status key is fail-closed',
+      code: `try { risky(); } catch (error) { return { data: [] }; }`,
+    },
+    {
+      name: 'object fallback with a computed status is fail-closed',
+      code: `try { risky(); } catch (error) { return { statusCode: fallbackCode }; }`,
+    },
+    // ── end corpus regressions ──────────────────────────────────────────
     // Rethrows the error — not swallowed
     {
       code: `
@@ -183,6 +284,99 @@ ruleTester.run('no-error-swallowing', noErrorSwallowing, {
   ],
 
   invalid: [
+    // ── FN boundary for the AST rewrite above ───────────────────────────
+    // Widening a rule to kill false positives is exactly how a false
+    // negative gets introduced (see #441, where excluding TemplateLiteral
+    // by name silenced `res.send(req.query.name || '<p>x</p>')`). These pin
+    // the edge of each new exemption.
+    //
+    // `return <value>` is a deliberate fallback; a bare `return;` records
+    // nothing and produces nothing. It must still report.
+    {
+      name: 'bare return is still swallowing',
+      code: `
+        function attempt() {
+          try {
+            riskyOperation();
+          } catch (error) {
+            return;
+          }
+        }
+      `,
+      errors: [{ messageId: 'emptyCatchBlock' }],
+    },
+    // The mirror of the two valid fallback cases above, and the reason the
+    // exemption is written in terms of fail-closed rather than "returns a
+    // value". `return false` from a hostname validator denies; `return true`
+    // from an auth check grants access on a malformed token. One token apart,
+    // opposite sides of the line. A draft of this fix exempted both and turned
+    // this exact corpus fixture into a false negative.
+    {
+      name: 'CWE-636/catch-returns-true — fail-open auth must still report',
+      code: `
+        function isAuthorized(token) {
+          try {
+            return verifyToken(token).valid;
+          } catch (err) {
+            return true;
+          }
+        }
+      `,
+      errors: [{ messageId: 'emptyCatchBlock' }],
+    },
+    {
+      name: 'fail-open object literal must still report',
+      code: `try { risky(); } catch (error) { return { authorized: true }; }`,
+      errors: [{ messageId: 'emptyCatchBlock' }],
+    },
+    // A non-forwarding call must not be mistaken for propagation just
+    // because a call is present.
+    {
+      name: 'an unrelated call is not propagation',
+      code: `try { risky(); } catch (error) { cleanup(); }`,
+      errors: [{ messageId: 'emptyCatchBlock' }],
+    },
+    // The caught error going nowhere, with a response object present but no
+    // response method called on it.
+    {
+      name: 'touching res without answering is still swallowing',
+      code: `
+        function handler(req, res) {
+          try { risky(); } catch (error) { res.locals.failed = true; }
+        }
+      `,
+      errors: [{ messageId: 'emptyCatchBlock' }],
+    },
+    {
+      name: 'return undefined is still swallowing',
+      code: `
+        function attempt() {
+          try { riskyOperation(); } catch (error) { return undefined; }
+        }
+      `,
+      errors: [{ messageId: 'emptyCatchBlock' }],
+    },
+    // Member chains the AST walk has to survive without mistaking them for a
+    // logger. A string-literal property is not an Identifier, so the chain
+    // yields no usable method name — the rule must fall through to reporting
+    // rather than treat the empty name as a match.
+    {
+      name: 'string-keyed member call is not logging',
+      code: `try { risky(); } catch (error) { registry['run'](); }`,
+      errors: [{ messageId: 'emptyCatchBlock' }],
+    },
+    {
+      name: 'string-keyed nested member call is not logging',
+      code: `try { risky(); } catch (error) { services['audit'].dispatch(error); }`,
+      errors: [{ messageId: 'emptyCatchBlock' }],
+    },
+    // A callee that is itself a call — neither Identifier nor MemberExpression.
+    {
+      name: 'immediately-invoked handler lookup is not logging',
+      code: `try { risky(); } catch (error) { (getHandler())(error); }`,
+      errors: [{ messageId: 'emptyCatchBlock' }],
+    },
+    // ── end FN boundary ─────────────────────────────────────────────────
     // Empty catch block — classic error swallowing (has suggestion with fix)
     {
       code: `

--- a/scripts/__tests__/benchmark-configs-load.test.ts
+++ b/scripts/__tests__/benchmark-configs-load.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Every benchmark arena config must import successfully.
+ *
+ * This is not a tidiness check — it is the guard for a silent-zero defect.
+ *
+ * `benchmarks/suites/ilb-arena/configs/*.config.js` are shared by three
+ * suites: ilb-arena, ilb-cwe-corpus and ilb-juliet. Each of them used to catch
+ * a config-load failure per fixture and carry on: cwe-corpus and juliet
+ * returned `{error}` whose missing `findings` field scored as zero, and arena
+ * printed a warning and returned `[]`. In all three, **a config that cannot
+ * load is scored identically to a plugin that detects nothing.**
+ *
+ * That is not hypothetical. #414 (2026-08-07) deleted the renamed
+ * `eslint-plugin-pg` and `eslint-plugin-jwt` sources; `interlace.config.js`
+ * still imported both, so the entire config threw and ilb-cwe-corpus published
+ * `Interlace: TP=0 FP=0 FN=69, F1=0%` — dead last behind every competitor —
+ * while the real numbers were TP=51 FN=18, F1=75%, first place. Nobody noticed
+ * for two days, and the weekly badge generator (#449) was one cron away from
+ * rendering the 0% onto the site.
+ *
+ * The runners now exit non-zero on a load failure. This test is the earlier
+ * gate: it fails on the PR that renames a package, not on the next benchmark
+ * run. It deliberately covers the *competitor* configs too — the first thing
+ * it caught was `vue.config.js` failing on a missing `vue-eslint-parser`,
+ * meaning the arena had been publishing eslint-plugin-vue as detecting
+ * nothing. Scoring a competitor at zero because we broke their config is the
+ * same defect pointed the other way, and a far worse look.
+ *
+ * Each config is loaded in a real `node` subprocess rather than with a bare
+ * `await import()`. Vitest's SSR transform resolves these packages through its
+ * own interop, where `plugin.configs` reads back `undefined` for a plugin that
+ * loads perfectly under node — so an in-process import reports failures the
+ * benchmark will never hit and misses the resolution differences it will.
+ * The runners use plain node; so does this test.
+ */
+import { describe, expect, it } from 'vitest';
+import { readdirSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+
+const CONFIG_DIR = join(import.meta.dirname, '../../benchmarks/suites/ilb-arena/configs');
+
+const CONFIGS = readdirSync(CONFIG_DIR)
+  .filter((f) => f.endsWith('.config.js'))
+  .sort();
+
+/** Import one config in a real node process; returns '' on success. */
+function loadFailure(name: string): string {
+  const probe = `
+    import(${JSON.stringify(join(CONFIG_DIR, name))})
+      .then((m) => {
+        const c = m.default;
+        if (!Array.isArray(c)) throw new Error('default export is not an array');
+        if (c.length === 0) throw new Error('exports an empty config — lints nothing');
+      })
+      .catch((e) => { console.error(e.message); process.exit(1); });
+  `;
+  try {
+    execFileSync(process.execPath, ['--input-type=module', '-e', probe], {
+      stdio: ['ignore', 'ignore', 'pipe'],
+      encoding: 'utf-8',
+    });
+    return '';
+  } catch (error) {
+    const e = error as { stderr?: string };
+    return (e.stderr ?? 'unknown failure').split('\n')[0]!.slice(0, 200);
+  }
+}
+
+describe('benchmark arena configs', () => {
+  it('finds the config directory', () => {
+    // A moved or renamed directory would otherwise turn this whole suite into
+    // zero passing assertions, which reports green.
+    expect(CONFIGS.length).toBeGreaterThan(10);
+  });
+
+  it.each(CONFIGS)('%s loads under node', { timeout: 30_000 }, (name) => {
+    expect(loadFailure(name), `${name} does not load`).toBe('');
+  });
+});


### PR DESCRIPTION
Stacked on #455 (which makes the corpus numbers below measurable at all). Retarget to `main` once that merges.

## The defect

Four of the sixteen ILB-CWE-Corpus false positives came from this one rule — **a quarter of the suite's FP count**. Every one is the *correct, secure* form of its pattern:

```js
catch (err) { return '#'; }                              // safe fallback (scheme allowlist)
catch (err) { return false; }                            // explicit denial (hostname validator)
catch (err) { next(err); }                               // forwarding to an error handler
catch { if (!res.headersSent) res.status(404).end(); }   // answering the request
```

Two causes:

1. **The return check demanded `/500|error|fail/`** on the returned expression, so `return false` from a validator read as swallowing while `return errorish` did not.
2. **Detection regexed `sourceCode.getText(block)`** — against this repo's own AST-not-printed-source doctrine. `/\b(log|error|warn)\w*\s*\(/` matched any identifier starting with "log", and matched inside comments and string literals, while missing `next(err)`, `reject(err)` and every response call.

## The fix

Rewritten on the AST. A catch handles its error when it **logs**, **forwards** to a callback, **answers** the request, or **returns a fail-closed value**.

## Fail-closed is the whole of it

A draft of this fix exempted every value-return. It cleared all four FPs — and turned `CWE-636/catch-returns-true.js` into a false negative:

```js
catch (err) { return false; }   // deny  — hostname validator failing closed
catch (err) { return true;  }   // GRANT — auth check letting an expired token through
```

One token apart, opposite sides of the line. The corpus caught it (`TP 51 → 50`), which is the argument for measuring rather than reasoning. `true`, a 2xx `statusCode`/`authorized`, `null` and `undefined` are all excluded from the exemption, and the CWE-636 fixture is locked as an `invalid` case.

## Numbers

ILB-CWE-Corpus, Interlace:

| | TP | FP | FN | F1 |
|---|---|---|---|---|
| before | 51 | 16 | 18 | 75% |
| **after** | **51** | **13** | **18** | **76.7%** |

No true positive lost.

## Tests

44 rule tests (18 added), 369 package tests, **100% coverage held**. The six edge paths the AST walk introduced — string-keyed member chains, a callee that is itself a call, computed `statusCode` values — are locked as cases, not excluded from coverage.

FN boundary explicitly pinned: bare `return;`, `return undefined;`, `return true;`, `return { authorized: true }`, an unrelated call, and a response object touched without being answered all still report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)