### PR TITLE
feat(docs): read downloads from the canonical source instead of recomputing them

### DIFF
--- a/apps/docs/src/components/stats/impact-card.tsx
+++ b/apps/docs/src/components/stats/impact-card.tsx
@@ -13,6 +13,21 @@ interface ImpactCardProps {
   stats: ImpactStats;
 }
 
+/**
+ * "2025-12-08" → "December 2025". Day precision would imply the total is
+ * pinned to a launch event; the month is the honest resolution for a window
+ * that simply began when the first package shipped.
+ */
+const formatMonthYear = (iso: string): string => {
+  const d = new Date(`${iso}T00:00:00Z`);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString('en-US', {
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'UTC',
+  });
+};
+
 const formatCompact = (n: number): string => {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
@@ -26,12 +41,24 @@ interface SupportMetric {
 }
 
 function buildSupportMetrics(stats: ImpactStats): SupportMetric[] {
+  const downloads = stats.npm.totalDownloads;
   return [
-    {
-      label: 'Weekly npm downloads',
-      value: stats.npm.totalDownloads,
-      display: formatCompact(stats.npm.totalDownloads),
-    },
+    // Omitted entirely when the canonical source was unreachable. A card
+    // reading "0 downloads" is a claim; a missing card is a gap.
+    ...(downloads === null
+      ? []
+      : [
+          {
+            // Cumulative, not weekly — and it says which. The same figure is
+            // published on ofriperetz.dev, and an unqualified number invites
+            // the reader to assume a different window than it covers.
+            label: stats.npm.since
+              ? `npm downloads since ${formatMonthYear(stats.npm.since)}`
+              : 'npm downloads (all-time)',
+            value: downloads,
+            display: formatCompact(downloads),
+          },
+        ]),
     {
       label: 'GitHub stars',
       value: stats.github.totalStars,
@@ -50,7 +77,11 @@ function buildSupportMetrics(stats: ImpactStats): SupportMetric[] {
   ];
 }
 
-function EngagementHero({ engagement }: { engagement: ImpactStats['engagement'] }) {
+function EngagementHero({
+  engagement,
+}: {
+  engagement: ImpactStats['engagement'];
+}) {
   return (
     <Card className="border-primary/40">
       <CardHeader>
@@ -66,7 +97,11 @@ function EngagementHero({ engagement }: { engagement: ImpactStats['engagement'] 
               Reach
             </dt>
             <dd className="mt-1 text-5xl font-bold tabular-nums sm:text-6xl">
-              <NumberTicker value={engagement.reach} startValue={0} delay={0.1} />
+              <NumberTicker
+                value={engagement.reach}
+                startValue={0}
+                delay={0.1}
+              />
             </dd>
             <p className="mt-1 text-xs text-fd-muted-foreground">
               People who read an article.
@@ -97,21 +132,28 @@ function EngagementHero({ engagement }: { engagement: ImpactStats['engagement'] 
           <div className="flex items-baseline justify-between">
             <dt className="text-fd-muted-foreground">Reactions</dt>
             <dd className="tabular-nums font-medium">
-              <NumberTicker value={engagement.reactions} startValue={0} delay={0.2} />
+              <NumberTicker
+                value={engagement.reactions}
+                startValue={0}
+                delay={0.2}
+              />
             </dd>
           </div>
           <div className="flex items-baseline justify-between">
             <dt className="text-fd-muted-foreground">Comments</dt>
             <dd className="tabular-nums font-medium">
-              <NumberTicker value={engagement.comments} startValue={0} delay={0.2} />
+              <NumberTicker
+                value={engagement.comments}
+                startValue={0}
+                delay={0.2}
+              />
             </dd>
           </div>
         </dl>
 
         <p className="sr-only">
-          Engagement: reach{' '}
-          {engagement.reach.toLocaleString('en-US')} (views), engagement rate{' '}
-          {engagement.ratePercent}%, reactions{' '}
+          Engagement: reach {engagement.reach.toLocaleString('en-US')} (views),
+          engagement rate {engagement.ratePercent}%, reactions{' '}
           {engagement.reactions.toLocaleString('en-US')}, comments{' '}
           {engagement.comments.toLocaleString('en-US')}.
         </p>
@@ -132,8 +174,8 @@ export function ImpactCard({ stats }: ImpactCardProps) {
             Code adoption
           </CardTitle>
           <CardDescription>
-            Engagement explains the audience; these show whether the audience
-            is actually shipping the rules.
+            Engagement explains the audience; these show whether the audience is
+            actually shipping the rules.
           </CardDescription>
         </CardHeader>
         <CardContent>

--- a/apps/docs/src/data/plugin-stats.json
+++ b/apps/docs/src/data/plugin-stats.json
@@ -5,7 +5,7 @@
       "rules": 45,
       "description": "ESLint plugin for browser security — detects DOM XSS, postMessage abuse, tokens in localStorage, insecure cookies, clickjacking, mixed content, and CSP gaps",
       "category": "security",
-      "version": "1.2.14",
+      "version": "1.3.0",
       "published": true
     },
     {
@@ -13,7 +13,7 @@
       "rules": 37,
       "description": "ESLint plugin for Node.js security — detects command injection, path traversal, SSRF, zip slip, and weak crypto (MD5/SHA-1, ECB, static IV) in fs, child_process, vm, and crypto",
       "category": "security",
-      "version": "4.8.1",
+      "version": "4.9.0",
       "published": true
     },
     {
@@ -21,7 +21,7 @@
       "rules": 28,
       "description": "ESLint plugin for secure coding — detects LDAP, XPath, XXE, GraphQL and template injection, unsafe deserialization, ReDoS, missing authentication, and PII in logs",
       "category": "security",
-      "version": "3.4.4",
+      "version": "3.5.0",
       "published": true
     },
     {
@@ -29,7 +29,7 @@
       "rules": 19,
       "description": "ESLint plugin for Vercel AI SDK security — detects prompt injection, system-prompt leaks, hardcoded API keys, and unvalidated model output in generateText and streamText",
       "category": "security",
-      "version": "1.5.3",
+      "version": "1.5.4",
       "published": true
     },
     {
@@ -37,7 +37,7 @@
       "rules": 16,
       "description": "ESLint plugin for MongoDB and Mongoose security — detects NoSQL operator injection, unsafe queries and regex, hardcoded connection strings, and missing TLS",
       "category": "security",
-      "version": "8.3.5",
+      "version": "8.4.0",
       "published": true
     },
     {
@@ -45,7 +45,7 @@
       "rules": 13,
       "description": "ESLint plugin for JWT security — detects algorithm confusion (CVE-2022-23540), alg:none, weak or hardcoded secrets, and decode-without-verify",
       "category": "security",
-      "version": "2.3.2",
+      "version": "2.3.3",
       "published": true
     },
     {
@@ -53,7 +53,7 @@
       "rules": 13,
       "description": "ESLint plugin for the pg PostgreSQL driver — detects SQL injection, unreleased clients, floating queries, unsafe search_path, and insecure SSL",
       "category": "security",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "published": true
     },
     {
@@ -61,7 +61,7 @@
       "rules": 5,
       "description": "ESLint plugin for knex — detects SQL injection in raw queries built with string concatenation or template literals, connection configuration that disables TLS or certificate validation, and hardcoded database credentials",
       "category": "security",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "published": true
     },
     {
@@ -69,7 +69,7 @@
       "rules": 4,
       "description": "ESLint plugin for drizzle-orm — detects SQL injection in raw queries built with string concatenation or template literals",
       "category": "security",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "published": true
     },
     {
@@ -77,7 +77,7 @@
       "rules": 4,
       "description": "ESLint plugin for Model Context Protocol (MCP) SDK security — catches tools registered without an input schema, handlers reading arguments the schema never declared, model-visible descriptions built from dynamic text, and tool arguments reaching a shell",
       "category": "security",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "published": true
     },
     {
@@ -85,7 +85,7 @@
       "rules": 4,
       "description": "ESLint plugin for @prisma/client — detects SQL injection in raw queries built with string concatenation or template literals",
       "category": "security",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "published": true
     },
     {
@@ -93,7 +93,7 @@
       "rules": 4,
       "description": "ESLint plugin for the Sequelize ORM — detects SQL injection in raw sequelize.query() and Sequelize.literal() calls built with string concatenation or template literals, connection configuration that disables TLS or certificate validation, and hardcoded database credentials",
       "category": "security",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "published": true
     },
     {
@@ -101,7 +101,7 @@
       "rules": 4,
       "description": "ESLint plugin for typeorm — detects SQL injection in raw queries built with string concatenation or template literals, connection configuration that disables TLS or certificate validation, and hardcoded database credentials",
       "category": "security",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "published": true
     },
     {
@@ -109,7 +109,7 @@
       "rules": 3,
       "description": "ESLint plugin for Anthropic SDK security — catches hardcoded Claude API keys, the browser escape hatch that ships them to every visitor, and system prompts assembled from untrusted input",
       "category": "security",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "published": true
     },
     {
@@ -117,7 +117,7 @@
       "rules": 3,
       "description": "ESLint plugin for Google Gemini SDK security — catches safety thresholds set to BLOCK_NONE, hardcoded API keys, and system instructions assembled from untrusted input",
       "category": "security",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "published": true
     },
     {
@@ -125,7 +125,7 @@
       "rules": 3,
       "description": "ESLint plugin for mysql2 / mysql — detects SQL injection in raw queries built with string concatenation or template literals, connection configuration that disables TLS or certificate validation, and hardcoded database credentials",
       "category": "security",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "published": true
     },
     {
@@ -133,7 +133,7 @@
       "rules": 3,
       "description": "ESLint plugin for OpenAI SDK security — catches dangerouslyAllowBrowser, hardcoded API keys, and system prompts assembled from untrusted input",
       "category": "security",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "published": true
     },
     {
@@ -141,7 +141,7 @@
       "rules": 1,
       "description": "ESLint plugin for better-sqlite3 / sqlite3 — detects SQL injection in raw queries built with string concatenation or template literals",
       "category": "security",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "published": true
     },
     {
@@ -149,7 +149,7 @@
       "rules": 28,
       "description": "ESLint plugin for Express.js security — detects permissive CORS, missing CSRF protection, missing helmet headers, insecure cookies, and GraphQL introspection in production",
       "category": "framework",
-      "version": "1.5.5",
+      "version": "1.5.6",
       "published": true
     },
     {
@@ -157,7 +157,7 @@
       "rules": 14,
       "description": "ESLint plugin for AWS Lambda security — detects overly permissive IAM policies and CORS, unvalidated event bodies, secrets in env vars, and leaked error details",
       "category": "framework",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "published": true
     },
     {
@@ -165,7 +165,7 @@
       "rules": 10,
       "description": "ESLint plugin for NestJS security — detects missing auth guards, missing validation pipes, unthrottled routes, and exposed private fields",
       "category": "framework",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "published": true
     },
     {
@@ -173,7 +173,7 @@
       "rules": 55,
       "description": "ESLint plugin for imports and module boundaries — drop-in replacement for eslint-plugin-import, 3.1x faster end-to-end, zero-config migration",
       "category": "architecture",
-      "version": "2.3.16",
+      "version": "2.3.17",
       "published": true
     },
     {
@@ -181,7 +181,7 @@
       "rules": 15,
       "description": "ESLint plugin for team code conventions — enforces filename case, magic-number bans, commented-out code, expiring TODOs, and deprecated-API usage",
       "category": "quality",
-      "version": "4.2.7",
+      "version": "4.2.8",
       "published": true
     },
     {
@@ -189,7 +189,7 @@
       "rules": 12,
       "description": "ESLint plugin for maintainable code — limits cognitive complexity, nesting depth, parameter counts, duplicate functions, and unhandled or silent errors",
       "category": "quality",
-      "version": "3.0.14",
+      "version": "3.0.15",
       "published": true
     },
     {
@@ -197,7 +197,7 @@
       "rules": 9,
       "description": "ESLint plugin for runtime reliability — enforces error handling, network timeouts, null checks, and safe type narrowing",
       "category": "quality",
-      "version": "3.1.11",
+      "version": "3.1.12",
       "published": true
     },
     {
@@ -205,7 +205,7 @@
       "rules": 6,
       "description": "ESLint plugin for module architecture — enforces DDD value objects and anemic-model checks, naming, REST conventions, and utility isolation",
       "category": "quality",
-      "version": "2.1.7",
+      "version": "2.1.8",
       "published": true
     },
     {
@@ -213,7 +213,7 @@
       "rules": 6,
       "description": "ESLint plugin for production operability — bans debug code and console logging in production, verbose error messages, and process.exit calls",
       "category": "quality",
-      "version": "3.0.15",
+      "version": "3.0.16",
       "published": true
     },
     {
@@ -221,7 +221,7 @@
       "rules": 4,
       "description": "ESLint plugin for modernizing JavaScript — auto-fixes legacy patterns to ES2022+ (Array.at, template literals, EventTarget, Array.isArray)",
       "category": "quality",
-      "version": "2.1.7",
+      "version": "2.1.8",
       "published": true
     },
     {
@@ -229,7 +229,7 @@
       "rules": 61,
       "description": "ESLint plugin for React — hooks, prop-types, JSX correctness, render performance, and class-to-hooks migration rules for modern React codebases",
       "category": "react",
-      "version": "1.2.10",
+      "version": "1.2.11",
       "published": true
     },
     {
@@ -237,12 +237,12 @@
       "rules": 37,
       "description": "ESLint plugin for React accessibility — WCAG 2.1 rules for ARIA, alt text, keyboard interaction, and focus management, with auto-fixes",
       "category": "react",
-      "version": "2.1.13",
+      "version": "2.1.14",
       "published": true
     }
   ],
   "totalRules": 466,
   "totalPlugins": 30,
   "allPluginsCount": 30,
-  "generatedAt": "2026-08-07"
+  "generatedAt": "2026-08-10"
 }

--- a/apps/docs/src/lib/impact-source.ts
+++ b/apps/docs/src/lib/impact-source.ts
@@ -1,0 +1,124 @@
+/**
+ * The one place this site learns how many times our packages were downloaded.
+ *
+ * It used to sum `api.npmjs.org/downloads/point/last-week` over the published
+ * plugins and call the result "downloads". ofriperetz.dev, meanwhile, published
+ * an all-time cumulative from Supabase, and its /npm page published a trailing
+ * 30-day total. Three surfaces, three numbers, three definitions, two sources —
+ * all of them honestly labelled inside their own codebase and mutually
+ * contradictory to anyone who visited two of them.
+ *
+ * So downloads are no longer computed here. `v_npm_alltime_ecosystem` is the
+ * canonical record, written once a day by ofri-peretz/impact-ingest, and this
+ * module only reads it. Adding a fourth surface should mean adding another
+ * reader, never another calculation.
+ *
+ * Deliberately NOT falling back to the npm registry when Supabase is
+ * unreachable: a fallback that quietly computes a different metric is exactly
+ * the failure being fixed. A missing number is visible; a wrong one is not.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { unstable_cache } from 'next/cache';
+
+const REVALIDATE = 3600;
+
+export interface EcosystemDownloads {
+  /** Cumulative downloads across every counted package. */
+  total: number;
+  /** How many packages that total covers. */
+  packages: number;
+  /**
+   * First day any of our packages recorded a download — the start of the
+   * window `total` covers, measured rather than assumed. `null` means the
+   * backfill hasn't measured it yet, and callers must then omit the "since"
+   * qualifier instead of guessing a date.
+   */
+  since: string | null;
+  /** Day the figure was last measured. */
+  measuredOn: string | null;
+}
+
+function client() {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_ANON_KEY;
+  if (!url || !key) return null;
+  return createClient(url, key, { auth: { persistSession: false } });
+}
+
+/**
+ * Throws rather than returning zeroes. `unstable_cache` stores whatever
+ * resolves, and Vercel's Data Cache outlives the deployment — so a transient
+ * blip cached as `0` would survive every redeploy until the tag was purged.
+ * A rejected promise is never cached, so the next request just retries.
+ */
+export const loadEcosystemDownloads = unstable_cache(
+  async (): Promise<EcosystemDownloads> => {
+    const supabase = client();
+    if (!supabase) {
+      throw new Error(
+        '[impact-source] SUPABASE_URL / SUPABASE_ANON_KEY missing — refusing to cache an empty download total',
+      );
+    }
+
+    const { data, error } = await supabase
+      .from('v_npm_alltime_ecosystem')
+      .select(
+        'ecosystem_alltime, packages_measured, measured_since, last_measured_on',
+      )
+      .single();
+
+    if (error || !data) {
+      throw new Error(
+        `[impact-source] v_npm_alltime_ecosystem: ${error?.message ?? 'no row'}`,
+      );
+    }
+
+    return {
+      total: Number(data.ecosystem_alltime ?? 0),
+      packages: Number(data.packages_measured ?? 0),
+      since: data.measured_since ?? null,
+      measuredOn: data.last_measured_on ?? null,
+    };
+  },
+  ['ecosystem-downloads-alltime'],
+  { revalidate: REVALIDATE, tags: ['stats', 'npm', 'ratchet'] },
+);
+
+/**
+ * Per-package cumulative downloads, keyed by package name — the same figures
+ * the ecosystem total is the sum of, so a table of rows and the headline above
+ * it can never disagree.
+ */
+export const loadPackageDownloads = unstable_cache(
+  async (): Promise<Record<string, number>> => {
+    const supabase = client();
+    if (!supabase) {
+      throw new Error(
+        '[impact-source] SUPABASE_URL / SUPABASE_ANON_KEY missing — refusing to cache empty per-package downloads',
+      );
+    }
+
+    const { data, error } = await supabase
+      .from('npm_alltime_downloads')
+      .select('alltime_total, plugins(name)');
+
+    if (error || !data) {
+      throw new Error(
+        `[impact-source] npm_alltime_downloads: ${error?.message ?? 'no rows'}`,
+      );
+    }
+
+    const out: Record<string, number> = {};
+    for (const row of data as Array<{
+      alltime_total: number | null;
+      plugins: { name: string } | { name: string }[] | null;
+    }>) {
+      const rel = Array.isArray(row.plugins) ? row.plugins[0] : row.plugins;
+      if (rel?.name) out[rel.name] = Number(row.alltime_total ?? 0);
+    }
+    return out;
+  },
+  ['package-downloads-alltime'],
+  { revalidate: REVALIDATE, tags: ['stats', 'npm', 'ratchet'] },
+);

--- a/apps/docs/src/lib/stats-page.ts
+++ b/apps/docs/src/lib/stats-page.ts
@@ -5,6 +5,10 @@ import { unstable_cache } from 'next/cache';
 
 import type { DevToArticle } from '@/lib/articles.types';
 import {
+  loadEcosystemDownloads,
+  loadPackageDownloads,
+} from '@/lib/impact-source';
+import {
   loadCoverageStats,
   loadPluginStats,
   type PluginStat,
@@ -32,7 +36,22 @@ export interface ImpactStats {
     totalForks: number;
     totalContributions: number;
   };
-  npm: { totalDownloads: number; packageCount: number };
+  /**
+   * Downloads are cumulative across the whole counted ecosystem, read from
+   * Supabase — never recomputed here. `since` is the measured start of that
+   * window; null means unmeasured, and the UI must then omit the qualifier
+   * rather than imply a start date.
+   */
+  npm: {
+    /**
+     * null when the canonical source was unreachable at build time. The UI
+     * omits the metric rather than rendering 0 — this figure is published on
+     * ofriperetz.dev too, and a confident zero is worse than a gap.
+     */
+    totalDownloads: number | null;
+    packageCount: number | null;
+    since: string | null;
+  };
   /**
    * Audience reach — shown as context, never summed into any headline.
    * `null` means the source was unavailable at build; the UI hides the stat
@@ -47,7 +66,8 @@ export interface PluginRow {
   category: PluginStat['category'];
   rules: number;
   version: string;
-  /** Weekly npm downloads, 0 if the registry didn't return a number. */
+  /** Cumulative npm downloads for this package, from the same source as the
+   * ecosystem total above — so the rows always sum to the headline. */
   downloads: number;
   /** Line coverage 0–100, null if the plugin isn't in the coverage report. */
   coverage: number | null;
@@ -103,42 +123,6 @@ async function loadEngagement(): Promise<Engagement> {
       : 0;
   return { ...totals, ratePercent };
 }
-
-/**
- * Fetch last-week npm downloads for every published plugin via the registry's
- * bulk endpoint. Cached for an hour; failures fall through to an empty map
- * so the page still renders (the chart owns the empty-state copy).
- */
-const loadNpmDownloads = unstable_cache(
-  async (packageNames: string[]): Promise<Record<string, number>> => {
-    if (packageNames.length === 0) return {};
-    try {
-      const url = `https://api.npmjs.org/downloads/point/last-week/${packageNames.join(',')}`;
-      const res = await fetch(url, { next: { revalidate: REVALIDATE } });
-      if (!res.ok) return {};
-      const json = (await res.json()) as
-        | Record<string, { downloads: number | null } | null>
-        | { downloads: number | null };
-      const out: Record<string, number> = {};
-      if ('downloads' in json && typeof json.downloads === 'number') {
-        out[packageNames[0]!] = json.downloads;
-        return out;
-      }
-      for (const [name, entry] of Object.entries(
-        json as Record<string, { downloads: number | null } | null>,
-      )) {
-        if (entry && typeof entry.downloads === 'number') {
-          out[name] = entry.downloads;
-        }
-      }
-      return out;
-    } catch {
-      return {};
-    }
-  },
-  ['npm-downloads-weekly'],
-  { revalidate: REVALIDATE, tags: ['stats', 'npm'] },
-);
 
 /**
  * Fetch repo-level GitHub numbers: stars, forks, and the sum of recorded
@@ -284,7 +268,20 @@ export async function getStatsPageData(): Promise<StatsPageData> {
   const publishedPlugins = (pluginStats?.plugins ?? []).filter(
     (p) => p.published,
   );
-  const downloads = await loadNpmDownloads(publishedPlugins.map((p) => p.name));
+  // /stats is prerendered, so an unreachable source must not fail the build —
+  // this repo is public and CI builds without Supabase credentials at all.
+  // Degrade the metric, never the page, and never by substituting a different
+  // metric: that is what this change exists to stop.
+  const [ecosystem, downloads] = await Promise.all([
+    loadEcosystemDownloads().catch((err: unknown) => {
+      console.error('[stats-page] ecosystem downloads unavailable:', err);
+      return null;
+    }),
+    loadPackageDownloads().catch((err: unknown) => {
+      console.error('[stats-page] per-package downloads unavailable:', err);
+      return {} as Record<string, number>;
+    }),
+  ]);
   const coverageMap = buildCoverageMap(coverage);
 
   const plugins: PluginRow[] = publishedPlugins
@@ -298,14 +295,18 @@ export async function getStatsPageData(): Promise<StatsPageData> {
     }))
     .sort((a, b) => b.downloads - a.downloads);
 
-  const totalDownloads = plugins.reduce((sum, p) => sum + p.downloads, 0);
-
+  // The headline is the ecosystem figure as published, NOT a sum of the rows
+  // above: the rows are the plugins this site documents, while the counted
+  // ecosystem also includes packages that have no docs page. Summing the rows
+  // would quietly publish a smaller number than ofriperetz.dev for the same
+  // metric — the divergence this whole change exists to remove.
   const impact: ImpactStats = {
     engagement,
     github,
     npm: {
-      totalDownloads,
-      packageCount: pluginStats?.allPluginsCount ?? publishedPlugins.length,
+      totalDownloads: ecosystem?.total ?? null,
+      packageCount: ecosystem?.packages ?? null,
+      since: ecosystem?.since ?? null,
     },
     audience,
   };


### PR DESCRIPTION
## The problem

Same metric name, three different numbers, depending which of our sites you opened:

| surface | showed | metric | source |
|---|---|---|---|
| `eslint.interlace.tools/stats` | **36.6K** | trailing last-week | `api.npmjs.org`, summed locally |
| `ofriperetz.dev` | **360,361** | all-time cumulative | Supabase `v_npm_alltime_ecosystem` |
| `ofriperetz.dev/npm` | **83,814** | trailing 30-day | Supabase `plugin_daily_metrics` |

Each is correct inside its own codebase. Together they're indefensible.

## The change

`v_npm_alltime_ecosystem` is the canonical record — written daily by [impact-ingest](https://github.com/ofri-peretz/impact-ingest) — and this site now reads it instead of computing its own. Per-package figures come from `npm_alltime_downloads`, the rows that total is the sum of, so the table and the headline can't disagree either.

**The headline is not a sum of the visible rows.** The counted ecosystem includes packages with no docs page; summing rows here would publish a smaller number than ofriperetz.dev for the same metric.

**The card states its window** — "npm downloads since December 2025". That date is *measured*, not written down: the backfill records the first day each package saw a non-zero download and `measured_since` exposes the earliest (2025-12-08, the day `eslint-plugin-secure-coding` shipped). Nothing hardcodes it, so nothing can drift from it. If it's ever null the qualifier is omitted rather than guessed.

**No npm-registry fallback.** A fallback that quietly computes a different metric is the exact failure being fixed — a missing number is visible, a wrong one isn't.

**The metric degrades, not the page.** `/stats` is prerendered and this repo is public, so CI builds with no Supabase credentials at all. When the source is unreachable the download card is omitted entirely and the rest of the page renders. It is never replaced with `0` — a confident zero is worse than a gap.

## Test plan

- [x] `SUPABASE_URL` + `SUPABASE_ANON_KEY` added to this Vercel project for production, preview and development, so the preview build exercises the real read. (Anon is public by design — it already ships in the blog's client bundle.)
- [x] Anon access verified against every queried relation, including the `npm_alltime_downloads → plugins(name)` embedded join.
- [x] `next build` with **no** Supabase env: succeeds, `/stats` prerenders, card omitted — the CI case.
- [x] Full pre-push gate green: typecheck, `turbo run build test`, `oxlint:shims:verify`, prettier.
- [ ] Confirm on the preview URL that `/stats` shows **360,361** with the "since December 2025" label.

## Follow-up, not in this PR

`ofriperetz.dev/npm` still publishes a trailing-30-day total under the same word "downloads". It reads the right source, so it's a labelling fix rather than a data one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)