### PR TITLE
fix(secure-coding): no-improper-sanitization reported authored output and correct escaping

### DIFF
--- a/.changeset/no-improper-sanitization-authored-text.md
+++ b/.changeset/no-improper-sanitization-authored-text.md
@@ -1,0 +1,28 @@
+---
+"eslint-plugin-secure-coding": patch
+---
+
+`no-improper-sanitization` no longer reports developer-authored output or code
+that already escapes.
+
+This rule produced 42 of the 411 findings on the 13-repo wild corpus — its
+largest single contributor — and one of the 16 ILB-CWE-Corpus false positives.
+
+**Removed the custom-sanitizer check** (8 wild findings, 1 corpus). It reported
+any call to a function whose *name* contained sanitize/escape/clean when an
+argument's printed text contained `req.`/`body`/`query`/`params`/`input`/`data`
+— so `sanitizeForLog(req.body.username)` was a finding. That is the correct
+code, and the claim "custom sanitizer may be incomplete or bypassable" was made
+about an implementation the check never read. The `dangerousSanitizerUsage`
+messageId is gone with it.
+
+**Widened the authored-text exemption** (34 wild findings). A literal reaching
+`res.send`/`write`/`json` is exempt when no tainted leaf reaches the sink with
+it, rather than only when it is the direct argument. Now covered: concatenated
+literals, `['<li>', '</li>'].join('\n')`, values passed through a named
+sanitizer (`escapeHtml`, `DOMPurify.sanitize`, `he.encode`), and object
+literals served as JSON.
+
+The #441 false negatives stay closed — `res.send(req.query.name || '<p>x</p>')`,
+the ternary form, and any tainted operand still report, as do computed callees,
+deeper member chains, and template literals carrying expressions.

--- a/benchmarks/results/ilb-cwe-corpus/2026-08-09.json
+++ b/benchmarks/results/ilb-cwe-corpus/2026-08-09.json
@@ -1,7 +1,7 @@
 {
   "bench": "ILB-CWE-Corpus",
   "version": "1.0",
-  "timestamp": "2026-08-09T17:04:36.607Z",
+  "timestamp": "2026-08-09T19:07:35.555Z",
   "environment": {
     "nodeVersion": "v24.12.0",
     "eslintVersion": "10.7.0",
@@ -937,13 +937,13 @@
           "name": "Improper Output Neutralization for Logs (log injection)",
           "owasp": "A09:2021",
           "TP": 0,
-          "FP": 1,
+          "FP": 0,
           "FN": 2,
-          "TN": 1,
+          "TN": 2,
           "precision": 0,
           "recall": 0,
           "f1": 0,
-          "bas": -50,
+          "bas": 0,
           "fixtures": [
             {
               "file": "newline-in-log-message.js",
@@ -960,10 +960,8 @@
             {
               "file": "stripped-newlines.js",
               "expectedVulnerable": false,
-              "findings": 1,
-              "ruleHits": {
-                "secure-coding/no-improper-sanitization": 1
-              }
+              "findings": 0,
+              "ruleHits": {}
             },
             {
               "file": "structured-logging.js",
@@ -1834,13 +1832,13 @@
       },
       "aggregate": {
         "TP": 51,
-        "FP": 13,
+        "FP": 12,
         "FN": 18,
-        "TN": 47,
-        "precision": 79.7,
+        "TN": 48,
+        "precision": 81,
         "recall": 73.9,
-        "f1": 76.7,
-        "bas": 52.2
+        "f1": 77.3,
+        "bas": 53.9
       }
     },
     "eslint-plugin-security": {

--- a/packages/eslint-plugin-secure-coding/src/rules/no-improper-sanitization/index.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/no-improper-sanitization/index.ts
@@ -33,7 +33,6 @@ type MessageIds =
   | 'incompleteHtmlEscaping'
   | 'unsafeReplaceSanitization'
   | 'missingContextEncoding'
-  | 'dangerousSanitizerUsage'
   | 'sqlInjectionSanitization'
   | 'commandInjectionSanitization'
   | 'useProperSanitization'
@@ -113,15 +112,6 @@ export const noImproperSanitization = createRule<RuleOptions, MessageIds>({
         severity: 'MEDIUM',
         fix: 'Encode output according to usage context (HTML, URL, SQL, etc.)',
         documentationLink: 'https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html',
-      }),
-      dangerousSanitizerUsage: formatLLMMessage({
-        icon: MessageIcons.SECURITY,
-        issueName: 'Dangerous Sanitizer Usage',
-        cwe: 'CWE-94',
-        description: 'Custom sanitizer may be incomplete or bypassable',
-        severity: 'LOW',
-        fix: 'Use well-tested sanitization libraries',
-        documentationLink: 'https://cwe.mitre.org/data/definitions/94.html',
       }),
       sqlInjectionSanitization: formatLLMMessage({
         icon: MessageIcons.SECURITY,
@@ -349,48 +339,30 @@ export const noImproperSanitization = createRule<RuleOptions, MessageIds>({
           }
         }
 
-        // Check for custom sanitizer functions
-        if (callee.type === 'Identifier') {
-          const functionName = callee.name;
-
-          // Check if it's a known dangerous sanitizer pattern
-          if (functionName.toLowerCase().includes('sanitize') ||
-              functionName.toLowerCase().includes('escape') ||
-              functionName.toLowerCase().includes('clean')) {
-
-            // If it's not in our safe list, flag it
-            if (!safeSanitizers.some(safe => functionName.includes(safe))) {
-              // Check if arguments contain user input
-              const args = node.arguments;
-              let hasUserInput = false;
-
-              for (const arg of args) {
-                const argText = sourceCode.getText(arg).toLowerCase();
-                if (argText.includes('req.') || argText.includes('body') ||
-                    argText.includes('query') || argText.includes('params') ||
-                    argText.includes('input') || argText.includes('data')) {
-                  hasUserInput = true;
-                  break;
-                }
-              }
-
-              if (hasUserInput) {
-                if (safetyChecker.isSafe(node, context)) {
-                  return;
-                }
-
-                context.report({
-                  node,
-                  messageId: 'dangerousSanitizerUsage',
-                  data: {
-                    filePath: filename,
-                    line: String(node.loc?.start.line ?? 0),
-                  },
-                });
-              }
-            }
-          }
-        }
+        // A "custom sanitizer" check used to live here. It reported any call
+        // to a function whose *name* contained sanitize/escape/clean when an
+        // argument's printed text contained req./body/query/params/input/data:
+        //
+        //   logger.info('login attempt: ' + sanitizeForLog(req.body.username));
+        //
+        // That is the ILB-CWE-Corpus fixture for CWE-117, and it is the
+        // *correct* code — `sanitizeForLog` strips \r\n\t before logging. The
+        // check fired on writing a sanitizer and using it on user input, which
+        // is the behaviour the rule is supposed to encourage, and it could not
+        // be resolved by any edit short of renaming the function.
+        //
+        // It also asserted an impact it never established. "Custom sanitizer
+        // may be incomplete or bypassable" is a claim about an implementation
+        // the rule never looked at — the callee is usually imported, and the
+        // check inspected only the call site. Name-and-substring matching on
+        // printed source made it worse: `data` matches `metadata`, `userData`,
+        // `dataset`, and the argument text was scanned inside comments and
+        // string literals too.
+        //
+        // 8 of this rule's 42 findings on the wild corpus came from here, and
+        // every one was a call to a working sanitizer. Removed rather than
+        // narrowed: there is no version of "your sanitizer might be bad" that
+        // is actionable without reading the sanitizer.
       },
 
       // Check assignments that might need sanitization
@@ -525,12 +497,135 @@ export const noImproperSanitization = createRule<RuleOptions, MessageIds>({
           // The literal only earns the exemption when it IS the argument, so
           // any wrapper (`||`, `?:`, a call, a member access) falls through to
           // the normal checks below.
-          const isDirectResponseArgument =
-            directParent?.type === 'CallExpression' &&
-            (directParent as TSESTree.CallExpression).arguments.includes(
-              node as TSESTree.CallExpressionArgument,
-            );
-          const isBareLiteral = isDirectResponseArgument;
+          // Concatenation of literals is still developer-authored. Requiring
+          // the literal to be the *direct* argument left 34 findings across
+          // express/examples alone, all of this shape:
+          //
+          //   res.send('<form method="post"><p>Check to <label>'
+          //     + '<input type="checkbox" name="remember"/> remember me</label> '
+          //     + '<input type="submit" value="Submit"/>.</p></form>');
+          //
+          // Zero variables, three string literals, reported three times.
+          //
+          // The walk only climbs `+` — a `||`, a ternary, a call or a member
+          // access stops it, so the #441 false negatives stay closed: in
+          // `res.send(req.query.name || '<p>fallback</p>')` the literal never
+          // reaches an argument position on its own, and in
+          // `res.send('<div>' + req.query.name + '</div>')` the concatenation
+          // is reached but contains a non-literal leaf.
+          const enclosingArgument = (
+            literal: TSESTree.Node,
+          ): TSESTree.Node | undefined => {
+            let current = literal;
+            let parent = current.parent as TSESTree.Node | undefined;
+            // Climb the text-composing nodes only: `+`, and the
+            // `[...] .join(sep)` triple (ArrayExpression → the `.join` member
+            // → its call). Anything else — `||`, `?:`, a member access, a
+            // call on a value — stops the climb, which is what keeps the
+            // #441 false negatives closed.
+            for (;;) {
+              if (parent?.type === 'BinaryExpression' && parent.operator === '+') {
+                current = parent;
+              } else if (parent?.type === 'ArrayExpression') {
+                current = parent;
+              } else if (
+                // `res.send({ error: "Sorry, can't find that" })` — an object
+                // argument is serialised as JSON and served as
+                // application/json, so an apostrophe in it is not markup. The
+                // literal was reported because `'` is in `dangerousChars`.
+                parent?.type === 'Property' ||
+                (parent?.type === 'ObjectExpression' && current.type === 'Property')
+              ) {
+                current = parent;
+              } else if (
+                parent?.type === 'MemberExpression' &&
+                parent.object === current &&
+                parent.property.type === 'Identifier' &&
+                parent.property.name === 'join'
+              ) {
+                current = parent;
+              } else if (parent?.type === 'CallExpression' && parent.callee === current) {
+                current = parent;
+              } else {
+                break;
+              }
+              parent = current.parent as TSESTree.Node | undefined;
+            }
+            if (
+              parent?.type === 'CallExpression' &&
+              (parent as TSESTree.CallExpression).arguments.includes(
+                current as TSESTree.CallExpressionArgument,
+              )
+            ) {
+              return current;
+            }
+            return undefined;
+          };
+
+          /** `escapeHtml` / `DOMPurify.sanitize` / `encodeURIComponent`… */
+          const sanitizerNames = new Set([
+            ...safeSanitizers,
+            ...trustedSanitizers,
+            'escapeHtml',
+            'escapeHTML',
+            'htmlEscape',
+          ]);
+          const calleeName = (callee: TSESTree.Node): string | undefined => {
+            if (callee.type === 'Identifier') return callee.name;
+            if (
+              callee.type === 'MemberExpression' &&
+              callee.object.type === 'Identifier' &&
+              callee.property.type === 'Identifier'
+            ) {
+              return `${callee.object.name}.${callee.property.name}`;
+            }
+            return undefined;
+          };
+
+          /**
+           * Every leaf is either text the developer typed or a value that has
+           * been run through a sanitizer — nothing an attacker controls
+           * reaches the sink unescaped.
+           */
+          const isSafeText = (expr: TSESTree.Node): boolean => {
+            if (expr.type === 'Literal') return typeof expr.value === 'string';
+            if (expr.type === 'TemplateLiteral') return expr.expressions.length === 0;
+            if (expr.type === 'BinaryExpression' && expr.operator === '+') {
+              return isSafeText(expr.left) && isSafeText(expr.right);
+            }
+            if (expr.type === 'ObjectExpression') {
+              return expr.properties.every(
+                (property) =>
+                  property.type === 'Property' && isSafeText(property.value),
+              );
+            }
+            if (expr.type === 'CallExpression') {
+              const callee = expr.callee;
+              // ['<h1>', '<li>…'].join('\n') — express/examples/resource
+              // builds eight lines of static markup this way, and every one
+              // of them was reported.
+              if (
+                callee.type === 'MemberExpression' &&
+                callee.property.type === 'Identifier' &&
+                callee.property.name === 'join' &&
+                callee.object.type === 'ArrayExpression'
+              ) {
+                return callee.object.elements.every(
+                  (element) => element !== null && isSafeText(element),
+                );
+              }
+              // `res.send('user ' + escapeHtml(req.params.uid) + "'s pets")`
+              // — this rule exists to demand escaping, and was reporting the
+              // code that escapes. Only *named* sanitizers count; an
+              // arbitrary call still taints the concatenation.
+              const name = calleeName(callee);
+              return name !== undefined && sanitizerNames.has(name);
+            }
+            return false;
+          };
+
+          const argument = enclosingArgument(node as TSESTree.Node);
+          const isBareLiteral = argument !== undefined && isSafeText(argument);
           const hasDangerousMarkup =
             /<script[\s>]|<\/script>|\son\w+\s*=|javascript:/i.test(text);
           if (isBareLiteral && !hasDangerousMarkup) {

--- a/packages/eslint-plugin-secure-coding/src/rules/no-improper-sanitization/no-improper-sanitization.test.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/no-improper-sanitization/no-improper-sanitization.test.ts
@@ -137,28 +137,24 @@ describe('no-improper-sanitization', () => {
     });
   });
 
-  describe('Invalid Code - Custom Sanitizer Functions', () => {
-    ruleTester.run('invalid - custom sanitizer with user input', noImproperSanitization, {
-      valid: [],
-      invalid: [
-        // Custom sanitize function with user input
-        {
-          code: 'const clean = mySanitize(req.body.content);',
-          errors: [{ messageId: 'dangerousSanitizerUsage' }],
-        },
-        // Custom escape function with user data
-        {
-          code: 'const safe = myEscape(req.query.data);',
-          errors: [{ messageId: 'dangerousSanitizerUsage' }],
-        },
-        // Custom clean function with user input
-        {
-          code: 'const result = myClean(req.params.id);',
-          errors: [{ messageId: 'dangerousSanitizerUsage' }],
-        },
-      ],
-    });
-  });
+  // The "custom sanitizer" checks that lived here asserted that calling a
+  // function whose NAME contains sanitize/escape/clean on user input is a
+  // finding — `mySanitize(req.body.content)`, `myEscape(req.query.data)`.
+  //
+  // That is the correct code. The rule fired on writing a sanitizer and using
+  // it on user input, which is the behaviour it exists to encourage, and no
+  // edit short of renaming the function resolved it. It also claimed an
+  // impact it never established: "custom sanitizer may be incomplete or
+  // bypassable" is a statement about an implementation the check never read.
+  //
+  // ILB-CWE-Corpus CWE-117/stripped-newlines.js was one of the 16 false
+  // positives for exactly this reason:
+  //
+  //   logger.info('login attempt: ' + sanitizeForLog(req.body.username));
+  //
+  // 8 of this rule's 42 findings on the wild corpus came from the same path.
+  // The detection and its messageId are gone; these tests went with them.
+
 
   describe('Invalid Code - innerHTML Without Sanitization', () => {
     ruleTester.run('invalid - innerHTML with user input', noImproperSanitization, {
@@ -251,23 +247,6 @@ describe('no-improper-sanitization', () => {
       invalid: [],
     });
 
-    // ids 25+27 FALSE: no user input in args (all OR arms false) → hasUserInput stays false
-    ruleTester.run('coverage - custom sanitizer with static arg', noImproperSanitization, {
-      valid: [{ code: 'const r = mySanitize("static text");' }],
-      invalid: [],
-    });
-
-    // id 26: 6-way OR binary-expr arms [1-5] - body/query/params/input/data without req. prefix
-    ruleTester.run('coverage - custom sanitizer user input variants', noImproperSanitization, {
-      valid: [],
-      invalid: [
-        { code: 'mySanitize(bodyParam);',  errors: [{ messageId: 'dangerousSanitizerUsage' }] },
-        { code: 'mySanitize(queryParam);', errors: [{ messageId: 'dangerousSanitizerUsage' }] },
-        { code: 'mySanitize(paramsValue);',errors: [{ messageId: 'dangerousSanitizerUsage' }] },
-        { code: 'mySanitize(inputValue);', errors: [{ messageId: 'dangerousSanitizerUsage' }] },
-        { code: 'mySanitize(dataValue);',  errors: [{ messageId: 'dangerousSanitizerUsage' }] },
-      ],
-    });
 
     // id 30 FALSE: AssignmentExpression left is not MemberExpression
     ruleTester.run('coverage - assignment to identifier left side', noImproperSanitization, {
@@ -326,19 +305,6 @@ describe('no-improper-sanitization', () => {
       expect(reports[0].data?.line).toBe('0');
     });
 
-    it('CallExpression dangerousSanitizerUsage falls back to line 0 when loc is missing', () => {
-      const { listeners, reports } = createWithMockContext(noImproperSanitization, {
-        sourceText: 'mySanitize(req.body.data)',
-      });
-      (listeners.CallExpression as (n: unknown) => void)({
-        type: 'CallExpression',
-        callee: { type: 'Identifier', name: 'mySanitize' },
-        arguments: [{ type: 'Identifier', name: 'reqBodyData' }],
-      });
-      expect(reports).toHaveLength(1);
-      expect(reports[0].data?.line).toBe('0');
-    });
-
     it('AssignmentExpression insufficientXssProtection falls back to line 0 when loc is missing', () => {
       const { listeners, reports } = createWithMockContext(noImproperSanitization, {
         sourceText: 'element.innerHTML = req.body.data',
@@ -378,5 +344,129 @@ describe('no-improper-sanitization', () => {
       expect(reports).toHaveLength(1);
       expect(reports[0].data?.line).toBe('0');
     });
+  });
+});
+
+/**
+ * ILB-CWE-Corpus and wild-corpus regressions.
+ *
+ * This rule produced 42 of the 411 findings on the 13-repo wild corpus — its
+ * single largest contributor — and one of the 16 ILB-CWE-Corpus false
+ * positives. 34 came from the literal-in-a-response-sink path below, 8 from
+ * the removed custom-sanitizer path.
+ *
+ * The exemption is written as "no tainted leaf reaches the sink", not as a
+ * node-type blacklist. #441 excluded TemplateLiteral/BinaryExpression by name
+ * and silenced `res.send(req.query.name || '<p>x</p>')` — trading a false
+ * positive for a false negative. Every widening here is paired with the
+ * invalid case that pins its edge.
+ */
+describe('corpus regressions', () => {
+  ruleTester.run('authored text reaching a response sink', noImproperSanitization, {
+    valid: [
+      // express/examples/cookies/index.js:28 — three string literals, zero
+      // variables, reported three times.
+      {
+        code: `res.send('<form method="post"><p>Check to <label>'
+          + '<input type="checkbox" name="remember"/> remember me</label> '
+          + '<input type="submit" value="Submit"/>.</p></form>');`,
+      },
+      // express/examples/resource/index.js:80-87 — eight lines of static
+      // markup in an array, joined. Eight findings.
+      {
+        code: `res.send(['<h1>Examples:</h1> <ul>', '<li>GET /users</li>', '</ul>'].join('\\n'));`,
+      },
+      // express/examples/route-map/index.js:47 — the input IS escaped. This
+      // rule exists to demand escaping and was reporting the code that does it.
+      {
+        code: `res.send('user ' + escapeHtml(req.params.uid) + "'s pets")`,
+      },
+      // express/examples/web-service/index.js:110 — an object argument is
+      // serialised as JSON and served as application/json; the apostrophe in
+      // it is not markup. Reported because `'` is in dangerousChars.
+      {
+        code: `res.send({ error: "Sorry, can't find that" })`,
+      },
+      {
+        code: `res.json({ message: 'Done <ok>' })`,
+      },
+      // A sanitizer reached through a member chain, not a bare identifier.
+      {
+        code: `res.send('<p>' + DOMPurify.sanitize(req.body.bio) + '</p>')`,
+      },
+      {
+        code: `res.send('<p>' + he.encode(req.body.bio) + '</p>')`,
+      },
+    ],
+    invalid: [
+      // Each concatenation reports once per literal operand — two literals
+      // bracketing a tainted value gives two findings, which is the existing
+      // behaviour and not what these cases are pinning.
+      //
+      // An unescaped value inside an otherwise-static array still taints it,
+      // so the `.join()` exemption cannot be reached by hiding input in the
+      // array.
+      {
+        code: `res.send(['<li>', req.query.name, '</li>'].join(''))`,
+        errors: [
+          { messageId: 'unsafeReplaceSanitization' },
+          { messageId: 'unsafeReplaceSanitization' },
+        ],
+      },
+      // Only *named* sanitizers earn the exemption — an arbitrary call does
+      // not, or `escapeHtml` recognition would become "any call launders
+      // taint".
+      {
+        code: `res.send('<p>' + renderBio(req.body.bio) + '</p>')`,
+        errors: [
+          { messageId: 'unsafeReplaceSanitization' },
+          { messageId: 'unsafeReplaceSanitization' },
+        ],
+      },
+      // A tainted object property is still tainted — the JSON exemption is
+      // per-value, not per-argument.
+      {
+        code: `res.send({ error: '<b>' + req.query.msg + '</b>' })`,
+        errors: [
+          { messageId: 'unsafeReplaceSanitization' },
+          { messageId: 'unsafeReplaceSanitization' },
+        ],
+      },
+      // A computed callee yields no resolvable name, so it cannot match the
+      // sanitizer list — taint launders through nothing.
+      {
+        code: `res.send('<p>' + sanitizers[kind](req.body.bio) + '</p>')`,
+        errors: [
+          { messageId: 'unsafeReplaceSanitization' },
+          { messageId: 'unsafeReplaceSanitization' },
+        ],
+      },
+      // A deeper member chain (`lib.html.escape`) resolves to no name at all,
+      // so it cannot match the sanitizer list. Widening the resolver to walk
+      // arbitrary chains would let `attacker.controlled.escape()` launder taint.
+      {
+        code: `res.send('<p>' + lib.html.escape(req.body.bio) + '</p>')`,
+        errors: [
+          { messageId: 'unsafeReplaceSanitization' },
+          { messageId: 'unsafeReplaceSanitization' },
+        ],
+      },
+      // A template literal WITH expressions is interpolation, not authored text.
+      {
+        code: 'res.send(\'<p>\' + `${req.body.bio}` + \'</p>\')',
+        errors: [
+          { messageId: 'unsafeReplaceSanitization' },
+          { messageId: 'unsafeReplaceSanitization' },
+        ],
+      },
+      // A non-string literal operand is not authored text either.
+      {
+        code: `res.send('<b>' + count + '</b>')`,
+        errors: [
+          { messageId: 'unsafeReplaceSanitization' },
+          { messageId: 'unsafeReplaceSanitization' },
+        ],
+      },
+    ],
   });
 });


### PR DESCRIPTION
Stacked on #456 → #455. Retarget to `main` as those merge.

## Scale

This rule produced **42 of the 411** findings on the 13-repo wild corpus — its largest single contributor — plus one of the 16 ILB-CWE-Corpus false positives. Measured split: **34** from the literal-in-a-response-sink path, **8** from the custom-sanitizer path.

## Removed: the custom-sanitizer check (8 wild + 1 corpus)

It reported any call to a function whose *name* contained sanitize/escape/clean when an argument's printed text contained `req.`/`body`/`query`/`params`/`input`/`data`:

```js
logger.info('login attempt: ' + sanitizeForLog(req.body.username));
```

That is the CWE-117 corpus fixture, and **it is the correct code**. The rule fired on writing a sanitizer and using it on user input — the behaviour it exists to encourage — and no edit short of renaming the function resolved it.

It also asserted an impact it never established. *"Custom sanitizer may be incomplete or bypassable"* describes an implementation the check never read; the callee is usually imported and only the call site was inspected. Substring matching on printed source made it worse: `data` matches `metadata`, `userData`, `dataset`, and argument text was scanned inside comments and string literals too.

There is no version of "your sanitizer might be bad" that is actionable without reading the sanitizer. Removed rather than narrowed; the `dangerousSanitizerUsage` messageId went with it.

## Widened: authored text reaching a response sink (34 wild)

#441 exempted a literal only when it **is** the direct argument, which left every multi-part construction reporting:

| Site | Code | Findings |
|---|---|---|
| `cookies/index.js:28` | `res.send('<form…' + '<input…' + '…</form>')` | 3 literals, 0 variables → 3 |
| `resource/index.js:80` | `res.send(['<h1>…', '<li>…', '</ul>'].join('\n'))` | 8 static lines → 8 |
| `route-map/index.js:47` | `res.send('user ' + escapeHtml(req.params.uid) + "'s pets")` | already escaped → 2 |
| `web-service/index.js:110` | `res.send({ error: "Sorry, can't find that" })` | JSON, not markup → 1 |

The exemption is now "no tainted leaf reaches the sink". The walk climbs only text-composing nodes — `+`, an array with `.join()`, object properties. A `||`, a ternary, a member access or an arbitrary call stops it.

Only **named** sanitizers launder taint (`escapeHtml`, `DOMPurify.sanitize`, `he.encode`, plus `safeSanitizers`/`trustedSanitizers`). Computed callees and deeper chains like `lib.html.escape` resolve to no name and do not — otherwise `attacker.controlled.escape()` would launder taint.

## The #441 false negatives stay closed

Every one is pinned as an `invalid` case: `res.send(req.query.name || '<p>x</p>')`, the ternary form, `'<div>' + req.query.name + '</div>'`, a tainted element inside a `.join()` array, a tainted object property, an arbitrary call, a computed callee, a deeper member chain, a template literal carrying expressions, and a non-string literal operand.

## Numbers

| | this rule, wild corpus | ecosystem FP | ecosystem TP | F1 |
|---|---|---|---|---|
| before | 42 | 13 | 51 | 76.7% |
| **after** | **14** | **12** | **51** | **77.3%** |

The 14 remaining are genuine unescaped interpolation into HTML — `'<li>' + user.name + '</li>'`, `req.session.views` — the same class express itself fixes with `escapeHtml` elsewhere in the same tree.

## Tests

1554 package tests pass, **100% coverage held**. The tests that asserted the removed behaviour were deleted with the reasoning recorded in place; every new exemption ships with the invalid case pinning its edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)