### PR TITLE
fix(ci): read an explicit lease before force-pushing the docs sync branch

### DIFF
--- a/.github/workflows/docs-data.yml
+++ b/.github/workflows/docs-data.yml
@@ -103,10 +103,30 @@ jobs:
 
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Read the lease value explicitly instead of letting
+          # `--force-with-lease` infer it.
+          #
+          # Bare `--force-with-lease` compares against the remote-tracking ref,
+          # and rejects the push as "stale info" when it can't resolve one.
+          # actions/checkout makes a SINGLE-BRANCH clone, so both the ref and
+          # the fetch refspec that would map it are absent — and simply fetching
+          # the branch does not help, because an unmapped refspec leaves the
+          # lease unresolvable either way. The result was a workflow that
+          # succeeded exactly once: the run that created $BRANCH pushed fine
+          # (no remote branch, empty lease satisfied) and every run after it
+          # failed on the push having done all the sync work correctly.
+          #
+          # An empty $LEASE is the documented "this ref must not exist yet"
+          # form, so the create path keeps working. This is not `--force` in
+          # disguise: a push that lands on $BRANCH after this read is still
+          # refused, which is the whole point of the lease.
+          LEASE=$(git ls-remote origin "refs/heads/$BRANCH" | cut -f1)
+
           git checkout -B "$BRANCH"
           git add apps/docs/src/data/
           git commit -m "chore(docs): sync data [automated]"
-          git push --force-with-lease origin "$BRANCH"
+          git push --force-with-lease="$BRANCH:$LEASE" origin "$BRANCH"
 
           if [ -n "$(gh pr list --head "$BRANCH" --state open --json number --jq '.[].number')" ]; then
             echo "Existing PR updated with the new sync commit."

--- a/scripts/__tests__/ci-bot-push-lock.test.ts
+++ b/scripts/__tests__/ci-bot-push-lock.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+const read = (p: string) => readFileSync(resolve(ROOT, p), 'utf-8');
+
+/**
+ * Locks for the two ways an automated push from CI died silently-but-red.
+ *
+ * Both failed the same way from the outside: the workflow did all of its real
+ * work correctly, printed a clean sync summary, and then lost everything on the
+ * final `git push`. Run 31341768906 is the reference for the first, run
+ * 31342693115 for the second.
+ *
+ * 1. `npm ci` runs `prepare` → `lefthook install`, so a workflow that commits
+ *    fires the developer pre-commit/commit-msg/pre-push battery on the bot's
+ *    own commit. pre-push scopes its build to `...[origin/main]`, so a docs-only
+ *    diff built one package while the chained `oxlint:shims:verify` needed dist
+ *    for all of them — nine `Cannot find module` failures, push rejected, and
+ *    6m52s of a 10-minute job spent re-running gates that have their own CI jobs.
+ *
+ * 2. Bare `--force-with-lease` resolves its expected value from the
+ *    remote-tracking ref. actions/checkout makes a single-branch clone, so
+ *    neither that ref nor the fetch refspec that would map it exists, and the
+ *    push is rejected as "stale info". Fetching the branch first does NOT fix
+ *    it — an unmapped refspec leaves the lease unresolvable either way. The
+ *    shape that works is an explicit `--force-with-lease=<ref>:<sha>` read via
+ *    `git ls-remote`, which also keeps the protection real: an empty value is
+ *    the documented "must not exist yet" form for the create path, and a push
+ *    landing after the read is still refused.
+ *
+ * The failure mode both share is why these are locked: the workflow reports red
+ * while behaving correctly, so the temptation is to reach for `--force` or a
+ * protection-bypassing token and clear the X without fixing anything.
+ */
+describe('automated pushes from CI', () => {
+  it('disables lefthook for every job, in the shared setup action', () => {
+    const setup = read('.github/actions/setup/action.yml');
+
+    expect(setup).toMatch(/LEFTHOOK=0\s*"?\s*>>\s*"?\$GITHUB_ENV/);
+  });
+
+  it('docs-data reads an explicit lease value before force-pushing', () => {
+    const wf = read('.github/workflows/docs-data.yml');
+
+    // The lease value has to be read from the remote, not inferred.
+    expect(wf).toMatch(/LEASE=\$\(git ls-remote origin "refs\/heads\/\$BRANCH"/);
+
+    // ...and the push has to actually use it.
+    expect(wf).toMatch(/git push --force-with-lease="\$BRANCH:\$LEASE" origin "\$BRANCH"/);
+
+    // Bare `--force-with-lease` is the broken shape; `--force` throws the
+    // protection away entirely. Neither may come back.
+    expect(wf).not.toMatch(/--force-with-lease\s+origin/);
+    expect(wf).not.toMatch(/git push\s+(-f|--force)\s/);
+  });
+
+  it('reads the lease before the branch is repointed', () => {
+    const wf = read('.github/workflows/docs-data.yml');
+    const lease = wf.indexOf('LEASE=$(git ls-remote');
+    const checkout = wf.indexOf('git checkout -B "$BRANCH"');
+
+    expect(lease).toBeGreaterThan(-1);
+    expect(checkout).toBeGreaterThan(-1);
+    // `checkout -B` moves the local branch; reading the remote afterwards would
+    // still work, but ordering it first keeps the lease a snapshot of what we
+    // looked at before touching anything.
+    expect(lease).toBeLessThan(checkout);
+  });
+
+  it('still opens a PR rather than pushing the sync straight to main', () => {
+    const wf = read('.github/workflows/docs-data.yml');
+
+    // main requires up-to-date branches and linear history by policy. The
+    // previous incarnation pushed to main and failed every run with GH006.
+    expect(wf).toMatch(/gh pr create --base main --head "\$BRANCH"/);
+    expect(wf).not.toMatch(/git push origin main/);
+    expect(wf).not.toMatch(/git push\s*$/m);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #465. With the git hooks out of the way, Docs Data Sync got as far as its `git push` and failed there instead:

```
! [rejected] automated/docs-data-sync -> automated/docs-data-sync (stale info)
```

- Read the lease value with `git ls-remote` and pass `--force-with-lease=$BRANCH:$LEASE` explicitly.
- Add `scripts/__tests__/ci-bot-push-lock.test.ts`, locking this and the `LEFTHOOK=0` fix from #465.

## Why bare `--force-with-lease` cannot work here

It resolves its expected value from the remote-tracking ref. `actions/checkout` makes a **single-branch clone**, so neither `refs/remotes/origin/automated/docs-data-sync` nor the fetch refspec that would map it exists.

This means the workflow succeeded exactly once — the run that created the branch pushed fine (no remote branch, empty lease satisfied) and **every run since has failed on the push having done all the sync work correctly**. Classic red-workflow-behaving-correctly, which is exactly the situation where someone reaches for `--force` and quietly deletes the protection.

Fetching the branch first does **not** fix it — an unmapped refspec leaves the lease unresolvable either way. Verified against a scratch bare remote:

| case | bare (before) | fetch-first | explicit lease (after) |
|---|---|---|---|
| branch exists remotely | ❌ stale info | ❌ stale info | ✅ forced update |
| branch absent | ✅ creates | ✅ creates | ✅ creates |
| someone else pushed after the read | — | — | ✅ still refused |

The third row is the point: this is not `--force` in disguise. An empty `$LEASE` is the documented "this ref must not exist yet" form, so the create path keeps working.

## Test plan

- [x] `npm run test:scripts` — 30 files, 1102 tests, all pass
- [x] `npm run lint:workflows` — 34 workflow files pass conventions
- [x] Lock fails on the unfixed tree: 3 of its 4 assertions go red against `docs-data.yml` and `.github/actions/setup/action.yml` as they were before these two PRs
- [x] Push semantics verified against a scratch bare remote across all three cases above

## After merge

Re-run Docs Data Sync via `workflow_dispatch`; it should open (or update) the `automated/docs-data-sync` PR with the regenerated `apps/docs/src/data/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)