### PR TITLE
fix(lambda-security): no-error-swallowing fired on four correct patterns

### DIFF
--- a/.changeset/no-error-swallowing-fail-closed.md
+++ b/.changeset/no-error-swallowing-fail-closed.md
@@ -1,0 +1,23 @@
+---
+"eslint-plugin-lambda-security": patch
+---
+
+`no-error-swallowing` no longer reports a catch that handles its error.
+
+The rule detected handling by regexing the block's printed source, so it
+missed `next(err)`, `reject(err)` and every response call, while matching any
+identifier that merely started with "log" — including inside comments and
+string literals. Its return check additionally demanded the returned
+expression match `/500|error|fail/`, so `return false` from a hostname
+validator read as swallowing.
+
+Detection is now AST-based. A catch handles its error when it logs, forwards
+to a callback (`next`, `reject`, `callback`, `done`), answers the request
+(`res.status(...)`, `res.end()`), or returns a **fail-closed** value.
+
+Fail-open returns still report, and that distinction is the point:
+`catch { return false }` denies, `catch { return true }` grants access on a
+malformed token. `true`, a 2xx `statusCode`, `null` and `undefined` are all
+excluded from the exemption.
+
+Fixes four false positives in ILB-CWE-Corpus with no loss of true positives.

--- a/.changeset/no-error-swallowing-fail-closed.md
+++ b/.changeset/no-error-swallowing-fail-closed.md
@@ -20,4 +20,9 @@ Fail-open returns still report, and that distinction is the point:
 malformed token. `true`, a 2xx `statusCode`, `null` and `undefined` are all
 excluded from the exemption.
 
-Fixes four false positives in ILB-CWE-Corpus with no loss of true positives.
+Removes the rule's findings from four ILB-CWE-Corpus fixtures. The corpus
+false-positive total drops from 16 to 13 rather than 4, because
+`pipeline-promises.js` is still reported by
+`node-security/detect-non-literal-fs-filename` — that fixture builds a read
+path straight from `req.params.id`, so the remaining finding is a true
+positive against a mislabelled fixture. No true positives lost.

--- a/benchmarks/results/ilb-cwe-corpus/2026-08-09.json
+++ b/benchmarks/results/ilb-cwe-corpus/2026-08-09.json
@@ -1,7 +1,7 @@
 {
   "bench": "ILB-CWE-Corpus",
   "version": "1.0",
-  "timestamp": "2026-08-09T16:26:14.541Z",
+  "timestamp": "2026-08-09T17:04:36.607Z",
   "environment": {
     "nodeVersion": "v24.12.0",
     "eslintVersion": "10.7.0",
@@ -426,13 +426,13 @@
           "name": "Improper Input Validation (validation-bypass cluster)",
           "owasp": "A03:2021",
           "TP": 3,
-          "FP": 5,
+          "FP": 3,
           "FN": 2,
-          "TN": 0,
-          "precision": 37.5,
+          "TN": 2,
+          "precision": 50,
           "recall": 60,
-          "f1": 46.2,
-          "bas": -40,
+          "f1": 54.5,
+          "bas": 0,
           "fixtures": [
             {
               "file": "incomplete-hostname-regexp.js",
@@ -497,18 +497,14 @@
             {
               "file": "scheme-allowlist.js",
               "expectedVulnerable": false,
-              "findings": 1,
-              "ruleHits": {
-                "lambda-security/no-error-swallowing": 1
-              }
+              "findings": 0,
+              "ruleHits": {}
             },
             {
               "file": "url-parse-hostname.js",
               "expectedVulnerable": false,
-              "findings": 1,
-              "ruleHits": {
-                "lambda-security/no-error-swallowing": 1
-              }
+              "findings": 0,
+              "ruleHits": {}
             }
           ]
         },
@@ -1069,47 +1065,43 @@
           "name": "Generation of Error Message Containing Sensitive Information (stack-trace exposure)",
           "owasp": "A05:2021",
           "TP": 2,
-          "FP": 1,
+          "FP": 0,
           "FN": 0,
-          "TN": 0,
-          "precision": 66.7,
+          "TN": 1,
+          "precision": 100,
           "recall": 100,
-          "f1": 80,
-          "bas": 0,
+          "f1": 100,
+          "bas": 100,
           "fixtures": [
             {
               "file": "error-object-in-json.js",
               "expectedVulnerable": true,
-              "findings": 8,
+              "findings": 7,
               "ruleHits": {
                 "express-security/require-helmet": 1,
                 "express-security/require-rate-limiting": 1,
                 "express-security/require-csrf-protection": 1,
                 "express-security/no-missing-csrf-protection": 1,
                 "express-security/require-route-authentication": 1,
-                "lambda-security/no-error-swallowing": 1,
                 "express-security/no-error-details-in-response": 2
               }
             },
             {
               "file": "stack-in-response.js",
               "expectedVulnerable": true,
-              "findings": 7,
+              "findings": 6,
               "ruleHits": {
                 "express-security/require-helmet": 1,
                 "express-security/require-rate-limiting": 1,
                 "lambda-security/no-missing-authorization-check": 2,
-                "express-security/no-error-details-in-response": 2,
-                "lambda-security/no-error-swallowing": 1
+                "express-security/no-error-details-in-response": 2
               }
             },
             {
               "file": "generic-error-response.js",
               "expectedVulnerable": false,
-              "findings": 1,
-              "ruleHits": {
-                "lambda-security/no-error-swallowing": 1
-              }
+              "findings": 0,
+              "ruleHits": {}
             }
           ]
         },
@@ -1152,10 +1144,9 @@
             {
               "file": "pipeline-promises.js",
               "expectedVulnerable": false,
-              "findings": 2,
+              "findings": 1,
               "ruleHits": {
-                "node-security/detect-non-literal-fs-filename": 1,
-                "lambda-security/no-error-swallowing": 1
+                "node-security/detect-non-literal-fs-filename": 1
               }
             }
           ]
@@ -1843,13 +1834,13 @@
       },
       "aggregate": {
         "TP": 51,
-        "FP": 16,
+        "FP": 13,
         "FN": 18,
-        "TN": 44,
-        "precision": 76.1,
+        "TN": 47,
+        "precision": 79.7,
         "recall": 73.9,
-        "f1": 75,
-        "bas": 47.2
+        "f1": 76.7,
+        "bas": 52.2
       }
     },
     "eslint-plugin-security": {

--- a/packages/eslint-plugin-lambda-security/src/rules/no-error-swallowing/index.ts
+++ b/packages/eslint-plugin-lambda-security/src/rules/no-error-swallowing/index.ts
@@ -95,29 +95,121 @@ export const noErrorSwallowing = createRule<RuleOptions, MessageIds>({
       return {};
     }
 
+    /** Loggers whose methods count as recording the error. */
+    const LOGGER_OBJECTS = /^(console|logger|log|winston|pino|bunyan|sentry|Sentry)$/;
+    const LOGGER_METHODS = /^(log|error|warn|info|debug|captureException|captureMessage)$/;
+    /** Bare calls that record: logError(), reportError(), captureError(), trackError(). */
+    const LOGGING_FUNCTIONS = /^(log|report|capture|track|record|notify)\w*$/i;
     /**
-     * Check if a catch block has any logging
+     * Callbacks that hand the error onward. Passing the error to one of these
+     * is propagation, not swallowing — it is `throw` spelled asynchronously,
+     * and Express's own error middleware is reached no other way.
      */
-    function hasLogging(block: TSESTree.BlockStatement): boolean {
-      const sourceCode = context.sourceCode;
-      const blockText = sourceCode.getText(block);
+    const FORWARDING_CALLBACKS = /^(next|reject|callback|cb|done|fail|emit)$/;
+    /** Response objects whose terminal methods answer the request. */
+    const RESPONSE_OBJECTS = /^(res|response|reply|ctx)$/;
+    const RESPONSE_METHODS =
+      /^(status|sendStatus|json|send|end|writeHead|render|redirect)$/;
 
-      // console.log/error/warn/info/debug
-      if (/console\.\s*(log|error|warn|info|debug)\s*\(/.test(blockText)) {
-        return true;
+    /** The root identifier of a member chain: `a.b.c()` → `a`. */
+    function rootName(node: TSESTree.Node): string | undefined {
+      let current: TSESTree.Node = node;
+      while (current.type === AST_NODE_TYPES.MemberExpression) current = current.object;
+      return current.type === AST_NODE_TYPES.Identifier ? current.name : undefined;
+    }
+
+    /** Every property name in a member chain: `a.b.c()` → ['b','c']. */
+    function memberNames(node: TSESTree.Node): string[] {
+      const names: string[] = [];
+      let current: TSESTree.Node = node;
+      while (current.type === AST_NODE_TYPES.MemberExpression) {
+        if (current.property.type === AST_NODE_TYPES.Identifier) {
+          names.unshift(current.property.name);
+        }
+        current = current.object;
+      }
+      return names;
+    }
+
+    /**
+     * Classify a single call. Read off the AST, never off printed source:
+     * the previous implementation regexed `sourceCode.getText(block)` for
+     * `/\b(log|error|warn)\w*\s*\(/`, which matched any identifier beginning
+     * with "log" — and matched inside comments and string literals too.
+     */
+    function classifyCall(call: TSESTree.CallExpression): 'log' | 'forward' | 'respond' | undefined {
+      const callee = call.callee;
+
+      if (callee.type === AST_NODE_TYPES.Identifier) {
+        if (FORWARDING_CALLBACKS.test(callee.name)) return 'forward';
+        if (LOGGING_FUNCTIONS.test(callee.name)) return 'log';
+        return undefined;
       }
 
-      // logger.error, winston.error, pino.error, bunyan.error, log.error
-      if (/(logger|log|winston|pino|bunyan)\.\s*(error|warn|info|debug|log)\s*\(/.test(blockText)) {
-        return true;
+      if (callee.type !== AST_NODE_TYPES.MemberExpression) return undefined;
+
+      const names = memberNames(callee);
+      const method = names.at(-1) ?? '';
+
+      // Nested loggers first, so `this.logger.error()` is recognised — its
+      // chain roots at a ThisExpression, which has no name at all.
+      if (
+        names.length > 1 &&
+        LOGGER_OBJECTS.test(names.at(-2) ?? '') &&
+        LOGGER_METHODS.test(method)
+      ) {
+        return 'log';
       }
 
-      // Direct function call: logError(), reportError(), warnUser()
-      if (/\b(log|error|warn)\w*\s*\(/.test(blockText)) {
-        return true;
-      }
+      const root = rootName(callee);
+      if (root === undefined) return undefined;
 
-      return false;
+      if (LOGGER_OBJECTS.test(root) && LOGGER_METHODS.test(method)) return 'log';
+      // res.status(500).json(...) — the terminal method is what answers, so
+      // check the whole chain rather than only its last link.
+      if (RESPONSE_OBJECTS.test(root) && names.some((n) => RESPONSE_METHODS.test(n))) {
+        return 'respond';
+      }
+      return undefined;
+    }
+
+    /**
+     * Walk every node under the catch body and report what the block does with
+     * the error. A nested function body is deliberately included: a `catch`
+     * that logs from inside a callback still records the error.
+     */
+    function analyze(block: TSESTree.BlockStatement): {
+      logs: boolean;
+      forwards: boolean;
+      responds: boolean;
+    } {
+      const result = { logs: false, forwards: false, responds: false };
+      const seen = new Set<TSESTree.Node>();
+
+      const visit = (node: TSESTree.Node | null | undefined): void => {
+        if (!node || typeof node.type !== 'string' || seen.has(node)) return;
+        seen.add(node);
+
+        if (node.type === AST_NODE_TYPES.CallExpression) {
+          const kind = classifyCall(node);
+          if (kind === 'log') result.logs = true;
+          else if (kind === 'forward') result.forwards = true;
+          else if (kind === 'respond') result.responds = true;
+        }
+
+        for (const key of Object.keys(node)) {
+          if (key === 'parent') continue;
+          const value = (node as unknown as Record<string, unknown>)[key];
+          if (Array.isArray(value)) {
+            for (const item of value) visit(item as TSESTree.Node);
+          } else if (value && typeof value === 'object') {
+            visit(value as TSESTree.Node);
+          }
+        }
+      };
+
+      visit(block);
+      return result;
     }
 
     /**
@@ -146,12 +238,65 @@ export const noErrorSwallowing = createRule<RuleOptions, MessageIds>({
     }
 
     /**
-     * Check if catch has return (might be valid in some contexts)
+     * A `return <value>` from a catch handles the error only when it **fails
+     * closed**. The distinction is not whether a value comes back — it is
+     * what that value grants:
+     *
+     *   return '#';                    fail closed  — the safe sentinel
+     *   return false;                  fail closed  — an explicit denial
+     *   return [];                     fail closed  — no results
+     *
+     *   return;                        swallowed    — records and produces nothing
+     *   return null; / undefined;      swallowed    — no signal a caller can
+     *                                                tell from "no data"
+     *   return true;                   FAIL OPEN    — `catch { return true }`
+     *                                                in an auth check grants
+     *                                                access on a malformed
+     *                                                token (CWE-636)
+     *   return { statusCode: 200 };    FAIL OPEN    — reports success on failure
+     *
+     * Getting this backwards is not a near-miss. `return false` and
+     * `return true` are one token apart and sit on opposite sides of the
+     * line: one is a hostname validator denying an untrusted host, the other
+     * is an authorization check letting an expired token through. An earlier
+     * revision of this fix treated every value-return as handled and turned
+     * the CWE-636 fixture into a false negative — it caught the fail-open
+     * auth bypass before, and stopped.
      */
-    function hasReturn(block: TSESTree.BlockStatement): boolean {
-      return block.body.some(
-        (stmt) => stmt.type === AST_NODE_TYPES.ReturnStatement,
-      );
+    function returnsFallback(block: TSESTree.BlockStatement): boolean {
+      return block.body.some((stmt) => {
+        if (stmt.type !== AST_NODE_TYPES.ReturnStatement) return false;
+        const value = stmt.argument;
+        if (value === null) return false;
+
+        // No signal at all.
+        if (value.type === AST_NODE_TYPES.Literal && value.value === null) return false;
+        if (value.type === AST_NODE_TYPES.Identifier && value.name === 'undefined') {
+          return false;
+        }
+
+        // Permissive: grants whatever the caller was asking permission for.
+        if (value.type === AST_NODE_TYPES.Literal && value.value === true) return false;
+
+        // An object literal claiming a 2xx status is failure dressed as success.
+        if (value.type === AST_NODE_TYPES.ObjectExpression) {
+          const status = value.properties.find(
+            (p): p is TSESTree.Property =>
+              p.type === AST_NODE_TYPES.Property &&
+              p.key.type === AST_NODE_TYPES.Identifier &&
+              /^(statusCode|status|ok|allowed|authorized)$/.test(p.key.name),
+          );
+          if (status) {
+            const literal =
+              status.value.type === AST_NODE_TYPES.Literal ? status.value.value : undefined;
+            if (literal === true) return false;
+            const code = Number(literal);
+            if (code >= 200 && code < 300) return false;
+          }
+        }
+
+        return true;
+      });
     }
 
     return {
@@ -189,31 +334,28 @@ export const noErrorSwallowing = createRule<RuleOptions, MessageIds>({
           return;
         }
 
-        // Check if there's logging
-        if (!hasLogging(body)) {
-          // If there's a return with error context, that's also OK
-          if (hasReturn(body)) {
-            // Check if return includes error info
-            const returnStmt = body.body.find(
-              (s) => s.type === AST_NODE_TYPES.ReturnStatement,
-            ) as TSESTree.ReturnStatement | undefined;
+        // Four ways a catch handles rather than swallows. The rule previously
+        // recognised only the first, and only by regexing the block's printed
+        // text — so it fired on the *correct* form of four separate patterns
+        // in the CWE corpus:
+        //
+        //   catch (err) { return '#'; }              a safe fallback value
+        //   catch (err) { next(err); }               forwarding to a handler
+        //   catch { res.status(404).end(); }         answering the request
+        //
+        // The old return check demanded the returned expression match
+        // /500|error|fail/, so `return false` from a hostname validator read
+        // as swallowing while `return errorish` did not.
+        const { logs, forwards, responds } = analyze(body);
+        if (logs || forwards || responds || returnsFallback(body)) {
+          return;
+        }
 
-            if (returnStmt?.argument) {
-              // Check if return includes status 500 or error body
-              const sourceCode = context.sourceCode;
-              const returnText = sourceCode.getText(returnStmt.argument);
-              if (/500|error|fail/i.test(returnText)) {
-                return; // Acceptable error handling
-              }
-            }
-          }
-
-          if (!hasIntentionalComment(node)) {
-            context.report({
-              node,
-              messageId: 'emptyCatchBlock',
-            });
-          }
+        if (!hasIntentionalComment(node)) {
+          context.report({
+            node,
+            messageId: 'emptyCatchBlock',
+          });
         }
       },
     };

--- a/packages/eslint-plugin-lambda-security/src/rules/no-error-swallowing/index.ts
+++ b/packages/eslint-plugin-lambda-security/src/rules/no-error-swallowing/index.ts
@@ -111,6 +111,29 @@ export const noErrorSwallowing = createRule<RuleOptions, MessageIds>({
     const RESPONSE_METHODS =
       /^(status|sendStatus|json|send|end|writeHead|render|redirect)$/;
 
+    /**
+     * Does the caught error appear anywhere in these arguments?
+     *
+     * Searches the whole subtree rather than the top level, so `next(err)`,
+     * `next(err.message)` and `reject(new Error(err))` all count — the error
+     * travels in each. `next()` does not.
+     */
+    function mentions(nodes: readonly TSESTree.Node[], name: string): boolean {
+      const stack = [...nodes];
+      while (stack.length > 0) {
+        const node = stack.pop();
+        if (!node || typeof node.type !== 'string') continue;
+        if (node.type === AST_NODE_TYPES.Identifier && node.name === name) return true;
+        for (const key of Object.keys(node)) {
+          if (key === 'parent') continue;
+          const value = (node as unknown as Record<string, unknown>)[key];
+          if (Array.isArray(value)) stack.push(...(value as TSESTree.Node[]));
+          else if (value && typeof value === 'object') stack.push(value as TSESTree.Node);
+        }
+      }
+      return false;
+    }
+
     /** The root identifier of a member chain: `a.b.c()` → `a`. */
     function rootName(node: TSESTree.Node): string | undefined {
       let current: TSESTree.Node = node;
@@ -137,11 +160,23 @@ export const noErrorSwallowing = createRule<RuleOptions, MessageIds>({
      * `/\b(log|error|warn)\w*\s*\(/`, which matched any identifier beginning
      * with "log" — and matched inside comments and string literals too.
      */
-    function classifyCall(call: TSESTree.CallExpression): 'log' | 'forward' | 'respond' | undefined {
+    function classifyCall(
+      call: TSESTree.CallExpression,
+      caughtName: string | undefined,
+    ): 'log' | 'forward' | 'respond' | undefined {
       const callee = call.callee;
 
       if (callee.type === AST_NODE_TYPES.Identifier) {
-        if (FORWARDING_CALLBACKS.test(callee.name)) return 'forward';
+        // Forwarding requires the caught error to actually travel. Classifying
+        // on the callee name alone let `catch (err) { next(); }` pass as
+        // handled while discarding the error entirely — the exact false
+        // negative this exemption was supposed to avoid creating. A catch with
+        // no binding at all has nothing to forward, so it cannot qualify.
+        if (FORWARDING_CALLBACKS.test(callee.name)) {
+          return caughtName !== undefined && mentions(call.arguments, caughtName)
+            ? 'forward'
+            : undefined;
+        }
         if (LOGGING_FUNCTIONS.test(callee.name)) return 'log';
         return undefined;
       }
@@ -178,7 +213,10 @@ export const noErrorSwallowing = createRule<RuleOptions, MessageIds>({
      * the error. A nested function body is deliberately included: a `catch`
      * that logs from inside a callback still records the error.
      */
-    function analyze(block: TSESTree.BlockStatement): {
+    function analyze(
+      block: TSESTree.BlockStatement,
+      caughtName: string | undefined,
+    ): {
       logs: boolean;
       forwards: boolean;
       responds: boolean;
@@ -191,7 +229,7 @@ export const noErrorSwallowing = createRule<RuleOptions, MessageIds>({
         seen.add(node);
 
         if (node.type === AST_NODE_TYPES.CallExpression) {
-          const kind = classifyCall(node);
+          const kind = classifyCall(node, caughtName);
           if (kind === 'log') result.logs = true;
           else if (kind === 'forward') result.forwards = true;
           else if (kind === 'respond') result.responds = true;
@@ -346,7 +384,9 @@ export const noErrorSwallowing = createRule<RuleOptions, MessageIds>({
         // The old return check demanded the returned expression match
         // /500|error|fail/, so `return false` from a hostname validator read
         // as swallowing while `return errorish` did not.
-        const { logs, forwards, responds } = analyze(body);
+        const caughtName =
+          node.param?.type === AST_NODE_TYPES.Identifier ? node.param.name : undefined;
+        const { logs, forwards, responds } = analyze(body, caughtName);
         if (logs || forwards || responds || returnsFallback(body)) {
           return;
         }

--- a/packages/eslint-plugin-lambda-security/src/rules/no-error-swallowing/no-error-swallowing.test.ts
+++ b/packages/eslint-plugin-lambda-security/src/rules/no-error-swallowing/no-error-swallowing.test.ts
@@ -11,6 +11,107 @@ const ruleTester = new RuleTester();
 
 ruleTester.run('no-error-swallowing', noErrorSwallowing, {
   valid: [
+    // ── The four ILB-CWE-Corpus fixtures this rule used to report ────────
+    // Each is the *correct, secure* form of its pattern. Together they were
+    // 4 of the suite's 16 false positives — a quarter, from one rule.
+    //
+    // A safe fallback value. The old check demanded the returned expression
+    // match /500|error|fail/, so `return '#'` from a scheme allowlist and
+    // `return false` from a hostname validator both read as swallowing.
+    {
+      name: 'CWE-020/scheme-allowlist — catch returns a safe fallback',
+      code: `
+        function sanitizeHref(raw) {
+          try {
+            const parsed = new URL(raw, window.location.origin);
+            return ALLOWED_PROTOCOLS.includes(parsed.protocol) ? parsed.href : '#';
+          } catch (err) {
+            return '#';
+          }
+        }
+      `,
+    },
+    {
+      name: 'CWE-020/url-parse-hostname — catch returns false',
+      code: `
+        function isTrustedApi(url) {
+          try {
+            return new URL(url).hostname === 'trusted.com';
+          } catch (err) {
+            return false;
+          }
+        }
+      `,
+    },
+    // Forwarding to an error handler is `throw` spelled asynchronously —
+    // Express's error middleware is reached no other way.
+    {
+      name: 'CWE-209/generic-error-response — catch forwards via next(err)',
+      code: `
+        app.get('/reports/:id', async (req, res, next) => {
+          try {
+            res.json(await loadReport(req.params.id));
+          } catch (err) {
+            next(err);
+          }
+        });
+      `,
+    },
+    // Answering the request is handling it. No return statement here — the
+    // response happens inside an if — so the old return check never applied.
+    {
+      name: 'CWE-248/pipeline-promises — catch answers the request',
+      code: `
+        async function download(req, res) {
+          try {
+            await pipeline(fs.createReadStream('./uploads/report.json'), res);
+          } catch {
+            if (!res.headersSent) res.status(404).end();
+          }
+        }
+      `,
+    },
+    // Related shapes the AST rewrite must also accept.
+    {
+      name: 'promise rejection is propagation',
+      code: `
+        new Promise((resolve, reject) => {
+          try { risky(); } catch (error) { reject(error); }
+        });
+      `,
+    },
+    {
+      name: 'node-style callback is propagation',
+      code: `try { risky(); } catch (error) { callback(error); }`,
+    },
+    {
+      name: 'logger reached through a member chain',
+      code: `try { risky(); } catch (error) { this.logger.error('failed', error); }`,
+    },
+    {
+      name: 'sentry capture counts as recording',
+      code: `try { risky(); } catch (error) { Sentry.captureException(error); }`,
+    },
+    {
+      name: 'logging from inside a nested callback still records',
+      code: `
+        try { risky(); } catch (error) {
+          process.nextTick(() => { console.error('failed', error); });
+        }
+      `,
+    },
+    // Object returns that carry no success claim are fail-closed fallbacks:
+    // no status-like key at all, and a status whose value is computed rather
+    // than a literal (nothing to read, so nothing to treat as 2xx).
+    {
+      name: 'object fallback with no status key is fail-closed',
+      code: `try { risky(); } catch (error) { return { data: [] }; }`,
+    },
+    {
+      name: 'object fallback with a computed status is fail-closed',
+      code: `try { risky(); } catch (error) { return { statusCode: fallbackCode }; }`,
+    },
+    // ── end corpus regressions ──────────────────────────────────────────
     // Rethrows the error — not swallowed
     {
       code: `
@@ -183,6 +284,99 @@ ruleTester.run('no-error-swallowing', noErrorSwallowing, {
   ],
 
   invalid: [
+    // ── FN boundary for the AST rewrite above ───────────────────────────
+    // Widening a rule to kill false positives is exactly how a false
+    // negative gets introduced (see #441, where excluding TemplateLiteral
+    // by name silenced `res.send(req.query.name || '<p>x</p>')`). These pin
+    // the edge of each new exemption.
+    //
+    // `return <value>` is a deliberate fallback; a bare `return;` records
+    // nothing and produces nothing. It must still report.
+    {
+      name: 'bare return is still swallowing',
+      code: `
+        function attempt() {
+          try {
+            riskyOperation();
+          } catch (error) {
+            return;
+          }
+        }
+      `,
+      errors: [{ messageId: 'emptyCatchBlock' }],
+    },
+    // The mirror of the two valid fallback cases above, and the reason the
+    // exemption is written in terms of fail-closed rather than "returns a
+    // value". `return false` from a hostname validator denies; `return true`
+    // from an auth check grants access on a malformed token. One token apart,
+    // opposite sides of the line. A draft of this fix exempted both and turned
+    // this exact corpus fixture into a false negative.
+    {
+      name: 'CWE-636/catch-returns-true — fail-open auth must still report',
+      code: `
+        function isAuthorized(token) {
+          try {
+            return verifyToken(token).valid;
+          } catch (err) {
+            return true;
+          }
+        }
+      `,
+      errors: [{ messageId: 'emptyCatchBlock' }],
+    },
+    {
+      name: 'fail-open object literal must still report',
+      code: `try { risky(); } catch (error) { return { authorized: true }; }`,
+      errors: [{ messageId: 'emptyCatchBlock' }],
+    },
+    // A non-forwarding call must not be mistaken for propagation just
+    // because a call is present.
+    {
+      name: 'an unrelated call is not propagation',
+      code: `try { risky(); } catch (error) { cleanup(); }`,
+      errors: [{ messageId: 'emptyCatchBlock' }],
+    },
+    // The caught error going nowhere, with a response object present but no
+    // response method called on it.
+    {
+      name: 'touching res without answering is still swallowing',
+      code: `
+        function handler(req, res) {
+          try { risky(); } catch (error) { res.locals.failed = true; }
+        }
+      `,
+      errors: [{ messageId: 'emptyCatchBlock' }],
+    },
+    {
+      name: 'return undefined is still swallowing',
+      code: `
+        function attempt() {
+          try { riskyOperation(); } catch (error) { return undefined; }
+        }
+      `,
+      errors: [{ messageId: 'emptyCatchBlock' }],
+    },
+    // Member chains the AST walk has to survive without mistaking them for a
+    // logger. A string-literal property is not an Identifier, so the chain
+    // yields no usable method name — the rule must fall through to reporting
+    // rather than treat the empty name as a match.
+    {
+      name: 'string-keyed member call is not logging',
+      code: `try { risky(); } catch (error) { registry['run'](); }`,
+      errors: [{ messageId: 'emptyCatchBlock' }],
+    },
+    {
+      name: 'string-keyed nested member call is not logging',
+      code: `try { risky(); } catch (error) { services['audit'].dispatch(error); }`,
+      errors: [{ messageId: 'emptyCatchBlock' }],
+    },
+    // A callee that is itself a call — neither Identifier nor MemberExpression.
+    {
+      name: 'immediately-invoked handler lookup is not logging',
+      code: `try { risky(); } catch (error) { (getHandler())(error); }`,
+      errors: [{ messageId: 'emptyCatchBlock' }],
+    },
+    // ── end FN boundary ─────────────────────────────────────────────────
     // Empty catch block — classic error swallowing (has suggestion with fix)
     {
       code: `

--- a/packages/eslint-plugin-lambda-security/src/rules/no-error-swallowing/no-error-swallowing.test.ts
+++ b/packages/eslint-plugin-lambda-security/src/rules/no-error-swallowing/no-error-swallowing.test.ts
@@ -85,6 +85,10 @@ ruleTester.run('no-error-swallowing', noErrorSwallowing, {
       code: `try { risky(); } catch (error) { callback(error); }`,
     },
     {
+      name: 'the error travelling inside a larger expression still forwards',
+      code: `try { risky(); } catch (error) { next(new Error(error.message)); }`,
+    },
+    {
       name: 'logger reached through a member chain',
       code: `try { risky(); } catch (error) { this.logger.error('failed', error); }`,
     },
@@ -327,6 +331,30 @@ ruleTester.run('no-error-swallowing', noErrorSwallowing, {
     {
       name: 'fail-open object literal must still report',
       code: `try { risky(); } catch (error) { return { authorized: true }; }`,
+      errors: [{ messageId: 'emptyCatchBlock' }],
+    },
+    // Forwarding must actually forward. Classifying on the callee name alone
+    // let a zero-argument `next()` count as handled while discarding the error
+    // — the exact false negative this exemption exists to avoid creating.
+    {
+      name: 'next() with no argument discards the error',
+      code: `try { risky(); } catch (err) { next(); }`,
+      errors: [{ messageId: 'emptyCatchBlock' }],
+    },
+    {
+      name: 'reject() with no argument discards the error',
+      code: `try { risky(); } catch (err) { reject(); }`,
+      errors: [{ messageId: 'emptyCatchBlock' }],
+    },
+    {
+      name: 'forwarding something other than the caught error',
+      code: `try { risky(); } catch (err) { next(previousFailure); }`,
+      errors: [{ messageId: 'emptyCatchBlock' }],
+    },
+    // An omitted catch binding has nothing to forward.
+    {
+      name: 'no catch binding leaves nothing to forward',
+      code: `try { risky(); } catch { next(); }`,
       errors: [{ messageId: 'emptyCatchBlock' }],
     },
     // A non-forwarding call must not be mistaken for propagation just


### PR DESCRIPTION
Supersedes #456, which GitHub auto-closed when its base branch (#455) was deleted on merge. Identical content, rebased onto `main`.

## The defect

Four of the sixteen ILB-CWE-Corpus false positives came from this one rule — **a quarter of the suite's FP count**. Every one is the *correct, secure* form of its pattern:

```js
catch (err) { return '#'; }                              // safe fallback (scheme allowlist)
catch (err) { return false; }                            // explicit denial (hostname validator)
catch (err) { next(err); }                               // forwarding to an error handler
catch { if (!res.headersSent) res.status(404).end(); }   // answering the request
```

Two causes:

1. **The return check demanded `/500|error|fail/`** on the returned expression, so `return false` from a validator read as swallowing while `return errorish` did not.
2. **Detection regexed `sourceCode.getText(block)`** — against this repo's own AST-not-printed-source doctrine. `/\b(log|error|warn)\w*\s*\(/` matched any identifier starting with "log", and matched inside comments and string literals, while missing `next(err)`, `reject(err)` and every response call.

## The fix

Rewritten on the AST. A catch handles its error when it **logs**, **forwards** to a callback, **answers** the request, or **returns a fail-closed value**.

## Fail-closed is the whole of it

A draft of this fix exempted every value-return. It cleared all four FPs — and turned `CWE-636/catch-returns-true.js` into a false negative:

```js
catch (err) { return false; }   // deny  — hostname validator failing closed
catch (err) { return true;  }   // GRANT — auth check letting an expired token through
```

One token apart, opposite sides of the line. The corpus caught it (`TP 51 → 50`), which is the argument for measuring rather than reasoning. `true`, a 2xx `statusCode`/`authorized`, `null` and `undefined` are all excluded from the exemption, and the CWE-636 fixture is locked as an `invalid` case.

## Numbers

ILB-CWE-Corpus, Interlace:

| | TP | FP | FN | F1 |
|---|---|---|---|---|
| before | 51 | 16 | 18 | 75% |
| **after** | **51** | **13** | **18** | **76.7%** |

No true positive lost.

## Tests

44 rule tests (18 added), 369 package tests, **100% coverage held**. The six edge paths the AST walk introduced — string-keyed member chains, a callee that is itself a call, computed `statusCode` values — are locked as cases, not excluded from coverage.

FN boundary explicitly pinned: bare `return;`, `return undefined;`, `return true;`, `return { authorized: true }`, an unrelated call, and a response object touched without being answered all still report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of handled errors, including logging, error forwarding, response handling, and secure fallback returns.
  * Reduced false-positive warnings while continuing to flag fail-open or unhandled error paths.
  * Added support for nested logging and callback patterns.

* **Tests**
  * Expanded coverage for secure fallback responses, error propagation, logging integrations, and invalid error-handling patterns.
  * Updated benchmark results to reflect improved detection accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->