### PR TITLE
feat(node-security): put no-self-signed-certs in recommended

### DIFF
--- a/.changeset/promote-no-self-signed-certs.md
+++ b/.changeset/promote-no-self-signed-certs.md
@@ -1,0 +1,15 @@
+---
+"eslint-plugin-node-security": minor
+---
+
+`no-self-signed-certs` is now part of the `recommended` preset.
+
+`rejectUnauthorized: false` accepts any certificate, including a MITM's
+self-signed one, and is the most-cited Node TLS mistake there is. The rule
+already detected it correctly — it simply was not in any preset, so nobody
+running `recommended` had it enabled. ILB-CWE-Corpus scored CWE-295 as a miss
+for that reason alone.
+
+Measured over the 13-repo wild corpus (~1,900 files of real Express and NestJS
+code) before promoting: **0 findings**. Pure recall, no false-positive cost.
+Ecosystem corpus score moves TP 51 → 52, FN 18 → 17, FP unchanged at 11.

--- a/benchmarks/results/ilb-cwe-corpus/2026-08-09.json
+++ b/benchmarks/results/ilb-cwe-corpus/2026-08-09.json
@@ -1,9 +1,9 @@
 {
   "bench": "ILB-CWE-Corpus",
   "version": "1.0",
-  "timestamp": "2026-08-09T19:37:04.767Z",
+  "timestamp": "2026-08-09T20:02:30.908Z",
   "environment": {
-    "nodeVersion": "v24.18.0",
+    "nodeVersion": "v18.16.1",
     "eslintVersion": "10.7.0",
     "platform": "darwin",
     "arch": "arm64"
@@ -1150,20 +1150,22 @@
         "CWE-295": {
           "name": "Improper Certificate Validation",
           "owasp": "A07:2021",
-          "TP": 0,
+          "TP": 1,
           "FP": 0,
-          "FN": 2,
+          "FN": 1,
           "TN": 2,
-          "precision": 0,
-          "recall": 0,
-          "f1": 0,
-          "bas": 0,
+          "precision": 100,
+          "recall": 50,
+          "f1": 66.7,
+          "bas": 50,
           "fixtures": [
             {
               "file": "reject-unauthorized-false.js",
               "expectedVulnerable": true,
-              "findings": 0,
-              "ruleHits": {}
+              "findings": 1,
+              "ruleHits": {
+                "node-security/no-self-signed-certs": 1
+              }
             },
             {
               "file": "tls-checkserveridentity-noop.js",
@@ -1829,14 +1831,14 @@
         }
       },
       "aggregate": {
-        "TP": 51,
+        "TP": 52,
         "FP": 11,
-        "FN": 18,
+        "FN": 17,
         "TN": 49,
-        "precision": 82.3,
-        "recall": 73.9,
-        "f1": 77.9,
-        "bas": 55.6
+        "precision": 82.5,
+        "recall": 75.4,
+        "f1": 78.8,
+        "bas": 57
       }
     },
     "eslint-plugin-security": {

--- a/packages/eslint-plugin-node-security/src/index.ts
+++ b/packages/eslint-plugin-node-security/src/index.ts
@@ -165,6 +165,23 @@ const recommendedRules: Record<string, TSESLint.FlatConfig.RuleEntry> = {
   'node-security/no-ecb-mode': 'error',
   'node-security/no-math-random-crypto': 'error',
   'node-security/no-cryptojs': 'error',
+
+  // Added to `recommended` 2026-08-09. `rejectUnauthorized: false` accepts any
+  // certificate, including a MITM's self-signed one, and is the most-cited
+  // Node TLS mistake there is — yet ILB-CWE-Corpus scored CWE-295 as a miss
+  // for the ecosystem. The rule was never the problem: it fires on the
+  // fixture exactly as intended, it simply was not in any preset, so nobody
+  // running `recommended` ever had it on.
+  //
+  // Measured before promoting, over the 13-repo wild corpus (~1,900 files of
+  // real Express and NestJS code): **0 findings**. Pure recall, no FP cost.
+  //
+  // `browser-security/no-disabled-certificate-validation` detects the same
+  // thing and was deliberately left out of that plugin's preset: enabling
+  // both would double-report one defect, which is its own FP class (see the
+  // two CSRF rules). `rejectUnauthorized` is a Node TLS option with no
+  // browser equivalent, so node-security owns it.
+  'node-security/no-self-signed-certs': 'error',
 };
 
 export const configs: Record<string, TSESLint.FlatConfig.Config> = {


### PR DESCRIPTION
Stacked on #459 → #457 → #456 → #455. Retarget to `main` as those merge.

## We did not need a new rule

ILB-CWE-Corpus scored **CWE-295 (Improper Certificate Validation)** as a miss, and the obvious reading was "we have no certificate-validation rule — write one". That reading was wrong. Two shipped rules detect `rejectUnauthorized: false` correctly today:

```
node-security/no-self-signed-certs
browser-security/no-disabled-certificate-validation
```

Neither is in any `recommended` preset. The benchmark runs `recommended`, so nobody — benchmark or user — ever had them on. The gap was preset membership, not detection.

## Promoted one, not both

They detect the same defect. Enabling both would double-report it, which is its own false-positive class — the two CSRF rules already do exactly that on 19 corpus locations. `rejectUnauthorized` is a Node TLS option with no browser equivalent, so node-security owns it and browser-security's stays out.

## Measured before promoting

Over the 13-repo wild corpus (~1,900 files of real Express and NestJS code): **0 findings**. Pure recall, no FP cost.

| | TP | FP | FN | F1 |
|---|---|---|---|---|
| before | 51 | 11 | 18 | 77.9% |
| **after** | **52** | **11** | **17** | **78.8%** |

One line of config.

## Seven other candidates measured and left out

The same pass measured every other rule sitting outside `recommended` in these two plugins:

`no-sha1-hash`, `no-deprecated-cipher-method`, `no-insecure-rsa-padding`, `no-insecure-key-derivation`, `no-cryptojs-weak-random`, `no-password-in-url`, `require-url-validation`

All score **0 on the wild corpus and 0 on the CWE corpus** — no measurable yield in either direction. They stay out. A rule that sounds useful and fires on nothing we can measure is not evidence for promotion, and promoting a batch of them would be exactly the "coverage theatre" this exercise is meant to avoid.

Three more (`no-dynamic-require` 4, `prefer-native-crypto` 9, `no-unencrypted-transmission` 14) do produce wild-corpus findings and need triage before any decision.

998 package tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)