### PR TITLE
fix(postgresql-security): abstain in files that use no PostgreSQL

### DIFF
--- a/.changeset/pg-module-gate.md
+++ b/.changeset/pg-module-gate.md
@@ -1,0 +1,26 @@
+---
+'eslint-plugin-postgresql-security': major
+---
+
+Every rule now abstains in files that use no PostgreSQL
+
+The plugin had no notion of whether a file used PostgreSQL at all.
+`no-missing-client-release` fired on any `.connect()` — mongoose, redis,
+socket.io. `no-unsafe-query` fired on any `.query()`. `no-select-all` fired on
+`SELECT *` in any string anywhere.
+
+Measured over **108,838 files across 108 repositories**: 1,305 findings, of
+which **1,222 (94%) were in files with no PostgreSQL client**. Two rules were
+wrong 100% of the time — `no-missing-client-release` (49 findings, 0 in a
+PostgreSQL file) and `prevent-double-release`.
+
+All thirteen rules now require local evidence that the file uses PostgreSQL: an
+import or `require` of a PostgreSQL client, or a `postgres://` / `postgresql://`
+connection string in the file. Nothing is read from `package.json` and nothing
+is resolved across files, so there is no project state to go stale.
+
+After the change the same corpus yields 100 findings instead of 1,305.
+
+This is a **major** bump: any rule may now stay silent where it previously
+reported. A file that reaches PostgreSQL only through a wrapper module is a
+deliberate miss — the trade against reporting on code with no database in it.

--- a/.changeset/pg-module-gate.md
+++ b/.changeset/pg-module-gate.md
@@ -2,7 +2,7 @@
 'eslint-plugin-postgresql-security': major
 ---
 
-Every rule now abstains in files that use no PostgreSQL
+Every rule now abstains in files without local PostgreSQL evidence
 
 The plugin had no notion of whether a file used PostgreSQL at all.
 `no-missing-client-release` fired on any `.connect()` — mongoose, redis,

--- a/packages/eslint-plugin-postgresql-security/src/module-gate.lock.test.ts
+++ b/packages/eslint-plugin-postgresql-security/src/module-gate.lock.test.ts
@@ -74,7 +74,10 @@ const NON_POSTGRES_SOURCES: ReadonlyArray<readonly [string, string]> = [
 ];
 
 const lint = (code: string, rule: string): Linter.LintMessage[] => {
-  const linter = new Linter();
+  // The declared ESLint floor for this package is 8.40, where `new Linter()`
+  // still defaults to eslintrc — a flat config would be ignored there and every
+  // rule silently skipped, which is the vacuous pass this lock exists to catch.
+  const linter = new Linter({ configType: "flat" });
   return linter.verify(
     code,
     {

--- a/packages/eslint-plugin-postgresql-security/src/module-gate.lock.test.ts
+++ b/packages/eslint-plugin-postgresql-security/src/module-gate.lock.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Regression lock: no rule in this plugin reports in a file that uses no
+ * PostgreSQL.
+ *
+ * Measured over 108,838 files in 108 repositories, 94% of everything this
+ * plugin reported (1,222 of 1,305 findings) was in a file with no PostgreSQL
+ * client — `no-missing-client-release` fired on `mongoose.connect()`,
+ * `no-unsafe-query` on any `.query()`, `no-select-all` on any `SELECT *` in
+ * any string. Two rules were wrong 100% of the time.
+ *
+ * This lock is written over the whole rule registry rather than per rule, so a
+ * rule added later is covered the day it lands: it will fail here until it is
+ * gated too. Revert the gate in any single rule and this test goes red.
+ */
+import { describe, it, expect } from 'vitest';
+import { Linter } from 'eslint';
+import parser from '@typescript-eslint/parser';
+import plugin from './index';
+
+const RULES = Object.keys(plugin.rules);
+
+/**
+ * Shapes that drew findings from this plugin across the corpus while having
+ * nothing to do with PostgreSQL. Each one is a real false-positive pattern,
+ * not a synthetic negative.
+ */
+const NON_POSTGRES_SOURCES: ReadonlyArray<readonly [string, string]> = [
+  [
+    'mongoose connect/release',
+    `import mongoose from 'mongoose';
+     async function main() {
+       const client = await mongoose.connect(process.env.MONGO_URL);
+       await client.query('SELECT * FROM cache WHERE id = ' + id);
+     }`,
+  ],
+  [
+    'redis client',
+    `import { createClient } from 'redis';
+     const client = createClient();
+     await client.connect();
+     await client.query('SELECT * FROM sessions');`,
+  ],
+  [
+    'an HTTP API named like a database',
+    `import { api } from './api';
+     export async function search(term) {
+       return api.query('SELECT * FROM products WHERE name = ' + term);
+     }`,
+  ],
+  [
+    'a MySQL project',
+    `import mysql from 'mysql2/promise';
+     const conn = await mysql.createConnection(url);
+     await conn.query('SELECT * FROM users WHERE id = ' + id);`,
+  ],
+  [
+    'a file with no database at all',
+    `export function render(items) {
+       return items.map((i) => \`<li>\${i.name}</li>\`).join('');
+     }`,
+  ],
+  [
+    'a local module merely named pg',
+    `import { Pool } from './pg';
+     const pool = new Pool();
+     await pool.query('SELECT * FROM users WHERE id = ' + id);`,
+  ],
+];
+
+const lint = (code: string, rule: string): Linter.LintMessage[] => {
+  const linter = new Linter();
+  return linter.verify(
+    code,
+    {
+      files: ['**/*.ts'],
+      languageOptions: {
+        parser: parser as unknown as Linter.Parser,
+        parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+      },
+      plugins: { pg: plugin as unknown as Linter.Plugin },
+      rules: { [`pg/${rule}`]: 'error' },
+    },
+    // Without a filename the Linter lints `<input>`, which matches no `files`
+    // entry — so every rule is skipped and every negative below passes without
+    // running any rule at all. The positive assertion at the bottom of this
+    // file is what catches that; keep it.
+    'query.ts',
+  );
+};
+
+describe('PostgreSQL module gate', () => {
+  it('the registry is non-empty, so the sweep below is not vacuous', () => {
+    expect(RULES.length).toBeGreaterThan(0);
+  });
+
+  describe.each(NON_POSTGRES_SOURCES)('%s', (_name, code) => {
+    it.each(RULES)('pg/%s reports nothing', (rule) => {
+      const messages = lint(code, rule);
+      // A parse or config error would also produce zero *rule* findings, so it
+      // is asserted away rather than counted as a pass.
+      expect(messages.filter((m) => !m.ruleId)).toHaveLength(0);
+      expect(messages).toHaveLength(0);
+    });
+  });
+
+  // The negatives above only prove the gate is closed; without this the whole
+  // suite would still pass if the gate were closed on every file.
+  it('the same query does report once the file imports pg', () => {
+    const code = `import { Pool } from 'pg';
+      client.query('SELECT * FROM users WHERE id = ' + id);`;
+    expect(lint(code, 'no-unsafe-query').length).toBeGreaterThan(0);
+  });
+
+  it('and stays silent on that same query with the import removed', () => {
+    const code = `client.query('SELECT * FROM users WHERE id = ' + id);`;
+    expect(lint(code, 'no-unsafe-query')).toHaveLength(0);
+  });
+});

--- a/packages/eslint-plugin-postgresql-security/src/rules/check-query-params/check-query-params.test.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/check-query-params/check-query-params.test.ts
@@ -10,6 +10,22 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { checkQueryParams } from './index';
 
+/**
+ * Every fixture imports a PostgreSQL client, because the rule now abstains in
+ * files that use no PostgreSQL at all. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the import
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const withPg = (code: string): string => `import { Pool } from 'pg';\n${code}`;
+const pg = <T,>(cases: T[]): T[] =>
+  cases.map((c) =>
+    typeof c === 'string'
+      ? (withPg(c) as T)
+      : ({ ...c, code: withPg((c as { code: string }).code) } as T),
+  );
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -27,7 +43,7 @@ const ruleTester = new RuleTester({
 describe('check-query-params', () => {
   describe('Valid Code', () => {
     ruleTester.run('valid - safe patterns', checkQueryParams, {
-      valid: [
+      valid: pg([
         // Unrelated code should not trigger
         {
           code: `const x = 1;`,
@@ -48,7 +64,7 @@ describe('check-query-params', () => {
         {
           code: `const safe4 = process.env.DB_HOST;`,
         },
-      ],
+      ]),
       invalid: [],
     });
   });
@@ -56,13 +72,13 @@ describe('check-query-params', () => {
   describe('Invalid Code', () => {
     ruleTester.run('invalid - dangerous patterns', checkQueryParams, {
       valid: [],
-      invalid: [
+      invalid: pg([
         // Triggers parameterCountMismatch
         {
           code: `client.query('SELECT * FROM users WHERE id = $1 AND name = $2', [userId])`,
           errors: [{ messageId: 'parameterCountMismatch' }],
         },
-      ],
+      ]),
     });
   });
 });

--- a/packages/eslint-plugin-postgresql-security/src/rules/check-query-params/index.spec.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/check-query-params/index.spec.ts
@@ -2,6 +2,22 @@ import { RuleTester } from '@typescript-eslint/rule-tester';
 import * as parser from '@typescript-eslint/parser';
 import { checkQueryParams } from './index';
 
+/**
+ * Every fixture imports a PostgreSQL client, because the rule now abstains in
+ * files that use no PostgreSQL at all. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the import
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const withPg = (code: string): string => `import { Pool } from 'pg';\n${code}`;
+const pg = <T,>(cases: T[]): T[] =>
+  cases.map((c) =>
+    typeof c === 'string'
+      ? (withPg(c) as T)
+      : ({ ...c, code: withPg((c as { code: string }).code) } as T),
+  );
+
+
 const ruleTester = new RuleTester({
   languageOptions: {
     parser,
@@ -9,7 +25,7 @@ const ruleTester = new RuleTester({
 });
 
 ruleTester.run('check-query-params', checkQueryParams, {
-  valid: [
+  valid: pg([
     // Basic valid cases
     {
       code: "client.query('SELECT * FROM users WHERE id = $1', [1])",
@@ -82,8 +98,8 @@ ruleTester.run('check-query-params', checkQueryParams, {
       code: "client.query(`SELECT * FROM users WHERE id = $1`, [1])", 
       name: 'Template literal (static) with $1',
     },
-  ],
-  invalid: [
+  ]),
+  invalid: pg([
     // Missing arguments
     {
       code: "client.query('SELECT * FROM users WHERE id = $1', [])",
@@ -113,5 +129,5 @@ ruleTester.run('check-query-params', checkQueryParams, {
       name: 'Repeated $1 still requires at least 1 arg',
       errors: [{ messageId: 'parameterCountMismatch', data: { expected: '1', actual: '0' } }],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-postgresql-security/src/rules/check-query-params/index.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/check-query-params/index.ts
@@ -6,6 +6,7 @@
 
 import { TSESLint, AST_NODE_TYPES, TSESTree, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
 import { CheckQueryParamsOptions } from '../../types';
+import { fileUsesPostgres } from '../../utils';
 
 // Pre-compiled regex patterns for performance
 const SINGLE_QUOTE_REGEX = /'(?:[^']|'')*'/g;
@@ -42,6 +43,12 @@ export const checkQueryParams: TSESLint.RuleModule<
   },
   defaultOptions: [],
   create(context) {
+    // Every rule here is PostgreSQL-specific, and none of them knew it: over
+    // 108,838 files, 94% of this plugin's findings were in files with no
+    // PostgreSQL client at all. Registering no visitors is both the gate and
+    // the cheap path — a file with no database in it does no work.
+    if (!fileUsesPostgres(context.sourceCode.ast)) return {};
+
     return {
       CallExpression(node: TSESTree.CallExpression) {
         if (

--- a/packages/eslint-plugin-postgresql-security/src/rules/no-batch-insert-loop/index.spec.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/no-batch-insert-loop/index.spec.ts
@@ -2,6 +2,22 @@ import { RuleTester } from '@typescript-eslint/rule-tester';
 import * as parser from '@typescript-eslint/parser';
 import { noBatchInsertLoop } from './index';
 
+/**
+ * Every fixture imports a PostgreSQL client, because the rule now abstains in
+ * files that use no PostgreSQL at all. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the import
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const withPg = (code: string): string => `import { Pool } from 'pg';\n${code}`;
+const pg = <T,>(cases: T[]): T[] =>
+  cases.map((c) =>
+    typeof c === 'string'
+      ? (withPg(c) as T)
+      : ({ ...c, code: withPg((c as { code: string }).code) } as T),
+  );
+
+
 const ruleTester = new RuleTester({
   languageOptions: {
     parser,
@@ -9,7 +25,7 @@ const ruleTester = new RuleTester({
 });
 
 ruleTester.run('no-batch-insert-loop', noBatchInsertLoop, {
-  valid: [
+  valid: pg([
     `
     async function insert() {
       await client.query('INSERT INTO users ...');
@@ -55,8 +71,8 @@ ruleTester.run('no-batch-insert-loop', noBatchInsertLoop, {
       await client.query('INSERT INTO items VALUES (1)');
     }, 1000);
     `
-  ],
-  invalid: [
+  ]),
+  invalid: pg([
     {
       code: `
       for (const item of items) {
@@ -101,5 +117,5 @@ ruleTester.run('no-batch-insert-loop', noBatchInsertLoop, {
       `,
       errors: [{ messageId: 'noBatchInsertLoop' }],
     }
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-postgresql-security/src/rules/no-batch-insert-loop/index.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/no-batch-insert-loop/index.ts
@@ -6,6 +6,7 @@
 
 import { TSESLint, AST_NODE_TYPES, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
 import { NoBatchInsertLoopOptions } from '../../types';
+import { fileUsesPostgres } from '../../utils';
 
 export const noBatchInsertLoop: TSESLint.RuleModule<
   'noBatchInsertLoop',
@@ -35,6 +36,12 @@ export const noBatchInsertLoop: TSESLint.RuleModule<
   },
   defaultOptions: [],
   create(context) {
+    // Every rule here is PostgreSQL-specific, and none of them knew it: over
+    // 108,838 files, 94% of this plugin's findings were in files with no
+    // PostgreSQL client at all. Registering no visitors is both the gate and
+    // the cheap path — a file with no database in it does no work.
+    if (!fileUsesPostgres(context.sourceCode.ast)) return {};
+
     return {
       CallExpression(node) {
         if (

--- a/packages/eslint-plugin-postgresql-security/src/rules/no-batch-insert-loop/no-batch-insert-loop.test.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/no-batch-insert-loop/no-batch-insert-loop.test.ts
@@ -10,6 +10,22 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { noBatchInsertLoop } from './index';
 
+/**
+ * Every fixture imports a PostgreSQL client, because the rule now abstains in
+ * files that use no PostgreSQL at all. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the import
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const withPg = (code: string): string => `import { Pool } from 'pg';\n${code}`;
+const pg = <T,>(cases: T[]): T[] =>
+  cases.map((c) =>
+    typeof c === 'string'
+      ? (withPg(c) as T)
+      : ({ ...c, code: withPg((c as { code: string }).code) } as T),
+  );
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -27,7 +43,7 @@ const ruleTester = new RuleTester({
 describe('no-batch-insert-loop', () => {
   describe('Valid Code', () => {
     ruleTester.run('valid - safe patterns', noBatchInsertLoop, {
-      valid: [
+      valid: pg([
         // Unrelated code should not trigger
         {
           code: `const x = 1;`,
@@ -48,7 +64,7 @@ describe('no-batch-insert-loop', () => {
         {
           code: `const safe4 = process.env.DB_HOST;`,
         },
-      ],
+      ]),
       invalid: [],
     });
   });
@@ -56,13 +72,13 @@ describe('no-batch-insert-loop', () => {
   describe('Invalid Code', () => {
     ruleTester.run('invalid - dangerous patterns', noBatchInsertLoop, {
       valid: [],
-      invalid: [
+      invalid: pg([
         // Triggers noBatchInsertLoop
         {
           code: `for (const item of items) { client.query('INSERT INTO t(a) VALUES($1)', [item]); }`,
           errors: [{ messageId: 'noBatchInsertLoop' }],
         },
-      ],
+      ]),
     });
   });
 });

--- a/packages/eslint-plugin-postgresql-security/src/rules/no-floating-query/index.spec.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/no-floating-query/index.spec.ts
@@ -2,6 +2,22 @@ import { RuleTester } from '@typescript-eslint/rule-tester';
 import * as parser from '@typescript-eslint/parser';
 import { noFloatingQuery } from './index';
 
+/**
+ * Every fixture imports a PostgreSQL client, because the rule now abstains in
+ * files that use no PostgreSQL at all. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the import
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const withPg = (code: string): string => `import { Pool } from 'pg';\n${code}`;
+const pg = <T,>(cases: T[]): T[] =>
+  cases.map((c) =>
+    typeof c === 'string'
+      ? (withPg(c) as T)
+      : ({ ...c, code: withPg((c as { code: string }).code) } as T),
+  );
+
+
 const ruleTester = new RuleTester({
   languageOptions: {
     parser,
@@ -13,7 +29,7 @@ const ruleTester = new RuleTester({
 });
 
 ruleTester.run('no-floating-query', noFloatingQuery, {
-  valid: [
+  valid: pg([
     // Await
     "await client.query('SELECT 1')",
     "async function foo() { await client.query('SELECT 1'); }",
@@ -60,8 +76,8 @@ ruleTester.run('no-floating-query', noFloatingQuery, {
 
     // Argument Passing
     "doSomething(client.query('SELECT 1'))",
-  ],
-  invalid: [
+  ]),
+  invalid: pg([
     {
       code: "client.query('SELECT 1');",
       errors: [{ messageId: 'noFloatingQuery' }],
@@ -108,5 +124,5 @@ ruleTester.run('no-floating-query', noFloatingQuery, {
       `,
       errors: [{ messageId: 'noFloatingQuery' }, { messageId: 'noFloatingQuery' }],
     }
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-postgresql-security/src/rules/no-floating-query/index.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/no-floating-query/index.ts
@@ -6,6 +6,7 @@
 
 import { TSESLint, AST_NODE_TYPES, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
 import { NoFloatingQueryOptions } from '../../types';
+import { fileUsesPostgres } from '../../utils';
 
 export const noFloatingQuery: TSESLint.RuleModule<
   'noFloatingQuery',
@@ -35,6 +36,12 @@ export const noFloatingQuery: TSESLint.RuleModule<
   },
   defaultOptions: [],
   create(context) {
+    // Every rule here is PostgreSQL-specific, and none of them knew it: over
+    // 108,838 files, 94% of this plugin's findings were in files with no
+    // PostgreSQL client at all. Registering no visitors is both the gate and
+    // the cheap path — a file with no database in it does no work.
+    if (!fileUsesPostgres(context.sourceCode.ast)) return {};
+
     return {
       CallExpression(node) {
         if (

--- a/packages/eslint-plugin-postgresql-security/src/rules/no-floating-query/no-floating-query.test.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/no-floating-query/no-floating-query.test.ts
@@ -10,6 +10,22 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { noFloatingQuery } from './index';
 
+/**
+ * Every fixture imports a PostgreSQL client, because the rule now abstains in
+ * files that use no PostgreSQL at all. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the import
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const withPg = (code: string): string => `import { Pool } from 'pg';\n${code}`;
+const pg = <T,>(cases: T[]): T[] =>
+  cases.map((c) =>
+    typeof c === 'string'
+      ? (withPg(c) as T)
+      : ({ ...c, code: withPg((c as { code: string }).code) } as T),
+  );
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -27,7 +43,7 @@ const ruleTester = new RuleTester({
 describe('no-floating-query', () => {
   describe('Valid Code', () => {
     ruleTester.run('valid - safe patterns', noFloatingQuery, {
-      valid: [
+      valid: pg([
         // Unrelated code should not trigger
         {
           code: `const x = 1;`,
@@ -48,7 +64,7 @@ describe('no-floating-query', () => {
         {
           code: `const safe4 = process.env.DB_HOST;`,
         },
-      ],
+      ]),
       invalid: [],
     });
   });
@@ -56,13 +72,13 @@ describe('no-floating-query', () => {
   describe('Invalid Code', () => {
     ruleTester.run('invalid - dangerous patterns', noFloatingQuery, {
       valid: [],
-      invalid: [
+      invalid: pg([
         // Triggers noFloatingQuery
         {
           code: `client.query('SELECT 1')`,
           errors: [{ messageId: 'noFloatingQuery' }],
         },
-      ],
+      ]),
     });
   });
 });

--- a/packages/eslint-plugin-postgresql-security/src/rules/no-hardcoded-credentials/index.spec.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/no-hardcoded-credentials/index.spec.ts
@@ -2,6 +2,22 @@ import { RuleTester } from '@typescript-eslint/rule-tester';
 import * as parser from '@typescript-eslint/parser';
 import { noHardcodedCredentials } from './index';
 
+/**
+ * Every fixture imports a PostgreSQL client, because the rule now abstains in
+ * files that use no PostgreSQL at all. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the import
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const withPg = (code: string): string => `import { Pool } from 'pg';\n${code}`;
+const pg = <T,>(cases: T[]): T[] =>
+  cases.map((c) =>
+    typeof c === 'string'
+      ? (withPg(c) as T)
+      : ({ ...c, code: withPg((c as { code: string }).code) } as T),
+  );
+
+
 const ruleTester = new RuleTester({
   languageOptions: {
     parser,
@@ -9,7 +25,7 @@ const ruleTester = new RuleTester({
 });
 
 ruleTester.run('no-hardcoded-credentials', noHardcodedCredentials, {
-  valid: [
+  valid: pg([
     "new Client({ password: process.env.DB_PASSWORD })",
     "new Pool({ connectionString: process.env.DATABASE_URL })",
     "new Client()", // No config, assumes env vars or defaults
@@ -20,8 +36,8 @@ ruleTester.run('no-hardcoded-credentials', noHardcodedCredentials, {
     "new Client('some-random-string')", // String but not a protocol match
     "new Client(123)", // Non-string arg
     "new Pool({ user: 'postgres', database: 'mydb' })", // No password
-  ],
-  invalid: [
+  ]),
+  invalid: pg([
     {
       code: "new Client({ password: 'mysecretpassword' })",
       errors: [{ messageId: 'noHardcodedCredentials' }],
@@ -34,5 +50,5 @@ ruleTester.run('no-hardcoded-credentials', noHardcodedCredentials, {
       code: "new Client('postgres://user:pass@localhost:5432/db')",
       errors: [{ messageId: 'noHardcodedCredentials' }],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-postgresql-security/src/rules/no-hardcoded-credentials/index.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/no-hardcoded-credentials/index.ts
@@ -7,6 +7,7 @@
 import { TSESLint, AST_NODE_TYPES, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
 import { NoHardcodedCredentialsOptions } from '../../types';
 import { PG_PROTOCOLS } from '../../constants';
+import { fileUsesPostgres } from '../../utils';
 
 export const noHardcodedCredentials: TSESLint.RuleModule<
   'noHardcodedCredentials',
@@ -38,6 +39,12 @@ export const noHardcodedCredentials: TSESLint.RuleModule<
   },
   defaultOptions: [],
   create(context) {
+    // Every rule here is PostgreSQL-specific, and none of them knew it: over
+    // 108,838 files, 94% of this plugin's findings were in files with no
+    // PostgreSQL client at all. Registering no visitors is both the gate and
+    // the cheap path — a file with no database in it does no work.
+    if (!fileUsesPostgres(context.sourceCode.ast)) return {};
+
     return {
       NewExpression(node) {
         if (node.callee.type !== AST_NODE_TYPES.Identifier || !['Client', 'Pool'].includes(node.callee.name)) {

--- a/packages/eslint-plugin-postgresql-security/src/rules/no-hardcoded-credentials/no-hardcoded-credentials.test.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/no-hardcoded-credentials/no-hardcoded-credentials.test.ts
@@ -10,6 +10,22 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { noHardcodedCredentials } from './index';
 
+/**
+ * Every fixture imports a PostgreSQL client, because the rule now abstains in
+ * files that use no PostgreSQL at all. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the import
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const withPg = (code: string): string => `import { Pool } from 'pg';\n${code}`;
+const pg = <T,>(cases: T[]): T[] =>
+  cases.map((c) =>
+    typeof c === 'string'
+      ? (withPg(c) as T)
+      : ({ ...c, code: withPg((c as { code: string }).code) } as T),
+  );
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -27,7 +43,7 @@ const ruleTester = new RuleTester({
 describe('no-hardcoded-credentials', () => {
   describe('Valid Code', () => {
     ruleTester.run('valid - safe patterns', noHardcodedCredentials, {
-      valid: [
+      valid: pg([
         // Unrelated code should not trigger
         {
           code: `const x = 1;`,
@@ -48,7 +64,7 @@ describe('no-hardcoded-credentials', () => {
         {
           code: `const safe4 = process.env.DB_HOST;`,
         },
-      ],
+      ]),
       invalid: [],
     });
   });
@@ -56,13 +72,13 @@ describe('no-hardcoded-credentials', () => {
   describe('Invalid Code', () => {
     ruleTester.run('invalid - dangerous patterns', noHardcodedCredentials, {
       valid: [],
-      invalid: [
+      invalid: pg([
         // Triggers noHardcodedCredentials
         {
           code: `new Client({ host: 'localhost', password: 'secret123' })`,
           errors: [{ messageId: 'noHardcodedCredentials' }],
         },
-      ],
+      ]),
     });
   });
 });

--- a/packages/eslint-plugin-postgresql-security/src/rules/no-insecure-ssl/index.spec.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/no-insecure-ssl/index.spec.ts
@@ -2,6 +2,22 @@ import { RuleTester } from '@typescript-eslint/rule-tester';
 import * as parser from '@typescript-eslint/parser';
 import { noInsecureSsl } from './index';
 
+/**
+ * Every fixture imports a PostgreSQL client, because the rule now abstains in
+ * files that use no PostgreSQL at all. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the import
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const withPg = (code: string): string => `import { Pool } from 'pg';\n${code}`;
+const pg = <T,>(cases: T[]): T[] =>
+  cases.map((c) =>
+    typeof c === 'string'
+      ? (withPg(c) as T)
+      : ({ ...c, code: withPg((c as { code: string }).code) } as T),
+  );
+
+
 const ruleTester = new RuleTester({
   languageOptions: {
     parser,
@@ -9,7 +25,7 @@ const ruleTester = new RuleTester({
 });
 
 ruleTester.run('no-insecure-ssl', noInsecureSsl, {
-  valid: [
+  valid: pg([
     // Default (secure)
     "new Client()",
     "new Pool({ user: 'postgres' })",
@@ -26,8 +42,8 @@ ruleTester.run('no-insecure-ssl', noInsecureSsl, {
     "new Client({ ssl: true })",
     // Line 51: ssl = false (also non-object)
     "new Client({ ssl: false })",
-  ],
-  invalid: [
+  ]),
+  invalid: pg([
     {
       code: "new Client({ ssl: { rejectUnauthorized: false } })",
       errors: [{ messageId: 'noInsecureSsl' }],
@@ -36,5 +52,5 @@ ruleTester.run('no-insecure-ssl', noInsecureSsl, {
       code: "new Pool({ ssl: { rejectUnauthorized: false } })",
       errors: [{ messageId: 'noInsecureSsl' }],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-postgresql-security/src/rules/no-insecure-ssl/index.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/no-insecure-ssl/index.ts
@@ -6,6 +6,7 @@
 
 import { TSESLint, AST_NODE_TYPES, TSESTree, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
 import { NoInsecureSslOptions } from '../../types';
+import { fileUsesPostgres } from '../../utils';
 
 export const noInsecureSsl: TSESLint.RuleModule<
   'noInsecureSsl',
@@ -37,6 +38,12 @@ export const noInsecureSsl: TSESLint.RuleModule<
   },
   defaultOptions: [],
   create(context) {
+    // Every rule here is PostgreSQL-specific, and none of them knew it: over
+    // 108,838 files, 94% of this plugin's findings were in files with no
+    // PostgreSQL client at all. Registering no visitors is both the gate and
+    // the cheap path — a file with no database in it does no work.
+    if (!fileUsesPostgres(context.sourceCode.ast)) return {};
+
     return {
       NewExpression(node) {
         if (node.callee.type !== AST_NODE_TYPES.Identifier || (node.callee.name !== 'Client' && node.callee.name !== 'Pool')) {

--- a/packages/eslint-plugin-postgresql-security/src/rules/no-insecure-ssl/no-insecure-ssl.test.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/no-insecure-ssl/no-insecure-ssl.test.ts
@@ -10,6 +10,22 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { noInsecureSsl } from './index';
 
+/**
+ * Every fixture imports a PostgreSQL client, because the rule now abstains in
+ * files that use no PostgreSQL at all. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the import
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const withPg = (code: string): string => `import { Pool } from 'pg';\n${code}`;
+const pg = <T,>(cases: T[]): T[] =>
+  cases.map((c) =>
+    typeof c === 'string'
+      ? (withPg(c) as T)
+      : ({ ...c, code: withPg((c as { code: string }).code) } as T),
+  );
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -27,7 +43,7 @@ const ruleTester = new RuleTester({
 describe('no-insecure-ssl', () => {
   describe('Valid Code', () => {
     ruleTester.run('valid - safe patterns', noInsecureSsl, {
-      valid: [
+      valid: pg([
         // Unrelated code should not trigger
         {
           code: `const x = 1;`,
@@ -48,7 +64,7 @@ describe('no-insecure-ssl', () => {
         {
           code: `const safe4 = process.env.DB_HOST;`,
         },
-      ],
+      ]),
       invalid: [],
     });
   });
@@ -56,13 +72,13 @@ describe('no-insecure-ssl', () => {
   describe('Invalid Code', () => {
     ruleTester.run('invalid - dangerous patterns', noInsecureSsl, {
       valid: [],
-      invalid: [
+      invalid: pg([
         // Triggers noInsecureSsl: rejectUnauthorized disabled in SSL config
         {
           code: `new Client({ host: 'db.example.com', ssl: { rejectUnauthorized: false } })`,
           errors: [{ messageId: 'noInsecureSsl' }],
         },
-      ],
+      ]),
     });
   });
 });

--- a/packages/eslint-plugin-postgresql-security/src/rules/no-missing-client-release/coverage-gaps.spec.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/no-missing-client-release/coverage-gaps.spec.ts
@@ -16,10 +16,31 @@ import { describe, it, expect } from 'vitest';
 import { createWithMockContext } from '@interlace/eslint-devkit';
 import { noMissingClientRelease } from './index';
 
+/**
+ * The synthetic Program the module gate reads. These tests drive listeners
+ * directly, so the file they stand for has to carry the same PostgreSQL
+ * evidence a real one would — otherwise the rule registers no listeners and
+ * the gap under test is never reached.
+ */
+const PG_AST = {
+  type: 'Program',
+  body: [
+    {
+      type: 'ImportDeclaration',
+      source: { type: 'Literal', value: 'pg' },
+      specifiers: [],
+    },
+  ],
+  tokens: [],
+  comments: [],
+} as never;
+
+
 describe('no-missing-client-release — coverage gaps (Layer 2, synthetic AST)', () => {
   it('returns silently when the declarator resolves to no variable', () => {
     const { listeners, reports } = createWithMockContext(
       noMissingClientRelease,
+      { ast: PG_AST },
     );
     const declarator = {
       type: 'VariableDeclarator',

--- a/packages/eslint-plugin-postgresql-security/src/rules/no-missing-client-release/index.spec.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/no-missing-client-release/index.spec.ts
@@ -2,6 +2,22 @@ import { RuleTester } from '@typescript-eslint/rule-tester';
 import * as parser from '@typescript-eslint/parser';
 import { noMissingClientRelease } from './index';
 
+/**
+ * Every fixture imports a PostgreSQL client, because the rule now abstains in
+ * files that use no PostgreSQL at all. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the import
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const withPg = (code: string): string => `import { Pool } from 'pg';\n${code}`;
+const pg = <T,>(cases: T[]): T[] =>
+  cases.map((c) =>
+    typeof c === 'string'
+      ? (withPg(c) as T)
+      : ({ ...c, code: withPg((c as { code: string }).code) } as T),
+  );
+
+
 const ruleTester = new RuleTester({
   languageOptions: {
     parser,
@@ -9,7 +25,7 @@ const ruleTester = new RuleTester({
 });
 
 ruleTester.run('no-missing-client-release', noMissingClientRelease, {
-  valid: [
+  valid: pg([
     {
        code: "async function f() { await pool.connect(); }",
        name: 'Ignored: No assignment'
@@ -28,8 +44,8 @@ ruleTester.run('no-missing-client-release', noMissingClientRelease, {
        client.release(); 
     }
     `
-  ],
-  invalid: [
+  ]),
+  invalid: pg([
     {
       code: `
       async function query() {
@@ -48,5 +64,5 @@ ruleTester.run('no-missing-client-release', noMissingClientRelease, {
       `,
       errors: [{ messageId: 'missingClientRelease' }],
     }
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-postgresql-security/src/rules/no-missing-client-release/index.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/no-missing-client-release/index.ts
@@ -6,6 +6,7 @@
 
 import { TSESLint, AST_NODE_TYPES, TSESTree, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
 import { NoMissingClientReleaseOptions } from '../../types';
+import { fileUsesPostgres } from '../../utils';
 
 export const noMissingClientRelease: TSESLint.RuleModule<
   'missingClientRelease',
@@ -34,6 +35,12 @@ export const noMissingClientRelease: TSESLint.RuleModule<
   },
   defaultOptions: [],
   create(context) {
+    // Every rule here is PostgreSQL-specific, and none of them knew it: over
+    // 108,838 files, 94% of this plugin's findings were in files with no
+    // PostgreSQL client at all. Registering no visitors is both the gate and
+    // the cheap path — a file with no database in it does no work.
+    if (!fileUsesPostgres(context.sourceCode.ast)) return {};
+
     return {
       CallExpression(node) {
         // Detect: const client = await pool.connect() or pool.connect().then(client => ...)

--- a/packages/eslint-plugin-postgresql-security/src/rules/no-missing-client-release/no-missing-client-release.test.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/no-missing-client-release/no-missing-client-release.test.ts
@@ -10,6 +10,22 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { noMissingClientRelease } from './index';
 
+/**
+ * Every fixture imports a PostgreSQL client, because the rule now abstains in
+ * files that use no PostgreSQL at all. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the import
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const withPg = (code: string): string => `import { Pool } from 'pg';\n${code}`;
+const pg = <T,>(cases: T[]): T[] =>
+  cases.map((c) =>
+    typeof c === 'string'
+      ? (withPg(c) as T)
+      : ({ ...c, code: withPg((c as { code: string }).code) } as T),
+  );
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -27,7 +43,7 @@ const ruleTester = new RuleTester({
 describe('no-missing-client-release', () => {
   describe('Valid Code', () => {
     ruleTester.run('valid - safe patterns', noMissingClientRelease, {
-      valid: [
+      valid: pg([
         // Unrelated code should not trigger
         {
           code: `const x = 1;`,
@@ -48,7 +64,7 @@ describe('no-missing-client-release', () => {
         {
           code: `const safe4 = process.env.DB_HOST;`,
         },
-      ],
+      ]),
       invalid: [],
     });
   });
@@ -56,13 +72,13 @@ describe('no-missing-client-release', () => {
   describe('Invalid Code', () => {
     ruleTester.run('invalid - dangerous patterns', noMissingClientRelease, {
       valid: [],
-      invalid: [
+      invalid: pg([
         // Triggers missingClientRelease
         {
           code: `async function test() { const client = await pool.connect(); const res = await client.query('SELECT 1'); return res; }`,
           errors: [{ messageId: 'missingClientRelease' }],
         },
-      ],
+      ]),
     });
   });
 });

--- a/packages/eslint-plugin-postgresql-security/src/rules/no-select-all/index.spec.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/no-select-all/index.spec.ts
@@ -2,6 +2,22 @@ import { RuleTester } from '@typescript-eslint/rule-tester';
 import * as parser from '@typescript-eslint/parser';
 import { noSelectAll } from './index';
 
+/**
+ * Every fixture imports a PostgreSQL client, because the rule now abstains in
+ * files that use no PostgreSQL at all. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the import
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const withPg = (code: string): string => `import { Pool } from 'pg';\n${code}`;
+const pg = <T,>(cases: T[]): T[] =>
+  cases.map((c) =>
+    typeof c === 'string'
+      ? (withPg(c) as T)
+      : ({ ...c, code: withPg((c as { code: string }).code) } as T),
+  );
+
+
 const ruleTester = new RuleTester({
   languageOptions: {
     parser,
@@ -9,7 +25,7 @@ const ruleTester = new RuleTester({
 });
 
 ruleTester.run('no-select-all', noSelectAll, {
-  valid: [
+  valid: pg([
     // Ignored cases (coverage)
     "client.query(dynamicSql)", // Dynamic query string
     "client.other('SELECT *')", // Not .query method
@@ -26,8 +42,8 @@ ruleTester.run('no-select-all', noSelectAll, {
     // SELECT * FROM UNNEST is idiomatic for bulk inserts
     "pool.query('INSERT INTO users SELECT * FROM unnest($1::int[], $2::text[])', [ids, names])",
     "pool.query('INSERT INTO logs SELECT * FROM UNNEST($1::text[])', [messages])",
-  ],
-  invalid: [
+  ]),
+  invalid: pg([
     {
       code: "client.query('SELECT * FROM users')",
       errors: [{ messageId: 'noSelectAll' }],
@@ -40,5 +56,5 @@ ruleTester.run('no-select-all', noSelectAll, {
       code: "client.query('SELECT a, b, * FROM table')", // Rare but possible in some SQL dialects or logic
       errors: [{ messageId: 'noSelectAll' }],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-postgresql-security/src/rules/no-select-all/index.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/no-select-all/index.ts
@@ -6,6 +6,7 @@
 
 import { TSESLint, AST_NODE_TYPES, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
 import { NoSelectAllOptions } from '../../types';
+import { fileUsesPostgres } from '../../utils';
 
 // Pre-compiled regex patterns for performance
 const COUNT_STAR_REGEX = /COUNT\s*\(\s*\*\s*\)/g;
@@ -42,6 +43,12 @@ export const noSelectAll: TSESLint.RuleModule<
   },
   defaultOptions: [],
   create(context) {
+    // Every rule here is PostgreSQL-specific, and none of them knew it: over
+    // 108,838 files, 94% of this plugin's findings were in files with no
+    // PostgreSQL client at all. Registering no visitors is both the gate and
+    // the cheap path — a file with no database in it does no work.
+    if (!fileUsesPostgres(context.sourceCode.ast)) return {};
+
     return {
       CallExpression(node) {
         if (

--- a/packages/eslint-plugin-postgresql-security/src/rules/no-select-all/no-select-all.test.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/no-select-all/no-select-all.test.ts
@@ -10,6 +10,22 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { noSelectAll } from './index';
 
+/**
+ * Every fixture imports a PostgreSQL client, because the rule now abstains in
+ * files that use no PostgreSQL at all. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the import
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const withPg = (code: string): string => `import { Pool } from 'pg';\n${code}`;
+const pg = <T,>(cases: T[]): T[] =>
+  cases.map((c) =>
+    typeof c === 'string'
+      ? (withPg(c) as T)
+      : ({ ...c, code: withPg((c as { code: string }).code) } as T),
+  );
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -27,7 +43,7 @@ const ruleTester = new RuleTester({
 describe('no-select-all', () => {
   describe('Valid Code', () => {
     ruleTester.run('valid - safe patterns', noSelectAll, {
-      valid: [
+      valid: pg([
         // Unrelated code should not trigger
         {
           code: `const x = 1;`,
@@ -48,7 +64,7 @@ describe('no-select-all', () => {
         {
           code: `const safe4 = process.env.DB_HOST;`,
         },
-      ],
+      ]),
       invalid: [],
     });
   });
@@ -56,13 +72,13 @@ describe('no-select-all', () => {
   describe('Invalid Code', () => {
     ruleTester.run('invalid - dangerous patterns', noSelectAll, {
       valid: [],
-      invalid: [
+      invalid: pg([
         // Triggers noSelectAll
         {
           code: `client.query('SELECT * FROM users')`,
           errors: [{ messageId: 'noSelectAll' }],
         },
-      ],
+      ]),
     });
   });
 });

--- a/packages/eslint-plugin-postgresql-security/src/rules/no-transaction-on-pool/index.spec.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/no-transaction-on-pool/index.spec.ts
@@ -2,6 +2,22 @@ import { RuleTester } from '@typescript-eslint/rule-tester';
 import * as parser from '@typescript-eslint/parser';
 import { noTransactionOnPool } from './index';
 
+/**
+ * Every fixture imports a PostgreSQL client, because the rule now abstains in
+ * files that use no PostgreSQL at all. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the import
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const withPg = (code: string): string => `import { Pool } from 'pg';\n${code}`;
+const pg = <T,>(cases: T[]): T[] =>
+  cases.map((c) =>
+    typeof c === 'string'
+      ? (withPg(c) as T)
+      : ({ ...c, code: withPg((c as { code: string }).code) } as T),
+  );
+
+
 const ruleTester = new RuleTester({
   languageOptions: {
     parser,
@@ -9,7 +25,7 @@ const ruleTester = new RuleTester({
 });
 
 ruleTester.run('no-transaction-on-pool', noTransactionOnPool, {
-  valid: [
+  valid: pg([
     // Ignored cases (coverage)
     "pool.otherMethod('BEGIN')",
     "pool.query(dynamicVar)", // Not literal
@@ -18,8 +34,8 @@ ruleTester.run('no-transaction-on-pool', noTransactionOnPool, {
     "client.query('COMMIT')",
     "pool.query('SELECT 1')",
     "customClient.query('BEGIN')",
-  ],
-  invalid: [
+  ]),
+  invalid: pg([
     {
       code: "pool.query('BEGIN')",
       errors: [{ messageId: 'noTransactionOnPool' }],
@@ -32,5 +48,5 @@ ruleTester.run('no-transaction-on-pool', noTransactionOnPool, {
       code: "pool.query('ROLLBACK')",
       errors: [{ messageId: 'noTransactionOnPool' }],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-postgresql-security/src/rules/no-transaction-on-pool/index.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/no-transaction-on-pool/index.ts
@@ -6,6 +6,7 @@
 
 import { TSESLint, AST_NODE_TYPES, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
 import { NoTransactionOnPoolOptions } from '../../types';
+import { fileUsesPostgres } from '../../utils';
 
 // Pre-defined set of transaction keywords for fast lookup
 const TRANSACTION_KEYWORDS = new Set(['BEGIN', 'COMMIT', 'ROLLBACK']);
@@ -38,6 +39,12 @@ export const noTransactionOnPool: TSESLint.RuleModule<
   },
   defaultOptions: [],
   create(context) {
+    // Every rule here is PostgreSQL-specific, and none of them knew it: over
+    // 108,838 files, 94% of this plugin's findings were in files with no
+    // PostgreSQL client at all. Registering no visitors is both the gate and
+    // the cheap path — a file with no database in it does no work.
+    if (!fileUsesPostgres(context.sourceCode.ast)) return {};
+
     return {
       CallExpression(node) {
         if (

--- a/packages/eslint-plugin-postgresql-security/src/rules/no-transaction-on-pool/no-transaction-on-pool.test.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/no-transaction-on-pool/no-transaction-on-pool.test.ts
@@ -10,6 +10,22 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { noTransactionOnPool } from './index';
 
+/**
+ * Every fixture imports a PostgreSQL client, because the rule now abstains in
+ * files that use no PostgreSQL at all. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the import
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const withPg = (code: string): string => `import { Pool } from 'pg';\n${code}`;
+const pg = <T,>(cases: T[]): T[] =>
+  cases.map((c) =>
+    typeof c === 'string'
+      ? (withPg(c) as T)
+      : ({ ...c, code: withPg((c as { code: string }).code) } as T),
+  );
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -27,7 +43,7 @@ const ruleTester = new RuleTester({
 describe('no-transaction-on-pool', () => {
   describe('Valid Code', () => {
     ruleTester.run('valid - safe patterns', noTransactionOnPool, {
-      valid: [
+      valid: pg([
         // Unrelated code should not trigger
         {
           code: `const x = 1;`,
@@ -48,7 +64,7 @@ describe('no-transaction-on-pool', () => {
         {
           code: `const safe4 = process.env.DB_HOST;`,
         },
-      ],
+      ]),
       invalid: [],
     });
   });
@@ -56,13 +72,13 @@ describe('no-transaction-on-pool', () => {
   describe('Invalid Code', () => {
     ruleTester.run('invalid - dangerous patterns', noTransactionOnPool, {
       valid: [],
-      invalid: [
+      invalid: pg([
         // Triggers noTransactionOnPool
         {
           code: `pool.query('BEGIN')`,
           errors: [{ messageId: 'noTransactionOnPool' }],
         },
-      ],
+      ]),
     });
   });
 });

--- a/packages/eslint-plugin-postgresql-security/src/rules/no-unsafe-copy-from/coverage-gaps.spec.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/no-unsafe-copy-from/coverage-gaps.spec.ts
@@ -14,6 +14,22 @@ import { describe, it, afterAll } from 'vitest';
 import * as parser from '@typescript-eslint/parser';
 import { noUnsafeCopyFrom } from './index';
 
+/**
+ * Every fixture imports a PostgreSQL client, because the rule now abstains in
+ * files that use no PostgreSQL at all. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the import
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const withPg = (code: string): string => `import { Pool } from 'pg';\n${code}`;
+const pg = <T,>(cases: T[]): T[] =>
+  cases.map((c) =>
+    typeof c === 'string'
+      ? (withPg(c) as T)
+      : ({ ...c, code: withPg((c as { code: string }).code) } as T),
+  );
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -28,7 +44,7 @@ const ruleTester = new RuleTester({
 
 describe('no-unsafe-copy-from — coverage gaps', () => {
   ruleTester.run('allowlist and path-extraction branches', noUnsafeCopyFrom, {
-    valid: [
+    valid: pg([
       {
         name: 'template literal (no expressions) with allowlisted path',
         code: 'client.query(`COPY t FROM \'/data/ok.csv\'`);',
@@ -52,8 +68,8 @@ describe('no-unsafe-copy-from — coverage gaps', () => {
         name: 'member-expression query argument falls through all cases',
         code: `client.query(cfg.sql);`,
       },
-    ],
-    invalid: [
+    ]),
+    invalid: pg([
       {
         name: 'COPY FROM PROGRAM has no extractable quoted path (still hardcoded)',
         code: `client.query("COPY t FROM PROGRAM 'gzip -dc backup.gz'");`,
@@ -71,6 +87,6 @@ describe('no-unsafe-copy-from — coverage gaps', () => {
         options: [{ allowedPaths: ['^/data/'] }],
         errors: [{ messageId: 'hardcodedPath' }],
       },
-    ],
+    ]),
   });
 });

--- a/packages/eslint-plugin-postgresql-security/src/rules/no-unsafe-copy-from/index.spec.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/no-unsafe-copy-from/index.spec.ts
@@ -2,6 +2,22 @@ import { RuleTester } from '@typescript-eslint/rule-tester';
 import * as parser from '@typescript-eslint/parser';
 import { noUnsafeCopyFrom } from './index';
 
+/**
+ * Every fixture imports a PostgreSQL client, because the rule now abstains in
+ * files that use no PostgreSQL at all. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the import
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const withPg = (code: string): string => `import { Pool } from 'pg';\n${code}`;
+const pg = <T,>(cases: T[]): T[] =>
+  cases.map((c) =>
+    typeof c === 'string'
+      ? (withPg(c) as T)
+      : ({ ...c, code: withPg((c as { code: string }).code) } as T),
+  );
+
+
 const ruleTester = new RuleTester({
   languageOptions: {
     parser,
@@ -9,7 +25,7 @@ const ruleTester = new RuleTester({
 });
 
 ruleTester.run('no-unsafe-copy-from', noUnsafeCopyFrom, {
-  valid: [
+  valid: pg([
     // ===========================================
     // STDIN patterns (always safe)
     // ===========================================
@@ -135,9 +151,9 @@ ruleTester.run('no-unsafe-copy-from', noUnsafeCopyFrom, {
       name: 'COPY TO is not flagged (different rule)',
       code: "client.query(\"COPY users TO '/tmp/export.csv'\")",
     },
-  ],
+  ]),
 
-  invalid: [
+  invalid: pg([
     // ===========================================
     // Dynamic paths - CRITICAL (injection risk)
     // ===========================================
@@ -270,5 +286,5 @@ ruleTester.run('no-unsafe-copy-from', noUnsafeCopyFrom, {
       options: [{ allowedPaths: ['^/var/', '^/tmp/'] }],
       errors: [{ messageId: 'hardcodedPath' }],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-postgresql-security/src/rules/no-unsafe-copy-from/index.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/no-unsafe-copy-from/index.ts
@@ -6,6 +6,7 @@
 
 import { TSESLint, AST_NODE_TYPES, TSESTree, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
 import { NoUnsafeCopyFromOptions } from '../../types';
+import { fileUsesPostgres } from '../../utils';
 
 // Pre-compiled regex patterns for performance
 const COPY_FROM_REGEX = /\bCOPY\b.*\bFROM\b/i;
@@ -90,6 +91,12 @@ export const noUnsafeCopyFrom: TSESLint.RuleModule<
   },
   defaultOptions: [{}],
   create(context) {
+    // Every rule here is PostgreSQL-specific, and none of them knew it: over
+    // 108,838 files, 94% of this plugin's findings were in files with no
+    // PostgreSQL client at all. Registering no visitors is both the gate and
+    // the cheap path — a file with no database in it does no work.
+    if (!fileUsesPostgres(context.sourceCode.ast)) return {};
+
     const options = context.options[0] ?? {};
     const allowHardcodedPaths = options.allowHardcodedPaths ?? false;
     const allowedPaths = (options.allowedPaths ?? []).map((p: string) => new RegExp(p));

--- a/packages/eslint-plugin-postgresql-security/src/rules/no-unsafe-copy-from/no-unsafe-copy-from.test.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/no-unsafe-copy-from/no-unsafe-copy-from.test.ts
@@ -10,6 +10,22 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { noUnsafeCopyFrom } from './index';
 
+/**
+ * Every fixture imports a PostgreSQL client, because the rule now abstains in
+ * files that use no PostgreSQL at all. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the import
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const withPg = (code: string): string => `import { Pool } from 'pg';\n${code}`;
+const pg = <T,>(cases: T[]): T[] =>
+  cases.map((c) =>
+    typeof c === 'string'
+      ? (withPg(c) as T)
+      : ({ ...c, code: withPg((c as { code: string }).code) } as T),
+  );
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -27,7 +43,7 @@ const ruleTester = new RuleTester({
 describe('no-unsafe-copy-from', () => {
   describe('Valid Code', () => {
     ruleTester.run('valid - safe patterns', noUnsafeCopyFrom, {
-      valid: [
+      valid: pg([
         // Unrelated code should not trigger
         {
           code: `const x = 1;`,
@@ -48,7 +64,7 @@ describe('no-unsafe-copy-from', () => {
         {
           code: `const safe4 = process.env.DB_HOST;`,
         },
-      ],
+      ]),
       invalid: [],
     });
   });
@@ -56,7 +72,7 @@ describe('no-unsafe-copy-from', () => {
   describe('Invalid Code', () => {
     ruleTester.run('invalid - dangerous patterns', noUnsafeCopyFrom, {
       valid: [],
-      invalid: [
+      invalid: pg([
         // Triggers dynamicPath
         {
           code: `client.query(\`COPY users FROM '\${filePath}'\`)`,
@@ -72,7 +88,7 @@ describe('no-unsafe-copy-from', () => {
           code: `client.query('COPY users FROM ' + filePath)`,
           errors: [{ messageId: 'dynamicPath' }],
         },
-      ],
+      ]),
     });
   });
 });

--- a/packages/eslint-plugin-postgresql-security/src/rules/no-unsafe-query/coverage-gaps.spec.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/no-unsafe-query/coverage-gaps.spec.ts
@@ -14,6 +14,22 @@ import { describe, it, afterAll } from 'vitest';
 import * as parser from '@typescript-eslint/parser';
 import { noUnsafeQuery } from './index';
 
+/**
+ * Every fixture imports a PostgreSQL client, because the rule now abstains in
+ * files that use no PostgreSQL at all. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the import
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const withPg = (code: string): string => `import { Pool } from 'pg';\n${code}`;
+const pg = <T,>(cases: T[]): T[] =>
+  cases.map((c) =>
+    typeof c === 'string'
+      ? (withPg(c) as T)
+      : ({ ...c, code: withPg((c as { code: string }).code) } as T),
+  );
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -28,7 +44,7 @@ const ruleTester = new RuleTester({
 
 describe('no-unsafe-query — coverage gaps', () => {
   ruleTester.run('taint-listener guards', noUnsafeQuery, {
-    valid: [
+    valid: pg([
       {
         name: 'declarator without init is not tracked',
         code: `let q; db.query('SELECT 1');`,
@@ -49,13 +65,13 @@ describe('no-unsafe-query — coverage gaps', () => {
         name: 'member-expression += target is ignored',
         code: `state.q += 'a' + suffix; db.query(state.q);`,
       },
-    ],
-    invalid: [
+    ]),
+    invalid: pg([
       {
         name: 'template-tainted variable via += reports unsafeTemplateLiteral',
         code: 'let q = "SELECT 1"; q += ` AND id = ${id}`; db.query(q);',
         errors: [{ messageId: 'unsafeTemplateLiteral' }],
       },
-    ],
+    ]),
   });
 });

--- a/packages/eslint-plugin-postgresql-security/src/rules/no-unsafe-query/index.spec.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/no-unsafe-query/index.spec.ts
@@ -3,6 +3,22 @@ import { describe, it, afterAll } from 'vitest';
 import * as parser from '@typescript-eslint/parser';
 import { noUnsafeQuery } from './index';
 
+/**
+ * Every fixture imports a PostgreSQL client, because the rule now abstains in
+ * files that use no PostgreSQL at all. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the import
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const withPg = (code: string): string => `import { Pool } from 'pg';\n${code}`;
+const pg = <T,>(cases: T[]): T[] =>
+  cases.map((c) =>
+    typeof c === 'string'
+      ? (withPg(c) as T)
+      : ({ ...c, code: withPg((c as { code: string }).code) } as T),
+  );
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -19,7 +35,7 @@ const ruleTester = new RuleTester({
 describe('no-unsafe-query', () => {
   describe('Valid - Parameterized Queries', () => {
     ruleTester.run('valid - safe queries', noUnsafeQuery, {
-      valid: [
+      valid: pg([
         // Ignored cases (coverage)
         "client.query()", // Empty args
         "client.other('SELECT ' + 1)", // Not query method
@@ -35,7 +51,7 @@ describe('no-unsafe-query', () => {
         "client.query(format('SELECT * FROM %I', table))",
         // Variable with safe init (no concat/template)
         `const query = 'SELECT * FROM users'; db.query(query);`,
-      ],
+      ]),
       invalid: [],
     });
   });
@@ -43,7 +59,7 @@ describe('no-unsafe-query', () => {
   describe('Invalid - Direct Concatenation/Interpolation', () => {
     ruleTester.run('invalid - direct', noUnsafeQuery, {
       valid: [],
-      invalid: [
+      invalid: pg([
         {
           code: "client.query('SELECT * FROM users WHERE id = ' + id)",
           errors: [{ messageId: 'noUnsafeQuery' }],
@@ -56,14 +72,14 @@ describe('no-unsafe-query', () => {
           code: "client.query('INSERT INTO users VALUES (' + val + ')')",
           errors: [{ messageId: 'noUnsafeQuery' }],
         },
-      ],
+      ]),
     });
   });
 
   describe('Invalid - Variable Taint Tracking', () => {
     ruleTester.run('invalid - tainted variables', noUnsafeQuery, {
       valid: [],
-      invalid: [
+      invalid: pg([
         // vuln_sql_string_concat — concat assigned to variable, then passed to .query()
         {
           code: `
@@ -97,7 +113,7 @@ describe('no-unsafe-query', () => {
           `,
           errors: [{ messageId: 'unsafeTemplateLiteral' }],
         },
-      ],
+      ]),
     });
   });
 });

--- a/packages/eslint-plugin-postgresql-security/src/rules/no-unsafe-query/index.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/no-unsafe-query/index.ts
@@ -6,6 +6,7 @@
 
 import { TSESLint, AST_NODE_TYPES, TSESTree, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
 import { NoUnsafeQueryOptions } from '../../types';
+import { fileUsesPostgres } from '../../utils';
 
 /**
  * Check if a node contains unsafe string construction (concatenation or interpolation)
@@ -67,6 +68,12 @@ export const noUnsafeQuery: TSESLint.RuleModule<
   },
   defaultOptions: [],
   create(context) {
+    // Every rule here is PostgreSQL-specific, and none of them knew it: over
+    // 108,838 files, 94% of this plugin's findings were in files with no
+    // PostgreSQL client at all. Registering no visitors is both the gate and
+    // the cheap path — a file with no database in it does no work.
+    if (!fileUsesPostgres(context.sourceCode.ast)) return {};
+
     // Track variables tainted by unsafe string construction
     const taintedVariables = new Map<string, 'concat' | 'template'>();
 

--- a/packages/eslint-plugin-postgresql-security/src/rules/no-unsafe-query/no-unsafe-query.test.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/no-unsafe-query/no-unsafe-query.test.ts
@@ -10,6 +10,22 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { noUnsafeQuery } from './index';
 
+/**
+ * Every fixture imports a PostgreSQL client, because the rule now abstains in
+ * files that use no PostgreSQL at all. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the import
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const withPg = (code: string): string => `import { Pool } from 'pg';\n${code}`;
+const pg = <T,>(cases: T[]): T[] =>
+  cases.map((c) =>
+    typeof c === 'string'
+      ? (withPg(c) as T)
+      : ({ ...c, code: withPg((c as { code: string }).code) } as T),
+  );
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -27,7 +43,7 @@ const ruleTester = new RuleTester({
 describe('no-unsafe-query', () => {
   describe('Valid Code', () => {
     ruleTester.run('valid - safe patterns', noUnsafeQuery, {
-      valid: [
+      valid: pg([
         // Unrelated code should not trigger
         {
           code: `const x = 1;`,
@@ -48,7 +64,7 @@ describe('no-unsafe-query', () => {
         {
           code: `const safe4 = process.env.DB_HOST;`,
         },
-      ],
+      ]),
       invalid: [],
     });
   });
@@ -56,7 +72,7 @@ describe('no-unsafe-query', () => {
   describe('Invalid Code', () => {
     ruleTester.run('invalid - dangerous patterns', noUnsafeQuery, {
       valid: [],
-      invalid: [
+      invalid: pg([
         // Triggers noUnsafeQuery
         {
           code: `client.query('SELECT * FROM users WHERE id = ' + userId)`,
@@ -67,7 +83,7 @@ describe('no-unsafe-query', () => {
           code: 'client.query(`SELECT * FROM users WHERE id = ${userId}`)',
           errors: [{ messageId: 'unsafeTemplateLiteral' }],
         },
-      ],
+      ]),
     });
   });
 });

--- a/packages/eslint-plugin-postgresql-security/src/rules/no-unsafe-search-path/index.spec.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/no-unsafe-search-path/index.spec.ts
@@ -2,6 +2,22 @@ import { RuleTester } from '@typescript-eslint/rule-tester';
 import * as parser from '@typescript-eslint/parser';
 import { noUnsafeSearchPath } from './index';
 
+/**
+ * Every fixture imports a PostgreSQL client, because the rule now abstains in
+ * files that use no PostgreSQL at all. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the import
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const withPg = (code: string): string => `import { Pool } from 'pg';\n${code}`;
+const pg = <T,>(cases: T[]): T[] =>
+  cases.map((c) =>
+    typeof c === 'string'
+      ? (withPg(c) as T)
+      : ({ ...c, code: withPg((c as { code: string }).code) } as T),
+  );
+
+
 const ruleTester = new RuleTester({
   languageOptions: {
     parser,
@@ -9,7 +25,7 @@ const ruleTester = new RuleTester({
 });
 
 ruleTester.run('no-unsafe-search-path', noUnsafeSearchPath, {
-  valid: [
+  valid: pg([
     "client.query('SET search_path = public, my_schema')",
     "pool.query(`SET search_path TO public`)",
     // Not search_path related
@@ -28,8 +44,8 @@ ruleTester.run('no-unsafe-search-path', noUnsafeSearchPath, {
     "client.query('SELECT 1')",
     // Line 138: format() call with all literals (safe - line 146)
     "client.query(format('SET search_path = %I', 'public'))",
-  ],
-  invalid: [
+  ]),
+  invalid: pg([
     {
       code: "client.query('SET search_path = ' + userSchema)",
       errors: [{ messageId: 'noUnsafeSearchPath' }],
@@ -42,5 +58,5 @@ ruleTester.run('no-unsafe-search-path', noUnsafeSearchPath, {
       code: "client.query(format('SET search_path = %I', schema))",
       errors: [{ messageId: 'noUnsafeSearchPath' }],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-postgresql-security/src/rules/no-unsafe-search-path/index.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/no-unsafe-search-path/index.ts
@@ -6,6 +6,7 @@
 
 import { TSESLint, AST_NODE_TYPES, TSESTree, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
 import { NoUnsafeSearchPathOptions } from '../../types';
+import { fileUsesPostgres } from '../../utils';
 
 // Pre-compiled pattern check for search_path
 const hasSearchPath = (str: string) => str.toLowerCase().includes('set search_path');
@@ -40,6 +41,12 @@ export const noUnsafeSearchPath: TSESLint.RuleModule<
   },
   defaultOptions: [],
   create(context) {
+    // Every rule here is PostgreSQL-specific, and none of them knew it: over
+    // 108,838 files, 94% of this plugin's findings were in files with no
+    // PostgreSQL client at all. Registering no visitors is both the gate and
+    // the cheap path — a file with no database in it does no work.
+    if (!fileUsesPostgres(context.sourceCode.ast)) return {};
+
     return {
       CallExpression(node: TSESTree.CallExpression) {
         if (

--- a/packages/eslint-plugin-postgresql-security/src/rules/no-unsafe-search-path/no-unsafe-search-path.test.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/no-unsafe-search-path/no-unsafe-search-path.test.ts
@@ -10,6 +10,22 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { noUnsafeSearchPath } from './index';
 
+/**
+ * Every fixture imports a PostgreSQL client, because the rule now abstains in
+ * files that use no PostgreSQL at all. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the import
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const withPg = (code: string): string => `import { Pool } from 'pg';\n${code}`;
+const pg = <T,>(cases: T[]): T[] =>
+  cases.map((c) =>
+    typeof c === 'string'
+      ? (withPg(c) as T)
+      : ({ ...c, code: withPg((c as { code: string }).code) } as T),
+  );
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -27,7 +43,7 @@ const ruleTester = new RuleTester({
 describe('no-unsafe-search-path', () => {
   describe('Valid Code', () => {
     ruleTester.run('valid - safe patterns', noUnsafeSearchPath, {
-      valid: [
+      valid: pg([
         // Unrelated code should not trigger
         {
           code: `const x = 1;`,
@@ -48,7 +64,7 @@ describe('no-unsafe-search-path', () => {
         {
           code: `const safe4 = process.env.DB_HOST;`,
         },
-      ],
+      ]),
       invalid: [],
     });
   });
@@ -56,13 +72,13 @@ describe('no-unsafe-search-path', () => {
   describe('Invalid Code', () => {
     ruleTester.run('invalid - dangerous patterns', noUnsafeSearchPath, {
       valid: [],
-      invalid: [
+      invalid: pg([
         // Triggers noUnsafeSearchPath
         {
           code: `client.query(\`SET search_path TO \${schema}\`)`,
           errors: [{ messageId: 'noUnsafeSearchPath' }],
         },
-      ],
+      ]),
     });
   });
 });

--- a/packages/eslint-plugin-postgresql-security/src/rules/prefer-pool-query/coverage-gaps.spec.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/prefer-pool-query/coverage-gaps.spec.ts
@@ -19,6 +19,42 @@ import * as parser from '@typescript-eslint/parser';
 import { createWithMockContext } from '@interlace/eslint-devkit';
 import { preferPoolQuery } from './index';
 
+/**
+ * The synthetic Program the module gate reads. These tests drive listeners
+ * directly, so the file they stand for has to carry the same PostgreSQL
+ * evidence a real one would — otherwise the rule registers no listeners and
+ * the gap under test is never reached.
+ */
+const PG_AST = {
+  type: 'Program',
+  body: [
+    {
+      type: 'ImportDeclaration',
+      source: { type: 'Literal', value: 'pg' },
+      specifiers: [],
+    },
+  ],
+  tokens: [],
+  comments: [],
+} as never;
+
+
+/**
+ * Every fixture imports a PostgreSQL client, because the rule now abstains in
+ * files that use no PostgreSQL at all. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the import
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const withPg = (code: string): string => `import { Pool } from 'pg';\n${code}`;
+const pg = <T,>(cases: T[]): T[] =>
+  cases.map((c) =>
+    typeof c === 'string'
+      ? (withPg(c) as T)
+      : ({ ...c, code: withPg((c as { code: string }).code) } as T),
+  );
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -34,7 +70,7 @@ const ruleTester = new RuleTester({
 describe('prefer-pool-query — coverage gaps (Layer 1)', () => {
   ruleTester.run('uninvoked query member access', preferPoolQuery, {
     valid: [],
-    invalid: [
+    invalid: pg([
       {
         name: 'client.query referenced without a call still counts as single-query usage',
         code: `
@@ -46,13 +82,13 @@ describe('prefer-pool-query — coverage gaps (Layer 1)', () => {
         `,
         errors: [{ messageId: 'preferPoolQuery' }],
       },
-    ],
+    ]),
   });
 });
 
 describe('prefer-pool-query — coverage gaps (Layer 2, synthetic AST)', () => {
   it('returns silently when the declarator resolves to no variable', () => {
-    const { listeners, reports } = createWithMockContext(preferPoolQuery);
+    const { listeners, reports } = createWithMockContext(preferPoolQuery, { ast: PG_AST });
     const node = {
       type: 'VariableDeclarator',
       id: { type: 'Identifier', name: 'client' },

--- a/packages/eslint-plugin-postgresql-security/src/rules/prefer-pool-query/index.spec.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/prefer-pool-query/index.spec.ts
@@ -2,6 +2,22 @@ import { RuleTester } from '@typescript-eslint/rule-tester';
 import * as parser from '@typescript-eslint/parser';
 import { preferPoolQuery } from './index';
 
+/**
+ * Every fixture imports a PostgreSQL client, because the rule now abstains in
+ * files that use no PostgreSQL at all. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the import
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const withPg = (code: string): string => `import { Pool } from 'pg';\n${code}`;
+const pg = <T,>(cases: T[]): T[] =>
+  cases.map((c) =>
+    typeof c === 'string'
+      ? (withPg(c) as T)
+      : ({ ...c, code: withPg((c as { code: string }).code) } as T),
+  );
+
+
 const ruleTester = new RuleTester({
   languageOptions: {
     parser,
@@ -9,7 +25,7 @@ const ruleTester = new RuleTester({
 });
 
 ruleTester.run('prefer-pool-query', preferPoolQuery, {
-  valid: [
+  valid: pg([
     `
     async function valid() {
       const client = await pool.connect();
@@ -68,8 +84,8 @@ ruleTester.run('prefer-pool-query', preferPoolQuery, {
       client.release();
     }
     `,
-  ],
-  invalid: [
+  ]),
+  invalid: pg([
     {
       code: `
       async function invalid() {
@@ -93,5 +109,5 @@ ruleTester.run('prefer-pool-query', preferPoolQuery, {
        `,
        errors: [{ messageId: 'preferPoolQuery' }],
     }
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-postgresql-security/src/rules/prefer-pool-query/index.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/prefer-pool-query/index.ts
@@ -6,6 +6,7 @@
 
 import { TSESLint, AST_NODE_TYPES, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
 import { PreferPoolQueryOptions } from '../../types';
+import { fileUsesPostgres } from '../../utils';
 
 export const preferPoolQuery: TSESLint.RuleModule<
   'preferPoolQuery',
@@ -33,6 +34,12 @@ export const preferPoolQuery: TSESLint.RuleModule<
   },
   defaultOptions: [],
   create(context) {
+    // Every rule here is PostgreSQL-specific, and none of them knew it: over
+    // 108,838 files, 94% of this plugin's findings were in files with no
+    // PostgreSQL client at all. Registering no visitors is both the gate and
+    // the cheap path — a file with no database in it does no work.
+    if (!fileUsesPostgres(context.sourceCode.ast)) return {};
+
     return {
       VariableDeclarator(node) {
         // Look for: const client = await pool.connect()

--- a/packages/eslint-plugin-postgresql-security/src/rules/prefer-pool-query/prefer-pool-query.test.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/prefer-pool-query/prefer-pool-query.test.ts
@@ -10,6 +10,22 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { preferPoolQuery } from './index';
 
+/**
+ * Every fixture imports a PostgreSQL client, because the rule now abstains in
+ * files that use no PostgreSQL at all. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the import
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const withPg = (code: string): string => `import { Pool } from 'pg';\n${code}`;
+const pg = <T,>(cases: T[]): T[] =>
+  cases.map((c) =>
+    typeof c === 'string'
+      ? (withPg(c) as T)
+      : ({ ...c, code: withPg((c as { code: string }).code) } as T),
+  );
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -27,7 +43,7 @@ const ruleTester = new RuleTester({
 describe('prefer-pool-query', () => {
   describe('Valid Code', () => {
     ruleTester.run('valid - safe patterns', preferPoolQuery, {
-      valid: [
+      valid: pg([
         // Unrelated code should not trigger
         {
           code: `const x = 1;`,
@@ -48,7 +64,7 @@ describe('prefer-pool-query', () => {
         {
           code: `const safe4 = process.env.DB_HOST;`,
         },
-      ],
+      ]),
       invalid: [],
     });
   });
@@ -56,13 +72,13 @@ describe('prefer-pool-query', () => {
   describe('Invalid Code', () => {
     ruleTester.run('invalid - dangerous patterns', preferPoolQuery, {
       valid: [],
-      invalid: [
+      invalid: pg([
         // Triggers preferPoolQuery
         {
           code: `async function test() { const client = await pool.connect(); await client.query('SELECT 1'); client.release(); }`,
           errors: [{ messageId: 'preferPoolQuery' }],
         },
-      ],
+      ]),
     });
   });
 });

--- a/packages/eslint-plugin-postgresql-security/src/rules/prevent-double-release/coverage-gaps.spec.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/prevent-double-release/coverage-gaps.spec.ts
@@ -22,6 +22,42 @@ import * as parser from '@typescript-eslint/parser';
 import { createWithMockContext } from '@interlace/eslint-devkit';
 import { preventDoubleRelease } from './index';
 
+/**
+ * The synthetic Program the module gate reads. These tests drive listeners
+ * directly, so the file they stand for has to carry the same PostgreSQL
+ * evidence a real one would — otherwise the rule registers no listeners and
+ * the gap under test is never reached.
+ */
+const PG_AST = {
+  type: 'Program',
+  body: [
+    {
+      type: 'ImportDeclaration',
+      source: { type: 'Literal', value: 'pg' },
+      specifiers: [],
+    },
+  ],
+  tokens: [],
+  comments: [],
+} as never;
+
+
+/**
+ * Every fixture imports a PostgreSQL client, because the rule now abstains in
+ * files that use no PostgreSQL at all. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the import
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const withPg = (code: string): string => `import { Pool } from 'pg';\n${code}`;
+const pg = <T,>(cases: T[]): T[] =>
+  cases.map((c) =>
+    typeof c === 'string'
+      ? (withPg(c) as T)
+      : ({ ...c, code: withPg((c as { code: string }).code) } as T),
+  );
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -36,7 +72,7 @@ const ruleTester = new RuleTester({
 
 describe('prevent-double-release — coverage gaps (Layer 1)', () => {
   ruleTester.run('guard-name variants', preventDoubleRelease, {
-    valid: [
+    valid: pg([
       {
         name: 'both releases guarded by member flags: .released then .done',
         code: `
@@ -57,8 +93,8 @@ describe('prevent-double-release — coverage gaps (Layer 1)', () => {
           }
         `,
       },
-    ],
-    invalid: [
+    ]),
+    invalid: pg([
       {
         name: 'computed-member guard is not recognized as a guard',
         code: `
@@ -70,12 +106,12 @@ describe('prevent-double-release — coverage gaps (Layer 1)', () => {
         `,
         errors: [{ messageId: 'doubleRelease' }],
       },
-    ],
+    ]),
   });
 
   ruleTester.run('same-if branch combinations', preventDoubleRelease, {
     valid: [],
-    invalid: [
+    invalid: pg([
       {
         name: 'both releases inside the same if (no else) — sequential in block',
         code: `
@@ -96,11 +132,11 @@ describe('prevent-double-release — coverage gaps (Layer 1)', () => {
         `,
         errors: [{ messageId: 'doubleRelease' }],
       },
-    ],
+    ]),
   });
 
   ruleTester.run('switch-case exits', preventDoubleRelease, {
-    valid: [
+    valid: pg([
       {
         name: 'each case exits with break — no fallthrough double release',
         code: `
@@ -147,12 +183,12 @@ describe('prevent-double-release — coverage gaps (Layer 1)', () => {
           }
         `,
       },
-    ],
+    ]),
     invalid: [],
   });
 
   ruleTester.run('scope and statement-shape guards', preventDoubleRelease, {
-    valid: [
+    valid: pg([
       {
         name: 'releases in different arrow functions are not paired',
         code: `
@@ -201,13 +237,13 @@ describe('prevent-double-release — coverage gaps (Layer 1)', () => {
           }
         `,
       },
-    ],
+    ]),
     invalid: [],
   });
 
   ruleTester.run('if-branch exit analysis (ifBranchHasExitAfterRelease)', preventDoubleRelease, {
     valid: [],
-    invalid: [
+    invalid: pg([
       {
         name: 'release in else-block of finally, then unconditional release',
         code: `
@@ -280,11 +316,11 @@ describe('prevent-double-release — coverage gaps (Layer 1)', () => {
         `,
         errors: [{ messageId: 'doubleRelease' }],
       },
-    ],
+    ]),
   });
 
   ruleTester.run('try-catch-finally interplay', preventDoubleRelease, {
-    valid: [
+    valid: pg([
       {
         name: 'guarded-if release with return inside finally, then tail release',
         code: `
@@ -319,8 +355,8 @@ describe('prevent-double-release — coverage gaps (Layer 1)', () => {
           }
         `,
       },
-    ],
-    invalid: [
+    ]),
+    invalid: pg([
       {
         name: 'inner-catch release then release later in the outer try block',
         code: `
@@ -345,11 +381,11 @@ describe('prevent-double-release — coverage gaps (Layer 1)', () => {
         `,
         errors: [{ messageId: 'doubleRelease' }],
       },
-    ],
+    ]),
   });
 
   ruleTester.run('expression-form releases (Case 13)', preventDoubleRelease, {
-    valid: [
+    valid: pg([
       {
         name: 'logical-expression release inside a declarator (walk ends at Program)',
         code: `
@@ -380,8 +416,8 @@ describe('prevent-double-release — coverage gaps (Layer 1)', () => {
           }
         `,
       },
-    ],
-    invalid: [
+    ]),
+    invalid: pg([
       {
         name: 'ternary release then sequential release in the same block',
         code: `
@@ -393,7 +429,7 @@ describe('prevent-double-release — coverage gaps (Layer 1)', () => {
         `,
         errors: [{ messageId: 'doubleRelease' }],
       },
-    ],
+    ]),
   });
 });
 
@@ -446,6 +482,7 @@ function attachAsStatement(
 function runDeclaratorListener(referenceIdentifiers: SyntheticNode[]) {
   const { listeners, reports, context } = createWithMockContext(
     preventDoubleRelease,
+    { ast: PG_AST },
   );
   const variable = {
     defs: [

--- a/packages/eslint-plugin-postgresql-security/src/rules/prevent-double-release/index.spec.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/prevent-double-release/index.spec.ts
@@ -2,6 +2,22 @@ import { RuleTester } from '@typescript-eslint/rule-tester';
 import * as parser from '@typescript-eslint/parser';
 import { preventDoubleRelease } from './index';
 
+/**
+ * Every fixture imports a PostgreSQL client, because the rule now abstains in
+ * files that use no PostgreSQL at all. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the import
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const withPg = (code: string): string => `import { Pool } from 'pg';\n${code}`;
+const pg = <T,>(cases: T[]): T[] =>
+  cases.map((c) =>
+    typeof c === 'string'
+      ? (withPg(c) as T)
+      : ({ ...c, code: withPg((c as { code: string }).code) } as T),
+  );
+
+
 const ruleTester = new RuleTester({
   languageOptions: {
     parser,
@@ -9,7 +25,7 @@ const ruleTester = new RuleTester({
 });
 
 ruleTester.run('prevent-double-release', preventDoubleRelease, {
-  valid: [
+  valid: pg([
     // ============================================
     // BASIC VALID PATTERNS
     // ============================================
@@ -292,9 +308,9 @@ ruleTester.run('prevent-double-release', preventDoubleRelease, {
         }
       `,
     },
-  ],
+  ]),
 
-  invalid: [
+  invalid: pg([
     // ============================================
     // BASIC DOUBLE RELEASE
     // ============================================
@@ -820,5 +836,5 @@ ruleTester.run('prevent-double-release', preventDoubleRelease, {
       `,
       errors: [{ messageId: 'doubleRelease' }],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-postgresql-security/src/rules/prevent-double-release/index.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/prevent-double-release/index.ts
@@ -12,6 +12,7 @@ import {
   MessageIcons,
 } from '@interlace/eslint-devkit';
 import { PreventDoubleReleaseOptions } from '../../types';
+import { fileUsesPostgres } from '../../utils';
 
 /**
  * Finds the nearest ancestor of a given type.
@@ -258,6 +259,12 @@ export const preventDoubleRelease: TSESLint.RuleModule<
   },
   defaultOptions: [],
   create(context) {
+    // Every rule here is PostgreSQL-specific, and none of them knew it: over
+    // 108,838 files, 94% of this plugin's findings were in files with no
+    // PostgreSQL client at all. Registering no visitors is both the gate and
+    // the cheap path — a file with no database in it does no work.
+    if (!fileUsesPostgres(context.sourceCode.ast)) return {};
+
     return {
       VariableDeclarator(node: TSESTree.VariableDeclarator) {
         const declaredVariables = context.sourceCode.getDeclaredVariables(node);

--- a/packages/eslint-plugin-postgresql-security/src/rules/prevent-double-release/prevent-double-release.test.ts
+++ b/packages/eslint-plugin-postgresql-security/src/rules/prevent-double-release/prevent-double-release.test.ts
@@ -10,6 +10,22 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { preventDoubleRelease } from './index';
 
+/**
+ * Every fixture imports a PostgreSQL client, because the rule now abstains in
+ * files that use no PostgreSQL at all. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the import
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const withPg = (code: string): string => `import { Pool } from 'pg';\n${code}`;
+const pg = <T,>(cases: T[]): T[] =>
+  cases.map((c) =>
+    typeof c === 'string'
+      ? (withPg(c) as T)
+      : ({ ...c, code: withPg((c as { code: string }).code) } as T),
+  );
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -27,7 +43,7 @@ const ruleTester = new RuleTester({
 describe('prevent-double-release', () => {
   describe('Valid Code', () => {
     ruleTester.run('valid - safe patterns', preventDoubleRelease, {
-      valid: [
+      valid: pg([
         // Unrelated code should not trigger
         {
           code: `const x = 1;`,
@@ -48,7 +64,7 @@ describe('prevent-double-release', () => {
         {
           code: `const safe4 = process.env.DB_HOST;`,
         },
-      ],
+      ]),
       invalid: [],
     });
   });
@@ -56,7 +72,7 @@ describe('prevent-double-release', () => {
   describe('Invalid Code', () => {
     ruleTester.run('invalid - dangerous patterns', preventDoubleRelease, {
       valid: [],
-      invalid: [
+      invalid: pg([
         // Triggers doubleRelease
         {
           code: `async function test() { const client = await pool.connect(); try { await client.query('SELECT 1'); client.release(); } catch(e) { client.release(); } }`,
@@ -64,7 +80,7 @@ describe('prevent-double-release', () => {
         },
         // NOTE: doubleReleaseCallback requires complex scope analysis.
         // Run /write-tests prevent-double-release for comprehensive test coverage.
-      ],
+      ]),
     });
   });
 });

--- a/packages/eslint-plugin-postgresql-security/src/utils/index.test.ts
+++ b/packages/eslint-plugin-postgresql-security/src/utils/index.test.ts
@@ -136,4 +136,29 @@ describe('fileUsesPostgres', () => {
       expect(uses(`import x from '${mod}';`)).toBe(true);
     }
   });
+
+  describe('a locally bound `require` is not module loading', () => {
+    // The plugin's own lesson turned on itself: a *name* is not proof of an
+    // *interface*. Without this, the gate opened every rule on a file with no
+    // PostgreSQL in it at all.
+    it.each([
+      "function f(require) { require('pg'); }",
+      "const load = (require) => require('pg');",
+      "const require = (m) => m; require('pg');",
+      "let require; require('pg');",
+    ])('%s → false', (code) => {
+      expect(uses(code)).toBe(false);
+    });
+
+    it('the other arms still apply when `require` is shadowed', () => {
+      expect(uses("import { Pool } from 'pg';\nfunction f(require) { require('pg'); }")).toBe(true);
+      expect(uses("const url = 'postgres://h/db';\nfunction f(require) { require('pg'); }")).toBe(true);
+    });
+  });
+
+  it('the result is cached per Program, so thirteen rules cost one scan', () => {
+    const ast = parse("import { Pool } from 'pg';", { sourceType: 'module', range: true });
+    expect(fileUsesPostgres(ast)).toBe(true);
+    expect(fileUsesPostgres(ast)).toBe(true);
+  });
 });

--- a/packages/eslint-plugin-postgresql-security/src/utils/index.test.ts
+++ b/packages/eslint-plugin-postgresql-security/src/utils/index.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Tests for the PostgreSQL module gate.
+ *
+ * Every rule in this plugin abstains unless `fileUsesPostgres` says the file
+ * has a PostgreSQL client, so a bug here is a bug in all thirteen at once —
+ * silently, in whichever direction the bug leans.
+ */
+import { describe, it, expect } from 'vitest';
+import { parse } from '@typescript-eslint/parser';
+import { fileUsesPostgres, PG_MODULES } from './index';
+
+const uses = (code: string): boolean =>
+  fileUsesPostgres(parse(code, { sourceType: 'module', range: true }));
+
+describe('fileUsesPostgres', () => {
+  describe('ESM imports', () => {
+    it.each([
+      ["import { Pool } from 'pg';", 'bare package'],
+      ["import Client from 'pg/lib/client';", 'deep path'],
+      ["import { sql } from '@vercel/postgres';", 'scoped package'],
+      ["import x from '@vercel/postgres/edge';", 'scoped deep path'],
+      ["import postgres from 'postgres';", 'postgres.js'],
+      ["import { createPool } from 'slonik';", 'slonik'],
+      ["import 'pg';", 'side-effect import with no specifiers'],
+    ])('%s → true (%s)', (code) => {
+      expect(uses(code)).toBe(true);
+    });
+
+    it.each([
+      ["import { Pool } from 'mysql2';", 'a different driver'],
+      ["import x from 'pgx';", 'a package merely sharing the prefix'],
+      // A local file named after the package is not the package. Without this,
+      // `./pg` would satisfy the gate in a repo that has no `pg` at all.
+      ["import { Pool } from './pg';", 'relative specifier'],
+      ["import { Pool } from '../db/pg';", 'relative parent specifier'],
+      ["import { Pool } from '/pg';", 'absolute specifier'],
+    ])('%s → false (%s)', (code) => {
+      expect(uses(code)).toBe(false);
+    });
+  });
+
+  describe('re-exports', () => {
+    it('`export { Pool } from "pg"` counts', () => {
+      expect(uses("export { Pool } from 'pg';")).toBe(true);
+    });
+
+    it('`export * from "pg"` counts', () => {
+      expect(uses("export * from 'pg';")).toBe(true);
+    });
+
+    it('a re-export of something else does not', () => {
+      expect(uses("export * from './helpers';")).toBe(false);
+    });
+
+    it('a local export with no source does not', () => {
+      expect(uses('export const x = 1;')).toBe(false);
+    });
+  });
+
+  describe('CommonJS requires', () => {
+    it('top-level require counts', () => {
+      expect(uses("const { Pool } = require('pg');")).toBe(true);
+    });
+
+    // `require` can sit anywhere, which is why the gate walks the whole tree
+    // rather than only the top-level statements.
+    it('require inside a function counts', () => {
+      expect(uses('function f() { return require("pg"); }')).toBe(true);
+    });
+
+    it('require inside a conditional branch counts', () => {
+      expect(uses('if (x) { require("pg"); }')).toBe(true);
+    });
+
+    it.each([
+      ["require('mysql2');", 'a different driver'],
+      ["require('./pg');", 'a relative path'],
+      ['require(name);', 'a non-literal specifier'],
+      ['require();', 'no arguments at all'],
+      ['require(123);', 'a non-string literal'],
+      ['notRequire("pg");', 'a differently named function'],
+      ['obj.require("pg");', 'a member call, not the global require'],
+    ])('%s → false (%s)', (code) => {
+      expect(uses(code)).toBe(false);
+    });
+  });
+
+  describe('connection strings', () => {
+    // A config module holding the DSN but importing no driver is exactly where
+    // no-hardcoded-credentials earns its keep, so the DSN is evidence by itself.
+    it.each([
+      "const url = 'postgres://user:pw@host/db';",
+      "const url = 'postgresql://user:pw@host/db';",
+      'const url = `postgres://user:pw@host/db`;',
+      'const url = `postgresql://${user}@host/db`;',
+    ])('%s → true', (code) => {
+      expect(uses(code)).toBe(true);
+    });
+
+    it.each([
+      "const url = 'mysql://user:pw@host/db';",
+      "const url = 'https://example.test/postgres';",
+      'const url = `mysql://${user}@host/db`;',
+      'const n = 5;',
+      'const t = ``;',
+    ])('%s → false', (code) => {
+      expect(uses(code)).toBe(false);
+    });
+  });
+
+  describe('files with no PostgreSQL at all', () => {
+    it('an empty file', () => {
+      expect(uses('')).toBe(false);
+    });
+
+    // The shapes that produced the plugin's false positives: generic method
+    // names on receivers that have nothing to do with PostgreSQL.
+    it.each([
+      'await mongoose.connect(uri);',
+      'const rows = await api.query(userInput);',
+      'redis.connect();',
+      'const all = await Promise.all(tasks);',
+    ])('%s stays outside the gate', (code) => {
+      expect(uses(code)).toBe(false);
+    });
+  });
+
+  it('every declared module is recognised as itself', () => {
+    for (const mod of PG_MODULES) {
+      expect(uses(`import x from '${mod}';`)).toBe(true);
+    }
+  });
+});

--- a/packages/eslint-plugin-postgresql-security/src/utils/index.ts
+++ b/packages/eslint-plugin-postgresql-security/src/utils/index.ts
@@ -87,6 +87,74 @@ function isPgConnectionString(node: TSESTree.Node): boolean {
 }
 
 /**
+ * Whether the file declares a binding named `require` anywhere — a parameter,
+ * a variable, a function.
+ *
+ * `function f(require) { require('pg'); }` is not module loading, and treating
+ * it as PostgreSQL evidence would be this plugin committing the exact error it
+ * was just fixed for: taking a *name* as proof of an *interface*. When the name
+ * is bound locally the `require` arm is dropped entirely; imports, DSNs, and
+ * every other arm still apply.
+ */
+function declaresRequireBinding(ast: TSESTree.Program): boolean {
+  let shadowed = false;
+  // As in `visit` below: no top guard, because every recursive call site here
+  // already checks, which would make it unreachable.
+  const scan = (node: TSESTree.Node): void => {
+    if (
+      (node.type === AST_NODE_TYPES.FunctionDeclaration ||
+        node.type === AST_NODE_TYPES.FunctionExpression ||
+        node.type === AST_NODE_TYPES.ArrowFunctionExpression) &&
+      node.params.some(
+        (p) => p.type === AST_NODE_TYPES.Identifier && p.name === 'require',
+      )
+    ) {
+      shadowed = true;
+      return;
+    }
+    if (
+      node.type === AST_NODE_TYPES.VariableDeclarator &&
+      node.id.type === AST_NODE_TYPES.Identifier &&
+      node.id.name === 'require'
+    ) {
+      shadowed = true;
+      return;
+    }
+    for (const key of Object.keys(node)) {
+      if (key === 'parent') continue;
+      const value = (node as unknown as Record<string, unknown>)[key];
+      if (Array.isArray(value)) {
+        for (const child of value) {
+          if (child && typeof (child as TSESTree.Node).type === 'string') {
+            scan(child as TSESTree.Node);
+            if (shadowed) return;
+          }
+        }
+      } else if (
+        value &&
+        typeof value === 'object' &&
+        typeof (value as TSESTree.Node).type === 'string'
+      ) {
+        scan(value as TSESTree.Node);
+        if (shadowed) return;
+      }
+    }
+  };
+  scan(ast);
+  return shadowed;
+}
+
+/**
+ * One evidence scan per file, not one per rule.
+ *
+ * `create` runs for each of the thirteen rules, so an uncached probe walks the
+ * whole AST thirteen times for every file in the project — and the files that
+ * pay that cost most are the non-PostgreSQL ones the gate exists to skip
+ * cheaply.
+ */
+const cache = new WeakMap<TSESTree.Program, boolean>();
+
+/**
  * Whether this file uses PostgreSQL at all.
  *
  * Every rule in this plugin is gated on it, because none of them had any notion
@@ -104,7 +172,16 @@ function isPgConnectionString(node: TSESTree.Node): boolean {
  * in it at all.
  */
 export function fileUsesPostgres(ast: TSESTree.Program): boolean {
+  const cached = cache.get(ast);
+  if (cached !== undefined) return cached;
+  const result = computeUsesPostgres(ast);
+  cache.set(ast, result);
+  return result;
+}
+
+function computeUsesPostgres(ast: TSESTree.Program): boolean {
   let found = false;
+  const requireIsShadowed = declaresRequireBinding(ast);
 
   // No `if (found) return` guard at the top: every recursive call site below
   // already checks, so it would be unreachable.
@@ -120,7 +197,10 @@ export function fileUsesPostgres(ast: TSESTree.Program): boolean {
       found = true;
       return;
     }
-    if (isPgRequire(node) || isPgConnectionString(node)) {
+    if (
+      (!requireIsShadowed && isPgRequire(node)) ||
+      isPgConnectionString(node)
+    ) {
       found = true;
       return;
     }

--- a/packages/eslint-plugin-postgresql-security/src/utils/index.ts
+++ b/packages/eslint-plugin-postgresql-security/src/utils/index.ts
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+import type { TSESTree } from '@interlace/eslint-devkit';
+import { AST_NODE_TYPES } from '@interlace/eslint-devkit';
+import { PG_PROTOCOLS } from '../constants';
+
+/**
+ * Packages that give a file a PostgreSQL client.
+ *
+ * `postgres` is postgres.js, not a generic name — there is no other package by
+ * that name on npm. Drivers reached through an ORM are deliberately absent:
+ * `knex` configured with the `pg` dialect is knex's rules to enforce, because
+ * the sink decides the plugin.
+ *
+ * @internal
+ */
+export const PG_MODULES: readonly string[] = [
+  'pg',
+  'pg-pool',
+  'pg-native',
+  'pg-cursor',
+  'pg-promise',
+  'pg-copy-streams',
+  'postgres',
+  'slonik',
+  '@vercel/postgres',
+  '@neondatabase/serverless',
+  '@electric-sql/pglite',
+];
+
+const PG_MODULE_SET: ReadonlySet<string> = new Set(PG_MODULES);
+
+/**
+ * Whether an import specifier is a PostgreSQL client.
+ *
+ * Compared on the package root so `pg/lib/client` and `@vercel/postgres/edge`
+ * count. A relative specifier is never a package and is rejected outright —
+ * otherwise `'./pg'` would satisfy the gate in a repo that has no `pg`.
+ */
+function isPgSpecifier(specifier: string): boolean {
+  if (specifier.startsWith('.') || specifier.startsWith('/')) return false;
+  const parts = specifier.split('/');
+  const root = specifier.startsWith('@')
+    ? parts.slice(0, 2).join('/')
+    : parts[0];
+  return PG_MODULE_SET.has(root);
+}
+
+/** `require('pg')` — the CommonJS half of the same evidence. */
+function isPgRequire(node: TSESTree.Node): boolean {
+  if (node.type !== AST_NODE_TYPES.CallExpression) return false;
+  if (
+    node.callee.type !== AST_NODE_TYPES.Identifier ||
+    node.callee.name !== 'require'
+  ) {
+    return false;
+  }
+  const [arg] = node.arguments;
+  return (
+    arg?.type === AST_NODE_TYPES.Literal &&
+    typeof arg.value === 'string' &&
+    isPgSpecifier(arg.value)
+  );
+}
+
+/**
+ * A `postgres://` / `postgresql://` connection string is PostgreSQL evidence in
+ * its own right. Without this, a config module that holds the DSN but imports
+ * no driver would fall outside the gate — and that module is exactly where
+ * `no-hardcoded-credentials` earns its keep.
+ */
+function isPgConnectionString(node: TSESTree.Node): boolean {
+  const value =
+    node.type === AST_NODE_TYPES.Literal && typeof node.value === 'string'
+      ? node.value
+      : node.type === AST_NODE_TYPES.TemplateLiteral
+        ? node.quasis[0]?.value.cooked
+        : undefined;
+  return (
+    value !== undefined &&
+    PG_PROTOCOLS.some((protocol) => value.startsWith(protocol))
+  );
+}
+
+/**
+ * Whether this file uses PostgreSQL at all.
+ *
+ * Every rule in this plugin is gated on it, because none of them had any notion
+ * of it before. `no-missing-client-release` fired on any `.connect()` — mongoose,
+ * redis, socket.io — and `no-unsafe-query` on any `.query()`. Measured over
+ * 108,838 files across 108 repositories, **94% of everything this plugin
+ * reported (1,222 of 1,305 findings) was in a file with no PostgreSQL client**,
+ * and two rules were wrong 100% of the time.
+ *
+ * The evidence is local by design: an import, a `require`, or a DSN in this
+ * file. Nothing is read from `package.json` and nothing is resolved across
+ * files, so there is no project state to go stale and no dependency on lint
+ * order. A file that reaches PostgreSQL only through a wrapper module is a
+ * miss — the deliberate trade against reporting on code that has no database
+ * in it at all.
+ */
+export function fileUsesPostgres(ast: TSESTree.Program): boolean {
+  let found = false;
+
+  // No `if (found) return` guard at the top: every recursive call site below
+  // already checks, so it would be unreachable.
+  const visit = (node: TSESTree.Node): void => {
+    if (
+      (node.type === AST_NODE_TYPES.ImportDeclaration ||
+        node.type === AST_NODE_TYPES.ExportNamedDeclaration ||
+        node.type === AST_NODE_TYPES.ExportAllDeclaration) &&
+      node.source?.type === AST_NODE_TYPES.Literal &&
+      typeof node.source.value === 'string' &&
+      isPgSpecifier(node.source.value)
+    ) {
+      found = true;
+      return;
+    }
+    if (isPgRequire(node) || isPgConnectionString(node)) {
+      found = true;
+      return;
+    }
+    // `require` can sit anywhere — inside a function, a branch, an IIFE — so
+    // the whole tree is walked rather than just the top-level statements.
+    for (const key of Object.keys(node)) {
+      if (key === 'parent') continue;
+      const value = (node as unknown as Record<string, unknown>)[key];
+      if (Array.isArray(value)) {
+        for (const child of value) {
+          if (child && typeof (child as TSESTree.Node).type === 'string') {
+            visit(child as TSESTree.Node);
+            if (found) return;
+          }
+        }
+      } else if (
+        value &&
+        typeof (value as TSESTree.Node).type === 'string' &&
+        typeof value === 'object'
+      ) {
+        visit(value as TSESTree.Node);
+        if (found) return;
+      }
+    }
+  };
+
+  visit(ast);
+  return found;
+}


### PR DESCRIPTION
## Summary

`eslint-plugin-postgresql-security` had **no notion of whether a file used PostgreSQL at all** — no import resolution, no receiver identity, nothing. Rules matched on method name alone:

- `no-missing-client-release` fired on any `.connect()` — mongoose, redis, socket.io
- `no-unsafe-query` fired on any `.query()`
- `no-select-all` fired on `SELECT *` inside any string in any file

Measured over **108,838 files across 108 repositories**:

| | findings | in a file with **no** PostgreSQL client |
|---|---|---|
| before | 1,305 | **1,222 (94%)** |
| after | 100 | 17 |

Two rules were wrong **100%** of the time: `no-missing-client-release` (49 findings, 0 in a PostgreSQL file) and `prevent-double-release`.

Per-rule, findings in files with no PostgreSQL, before → after:

| rule | before | after |
|---|---|---|
| `no-unsafe-query` | 751 | 9 |
| `no-batch-insert-loop` | 346 | 0 |
| `no-select-all` | 63 | 0 |
| `no-missing-client-release` | 49 | 0 |
| `no-unsafe-search-path` | 8 | 8 † |
| `no-floating-query` | 4 | 0 |
| `prevent-double-release` | 1 | 0 |

† the harness's "has pg" probe is a narrower regex than the gate — those 8 files carry evidence the gate accepts (a `require`, or a DSN) that the probe does not look for.

## What changed

All thirteen rules gate on a new `fileUsesPostgres`, which accepts:

- an **import** or **`require`** of a PostgreSQL client, matched on the package root so `pg/lib/client` and `@vercel/postgres/edge` count, and relative/absolute specifiers never do (`'./pg'` must not satisfy the gate in a repo with no `pg`)
- a **`postgres://` / `postgresql://` connection string** in the file — a config module holding the DSN but importing no driver is exactly where `no-hardcoded-credentials` earns its keep

The evidence is **local by design**: nothing read from `package.json`, nothing resolved across files. No project state to go stale, no dependency on lint order. Gating by registering no visitors also makes the non-PostgreSQL case free rather than merely silent.

A file that reaches PostgreSQL only through a wrapper module is a deliberate miss — the trade against reporting on code with no database in it.

## Test plan

- [x] **Registry-wide lock** — `src/module-gate.lock.test.ts` sweeps *every* rule in `plugin.rules` over six real false-positive shapes taken from the corpus (mongoose, redis, an HTTP client named `api`, a MySQL project, a file with no database, and a local module named `./pg`). A rule added later is covered the day it lands; revert the gate in any one rule and this goes red.
- [x] **The lock has a positive control, and it earned its place.** The first version passed vacuously: `Linter.verify` with no filename lints `<input>`, which matches no `files` entry, so every rule was skipped and all 78 negatives passed *without running a single rule*. The positive assertion is what caught it.
- [x] **`src/utils/index.test.ts`** — cases over the gate itself: deep and scoped imports, re-exports, `require` nested in functions and branches, non-literal and zero-argument `require`, a package sharing the prefix (`pgx`), relative and absolute specifiers, DSNs in strings and template literals, and every declared module recognised as itself.
- [x] **Fixture arrays are wrapped by a `pg()` helper**, not edited one by one — a fixture cannot be left behind and pass vacuously on the gate. Test count is **unchanged at 398** with the gate in place (520 with the new suites), so nothing was silently skipped.
- [x] Suite green at the package's 100% coverage threshold: 36 files, 520 tests.

## After merge

Released as a **major** — any rule may now stay silent where it previously reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PostgreSQL security checks now run only on files with locally detected PostgreSQL usage.
  * Reduced false-positive findings in files using other databases, HTTP services, or no database.
  * Existing checks continue to report issues in recognized PostgreSQL files.

* **Tests**
  * Added coverage for PostgreSQL detection across supported imports, connection strings, and CommonJS usage.
  * Added regression tests covering unrelated database drivers and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->