### PR TITLE
fix(ci): stop CI jobs from running local git hooks

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -59,6 +59,21 @@ inputs:
 runs:
   using: composite
   steps:
+    # `npm ci` runs `prepare` → `lefthook install`, so every CI job that later
+    # commits or pushes silently fires the local pre-commit/commit-msg/pre-push
+    # battery on the bot's own commit. That is never what a workflow wants: the
+    # real gates run as their own jobs, and the hooks are scoped for a developer
+    # working tree, not a fresh checkout. docs-data.yml died exactly this way —
+    # its `git push` triggered pre-push, whose affected-scoped build produced
+    # dist for one package, and the chained `oxlint:shims:verify` then failed on
+    # the 9 packages it could not see (run 31341768906).
+    #
+    # Set once here rather than per-step in each workflow: CI has no use for git
+    # hooks in any job.
+    - name: Disable lefthook git hooks for this job
+      shell: bash
+      run: echo "LEFTHOOK=0" >> "$GITHUB_ENV"
+
     # No `cache: npm` here. ~/.npm is read by `npm ci` and nothing else, and
     # `npm ci` is skipped whenever the node_modules cache hits — which is the
     # common case, since its key is the lockfile hash. Every job was therefore


### PR DESCRIPTION
## What

`npm ci` runs `prepare` → `lefthook install`, so every CI job that later commits or pushes silently fires the local pre-commit / commit-msg / pre-push battery on the bot's own commit.

Sets `LEFTHOOK=0` once in `.github/actions/setup` instead of per-step in each workflow.

## Why

[Docs Data Sync run 31341768906](https://github.com/ofri-peretz/eslint/actions/runs/31341768906) failed on `git push`:

- pre-push `build-and-test` scoped its turbo build to `...[origin/main]` — the pushed diff was `apps/docs/src/data/*.json`, so turbo built **1 package** (`docs`)
- the chained `oxlint:shims:verify` needs `<pkg>/dist/src/index.js` for **every** package → 9 `Cannot find module` failures → push rejected
- the job spent 6m52s of its 10-minute budget re-running gates that already have their own CI jobs

`changesets-pr.yml` already carried a per-step `LEFTHOOK: "0"` for the same reason; this generalises it. All five pushing workflows (docs-data, peer-health, resource-profile, weekly-benchmark, release) use the shared setup action.

## Known follow-up (not fixed here)

lefthook's `build-and-test` comment claims chaining `oxlint:shims:verify` "guarantees it sees a finished dist". The later `--filter=...[origin/main]` addition broke that guarantee — on a clean tree, any push touching `apps/**` but not `packages/**` fails the gate with a misleading "stale dist" error. Only reachable locally from a fresh clone, so left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)