### PR TITLE
fix(secure-coding): no-unchecked-loop-condition inferred taint from names

### DIFF
--- a/.changeset/no-unchecked-loop-condition-structural-taint.md
+++ b/.changeset/no-unchecked-loop-condition-structural-taint.md
@@ -1,0 +1,24 @@
+---
+"eslint-plugin-secure-coding": patch
+---
+
+`no-unchecked-loop-condition` no longer infers user input from identifier names.
+
+Taint was decided by substring-matching identifiers — and the printed text of
+whole expressions — against
+`['req','request','body','query','params','input','data']`, with
+`includes('input')` and `includes('data')` OR-ed in unconditionally. So
+`metadataMap`, `dataSource`, `queryBuilder`, `LoggerRequestIdHeaders` and a
+local `query` object all read as attacker-controlled.
+
+The guess also propagated: a variable whose initializer *text* mentioned one of
+those names joined the taint set, so `const found = coll.find(query)` made
+`found` tainted and every later `for (const r of found)` a finding.
+
+Taint now starts only at a real request object (`req`, `request`, `ctx`,
+`context`, `event`) and spreads by assignment, seeded from the initializer's
+AST rather than its printed text. `req.query` is evidence; `query` is a name.
+
+28 findings across express, ultimate-backend and ack-nestjs-boilerplate drop to
+1 — a genuine true positive iterating `ctx.headers`. Request-derived loops
+still report, directly and through assignment.

--- a/benchmarks/results/ilb-cwe-corpus/2026-08-09.json
+++ b/benchmarks/results/ilb-cwe-corpus/2026-08-09.json
@@ -1,9 +1,9 @@
 {
   "bench": "ILB-CWE-Corpus",
   "version": "1.0",
-  "timestamp": "2026-08-09T19:07:35.555Z",
+  "timestamp": "2026-08-09T19:37:04.767Z",
   "environment": {
-    "nodeVersion": "v24.12.0",
+    "nodeVersion": "v24.18.0",
     "eslintVersion": "10.7.0",
     "platform": "darwin",
     "arch": "arm64"
@@ -891,13 +891,13 @@
           "name": "Improper Encoding or Escaping of Output (broken sanitizers)",
           "owasp": "A03:2021",
           "TP": 2,
-          "FP": 1,
+          "FP": 0,
           "FN": 0,
-          "TN": 1,
-          "precision": 66.7,
+          "TN": 2,
+          "precision": 100,
           "recall": 100,
-          "f1": 80,
-          "bas": 50,
+          "f1": 100,
+          "bas": 100,
           "fixtures": [
             {
               "file": "single-pass-replace.js",
@@ -926,10 +926,8 @@
             {
               "file": "replace-until-stable.js",
               "expectedVulnerable": false,
-              "findings": 1,
-              "ruleHits": {
-                "secure-coding/no-unchecked-loop-condition": 1
-              }
+              "findings": 0,
+              "ruleHits": {}
             }
           ]
         },
@@ -1832,13 +1830,13 @@
       },
       "aggregate": {
         "TP": 51,
-        "FP": 12,
+        "FP": 11,
         "FN": 18,
-        "TN": 48,
-        "precision": 81,
+        "TN": 49,
+        "precision": 82.3,
         "recall": 73.9,
-        "f1": 77.3,
-        "bas": 53.9
+        "f1": 77.9,
+        "bas": 55.6
       }
     },
     "eslint-plugin-security": {

--- a/packages/eslint-plugin-secure-coding/src/rules/no-unchecked-loop-condition/index.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/no-unchecked-loop-condition/index.ts
@@ -215,6 +215,22 @@ export const noUncheckedLoopCondition = createRule<RuleOptions, MessageIds>({
     const taintedVariables = new Set<string>();
 
     /**
+     * Names that actually denote a request. Taint starts here and spreads by
+     * assignment — it is not inferred from what a variable is called.
+     *
+     * The `body`/`query`/`params`/`input`/`data` entries in the default
+     * `userInputVariables` are *properties* of one of these, not standalone
+     * evidence: `req.query` is user input, a local `query` object is not.
+     */
+    const REQUEST_OBJECTS = new Set([
+      'req',
+      'request',
+      'ctx',
+      'context',
+      'event',
+    ]);
+
+    /**
      * Check if a variable contains user input
      */
     const isUserInput = (varName: string): boolean => {
@@ -235,14 +251,25 @@ export const noUncheckedLoopCondition = createRule<RuleOptions, MessageIds>({
         return userInputVariables.some(input => lowerVarName === input.toLowerCase());
       }
 
-      // Using defaults, use broader matching
-      return userInputVariables.some(input =>
-        lowerVarName.includes(input.toLowerCase()) ||
-        lowerVarName === input.toLowerCase() ||
-        // Handle cases like "userInput", "customInput", etc.
-        lowerVarName.includes('input') ||
-        lowerVarName.includes('data')
-      );
+      // Using defaults: a *request object* name is evidence; a bare noun is
+      // not. The previous form substring-matched the identifier against all
+      // seven defaults and additionally OR-ed in `includes('input')` and
+      // `includes('data')` unconditionally, so every one of these read as
+      // attacker-controlled:
+      //
+      //   metadataMap   dataSource   queryBuilder   requestId   bodyParser
+      //
+      // Worse, the guess propagated: a variable assigned from a "tainted"
+      // one joins `taintedVariables`, so `const found = coll.find(query)`
+      // made `found` tainted and every `for (const r of found)` a finding.
+      // 25 of this rule's 28 findings on the wild corpus started that way,
+      // as did the ILB-CWE-Corpus false positive — whose only sin was a
+      // parameter named `input`:
+      //
+      //   function stripTags(input) { … do { … } while (current !== previous); }
+      //
+      // `req.query` is evidence. `query` is a name.
+      return REQUEST_OBJECTS.has(lowerVarName);
     };
 
 
@@ -326,12 +353,17 @@ export const noUncheckedLoopCondition = createRule<RuleOptions, MessageIds>({
      * Check if an expression involves user input
      */
     const involvesUserInput = (expression: TSESTree.Expression): boolean => {
-      const expressionText = sourceCode.getText(expression).toLowerCase();
-
-      // Check for user input variables in expression text (case-insensitive)
-      if (userInputVariables.some(input => expressionText.includes(input.toLowerCase()))) {
-        return true;
-      }
+      // A printed-source substring test used to run first here:
+      //
+      //   const expressionText = sourceCode.getText(expression).toLowerCase();
+      //   if (userInputVariables.some(i => expressionText.includes(i))) return true;
+      //
+      // It short-circuited the AST walk below and matched the seven default
+      // names anywhere in the rendered text — inside a longer identifier, a
+      // property name, a string literal or a comment. `orderByExtractFromRequest`
+      // and `LoggerRequestIdHeaders` were both findings on that basis. The
+      // structural walk that follows was already the correct check; it just
+      // never got to run.
 
       // Recursively check all parts of the expression
       const checkExpression = (node: TSESTree.Expression): boolean => {
@@ -452,8 +484,18 @@ export const noUncheckedLoopCondition = createRule<RuleOptions, MessageIds>({
             const varName = declarator.id.name;
             const initText = sourceCode.getText(declarator.init);
 
-            // Check if the initializer contains user input patterns, but not if it's sanitized
-            const hasUserInput = userInputVariables.some(input => initText.toLowerCase().includes(input.toLowerCase()));
+            // Seed taint structurally, from the initializer's AST. This was a
+            // substring test over the initializer's printed text against the
+            // same seven names, and it is where the whole rule went wrong:
+            //
+            //   let current = String(input);   // 'String(input)' contains
+            //                                  // 'input' → `current` tainted
+            //   do { … } while (current !== previous);   // → reported
+            //
+            // The ILB-CWE-Corpus CWE-116 fixture is that exact code, and its
+            // loop provably terminates — the string shrinks on every pass.
+            // Its only offence was a parameter named `input`.
+            const hasUserInput = involvesUserInput(declarator.init);
             const isSanitized = initText.includes('Math.min(') || initText.includes('Math.max(') ||
                               initText.includes('parseInt(') || initText.includes('parseFloat(') ||
                               (initText.includes('&&') && initText.includes('.length'));

--- a/packages/eslint-plugin-secure-coding/src/rules/no-unchecked-loop-condition/no-unchecked-loop-condition.test.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/no-unchecked-loop-condition/no-unchecked-loop-condition.test.ts
@@ -108,7 +108,7 @@ describe('no-unchecked-loop-condition', () => {
           ],
         },
         {
-          code: 'while (userInput-- > 0) { doWork(); }',
+          code: 'const userInput = req.query.count; while (userInput-- > 0) { doWork(); }',
           errors: [
             {
               messageId: 'userControlledLoopBound',
@@ -132,19 +132,19 @@ describe('no-unchecked-loop-condition', () => {
       valid: [],
       invalid: [
         {
-          code: 'while (-userInput > 0) { /* UnaryExpression */ process(); }',
+          code: 'const userInput = req.query.count; while (-userInput > 0) { /* UnaryExpression */ process(); }',
           errors: [{ messageId: 'userControlledLoopBound' }],
         },
         {
-          code: 'while (userInput++ < 100) { /* UpdateExpression */ process(); }',
+          code: 'const userInput = req.query.count; while (userInput++ < 100) { /* UpdateExpression */ process(); }',
           errors: [{ messageId: 'userControlledLoopBound' }],
         },
         {
-          code: 'while (!userInput) { /* UnaryExpression ! */ process(); }',
+          code: 'const userInput = req.query.count; while (!userInput) { /* UnaryExpression ! */ process(); }',
           errors: [{ messageId: 'userControlledLoopBound' }],
         },
         {
-          code: 'while (check(userInput)) { /* CallExpression with user input */ process(); }',
+          code: 'const userInput = req.query.count; while (check(userInput)) { /* CallExpression with user input */ process(); }',
           errors: [{ messageId: 'userControlledLoopBound' }],
         },
       ],
@@ -270,7 +270,7 @@ describe('no-unchecked-loop-condition', () => {
           ],
         },
         {
-          code: 'for (const key in userInput) { console.log(key); }',
+          code: 'const userInput = req.query.count; for (const key in userInput) { console.log(key); }',
           errors: [
             {
               messageId: 'uncheckedLoopCondition',
@@ -568,7 +568,7 @@ describe('no-unchecked-loop-condition', () => {
       valid: [],
       invalid: [
         {
-          code: 'do { doWork(); } while (userInput-- > 0);',
+          code: 'const userInput = req.query.count; do { doWork(); } while (userInput-- > 0);',
           errors: [{ messageId: 'userControlledLoopBound' }],
         },
       ],
@@ -740,6 +740,7 @@ describe('no-unchecked-loop-condition', () => {
       valid: [
         {
           code: `
+            const userInput = req.query.count;
             /** @safe */
             while (userInput-- > 0) { doWork(); }
           `,
@@ -800,6 +801,7 @@ describe('no-unchecked-loop-condition', () => {
       valid: [
         {
           code: `
+            const userInput = req.query.count;
             /** @safe */
             for (let i = 0; i < userInput; i++) { doWork(); }
           `,
@@ -836,6 +838,7 @@ describe('no-unchecked-loop-condition', () => {
       valid: [
         {
           code: `
+            const userInput = req.query.count;
             /** @safe */
             do { doWork(); } while (userInput-- > 0);
           `,
@@ -978,13 +981,13 @@ describe('no-unchecked-loop-condition', () => {
 
     it('WhileStatement userControlledLoopBound falls back to line 0', () => {
       const { listeners, reports } = createWithMockContext(noUncheckedLoopCondition, {
-        sourceText: 'userInput > 0',
+        sourceText: 'req',
       });
       const whileStatement = listeners.WhileStatement as (node: unknown) => void;
 
       whileStatement({
         type: 'WhileStatement',
-        test: { type: 'BinaryExpression', operator: '>', left: { type: 'Identifier', name: 'userInput' }, right: { type: 'Literal', value: 0 } },
+        test: { type: 'BinaryExpression', operator: '>', left: { type: 'MemberExpression', object: { type: 'Identifier', name: 'req' }, property: { type: 'Identifier', name: 'count' } }, right: { type: 'Literal', value: 0 } },
         body: { type: 'BlockStatement', body: [] },
       });
 
@@ -1071,14 +1074,14 @@ describe('no-unchecked-loop-condition', () => {
 
     it('ForStatement userControlledLoopBound falls back to line 0', () => {
       const { listeners, reports } = createWithMockContext(noUncheckedLoopCondition, {
-        sourceText: 'userInput > 0',
+        sourceText: 'req',
       });
       const forStatement = listeners.ForStatement as (node: unknown) => void;
 
       forStatement({
         type: 'ForStatement',
         init: null,
-        test: { type: 'BinaryExpression', operator: '>', left: { type: 'Identifier', name: 'userInput' }, right: { type: 'Literal', value: 0 } },
+        test: { type: 'BinaryExpression', operator: '>', left: { type: 'MemberExpression', object: { type: 'Identifier', name: 'req' }, property: { type: 'Identifier', name: 'count' } }, right: { type: 'Literal', value: 0 } },
         update: { type: 'UpdateExpression' },
         body: { type: 'BlockStatement', body: [] },
       });
@@ -1141,13 +1144,13 @@ describe('no-unchecked-loop-condition', () => {
 
     it('DoWhileStatement userControlledLoopBound falls back to line 0', () => {
       const { listeners, reports } = createWithMockContext(noUncheckedLoopCondition, {
-        sourceText: 'userInput > 0',
+        sourceText: 'req',
       });
       const doWhileStatement = listeners.DoWhileStatement as (node: unknown) => void;
 
       doWhileStatement({
         type: 'DoWhileStatement',
-        test: { type: 'BinaryExpression', operator: '>', left: { type: 'Identifier', name: 'userInput' }, right: { type: 'Literal', value: 0 } },
+        test: { type: 'BinaryExpression', operator: '>', left: { type: 'MemberExpression', object: { type: 'Identifier', name: 'req' }, property: { type: 'Identifier', name: 'count' } }, right: { type: 'Literal', value: 0 } },
         body: { type: 'BlockStatement', body: [] },
       });
 
@@ -1158,14 +1161,14 @@ describe('no-unchecked-loop-condition', () => {
 
     it('ForInStatement uncheckedLoopCondition falls back to line 0', () => {
       const { listeners, reports } = createWithMockContext(noUncheckedLoopCondition, {
-        sourceText: 'req.body.data',
+        sourceText: 'req',
       });
       const forInStatement = listeners.ForInStatement as (node: unknown) => void;
 
       forInStatement({
         type: 'ForInStatement',
         left: { type: 'Identifier', name: 'key' },
-        right: { type: 'MemberExpression' },
+        right: { type: 'MemberExpression', object: { type: 'Identifier', name: 'req' }, property: { type: 'Identifier', name: 'body' } },
         body: { type: 'BlockStatement', body: [] },
       });
 
@@ -1176,7 +1179,7 @@ describe('no-unchecked-loop-condition', () => {
 
     it('ForOfStatement uncheckedLoopCondition falls back to line 0', () => {
       const { listeners, reports } = createWithMockContext(noUncheckedLoopCondition, {
-        sourceText: 'req.body.data',
+        sourceText: 'req',
       });
       const forOfStatement = listeners.ForOfStatement as (node: unknown) => void;
 
@@ -1184,7 +1187,7 @@ describe('no-unchecked-loop-condition', () => {
         type: 'ForOfStatement',
         parent: undefined,
         left: { type: 'Identifier', name: 'item' },
-        right: { type: 'MemberExpression' },
+        right: { type: 'MemberExpression', object: { type: 'Identifier', name: 'req' }, property: { type: 'Identifier', name: 'body' } },
         body: { type: 'BlockStatement', body: [] },
       });
 
@@ -1192,5 +1195,88 @@ describe('no-unchecked-loop-condition', () => {
       expect(reports[0].messageId).toBe('uncheckedLoopCondition');
       expect(reports[0].data?.line).toBe('0');
     });
+  });
+});
+
+/**
+ * Corpus regressions: a name is not evidence.
+ *
+ * This rule produced 28 findings across express + ultimate-backend +
+ * ack-nestjs-boilerplate, and one of the 16 ILB-CWE-Corpus false positives.
+ * Every one traced to taint inferred from identifier *names* — a substring
+ * test against ['req','request','body','query','params','input','data'] run
+ * over both bare identifiers and the printed text of whole expressions.
+ *
+ * It also propagated. `const found = coll.find(query)` made `found` tainted
+ * because the initializer's text contained "query", so every later
+ * `for (const r of found)` was a finding.
+ *
+ * Taint now starts only at a real request object and spreads by assignment.
+ */
+describe('corpus regressions — names are not taint', () => {
+  ruleTester.run('name-based taint', noUncheckedLoopCondition, {
+    valid: [
+      // ILB-CWE-Corpus CWE-116/replace-until-stable.js. The loop provably
+      // terminates — the string shrinks on every pass. Its only offence was
+      // a parameter named `input`, which tainted `current` through
+      // `String(input)` and made the exit condition "user-controlled".
+      {
+        code: `
+          function stripTags(input) {
+            let current = String(input);
+            let previous;
+            do {
+              previous = current;
+              current = current.replace(/<[^>]*>/g, '');
+            } while (current !== previous);
+            return current;
+          }
+        `,
+      },
+      // ultimate-backend/arango-parser.utils.ts:37 — a locally-built AQL
+      // query object, not a request.
+      { code: `for (let prop in query) { build(prop); }` },
+      // Names that merely contain a default substring.
+      { code: `for (const [k, v] of metadataMap) { use(v); }` },
+      { code: `for (const row of dataSource.rows) { use(row); }` },
+      { code: `for (const h of LoggerRequestIdHeaders) { use(h); }` },
+      { code: `for (const e of orderByExtractFromRequest) { use(e); }` },
+      // The propagation case: `found` is only "tainted" because the
+      // initializer's printed text mentioned `query`.
+      {
+        code: `
+          const found = collection.find(query);
+          for (const result of found) { use(result); }
+        `,
+      },
+    ],
+    invalid: [
+      // Real request-derived data still reports, directly…
+      {
+        code: `for (const key in req.body) { use(key); }`,
+        errors: [{ messageId: 'uncheckedLoopCondition' }],
+      },
+      {
+        code: `for (const item of request.query.items) { use(item); }`,
+        errors: [{ messageId: 'uncheckedLoopCondition' }],
+      },
+      // …and through assignment, which is what taint tracking is for.
+      // ultimate-backend/headers.datasource.ts:16 is this shape and remains
+      // a true positive.
+      {
+        code: `
+          const ctxHeaders = ctx.headers;
+          for (const key in ctxHeaders) { use(key); }
+        `,
+        errors: [{ messageId: 'uncheckedLoopCondition' }],
+      },
+      {
+        code: `
+          const limit = req.query.limit;
+          while (limit-- > 0) { doWork(); }
+        `,
+        errors: [{ messageId: 'userControlledLoopBound' }],
+      },
+    ],
   });
 });


### PR DESCRIPTION
Stacked on #457 → #456 → #455. Retarget to `main` as those merge.

## The defect

28 findings across express + ultimate-backend + ack-nestjs-boilerplate, plus one of the 16 ILB-CWE-Corpus false positives — all from taint decided by **what a variable is called**.

`isUserInput` substring-matched identifiers against the seven default `userInputVariables`, with `includes('input')` and `includes('data')` OR-ed in unconditionally for every candidate. `involvesUserInput` then ran a substring test over `sourceCode.getText(expression)` **before** the structural walk, short-circuiting it — so a default name matched anywhere in the rendered text, including inside a longer identifier, a string literal, or a comment.

Reported on that basis:

```js
for (const [kv, v] of metadataMap)          // 'metadatamap'.includes('data')
for (let prop in query)                     // a locally-built AQL query object
for (const h of LoggerRequestIdHeaders)     // substring 'request'
for (const e of orderByExtractFromRequest)  // substring 'request'
```

## And it propagated

The taint set was seeded by the same substring test over an initializer's printed text:

```js
const found = collection.find(query);   // text contains 'query' → found tainted
for (const result of found) { … }       // → finding
```

That accounts for most of the 28 — and for the corpus fixture, whose only offence was a parameter named `input`:

```js
function stripTags(input) {
  let current = String(input);              // 'String(input)' contains 'input'
  do { … } while (current !== previous);    // → "user-controlled"
}
```

That loop provably terminates; the string shrinks on every pass.

## The fix

Taint starts only at a real request object (`req`, `request`, `ctx`, `context`, `event`) and spreads by assignment, seeded from the initializer's **AST** rather than its printed text. The structural walk that was already there is now the only check — it just never got to run.

`req.query` is evidence. `query` is a name.

## Numbers

| | this rule, wild corpus | ecosystem FP | ecosystem TP | F1 |
|---|---|---|---|---|
| before | 28 | 12 | 51 | 77.3% |
| **after** | **1** | **11** | **51** | **77.9%** |

The remaining finding is a genuine true positive — `ultimate-backend/headers.datasource.ts:16` iterating `ctx.headers`.

## Tests

Twelve existing tests asserted the name-based premise (`while (userInput-- > 0)`). Rather than delete them, each now establishes taint structurally — `const userInput = req.query.count` — which preserves the detection they were written for and makes them honest.

Three `@safe`-annotation tests were passing **vacuously** once names stopped tainting: their subject no longer reported at all, so the short-circuit they exist to cover never ran. Coverage caught it. They now carry real taint.

1565 package tests pass, **100% coverage held**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)