### PR TITLE
fix(lambda-security): abstain in files without local Lambda evidence

### DIFF
--- a/.changeset/lambda-evidence-gate.md
+++ b/.changeset/lambda-evidence-gate.md
@@ -2,7 +2,7 @@
 'eslint-plugin-lambda-security': major
 ---
 
-Every rule now abstains in files that are not Lambda code
+Every rule now abstains in files without local Lambda evidence
 
 The plugin had no notion of whether a file was Lambda code.
 `no-error-swallowing` fired on any `try/catch` anywhere while its own

--- a/.changeset/lambda-evidence-gate.md
+++ b/.changeset/lambda-evidence-gate.md
@@ -1,0 +1,31 @@
+---
+'eslint-plugin-lambda-security': major
+---
+
+Every rule now abstains in files that are not Lambda code
+
+The plugin had no notion of whether a file was Lambda code.
+`no-error-swallowing` fired on any `try/catch` anywhere while its own
+description claimed to detect "empty catch blocks in Lambda handlers", and four
+rules contained no Lambda reference at all, not even in prose.
+
+Measured over **107,382 files across 108 repositories**: 9,473 findings, of
+which **9,244 (98%) were in files with no AWS anything in them**. A plain
+`JSON.parse` helper was being told it had an AWS Lambda defect.
+
+Every rule now requires local evidence that the file is Lambda code. The
+evidence is a **union**, because an import gate alone is the wrong gate here:
+measured over the 12-repo Lambda corpus, 413 files export a handler and **184
+of them (45%) import nothing AWS** — `aws-lambda` is a types package and a
+plain JS handler imports nothing. So the gate accepts a handler export, or the
+`(event, context)` calling convention, or an AWS import / require / dynamic
+import. All three are read from the file itself.
+
+After the change the same corpus yields 723 findings instead of 9,473.
+
+This is a **major** bump: any rule may now stay silent where it previously
+reported. Verified cost: exactly **4** in-SDK findings across the corpus, all in
+one `@aws-lambda-powertools/batch` library file that carries no in-file Lambda
+evidence — it imports only relative paths and takes
+`(event, recordHandler, processor, options)`. Library code reached only through
+a wrapper is the deliberate miss.

--- a/packages/eslint-plugin-lambda-security/src/coverage-dual-layer.test.ts
+++ b/packages/eslint-plugin-lambda-security/src/coverage-dual-layer.test.ts
@@ -38,6 +38,52 @@ import { noUnvalidatedEventBody } from './rules/no-unvalidated-event-body';
 import { noUserControlledRequests } from './rules/no-user-controlled-requests';
 import { requireTimeoutHandling } from './rules/require-timeout-handling';
 
+/**
+ * Every fixture carries the Lambda handler shape, because the rules now abstain
+ * in files that are not Lambda code. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the shape
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const asLambda = (code: string): string =>
+  `import type { Handler } from 'aws-lambda';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const lambda = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asLambda(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asLambda(test.code),
+      // Autofix and suggestion fixtures assert the WHOLE file back, so every
+      // `output` needs the same prefix or each fixable rule fails on the header
+      // alone — including the ones nested under errors[].suggestions[].
+      ...(typeof test.output === 'string' ? { output: asLambda(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asLambda(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -62,12 +108,12 @@ describe('module entry points', () => {
 // ---------------------------------------------------------------------------
 
 ruleTester.run('no-env-logging (coverage)', noEnvLogging, {
-  valid: [
+  valid: lambda([
     // Computed logging property → prop is a Literal, not an Identifier
     { code: `console['warn'](process.env.SECRET_KEY);` },
     // Identifier object whose name is neither console nor log-like
     { code: `metrics.error(process.env.SECRET_KEY);` },
-  ],
+  ]),
   invalid: [],
 });
 
@@ -76,7 +122,7 @@ ruleTester.run('no-env-logging (coverage)', noEnvLogging, {
 // ---------------------------------------------------------------------------
 
 ruleTester.run('no-error-swallowing (coverage)', noErrorSwallowing, {
-  valid: [
+  valid: lambda([
     // Non-empty catch with an "intentional" comment (allowWithComment=true default)
     {
       code: `
@@ -85,8 +131,8 @@ ruleTester.run('no-error-swallowing (coverage)', noErrorSwallowing, {
         }
       `,
     },
-  ],
-  invalid: [
+  ]),
+  invalid: lambda([
     // Catch whose only return is a bare "return;" — returnStmt.argument is null
     {
       code: `
@@ -96,7 +142,7 @@ ruleTester.run('no-error-swallowing (coverage)', noErrorSwallowing, {
       `,
       errors: [{ messageId: 'emptyCatchBlock' }],
     },
-  ],
+  ]),
 });
 
 // ---------------------------------------------------------------------------
@@ -104,7 +150,7 @@ ruleTester.run('no-error-swallowing (coverage)', noErrorSwallowing, {
 // ---------------------------------------------------------------------------
 
 ruleTester.run('no-exposed-debug-endpoints (coverage)', noExposedDebugEndpoints, {
-  valid: [
+  valid: lambda([
     // ignoreFiles option matches the filename → rule short-circuits to {}
     {
       code: `const route = '/debug';`,
@@ -123,8 +169,8 @@ ruleTester.run('no-exposed-debug-endpoints (coverage)', noExposedDebugEndpoints,
     { code: `const x = event.url === '/debug/x';` },
     // Computed identifier property with non-checked name
     { code: `const x = event[prop] === '/debug/x';` },
-  ],
-  invalid: [
+  ]),
+  invalid: lambda([
     // Debug literal on the LEFT of the comparison (checkNode side === node.left)
     {
       code: `if ('/debug' === event.path) { enableDebug(); }`,
@@ -145,7 +191,7 @@ ruleTester.run('no-exposed-debug-endpoints (coverage)', noExposedDebugEndpoints,
       code: `const x = getEvent().path === '/debug';`,
       errors: [{ messageId: 'violationDetected' }],
     },
-  ],
+  ]),
 });
 
 // ---------------------------------------------------------------------------
@@ -153,7 +199,7 @@ ruleTester.run('no-exposed-debug-endpoints (coverage)', noExposedDebugEndpoints,
 // ---------------------------------------------------------------------------
 
 ruleTester.run('no-exposed-error-details (coverage)', noExposedErrorDetails, {
-  valid: [
+  valid: lambda([
     // Computed sensitive access → property is a Literal (documented FN)
     {
       code: `
@@ -186,7 +232,7 @@ ruleTester.run('no-exposed-error-details (coverage)', noExposedErrorDetails, {
         }
       `,
     },
-  ],
+  ]),
   invalid: [],
 });
 
@@ -195,7 +241,7 @@ ruleTester.run('no-exposed-error-details (coverage)', noExposedErrorDetails, {
 // ---------------------------------------------------------------------------
 
 ruleTester.run('no-hardcoded-credentials-sdk (coverage)', noHardcodedCredentialsSdk, {
-  valid: [
+  valid: lambda([
     // NewExpression callee is not an Identifier
     { code: `const c = new (getClientCtor())({ credentials: { accessKeyId: 'AKIAIOSFODNN7EXAMPLE' } });` },
     // Spread inside config object
@@ -227,8 +273,8 @@ ruleTester.run('no-hardcoded-credentials-sdk (coverage)', noHardcodedCredentials
     { code: `const credentialsFromVault = getCreds();` },
     // Destructured id → not an Identifier
     { code: `const { credentials } = config;` },
-  ],
-  invalid: [
+  ]),
+  invalid: lambda([
     // *Client name matched via the AWS-prefix regex (not the known-client set)
     {
       code: `const c = new BedrockClient({ credentials: { accessKeyId: 'AKIAIOSFODNN7EXAMPLE' } });`,
@@ -244,7 +290,7 @@ ruleTester.run('no-hardcoded-credentials-sdk (coverage)', noHardcodedCredentials
       code: `const myCredentials = { accessKeyId: 'AKIAIOSFODNN7EXAMPLE' };`,
       errors: [{ messageId: 'hardcodedCredentials' }],
     },
-  ],
+  ]),
 });
 
 // ---------------------------------------------------------------------------
@@ -252,7 +298,7 @@ ruleTester.run('no-hardcoded-credentials-sdk (coverage)', noHardcodedCredentials
 // ---------------------------------------------------------------------------
 
 ruleTester.run('no-missing-authorization-check (coverage)', noMissingAuthorizationCheck, {
-  valid: [
+  valid: lambda([
     // Computed callee property (not an Identifier) is not a tracked sensitive op;
     // non-object return exercises the ReturnStatement fallthrough
     {
@@ -263,7 +309,7 @@ ruleTester.run('no-missing-authorization-check (coverage)', noMissingAuthorizati
         };
       `,
     },
-  ],
+  ]),
   invalid: [],
 });
 
@@ -273,13 +319,13 @@ ruleTester.run('no-missing-authorization-check (coverage)', noMissingAuthorizati
 
 ruleTester.run('no-overly-permissive-iam-policy (coverage)', noOverlyPermissiveIamPolicy, {
   valid: [],
-  invalid: [
+  invalid: lambda([
     // Array with non-literal and non-string elements around the wildcard
     {
       code: `const policy = { Effect: 'Allow', Action: [dynamicAction, 42, '*'], Resource: 'arn:aws:s3:::bucket/key' };`,
       errors: [{ messageId: 'permissivePolicy' }],
     },
-  ],
+  ]),
 });
 
 // ---------------------------------------------------------------------------
@@ -287,7 +333,7 @@ ruleTester.run('no-overly-permissive-iam-policy (coverage)', noOverlyPermissiveI
 // ---------------------------------------------------------------------------
 
 ruleTester.run('no-permissive-cors-middy (coverage)', noPermissiveCorsMiddy, {
-  valid: [
+  valid: lambda([
     // Spread in options object
     { code: `httpCors({ ...defaults });` },
     // String-literal key is skipped (documented FN)
@@ -296,7 +342,7 @@ ruleTester.run('no-permissive-cors-middy (coverage)', noPermissiveCorsMiddy, {
     { code: `httpCors({ credentials: true });` },
     // Non-object argument
     { code: `httpCors(corsOptions);` },
-  ],
+  ]),
   invalid: [],
 });
 
@@ -305,7 +351,7 @@ ruleTester.run('no-permissive-cors-middy (coverage)', noPermissiveCorsMiddy, {
 // ---------------------------------------------------------------------------
 
 ruleTester.run('no-permissive-cors-response (coverage)', noPermissiveCorsResponse, {
-  valid: [
+  valid: lambda([
     // Spread inside headers object
     { code: `function h() { return { statusCode: 200, headers: { ...baseHeaders } }; }` },
     // Numeric header key → neither Identifier nor string Literal
@@ -316,15 +362,15 @@ ruleTester.run('no-permissive-cors-response (coverage)', noPermissiveCorsRespons
     { code: `let response;` },
     // response-named object literal that is NOT a Lambda response shape
     { code: `const response = { headers: { 'Access-Control-Allow-Origin': '*' } };` },
-  ],
-  invalid: [
+  ]),
+  invalid: lambda([
     // Identifier header key (Vary) + string-literal response key + wildcard → autofixed
     {
       code: `function h() { return { statusCode: 200, 'x-extra': 1, headers: { Vary: 'Origin', 'Access-Control-Allow-Origin': '*' } }; }`,
       output: `function h() { return { statusCode: 200, 'x-extra': 1, headers: { Vary: 'Origin', 'Access-Control-Allow-Origin': "https://your-domain.com" } }; }`,
       errors: [{ messageId: 'permissiveCors' }],
     },
-  ],
+  ]),
 });
 
 // ---------------------------------------------------------------------------
@@ -332,7 +378,7 @@ ruleTester.run('no-permissive-cors-response (coverage)', noPermissiveCorsRespons
 // ---------------------------------------------------------------------------
 
 ruleTester.run('no-secrets-in-env (coverage)', noSecretsInEnv, {
-  valid: [
+  valid: lambda([
     // Assignment whose object chain is not process.env
     { code: `config.env.API_KEY = 'super-secret-value';` },
     { code: `process.argv.SECRET_KEY = 'super-secret-value';` },
@@ -342,7 +388,7 @@ ruleTester.run('no-secrets-in-env (coverage)', noSecretsInEnv, {
     { code: `process.env.DB_PASSWORD = loadFromVault();` },
     // Numeric property key in a config object
     { code: `const settings = { 42: 'some-longer-value' };` },
-  ],
+  ]),
   invalid: [],
 });
 
@@ -352,7 +398,7 @@ ruleTester.run('no-secrets-in-env (coverage)', noSecretsInEnv, {
 
 ruleTester.run('no-unbounded-batch-processing (coverage)', noUnboundedBatchProcessing, {
   valid: [],
-  invalid: [
+  invalid: lambda([
     // .length on a computed member, non-size binary comparisons — none of them
     // count as a batch-size check, so the unbounded loop still reports
     {
@@ -368,7 +414,7 @@ ruleTester.run('no-unbounded-batch-processing (coverage)', noUnboundedBatchProce
       `,
       errors: [{ messageId: 'unboundedBatch' }],
     },
-  ],
+  ]),
 });
 
 // ---------------------------------------------------------------------------
@@ -376,7 +422,7 @@ ruleTester.run('no-unbounded-batch-processing (coverage)', noUnboundedBatchProce
 // ---------------------------------------------------------------------------
 
 ruleTester.run('no-unvalidated-event-body (coverage)', noUnvalidatedEventBody, {
-  valid: [
+  valid: lambda([
     // Assignment to a plain identifier is not the exports.handler convention
     { code: `h = function (e) { const x = e.body; };` },
     // Computed exports key → left.property is a Literal
@@ -390,8 +436,8 @@ ruleTester.run('no-unvalidated-event-body (coverage)', noUnvalidatedEventBody, {
     { code: `const middleware2 = (request, response) => { const y = request.body; };` },
     // .use() argument whose callee is a MemberExpression (not bare validator())
     { code: `pipeline.use(mod.validator(opts));` },
-  ],
-  invalid: [
+  ]),
+  invalid: lambda([
     // FunctionDeclaration named handler with short event param
     {
       code: `function handler(e) { const x = e.body; }`,
@@ -415,7 +461,7 @@ ruleTester.run('no-unvalidated-event-body (coverage)', noUnvalidatedEventBody, {
       `,
       errors: [{ messageId: 'unvalidatedInput' }],
     },
-  ],
+  ]),
 });
 
 // ---------------------------------------------------------------------------
@@ -423,7 +469,7 @@ ruleTester.run('no-unvalidated-event-body (coverage)', noUnvalidatedEventBody, {
 // ---------------------------------------------------------------------------
 
 ruleTester.run('no-user-controlled-requests (coverage)', noUserControlledRequests, {
-  valid: [
+  valid: lambda([
     // Template literal whose expressions are untainted
     { code: `const handler = async (event) => { const id = 5; await fetch(\`https://api.example.com/\${id}\`); };` },
     // Binary concatenation with no tainted operand
@@ -440,8 +486,8 @@ ruleTester.run('no-user-controlled-requests (coverage)', noUserControlledRequest
     { code: `const handler = async (event) => { const store = {}; store.url = event.rawPath; };` },
     // Assignment from an untainted source
     { code: `const handler = async (event) => { let u; u = 'https://static.example.com'; await fetch(u); };` },
-  ],
-  invalid: [
+  ]),
+  invalid: lambda([
     // Computed (non-Identifier) leaf property → source rendered as [...]
     {
       code: `const handler = async (event) => { await fetch(event.queryStringParameters['target']); };`,
@@ -452,7 +498,7 @@ ruleTester.run('no-user-controlled-requests (coverage)', noUserControlledRequest
       code: `const handler = async (event) => { await fetch(event.rawPath + '/x'); };`,
       errors: [{ messageId: 'ssrfVulnerability' }],
     },
-  ],
+  ]),
 });
 
 // ---------------------------------------------------------------------------
@@ -460,7 +506,7 @@ ruleTester.run('no-user-controlled-requests (coverage)', noUserControlledRequest
 // ---------------------------------------------------------------------------
 
 ruleTester.run('require-timeout-handling (coverage)', requireTimeoutHandling, {
-  valid: [
+  valid: lambda([
     // Member/new expressions OUTSIDE any handler hit the early-return guards
     {
       code: `
@@ -472,7 +518,7 @@ ruleTester.run('require-timeout-handling (coverage)', requireTimeoutHandling, {
         };
       `,
     },
-  ],
+  ]),
   invalid: [],
 });
 
@@ -491,7 +537,20 @@ function createUnvalidatedEventBodyListeners() {
   const sourceCode = {
     text: '',
     getText: () => '',
-    ast: { body: [] },
+    // The synthetic Program the module gate reads. These tests drive listeners
+    // directly, so the file they stand for has to carry the same Lambda
+    // evidence a real one would — an `aws-lambda` import here — otherwise the
+    // rule registers no listeners and the gap under test is never reached.
+    ast: {
+      type: 'Program',
+      body: [
+        {
+          type: 'ImportDeclaration',
+          source: { type: 'Literal', value: 'aws-lambda' },
+          specifiers: [],
+        },
+      ],
+    },
   };
   const context = {
     id: 'mock-rule',

--- a/packages/eslint-plugin-lambda-security/src/module-gate.lock.test.ts
+++ b/packages/eslint-plugin-lambda-security/src/module-gate.lock.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Regression lock: no rule in this plugin reports in a file that is not Lambda
+ * code.
+ *
+ * Measured over 107,382 files in 108 repositories, **98% of everything this
+ * plugin reported (9,244 of 9,473 findings) was in a file with no AWS anything
+ * in it** — `no-error-swallowing` alone contributed 5,543, firing on any
+ * `try/catch` anywhere while its own description claimed to detect "empty catch
+ * blocks in Lambda handlers".
+ *
+ * Written over the whole rule registry rather than per rule, so a rule added
+ * later is covered the day it lands: it will fail here until it is gated too.
+ * Revert the gate in any single rule and this test goes red.
+ */
+import { describe, it, expect } from 'vitest';
+import { Linter } from 'eslint';
+import parser from '@typescript-eslint/parser';
+import plugin from './index';
+
+const RULES = Object.keys(plugin.rules);
+
+/**
+ * Shapes that drew findings from this plugin across the corpus while having
+ * nothing to do with AWS Lambda. Each is a real false-positive pattern.
+ */
+const NON_LAMBDA_SOURCES: ReadonlyArray<readonly [string, string]> = [
+  [
+    'a plain JSON parse helper',
+    `export function parse(s: string) {
+       try { return JSON.parse(s); } catch { return null; }
+     }`,
+  ],
+  [
+    'an Express route',
+    `import express from 'express';
+     const app = express();
+     app.get('/users', (req, res) => {
+       try { res.json({ ok: true }); } catch (e) {}
+     });`,
+  ],
+  [
+    'a React component',
+    `export default function Panel({ data }) {
+       try { return data.map((d) => d.name).join(', '); } catch { return ''; }
+     }`,
+  ],
+  [
+    'a DOM event listener taking one `event`',
+    `document.addEventListener('click', (event) => {
+       try { console.log(event.target); } catch {}
+     });`,
+  ],
+  [
+    'a config module with env access',
+    `export const config = {
+       retries: Number(process.env.RETRIES ?? 3),
+       token: process.env.API_TOKEN,
+     };`,
+  ],
+  [
+    'a local module merely named like the SDK',
+    `import AWS from './aws-sdk';
+     export function upload(file) {
+       try { return AWS.put(file); } catch { return null; }
+     }`,
+  ],
+];
+
+const lint = (code: string, rule: string): Linter.LintMessage[] => {
+  const linter = new Linter();
+  return linter.verify(
+    code,
+    {
+      files: ['**/*.ts'],
+      languageOptions: {
+        parser: parser as unknown as Linter.Parser,
+        parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+      },
+      plugins: { l: plugin as unknown as Linter.Plugin },
+      rules: { [`l/${rule}`]: 'error' },
+    },
+    // Without a filename the Linter lints `<input>`, which matches no `files`
+    // entry — so every rule is skipped and every negative below passes without
+    // running a rule at all. The positive assertions at the bottom of this file
+    // are what catch that; keep them.
+    'handler.ts',
+  );
+};
+
+describe('Lambda module gate', () => {
+  it('the registry is non-empty, so the sweep below is not vacuous', () => {
+    expect(RULES.length).toBeGreaterThan(0);
+  });
+
+  describe.each(NON_LAMBDA_SOURCES)('%s', (_name, code) => {
+    it.each(RULES)('l/%s reports nothing', (rule) => {
+      const messages = lint(code, rule);
+      // A parse or config error also produces zero *rule* findings, so it is
+      // asserted away rather than counted as a pass.
+      expect(messages.filter((m) => !m.ruleId)).toHaveLength(0);
+      expect(messages).toHaveLength(0);
+    });
+  });
+
+  describe('positive controls — the gate must open for real Lambda code', () => {
+    const swallowing = `try { riskyOperation(); } catch (error) {}`;
+
+    it('reports once the file exports a handler, with no AWS import at all', () => {
+      const code = `export const handler = async (event) => { ${swallowing} };`;
+      expect(lint(code, 'no-error-swallowing').length).toBeGreaterThan(0);
+    });
+
+    it('reports on the (event, context) convention alone', () => {
+      const code = `async function run(event, context) { ${swallowing} }`;
+      expect(lint(code, 'no-error-swallowing').length).toBeGreaterThan(0);
+    });
+
+    it('reports on a type-only aws-lambda import', () => {
+      const code = `import type { Handler } from 'aws-lambda';\nfunction f() { ${swallowing} }`;
+      expect(lint(code, 'no-error-swallowing').length).toBeGreaterThan(0);
+    });
+
+    it('and stays silent on that same catch with none of the three present', () => {
+      expect(lint(`function f() { ${swallowing} }`, 'no-error-swallowing')).toHaveLength(0);
+    });
+  });
+});

--- a/packages/eslint-plugin-lambda-security/src/module-gate.lock.test.ts
+++ b/packages/eslint-plugin-lambda-security/src/module-gate.lock.test.ts
@@ -73,7 +73,10 @@ const NON_LAMBDA_SOURCES: ReadonlyArray<readonly [string, string]> = [
 ];
 
 const lint = (code: string, rule: string): Linter.LintMessage[] => {
-  const linter = new Linter();
+  // The declared ESLint floor for this package is 8.40, where `new Linter()`
+  // still defaults to eslintrc — a flat config would be ignored there and every
+  // rule silently skipped, which is the vacuous pass this lock exists to catch.
+  const linter = new Linter({ configType: "flat" });
   return linter.verify(
     code,
     {

--- a/packages/eslint-plugin-lambda-security/src/rules/no-env-logging/index.ts
+++ b/packages/eslint-plugin-lambda-security/src/rules/no-env-logging/index.ts
@@ -13,6 +13,7 @@
  */
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
 import { AST_NODE_TYPES, createRule, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
+import { fileIsLambda } from '../../utils/lambda-evidence';
 
 type MessageIds = 'envLogging' | 'removeEnvLogging';
 
@@ -68,6 +69,11 @@ export const noEnvLogging = createRule<RuleOptions, MessageIds>({
   },
   defaultOptions: [{ allowInTests: true }],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>, [options = {}]) {
+    // Every rule here is Lambda-specific, and none of them knew it: over 107,382
+    // files, 98% of this plugin's findings were in files with no AWS anything.
+    // Registering no visitors is both the gate and the cheap path.
+    if (!fileIsLambda(context.sourceCode.ast)) return {};
+
     const { allowInTests = true } = options as Options;
     const filename = context.filename;
     const isTestFile = /\.(test|spec)\.(ts|tsx|js|jsx)$/.test(filename);

--- a/packages/eslint-plugin-lambda-security/src/rules/no-env-logging/no-env-logging.test.ts
+++ b/packages/eslint-plugin-lambda-security/src/rules/no-env-logging/no-env-logging.test.ts
@@ -1,10 +1,56 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { noEnvLogging } from './index';
 
+/**
+ * Every fixture carries the Lambda handler shape, because the rules now abstain
+ * in files that are not Lambda code. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the shape
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const asLambda = (code: string): string =>
+  `import type { Handler } from 'aws-lambda';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const lambda = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asLambda(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asLambda(test.code),
+      // Autofix and suggestion fixtures assert the WHOLE file back, so every
+      // `output` needs the same prefix or each fixable rule fails on the header
+      // alone — including the ones nested under errors[].suggestions[].
+      ...(typeof test.output === 'string' ? { output: asLambda(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asLambda(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 const ruleTester = new RuleTester();
 
 ruleTester.run('no-env-logging', noEnvLogging, {
-  valid: [
+  valid: lambda([
     // ========== VALID: Logging specific env vars ==========
     {
       code: `console.log('Region:', process.env.AWS_REGION);`,
@@ -38,8 +84,8 @@ ruleTester.run('no-env-logging', noEnvLogging, {
     {
       code: `console.log(JSON.stringify({ config }));`,
     },
-  ],
-  invalid: [
+  ]),
+  invalid: lambda([
     // ========== INVALID: Direct process.env logging ==========
     {
       code: `console.log(process.env);`,
@@ -74,5 +120,5 @@ ruleTester.run('no-env-logging', noEnvLogging, {
       options: [{ allowInTests: false }],
       errors: [{ messageId: 'envLogging' }],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-lambda-security/src/rules/no-error-swallowing/index.ts
+++ b/packages/eslint-plugin-lambda-security/src/rules/no-error-swallowing/index.ts
@@ -13,6 +13,7 @@
  * @see https://owasp.org/www-project-serverless-top-10/
  */
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
+import { fileIsLambda } from '../../utils/lambda-evidence';
 import {
   AST_NODE_TYPES,
   createRule,
@@ -87,6 +88,11 @@ export const noErrorSwallowing = createRule<RuleOptions, MessageIds>({
     context: TSESLint.RuleContext<MessageIds, RuleOptions>,
     [options = {}],
   ) {
+    // Every rule here is Lambda-specific, and none of them knew it: over 107,382
+    // files, 98% of this plugin's findings were in files with no AWS anything.
+    // Registering no visitors is both the gate and the cheap path.
+    if (!fileIsLambda(context.sourceCode.ast)) return {};
+
     const { allowInTests = true, allowWithComment = true } = options as Options;
     const filename = context.filename;
     const isTestFile = /\.(test|spec)\.(ts|tsx|js|jsx)$/.test(filename);

--- a/packages/eslint-plugin-lambda-security/src/rules/no-error-swallowing/no-error-swallowing.test.ts
+++ b/packages/eslint-plugin-lambda-security/src/rules/no-error-swallowing/no-error-swallowing.test.ts
@@ -2,6 +2,52 @@ import { describe, it, afterAll } from 'vitest';
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { noErrorSwallowing } from './index';
 
+/**
+ * Every fixture carries the Lambda handler shape, because the rules now abstain
+ * in files that are not Lambda code. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the shape
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const asLambda = (code: string): string =>
+  `import type { Handler } from 'aws-lambda';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const lambda = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asLambda(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asLambda(test.code),
+      // Autofix and suggestion fixtures assert the WHOLE file back, so every
+      // `output` needs the same prefix or each fixable rule fails on the header
+      // alone — including the ones nested under errors[].suggestions[].
+      ...(typeof test.output === 'string' ? { output: asLambda(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asLambda(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -10,7 +56,7 @@ RuleTester.describe = describe;
 const ruleTester = new RuleTester();
 
 ruleTester.run('no-error-swallowing', noErrorSwallowing, {
-  valid: [
+  valid: lambda([
     // ── The four ILB-CWE-Corpus fixtures this rule used to report ────────
     // Each is the *correct, secure* form of its pattern. Together they were
     // 4 of the suite's 16 false positives — a quarter, from one rule.
@@ -285,9 +331,9 @@ ruleTester.run('no-error-swallowing', noErrorSwallowing, {
         }
       `,
     },
-  ],
+  ]),
 
-  invalid: [
+  invalid: lambda([
     // ── FN boundary for the AST rewrite above ───────────────────────────
     // Widening a rule to kill false positives is exactly how a false
     // negative gets introduced (see #441, where excluding TemplateLiteral
@@ -510,5 +556,5 @@ ruleTester.run('no-error-swallowing', noErrorSwallowing, {
         }],
       }],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-lambda-security/src/rules/no-exposed-debug-endpoints/index.ts
+++ b/packages/eslint-plugin-lambda-security/src/rules/no-exposed-debug-endpoints/index.ts
@@ -10,6 +10,7 @@
 
 import { createRule, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
 import type { TSESTree } from '@interlace/eslint-devkit';
+import { fileIsLambda } from '../../utils/lambda-evidence';
 
 type MessageIds = 'violationDetected';
 
@@ -64,6 +65,11 @@ export const noExposedDebugEndpoints = createRule<RuleOptions, MessageIds>({
   },
   defaultOptions: [{}],
   create(context) {
+    // Every rule here is Lambda-specific, and none of them knew it: over 107,382
+    // files, 98% of this plugin's findings were in files with no AWS anything.
+    // Registering no visitors is both the gate and the cheap path.
+    if (!fileIsLambda(context.sourceCode.ast)) return {};
+
     const options = context.options[0] || {};
     const debugPaths = options.endpoints || DEFAULT_DEBUG_PATHS;
     const ignoreFiles = options.ignoreFiles || [];

--- a/packages/eslint-plugin-lambda-security/src/rules/no-exposed-debug-endpoints/no-exposed-debug-endpoints.test.ts
+++ b/packages/eslint-plugin-lambda-security/src/rules/no-exposed-debug-endpoints/no-exposed-debug-endpoints.test.ts
@@ -5,6 +5,52 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { noExposedDebugEndpoints } from './index';
 
+/**
+ * Every fixture carries the Lambda handler shape, because the rules now abstain
+ * in files that are not Lambda code. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the shape
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const asLambda = (code: string): string =>
+  `import type { Handler } from 'aws-lambda';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const lambda = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asLambda(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asLambda(test.code),
+      // Autofix and suggestion fixtures assert the WHOLE file back, so every
+      // `output` needs the same prefix or each fixable rule fails on the header
+      // alone — including the ones nested under errors[].suggestions[].
+      ...(typeof test.output === 'string' ? { output: asLambda(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asLambda(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 const ruleTester = new RuleTester({
   languageOptions: {
     ecmaVersion: 2022,
@@ -13,7 +59,7 @@ const ruleTester = new RuleTester({
 });
 
 ruleTester.run('no-exposed-debug-endpoints', noExposedDebugEndpoints, {
-  valid: [
+  valid: lambda([
         'const x = 42;',
         'const flag = true;',
         'function noop() {}',
@@ -23,9 +69,9 @@ ruleTester.run('no-exposed-debug-endpoints', noExposedDebugEndpoints, {
     {
       code: "const ok = '/status-check'"
     }
-  ],
+  ]),
 
-  invalid: [
+  invalid: lambda([
     {
       code: "if (event.path === '/debug') {}",
       errors: [{ messageId: 'violationDetected' }]
@@ -50,5 +96,5 @@ ruleTester.run('no-exposed-debug-endpoints', noExposedDebugEndpoints, {
       `,
       errors: [{ messageId: 'violationDetected' }]
     }
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-lambda-security/src/rules/no-exposed-error-details/index.ts
+++ b/packages/eslint-plugin-lambda-security/src/rules/no-exposed-error-details/index.ts
@@ -13,6 +13,7 @@
  * @see https://owasp.org/www-project-serverless-top-10/
  */
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
+import { fileIsLambda } from '../../utils/lambda-evidence';
 import {
   AST_NODE_TYPES,
   createRule,
@@ -95,6 +96,11 @@ export const noExposedErrorDetails = createRule<RuleOptions, MessageIds>({
     context: TSESLint.RuleContext<MessageIds, RuleOptions>,
     [options = {}],
   ) {
+    // Every rule here is Lambda-specific, and none of them knew it: over 107,382
+    // files, 98% of this plugin's findings were in files with no AWS anything.
+    // Registering no visitors is both the gate and the cheap path.
+    if (!fileIsLambda(context.sourceCode.ast)) return {};
+
     const { allowInTests = true } = options as Options;
     const filename = context.filename;
     const isTestFile = /\.(test|spec)\.(ts|tsx|js|jsx)$/.test(filename);

--- a/packages/eslint-plugin-lambda-security/src/rules/no-exposed-error-details/no-exposed-error-details.test.ts
+++ b/packages/eslint-plugin-lambda-security/src/rules/no-exposed-error-details/no-exposed-error-details.test.ts
@@ -2,6 +2,52 @@ import { describe, it, afterAll } from 'vitest';
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { noExposedErrorDetails } from './index';
 
+/**
+ * Every fixture carries the Lambda handler shape, because the rules now abstain
+ * in files that are not Lambda code. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the shape
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const asLambda = (code: string): string =>
+  `import type { Handler } from 'aws-lambda';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const lambda = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asLambda(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asLambda(test.code),
+      // Autofix and suggestion fixtures assert the WHOLE file back, so every
+      // `output` needs the same prefix or each fixable rule fails on the header
+      // alone — including the ones nested under errors[].suggestions[].
+      ...(typeof test.output === 'string' ? { output: asLambda(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asLambda(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -10,7 +56,7 @@ RuleTester.describe = describe;
 const ruleTester = new RuleTester();
 
 ruleTester.run('no-exposed-error-details', noExposedErrorDetails, {
-  valid: [
+  valid: lambda([
         'const x = 42;',
         'const flag = true;',
     // Generic error message
@@ -55,8 +101,8 @@ ruleTester.run('no-exposed-error-details', noExposedErrorDetails, {
       `,
       filename: 'handler.test.ts',
     },
-  ],
-  invalid: [
+  ]),
+  invalid: lambda([
     // Exposed stack trace
     {
       code: `
@@ -96,5 +142,5 @@ ruleTester.run('no-exposed-error-details', noExposedErrorDetails, {
       `,
       errors: [{ messageId: 'exposedErrorDetails' }],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-lambda-security/src/rules/no-hardcoded-credentials-sdk/index.ts
+++ b/packages/eslint-plugin-lambda-security/src/rules/no-hardcoded-credentials-sdk/index.ts
@@ -14,6 +14,7 @@
  */
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
 import { AST_NODE_TYPES, createRule, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
+import { fileIsLambda } from '../../utils/lambda-evidence';
 
 type MessageIds = 'hardcodedCredentials' | 'useCredentialProvider';
 
@@ -114,6 +115,11 @@ export const noHardcodedCredentialsSdk = createRule<RuleOptions, MessageIds>({
     },
   ],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>, [options = {}]) {
+    // Every rule here is Lambda-specific, and none of them knew it: over 107,382
+    // files, 98% of this plugin's findings were in files with no AWS anything.
+    // Registering no visitors is both the gate and the cheap path.
+    if (!fileIsLambda(context.sourceCode.ast)) return {};
+
     const { allowInTests = true } = options as Options;
     const filename = context.filename;
     const isTestFile = /\.(test|spec)\.(ts|tsx|js|jsx)$/.test(filename);

--- a/packages/eslint-plugin-lambda-security/src/rules/no-hardcoded-credentials-sdk/no-hardcoded-credentials-sdk.test.ts
+++ b/packages/eslint-plugin-lambda-security/src/rules/no-hardcoded-credentials-sdk/no-hardcoded-credentials-sdk.test.ts
@@ -1,10 +1,56 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { noHardcodedCredentialsSdk } from './index';
 
+/**
+ * Every fixture carries the Lambda handler shape, because the rules now abstain
+ * in files that are not Lambda code. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the shape
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const asLambda = (code: string): string =>
+  `import type { Handler } from 'aws-lambda';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const lambda = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asLambda(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asLambda(test.code),
+      // Autofix and suggestion fixtures assert the WHOLE file back, so every
+      // `output` needs the same prefix or each fixable rule fails on the header
+      // alone — including the ones nested under errors[].suggestions[].
+      ...(typeof test.output === 'string' ? { output: asLambda(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asLambda(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 const ruleTester = new RuleTester();
 
 ruleTester.run('no-hardcoded-credentials-sdk', noHardcodedCredentialsSdk, {
-  valid: [
+  valid: lambda([
     // ========== VALID: Credential Provider Chain ==========
     {
       code: `
@@ -87,8 +133,8 @@ ruleTester.run('no-hardcoded-credentials-sdk', noHardcodedCredentialsSdk, {
         });
       `,
     },
-  ],
-  invalid: [
+  ]),
+  invalid: lambda([
     // ========== INVALID: Real AWS access key pattern ==========
     {
       code: `
@@ -180,5 +226,5 @@ ruleTester.run('no-hardcoded-credentials-sdk', noHardcodedCredentialsSdk, {
         { messageId: 'hardcodedCredentials' },
       ],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-lambda-security/src/rules/no-missing-authorization-check/index.ts
+++ b/packages/eslint-plugin-lambda-security/src/rules/no-missing-authorization-check/index.ts
@@ -13,6 +13,7 @@
  * @see https://owasp.org/www-project-serverless-top-10/
  */
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
+import { fileIsLambda } from '../../utils/lambda-evidence';
 import {
   AST_NODE_TYPES,
   createRule,
@@ -138,6 +139,11 @@ export const noMissingAuthorizationCheck = createRule<RuleOptions, MessageIds>({
     context: TSESLint.RuleContext<MessageIds, RuleOptions>,
     [options = {}],
   ) {
+    // Every rule here is Lambda-specific, and none of them knew it: over 107,382
+    // files, 98% of this plugin's findings were in files with no AWS anything.
+    // Registering no visitors is both the gate and the cheap path.
+    if (!fileIsLambda(context.sourceCode.ast)) return {};
+
     const { allowInTests = true } = options as Options;
     const filename = context.filename;
     const isTestFile = /\.(test|spec)\.(ts|tsx|js|jsx)$/.test(filename);

--- a/packages/eslint-plugin-lambda-security/src/rules/no-missing-authorization-check/no-missing-authorization-check.test.ts
+++ b/packages/eslint-plugin-lambda-security/src/rules/no-missing-authorization-check/no-missing-authorization-check.test.ts
@@ -2,6 +2,52 @@ import { describe, it, afterAll } from 'vitest';
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { noMissingAuthorizationCheck } from './index';
 
+/**
+ * Every fixture carries the Lambda handler shape, because the rules now abstain
+ * in files that are not Lambda code. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the shape
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const asLambda = (code: string): string =>
+  `import type { Handler } from 'aws-lambda';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const lambda = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asLambda(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asLambda(test.code),
+      // Autofix and suggestion fixtures assert the WHOLE file back, so every
+      // `output` needs the same prefix or each fixable rule fails on the header
+      // alone — including the ones nested under errors[].suggestions[].
+      ...(typeof test.output === 'string' ? { output: asLambda(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asLambda(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -10,7 +56,7 @@ RuleTester.describe = describe;
 const ruleTester = new RuleTester();
 
 ruleTester.run('no-missing-authorization-check', noMissingAuthorizationCheck, {
-  valid: [
+  valid: lambda([
     // Test file (allowed by default)
     {
       code: `
@@ -123,9 +169,9 @@ ruleTester.run('no-missing-authorization-check', noMissingAuthorizationCheck, {
         };
       `,
     },
-  ],
+  ]),
 
-  invalid: [
+  invalid: lambda([
     // Lambda handler with DB query but no auth check (classic FN)
     {
       code: `
@@ -220,7 +266,7 @@ ruleTester.run('no-missing-authorization-check', noMissingAuthorizationCheck, {
       `,
       errors: [{ messageId: 'missingAuthCheck' }],
     },
-  ],
+  ]),
 });
 
 // Regression lock — function-exit `:exit` selector (ESLint 9 "Unknown class
@@ -235,7 +281,7 @@ ruleTester.run(
   'no-missing-authorization-check (function-exit selector regression)',
   noMissingAuthorizationCheck,
   {
-    valid: [
+    valid: lambda([
       // Clean handler of each node type — exit listeners run, no crash, no FP.
       {
         code: `export const handler = async (event) => {
@@ -252,8 +298,8 @@ ruleTester.run(
           return { statusCode: 200, body: 'ok' };
         }`,
       },
-    ],
-    invalid: [
+    ]),
+    invalid: lambda([
       // Sensitive op + no auth check reports once per node type.
       {
         code: `export const handler = async (event) => {
@@ -273,6 +319,6 @@ ruleTester.run(
         }`,
         errors: [{ messageId: 'missingAuthCheck' }],
       },
-    ],
+    ]),
   },
 );

--- a/packages/eslint-plugin-lambda-security/src/rules/no-overly-permissive-iam-policy/index.ts
+++ b/packages/eslint-plugin-lambda-security/src/rules/no-overly-permissive-iam-policy/index.ts
@@ -13,6 +13,7 @@
  * @see https://owasp.org/www-project-serverless-top-10/
  */
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
+import { fileIsLambda } from '../../utils/lambda-evidence';
 import {
   AST_NODE_TYPES,
   createRule,
@@ -88,6 +89,11 @@ export const noOverlyPermissiveIamPolicy = createRule<RuleOptions, MessageIds>({
     context: TSESLint.RuleContext<MessageIds, RuleOptions>,
     [options = {}],
   ) {
+    // Every rule here is Lambda-specific, and none of them knew it: over 107,382
+    // files, 98% of this plugin's findings were in files with no AWS anything.
+    // Registering no visitors is both the gate and the cheap path.
+    if (!fileIsLambda(context.sourceCode.ast)) return {};
+
     const { allowInTests = true } = options as Options;
     const filename = context.filename;
     const isTestFile = /\.(test|spec)\.(ts|tsx|js|jsx)$/.test(filename);

--- a/packages/eslint-plugin-lambda-security/src/rules/no-overly-permissive-iam-policy/no-overly-permissive-iam-policy.test.ts
+++ b/packages/eslint-plugin-lambda-security/src/rules/no-overly-permissive-iam-policy/no-overly-permissive-iam-policy.test.ts
@@ -2,6 +2,52 @@ import { describe, it, afterAll } from 'vitest';
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { noOverlyPermissiveIamPolicy } from './index';
 
+/**
+ * Every fixture carries the Lambda handler shape, because the rules now abstain
+ * in files that are not Lambda code. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the shape
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const asLambda = (code: string): string =>
+  `import type { Handler } from 'aws-lambda';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const lambda = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asLambda(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asLambda(test.code),
+      // Autofix and suggestion fixtures assert the WHOLE file back, so every
+      // `output` needs the same prefix or each fixable rule fails on the header
+      // alone — including the ones nested under errors[].suggestions[].
+      ...(typeof test.output === 'string' ? { output: asLambda(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asLambda(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -10,7 +56,7 @@ RuleTester.describe = describe;
 const ruleTester = new RuleTester();
 
 ruleTester.run('no-overly-permissive-iam-policy', noOverlyPermissiveIamPolicy, {
-  valid: [
+  valid: lambda([
     // Specific resource (multi-line)
     {
       code: `
@@ -84,8 +130,8 @@ ruleTester.run('no-overly-permissive-iam-policy', noOverlyPermissiveIamPolicy, {
         };
       `,
     },
-  ],
-  invalid: [
+  ]),
+  invalid: lambda([
     // Wildcard Resource (multi-line format)
     {
       code: `
@@ -196,5 +242,5 @@ ruleTester.run('no-overly-permissive-iam-policy', noOverlyPermissiveIamPolicy, {
         { messageId: 'permissivePolicy' },
       ],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-lambda-security/src/rules/no-permissive-cors-middy/index.ts
+++ b/packages/eslint-plugin-lambda-security/src/rules/no-permissive-cors-middy/index.ts
@@ -14,6 +14,7 @@
  */
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
 import { AST_NODE_TYPES, createRule, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
+import { fileIsLambda } from '../../utils/lambda-evidence';
 
 type MessageIds = 'permissiveCors' | 'useSpecificOrigins';
 
@@ -69,6 +70,11 @@ export const noPermissiveCorsMidly = createRule<RuleOptions, MessageIds>({
   },
   defaultOptions: [{ allowInTests: true }],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>, [options = {}]) {
+    // Every rule here is Lambda-specific, and none of them knew it: over 107,382
+    // files, 98% of this plugin's findings were in files with no AWS anything.
+    // Registering no visitors is both the gate and the cheap path.
+    if (!fileIsLambda(context.sourceCode.ast)) return {};
+
     const { allowInTests = true } = options as Options;
     const filename = context.filename;
     const isTestFile = /\.(test|spec)\.(ts|tsx|js|jsx)$/.test(filename);

--- a/packages/eslint-plugin-lambda-security/src/rules/no-permissive-cors-middy/no-permissive-cors-middy.test.ts
+++ b/packages/eslint-plugin-lambda-security/src/rules/no-permissive-cors-middy/no-permissive-cors-middy.test.ts
@@ -2,6 +2,52 @@ import { RuleTester } from '@typescript-eslint/rule-tester';
 import { describe, expect, it } from 'vitest';
 import { noPermissiveCorsMidly } from './index';
 
+/**
+ * Every fixture carries the Lambda handler shape, because the rules now abstain
+ * in files that are not Lambda code. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the shape
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const asLambda = (code: string): string =>
+  `import type { Handler } from 'aws-lambda';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const lambda = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asLambda(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asLambda(test.code),
+      // Autofix and suggestion fixtures assert the WHOLE file back, so every
+      // `output` needs the same prefix or each fixable rule fails on the header
+      // alone — including the ones nested under errors[].suggestions[].
+      ...(typeof test.output === 'string' ? { output: asLambda(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asLambda(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 const ruleTester = new RuleTester();
 
 // ========== REGRESSION LOCK: no dead options ==========
@@ -19,7 +65,7 @@ describe('no-permissive-cors-middy schema', () => {
 });
 
 ruleTester.run('no-permissive-cors-middy', noPermissiveCorsMidly, {
-  valid: [
+  valid: lambda([
     // ========== VALID: Specific origins ==========
     {
       code: `
@@ -67,8 +113,8 @@ ruleTester.run('no-permissive-cors-middy', noPermissiveCorsMidly, {
         middy(handler).use(httpCors({ origins: allowedOrigins }));
       `,
     },
-  ],
-  invalid: [
+  ]),
+  invalid: lambda([
     // ========== INVALID: No arguments (defaults to permissive) ==========
     {
       code: `middy(handler).use(httpCors());`,
@@ -107,5 +153,5 @@ ruleTester.run('no-permissive-cors-middy', noPermissiveCorsMidly, {
       options: [{ allowInTests: false }],
       errors: [{ messageId: 'permissiveCors' }],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-lambda-security/src/rules/no-permissive-cors-response/index.ts
+++ b/packages/eslint-plugin-lambda-security/src/rules/no-permissive-cors-response/index.ts
@@ -14,6 +14,7 @@
  */
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
 import { AST_NODE_TYPES, createRule, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
+import { fileIsLambda } from '../../utils/lambda-evidence';
 
 type MessageIds = 'permissiveCors' | 'useSpecificOrigin';
 
@@ -70,6 +71,11 @@ export const noPermissiveCorsResponse = createRule<RuleOptions, MessageIds>({
   },
   defaultOptions: [{ allowInTests: true }],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>, [options = {}]) {
+    // Every rule here is Lambda-specific, and none of them knew it: over 107,382
+    // files, 98% of this plugin's findings were in files with no AWS anything.
+    // Registering no visitors is both the gate and the cheap path.
+    if (!fileIsLambda(context.sourceCode.ast)) return {};
+
     const { allowInTests = true } = options as Options;
     const filename = context.filename;
     const isTestFile = /\.(test|spec)\.(ts|tsx|js|jsx)$/.test(filename);

--- a/packages/eslint-plugin-lambda-security/src/rules/no-permissive-cors-response/no-permissive-cors-response.test.ts
+++ b/packages/eslint-plugin-lambda-security/src/rules/no-permissive-cors-response/no-permissive-cors-response.test.ts
@@ -2,6 +2,52 @@ import { RuleTester } from '@typescript-eslint/rule-tester';
 import { describe, expect, it } from 'vitest';
 import { noPermissiveCorsResponse } from './index';
 
+/**
+ * Every fixture carries the Lambda handler shape, because the rules now abstain
+ * in files that are not Lambda code. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the shape
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const asLambda = (code: string): string =>
+  `import type { Handler } from 'aws-lambda';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const lambda = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asLambda(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asLambda(test.code),
+      // Autofix and suggestion fixtures assert the WHOLE file back, so every
+      // `output` needs the same prefix or each fixable rule fails on the header
+      // alone — including the ones nested under errors[].suggestions[].
+      ...(typeof test.output === 'string' ? { output: asLambda(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asLambda(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 const ruleTester = new RuleTester();
 
 // ========== REGRESSION LOCK: no dead options ==========
@@ -20,7 +66,7 @@ describe('no-permissive-cors-response schema', () => {
 });
 
 ruleTester.run('no-permissive-cors-response', noPermissiveCorsResponse, {
-  valid: [
+  valid: lambda([
     // ========== VALID: Specific origin ==========
     {
       code: `
@@ -85,8 +131,8 @@ ruleTester.run('no-permissive-cors-response', noPermissiveCorsResponse, {
         const config = () => ({ headers: { 'Access-Control-Allow-Origin': '*' } });
       `,
     },
-  ],
-  invalid: [
+  ]),
+  invalid: lambda([
     // ========== INVALID: Wildcard origin in return ==========
     {
       code: `
@@ -202,5 +248,5 @@ ruleTester.run('no-permissive-cors-response', noPermissiveCorsResponse, {
       `,
       errors: [{ messageId: 'permissiveCors' }],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-lambda-security/src/rules/no-secrets-in-env/index.ts
+++ b/packages/eslint-plugin-lambda-security/src/rules/no-secrets-in-env/index.ts
@@ -14,6 +14,7 @@
  */
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
 import { AST_NODE_TYPES, createRule, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
+import { fileIsLambda } from '../../utils/lambda-evidence';
 
 type MessageIds = 'secretsInEnv' | 'useSecretsManager';
 
@@ -87,6 +88,11 @@ export const noSecretsInEnv = createRule<RuleOptions, MessageIds>({
   },
   defaultOptions: [{ allowInTests: true, additionalPatterns: [] }],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>, [options = {}]) {
+    // Every rule here is Lambda-specific, and none of them knew it: over 107,382
+    // files, 98% of this plugin's findings were in files with no AWS anything.
+    // Registering no visitors is both the gate and the cheap path.
+    if (!fileIsLambda(context.sourceCode.ast)) return {};
+
     const { allowInTests = true, additionalPatterns = [] } = options as Options;
     const filename = context.filename;
     const isTestFile = /\.(test|spec)\.(ts|tsx|js|jsx)$/.test(filename);

--- a/packages/eslint-plugin-lambda-security/src/rules/no-secrets-in-env/no-secrets-in-env.test.ts
+++ b/packages/eslint-plugin-lambda-security/src/rules/no-secrets-in-env/no-secrets-in-env.test.ts
@@ -1,10 +1,56 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { noSecretsInEnv } from './index';
 
+/**
+ * Every fixture carries the Lambda handler shape, because the rules now abstain
+ * in files that are not Lambda code. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the shape
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const asLambda = (code: string): string =>
+  `import type { Handler } from 'aws-lambda';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const lambda = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asLambda(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asLambda(test.code),
+      // Autofix and suggestion fixtures assert the WHOLE file back, so every
+      // `output` needs the same prefix or each fixable rule fails on the header
+      // alone — including the ones nested under errors[].suggestions[].
+      ...(typeof test.output === 'string' ? { output: asLambda(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asLambda(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 const ruleTester = new RuleTester();
 
 ruleTester.run('no-secrets-in-env', noSecretsInEnv, {
-  valid: [
+  valid: lambda([
     // ========== VALID: Reading from process.env ==========
     {
       code: `const password = process.env.DB_PASSWORD;`,
@@ -65,8 +111,8 @@ ruleTester.run('no-secrets-in-env', noSecretsInEnv, {
         };
       `,
     },
-  ],
-  invalid: [
+  ]),
+  invalid: lambda([
     // ========== INVALID: Direct process.env assignment ==========
     {
       code: `process.env.DB_PASSWORD = 'my-secret-password-12345678901234';`,
@@ -158,5 +204,5 @@ ruleTester.run('no-secrets-in-env', noSecretsInEnv, {
       options: [{ additionalPatterns: ['custom_credential'] }],
       errors: [{ messageId: 'secretsInEnv' }],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-lambda-security/src/rules/no-unbounded-batch-processing/index.ts
+++ b/packages/eslint-plugin-lambda-security/src/rules/no-unbounded-batch-processing/index.ts
@@ -13,6 +13,7 @@
  * @see https://owasp.org/www-project-serverless-top-10/
  */
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
+import { fileIsLambda } from '../../utils/lambda-evidence';
 import {
   AST_NODE_TYPES,
   createRule,
@@ -99,6 +100,11 @@ export const noUnboundedBatchProcessing = createRule<RuleOptions, MessageIds>({
     context: TSESLint.RuleContext<MessageIds, RuleOptions>,
     [options = {}],
   ) {
+    // Every rule here is Lambda-specific, and none of them knew it: over 107,382
+    // files, 98% of this plugin's findings were in files with no AWS anything.
+    // Registering no visitors is both the gate and the cheap path.
+    if (!fileIsLambda(context.sourceCode.ast)) return {};
+
     const { allowInTests = true } = options as Options;
     const filename = context.filename;
     const isTestFile = /\.(test|spec)\.(ts|tsx|js|jsx)$/.test(filename);

--- a/packages/eslint-plugin-lambda-security/src/rules/no-unbounded-batch-processing/no-unbounded-batch-processing.test.ts
+++ b/packages/eslint-plugin-lambda-security/src/rules/no-unbounded-batch-processing/no-unbounded-batch-processing.test.ts
@@ -2,6 +2,52 @@ import { describe, it, afterAll } from 'vitest';
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { noUnboundedBatchProcessing } from './index';
 
+/**
+ * Every fixture carries the Lambda handler shape, because the rules now abstain
+ * in files that are not Lambda code. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the shape
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const asLambda = (code: string): string =>
+  `import type { Handler } from 'aws-lambda';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const lambda = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asLambda(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asLambda(test.code),
+      // Autofix and suggestion fixtures assert the WHOLE file back, so every
+      // `output` needs the same prefix or each fixable rule fails on the header
+      // alone — including the ones nested under errors[].suggestions[].
+      ...(typeof test.output === 'string' ? { output: asLambda(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asLambda(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -10,7 +56,7 @@ RuleTester.describe = describe;
 const ruleTester = new RuleTester();
 
 ruleTester.run('no-unbounded-batch-processing', noUnboundedBatchProcessing, {
-  valid: [
+  valid: lambda([
     // Test file (allowed)
     {
       code: `
@@ -107,9 +153,9 @@ ruleTester.run('no-unbounded-batch-processing', noUnboundedBatchProcessing, {
         }
       `,
     },
-  ],
+  ]),
 
-  invalid: [
+  invalid: lambda([
     // Lambda handler processing Records without size check (classic FN)
     {
       code: `
@@ -176,7 +222,7 @@ ruleTester.run('no-unbounded-batch-processing', noUnboundedBatchProcessing, {
       `,
       errors: [{ messageId: 'unboundedBatch' }],
     },
-  ],
+  ]),
 });
 
 // Regression lock — function-exit `:exit` selector (ESLint 9 "Unknown class
@@ -191,7 +237,7 @@ ruleTester.run(
   'no-unbounded-batch-processing (function-exit selector regression)',
   noUnboundedBatchProcessing,
   {
-    valid: [
+    valid: lambda([
       // Clean handler of each node type — exit listeners run, no crash, no FP.
       {
         code: `export const handler = async (event) => {
@@ -208,8 +254,8 @@ ruleTester.run(
           return { statusCode: 200, body: event.body };
         }`,
       },
-    ],
-    invalid: [
+    ]),
+    invalid: lambda([
       // Unbounded Records iteration reports once per node type.
       {
         code: `export const handler = async (event) => {
@@ -235,6 +281,6 @@ ruleTester.run(
         }`,
         errors: [{ messageId: 'unboundedBatch' }],
       },
-    ],
+    ]),
   },
 );

--- a/packages/eslint-plugin-lambda-security/src/rules/no-unvalidated-event-body/index.ts
+++ b/packages/eslint-plugin-lambda-security/src/rules/no-unvalidated-event-body/index.ts
@@ -13,6 +13,7 @@
  * @see https://owasp.org/www-project-serverless-top-10/
  */
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
+import { fileIsLambda } from '../../utils/lambda-evidence';
 import {
   AST_NODE_TYPES,
   createRule,
@@ -125,6 +126,11 @@ export const noUnvalidatedEventBody = createRule<RuleOptions, MessageIds>({
     context: TSESLint.RuleContext<MessageIds, RuleOptions>,
     [options = {}],
   ) {
+    // Every rule here is Lambda-specific, and none of them knew it: over 107,382
+    // files, 98% of this plugin's findings were in files with no AWS anything.
+    // Registering no visitors is both the gate and the cheap path.
+    if (!fileIsLambda(context.sourceCode.ast)) return {};
+
     const { allowInTests = true, additionalProperties = [] } = options as Options;
     const filename = context.filename;
     const isTestFile = /\.(test|spec)\.(ts|tsx|js|jsx)$/.test(filename);

--- a/packages/eslint-plugin-lambda-security/src/rules/no-unvalidated-event-body/no-unvalidated-event-body.test.ts
+++ b/packages/eslint-plugin-lambda-security/src/rules/no-unvalidated-event-body/no-unvalidated-event-body.test.ts
@@ -2,6 +2,52 @@ import { describe, it, afterAll } from 'vitest';
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { noUnvalidatedEventBody } from './index';
 
+/**
+ * Every fixture carries the Lambda handler shape, because the rules now abstain
+ * in files that are not Lambda code. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the shape
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const asLambda = (code: string): string =>
+  `import type { Handler } from 'aws-lambda';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const lambda = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asLambda(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asLambda(test.code),
+      // Autofix and suggestion fixtures assert the WHOLE file back, so every
+      // `output` needs the same prefix or each fixable rule fails on the header
+      // alone — including the ones nested under errors[].suggestions[].
+      ...(typeof test.output === 'string' ? { output: asLambda(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asLambda(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -10,7 +56,7 @@ RuleTester.describe = describe;
 const ruleTester = new RuleTester();
 
 ruleTester.run('no-unvalidated-event-body', noUnvalidatedEventBody, {
-  valid: [
+  valid: lambda([
     // Validation with Zod
     {
       code: `
@@ -127,8 +173,8 @@ ruleTester.run('no-unvalidated-event-body', noUnvalidatedEventBody, {
       `,
       filename: 'handler.test.ts',
     },
-  ],
-  invalid: [
+  ]),
+  invalid: lambda([
     // Direct use of event.body in variable assignment
     {
       code: `
@@ -167,6 +213,49 @@ ruleTester.run('no-unvalidated-event-body', noUnvalidatedEventBody, {
           return { statusCode: 200 };
         };
       `,
+      errors: [{ messageId: 'unvalidatedInput' }],
+    },
+  ]),
+});
+
+/**
+ * The `fileImportsLambda` probe is an OR chain over every import in the file,
+ * and `.some()` stops at the first match — so once the shared `lambda()` helper
+ * prepends `aws-lambda`, the later arms (`@aws-sdk/`, `@middy/`,
+ * `@aws-cdk/aws-lambda`) are never reached by any wrapped fixture.
+ *
+ * These cases are deliberately NOT wrapped: each names exactly one AWS import,
+ * which is both the file's Lambda evidence for the plugin-wide gate and the arm
+ * of the chain under test.
+ *
+ * The probe is narrower than the gate on purpose. It answers "may a *single*
+ * `event` argument count as a handler?", where the gate answers "is this file
+ * Lambda code at all?" — a handler export must not be allowed to promote every
+ * one-arg `event` function in the file.
+ */
+ruleTester.run('single-arg event, per import source', noUnvalidatedEventBody, {
+  valid: [],
+  invalid: [
+    {
+      name: '@aws-sdk/ subpath import',
+      code: `import { S3Client } from '@aws-sdk/client-s3';
+        const run = async (event) => { const data = event.body; return data; };`,
+      errors: [{ messageId: 'unvalidatedInput' }],
+    },
+    {
+      name: '@middy/ subpath import',
+      code: `import middy from '@middy/core';
+        const run = async (event) => { const data = event.body; return data; };`,
+      errors: [{ messageId: 'unvalidatedInput' }],
+    },
+    {
+      name: '@aws-cdk/aws-lambda arm (gate satisfied separately)',
+      // `@aws-cdk/aws-lambda` must be the ONLY import: `.some()` stops at the
+      // first arm that matches, so any earlier AWS import hides this one. The
+      // plugin-wide gate is satisfied by the (event, context) function instead.
+      code: `import * as cdk from '@aws-cdk/aws-lambda';
+        const boot = async (event, context) => cdk.Runtime;
+        const run = async (event) => { const data = event.body; return data; };`,
       errors: [{ messageId: 'unvalidatedInput' }],
     },
   ],

--- a/packages/eslint-plugin-lambda-security/src/rules/no-user-controlled-requests/index.ts
+++ b/packages/eslint-plugin-lambda-security/src/rules/no-user-controlled-requests/index.ts
@@ -13,6 +13,7 @@
  * @see https://owasp.org/www-community/attacks/Server_Side_Request_Forgery
  */
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
+import { fileIsLambda } from '../../utils/lambda-evidence';
 import {
   AST_NODE_TYPES,
   createRule,
@@ -125,6 +126,11 @@ export const noUserControlledRequests = createRule<RuleOptions, MessageIds>({
     context: TSESLint.RuleContext<MessageIds, RuleOptions>,
     [options = {}],
   ) {
+    // Every rule here is Lambda-specific, and none of them knew it: over 107,382
+    // files, 98% of this plugin's findings were in files with no AWS anything.
+    // Registering no visitors is both the gate and the cheap path.
+    if (!fileIsLambda(context.sourceCode.ast)) return {};
+
     const { allowInTests = true } = options as Options;
     const filename = context.filename;
     const isTestFile = /\.(test|spec)\.(ts|tsx|js|jsx)$/.test(filename);

--- a/packages/eslint-plugin-lambda-security/src/rules/no-user-controlled-requests/no-user-controlled-requests.test.ts
+++ b/packages/eslint-plugin-lambda-security/src/rules/no-user-controlled-requests/no-user-controlled-requests.test.ts
@@ -2,6 +2,52 @@ import { describe, it, afterAll } from 'vitest';
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { noUserControlledRequests } from './index';
 
+/**
+ * Every fixture carries the Lambda handler shape, because the rules now abstain
+ * in files that are not Lambda code. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the shape
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const asLambda = (code: string): string =>
+  `import type { Handler } from 'aws-lambda';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const lambda = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asLambda(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asLambda(test.code),
+      // Autofix and suggestion fixtures assert the WHOLE file back, so every
+      // `output` needs the same prefix or each fixable rule fails on the header
+      // alone — including the ones nested under errors[].suggestions[].
+      ...(typeof test.output === 'string' ? { output: asLambda(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asLambda(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -10,7 +56,7 @@ RuleTester.describe = describe;
 const ruleTester = new RuleTester();
 
 ruleTester.run('no-user-controlled-requests', noUserControlledRequests, {
-  valid: [
+  valid: lambda([
     // Safe: Static URL
     {
       code: `
@@ -59,8 +105,8 @@ ruleTester.run('no-user-controlled-requests', noUserControlledRequests, {
       `,
       filename: 'handler.test.ts',
     },
-  ],
-  invalid: [
+  ]),
+  invalid: lambda([
     // URL from query parameters
     {
       code: `
@@ -213,5 +259,5 @@ ruleTester.run('no-user-controlled-requests', noUserControlledRequests, {
       `,
       errors: [{ messageId: 'ssrfVulnerability' }],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-lambda-security/src/rules/require-timeout-handling/index.ts
+++ b/packages/eslint-plugin-lambda-security/src/rules/require-timeout-handling/index.ts
@@ -13,6 +13,7 @@
  * @see https://owasp.org/www-project-serverless-top-10/
  */
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
+import { fileIsLambda } from '../../utils/lambda-evidence';
 import {
   AST_NODE_TYPES,
   createRule,
@@ -108,6 +109,11 @@ export const requireTimeoutHandling = createRule<RuleOptions, MessageIds>({
     context: TSESLint.RuleContext<MessageIds, RuleOptions>,
     [options = {}],
   ) {
+    // Every rule here is Lambda-specific, and none of them knew it: over 107,382
+    // files, 98% of this plugin's findings were in files with no AWS anything.
+    // Registering no visitors is both the gate and the cheap path.
+    if (!fileIsLambda(context.sourceCode.ast)) return {};
+
     const { allowInTests = true } = options as Options;
     const filename = context.filename;
     const isTestFile = /\.(test|spec)\.(ts|tsx|js|jsx)$/.test(filename);

--- a/packages/eslint-plugin-lambda-security/src/rules/require-timeout-handling/require-timeout-handling.test.ts
+++ b/packages/eslint-plugin-lambda-security/src/rules/require-timeout-handling/require-timeout-handling.test.ts
@@ -2,6 +2,52 @@ import { describe, it, afterAll } from 'vitest';
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { requireTimeoutHandling } from './index';
 
+/**
+ * Every fixture carries the Lambda handler shape, because the rules now abstain
+ * in files that are not Lambda code. Wrapping the arrays rather than editing
+ * each fixture means one cannot be left behind — a fixture missing the shape
+ * would pass vacuously on the gate instead of exercising the detection it was
+ * written for.
+ */
+const asLambda = (code: string): string =>
+  `import type { Handler } from 'aws-lambda';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const lambda = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asLambda(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asLambda(test.code),
+      // Autofix and suggestion fixtures assert the WHOLE file back, so every
+      // `output` needs the same prefix or each fixable rule fails on the header
+      // alone — including the ones nested under errors[].suggestions[].
+      ...(typeof test.output === 'string' ? { output: asLambda(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asLambda(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -10,7 +56,7 @@ RuleTester.describe = describe;
 const ruleTester = new RuleTester();
 
 ruleTester.run('require-timeout-handling', requireTimeoutHandling, {
-  valid: [
+  valid: lambda([
     // Test file (allowed by default)
     {
       code: `
@@ -83,9 +129,9 @@ ruleTester.run('require-timeout-handling', requireTimeoutHandling, {
         };
       `,
     },
-  ],
+  ]),
 
-  invalid: [
+  invalid: lambda([
     // Lambda handler with fetch but no timeout handling (classic FN)
     {
       code: `
@@ -180,7 +226,7 @@ ruleTester.run('require-timeout-handling', requireTimeoutHandling, {
       `,
       errors: [{ messageId: 'missingTimeoutHandling' }],
     },
-  ],
+  ]),
 });
 
 // Regression lock — function-exit `:exit` selector (ESLint 9 "Unknown class
@@ -195,7 +241,7 @@ ruleTester.run(
   'require-timeout-handling (function-exit selector regression)',
   requireTimeoutHandling,
   {
-    valid: [
+    valid: lambda([
       // Clean handler of each node type — exit listeners run, no crash, no FP.
       {
         code: `export const handler = async (event, context) => {
@@ -212,8 +258,8 @@ ruleTester.run(
           return { statusCode: 200 };
         }`,
       },
-    ],
-    invalid: [
+    ]),
+    invalid: lambda([
       // External call + no timeout handling reports once per node type.
       {
         code: `export const handler = async (event, context) => {
@@ -233,6 +279,6 @@ ruleTester.run(
         }`,
         errors: [{ messageId: 'missingTimeoutHandling' }],
       },
-    ],
+    ]),
   },
 );

--- a/packages/eslint-plugin-lambda-security/src/utils/lambda-evidence.test.ts
+++ b/packages/eslint-plugin-lambda-security/src/utils/lambda-evidence.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Tests for the Lambda evidence probe.
+ *
+ * Every rule in this plugin abstains unless `fileIsLambda` says the file is
+ * Lambda code, so a bug here is a bug in all fourteen at once — silently, in
+ * whichever direction the bug leans.
+ */
+import { describe, it, expect } from 'vitest';
+import { parse } from '@typescript-eslint/parser';
+import { fileIsLambda } from './lambda-evidence';
+
+const isLambda = (code: string): boolean =>
+  fileIsLambda(parse(code, { sourceType: 'module', range: true }));
+
+describe('fileIsLambda', () => {
+  describe('handler exports — the half an import gate would miss', () => {
+    // Measured: 184 of 413 handler files in the corpus (45%) import nothing AWS.
+    it.each([
+      ['exports.handler = async (e) => {};', 'CommonJS exports.handler'],
+      ['module.exports.handler = async (e) => {};', 'module.exports.handler'],
+      ['export const handler = async (e) => {};', 'ESM const'],
+      ['export async function handler(e) {}', 'ESM function declaration'],
+      ['export function handler(e) {}', 'ESM sync function'],
+      ['const main = async (e) => {};\nexport { main as handler };', 'renamed export'],
+    ])('%s → true (%s)', (code) => {
+      expect(isLambda(code)).toBe(true);
+    });
+
+    it.each([
+      ['export const handleRequest = async (e) => {};', 'a name merely containing "handle"'],
+      ['export const handlers = [];', 'the plural is a different export'],
+      ['const handler = async (e) => {};', 'a local, unexported handler'],
+    ])('%s → false (%s)', (code) => {
+      expect(isLambda(code)).toBe(false);
+    });
+  });
+
+  describe('the (event, context) calling convention', () => {
+    it.each([
+      'async function run(event, context) {}',
+      'const run = (event, context) => {};',
+      'const run = function (event, context, callback) {};',
+    ])('%s → true', (code) => {
+      expect(isLambda(code)).toBe(true);
+    });
+
+    // One parameter named `event` is every DOM listener and every emitter
+    // callback ever written. It is not evidence of anything.
+    it.each([
+      'element.addEventListener("click", (event) => {});',
+      'emitter.on("data", function (event) {});',
+      'function f(event) {}',
+      'function f(context, event) {}',
+      'function f(req, res) {}',
+      'function f() {}',
+      'const f = (a, b) => a + b;',
+    ])('%s → false', (code) => {
+      expect(isLambda(code)).toBe(false);
+    });
+  });
+
+  describe('AWS imports and requires', () => {
+    it.each([
+      "import type { Handler } from 'aws-lambda';",
+      "import { S3Client } from '@aws-sdk/client-s3';",
+      "import AWS from 'aws-sdk';",
+      "import middy from '@middy/core';",
+      "import jsonBodyParser from '@middy/http-json-body-parser';",
+      "import { Logger } from '@aws-lambda-powertools/logger';",
+      "import serverless from 'serverless-http';",
+      "const AWS = require('aws-sdk');",
+      "const AWS = await import('aws-sdk');",
+      "const { S3Client } = await import('@aws-sdk/client-s3');",
+      "export * from 'aws-lambda';",
+      "export { Handler } from 'aws-lambda';",
+    ])('%s → true', (code) => {
+      expect(isLambda(code)).toBe(true);
+    });
+
+    it.each([
+      ["import express from 'express';", 'a different framework'],
+      ["import x from './aws-lambda';", 'a relative path that spells the package'],
+      ["import x from '/aws-lambda';", 'an absolute path'],
+      ["import x from 'aws-lambda-extra';", 'a package sharing the prefix'],
+      ["require('./aws-sdk');", 'a relative require'],
+      ['require(name);', 'a non-literal require'],
+      ['require();', 'a require with no arguments'],
+      ['require(123);', 'a non-string literal'],
+      ["await import('./aws-sdk');", 'a relative dynamic import'],
+      ['await import(name);', 'a non-literal dynamic import'],
+      ['notRequire("aws-sdk");', 'a differently named function'],
+    ])('%s → false (%s)', (code) => {
+      expect(isLambda(code)).toBe(false);
+    });
+  });
+
+  describe('files that are not Lambda code', () => {
+    it('an empty file', () => {
+      expect(isLambda('')).toBe(false);
+    });
+
+    // The exact shape that produced 5,543 findings from no-error-swallowing.
+    it('a plain JSON.parse helper', () => {
+      expect(
+        isLambda(
+          'export function parse(s) { try { return JSON.parse(s); } catch { return null; } }',
+        ),
+      ).toBe(false);
+    });
+
+    it.each([
+      'export default function Button() { return null; }',
+      'const app = express();\napp.get("/x", (req, res) => res.json({}));',
+      'export const config = { retries: 3 };',
+    ])('%s stays outside the gate', (code) => {
+      expect(isLambda(code)).toBe(false);
+    });
+  });
+
+  describe('the remaining shapes', () => {
+    it('a deep import of an exact package still matches on its root', () => {
+      // `aws-sdk/clients/s3` is `aws-sdk`; the prefix list would not catch it.
+      expect(isLambda("import S3 from 'aws-sdk/clients/s3';")).toBe(true);
+    });
+
+    it('a computed export assignment is not a handler declaration', () => {
+      // `namesHandler` sees neither an Identifier nor a MemberExpression here.
+      expect(isLambda('[handler] = arr;')).toBe(false);
+    });
+
+    it('a computed member assignment named handler is not evidence', () => {
+      expect(isLambda('exports[name] = async (e) => {};')).toBe(false);
+    });
+
+    it('an exported class named handler is not a handler function', () => {
+      expect(isLambda('export class handler {}')).toBe(false);
+    });
+  });
+});

--- a/packages/eslint-plugin-lambda-security/src/utils/lambda-evidence.test.ts
+++ b/packages/eslint-plugin-lambda-security/src/utils/lambda-evidence.test.ts
@@ -142,4 +142,34 @@ describe('fileIsLambda', () => {
       expect(isLambda('export class handler {}')).toBe(false);
     });
   });
+
+  describe('a locally bound `require` is not module loading', () => {
+    // The plugin's own lesson turned on itself: a *name* is not proof of an
+    // *interface*.
+    it.each([
+      "function f(require) { require('aws-sdk'); }",
+      "const load = (require) => require('aws-lambda');",
+      "const require = (m) => m; require('aws-sdk');",
+    ])('%s → false', (code) => {
+      expect(isLambda(code)).toBe(false);
+    });
+
+    it('the other arms still apply when `require` is shadowed', () => {
+      expect(
+        isLambda("import type { H } from 'aws-lambda';\nfunction f(require) { require('aws-sdk'); }"),
+      ).toBe(true);
+      expect(
+        isLambda("export const handler = async (e) => {};\nfunction f(require) { require('aws-sdk'); }"),
+      ).toBe(true);
+    });
+  });
+
+  it('the result is cached per Program, so fourteen rules cost one scan', () => {
+    const ast = parse("import type { Handler } from 'aws-lambda';", {
+      sourceType: 'module',
+      range: true,
+    });
+    expect(fileIsLambda(ast)).toBe(true);
+    expect(fileIsLambda(ast)).toBe(true);
+  });
 });

--- a/packages/eslint-plugin-lambda-security/src/utils/lambda-evidence.ts
+++ b/packages/eslint-plugin-lambda-security/src/utils/lambda-evidence.ts
@@ -1,0 +1,206 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+import type { TSESTree } from '@interlace/eslint-devkit';
+import { AST_NODE_TYPES } from '@interlace/eslint-devkit';
+
+/**
+ * Packages whose presence means this file is Lambda code.
+ *
+ * `serverless-*` and `@middy/*` are matched by prefix because both are families
+ * (`@middy/http-json-body-parser`, `serverless-http`).
+ */
+const AWS_PACKAGES: ReadonlySet<string> = new Set([
+  'aws-lambda',
+  'aws-sdk',
+  'aws-xray-sdk',
+  'aws-xray-sdk-core',
+  // The bare framework package, distinct from the `serverless-*` plugin family
+  // below. Without it, a file importing exactly `serverless` fell outside the
+  // gate — 8 in-SDK corpus findings went silent before this line was added.
+  'serverless',
+  '@aws-lambda-powertools/logger',
+  '@aws-lambda-powertools/tracer',
+  '@aws-lambda-powertools/metrics',
+]);
+
+const AWS_PREFIXES: readonly string[] = [
+  '@aws-sdk/',
+  '@middy/',
+  'serverless-',
+  '@aws-lambda-powertools/',
+];
+
+/** The Lambda calling convention, in the order the runtime passes them. */
+const HANDLER_PARAMS: readonly string[] = ['event', 'context', 'callback'];
+
+function isAwsSpecifier(specifier: string): boolean {
+  if (specifier.startsWith('.') || specifier.startsWith('/')) return false;
+  if (AWS_PACKAGES.has(specifier)) return true;
+  const parts = specifier.split('/');
+  const root = specifier.startsWith('@')
+    ? parts.slice(0, 2).join('/')
+    : parts[0];
+  if (AWS_PACKAGES.has(root)) return true;
+  return AWS_PREFIXES.some((prefix) => specifier.startsWith(prefix));
+}
+
+/**
+ * `require('aws-sdk')` and `await import('aws-sdk')` — the two dynamic forms.
+ *
+ * A Lambda bundle loads the SDK lazily often enough that omitting the dynamic
+ * `import()` arm cost six real findings in the corpus: it is an
+ * `ImportExpression`, not a `CallExpression`, so the `require` check never sees
+ * it.
+ */
+function isAwsDynamicLoad(node: TSESTree.Node): boolean {
+  const argument =
+    node.type === AST_NODE_TYPES.ImportExpression
+      ? node.source
+      : node.type === AST_NODE_TYPES.CallExpression &&
+          node.callee.type === AST_NODE_TYPES.Identifier &&
+          node.callee.name === 'require'
+        ? node.arguments[0]
+        : undefined;
+  return (
+    argument?.type === AST_NODE_TYPES.Literal &&
+    typeof argument.value === 'string' &&
+    isAwsSpecifier(argument.value)
+  );
+}
+
+/** Whether a member/identifier chain ends in `handler`. */
+function namesHandler(node: TSESTree.Node): boolean {
+  if (node.type === AST_NODE_TYPES.Identifier) return node.name === 'handler';
+  if (node.type === AST_NODE_TYPES.MemberExpression) {
+    return (
+      node.property.type === AST_NODE_TYPES.Identifier &&
+      node.property.name === 'handler'
+    );
+  }
+  return false;
+}
+
+/**
+ * `exports.handler = …`, `module.exports.handler = …`, `export const handler`,
+ * `export async function handler`, `export { x as handler }`.
+ */
+function declaresHandler(node: TSESTree.Node): boolean {
+  if (
+    node.type === AST_NODE_TYPES.AssignmentExpression &&
+    namesHandler(node.left)
+  ) {
+    return true;
+  }
+  if (node.type === AST_NODE_TYPES.ExportNamedDeclaration) {
+    if (node.specifiers.some((s) => namesHandler(s.exported))) return true;
+    const decl = node.declaration;
+    if (decl?.type === AST_NODE_TYPES.FunctionDeclaration && decl.id) {
+      return decl.id.name === 'handler';
+    }
+    if (decl?.type === AST_NODE_TYPES.VariableDeclaration) {
+      return decl.declarations.some(
+        (d) =>
+          d.id.type === AST_NODE_TYPES.Identifier && d.id.name === 'handler',
+      );
+    }
+  }
+  return false;
+}
+
+/**
+ * A function taking `(event, context)` — the Lambda calling convention.
+ *
+ * Requires at least two parameters in order. `(event)` alone is far too common
+ * outside Lambda to be evidence of anything: every DOM listener and every
+ * emitter callback takes one parameter named `event`.
+ */
+function hasHandlerSignature(node: TSESTree.Node): boolean {
+  if (
+    node.type !== AST_NODE_TYPES.FunctionDeclaration &&
+    node.type !== AST_NODE_TYPES.FunctionExpression &&
+    node.type !== AST_NODE_TYPES.ArrowFunctionExpression
+  ) {
+    return false;
+  }
+  const params = node.params;
+  if (params.length < 2) return false;
+  return HANDLER_PARAMS.slice(0, params.length).every(
+    (expected, i) =>
+      params[i].type === AST_NODE_TYPES.Identifier &&
+      (params[i] as TSESTree.Identifier).name === expected,
+  );
+}
+
+/**
+ * Whether this file is AWS Lambda code.
+ *
+ * Every rule in this plugin is gated on it. Measured over 107,382 files,
+ * **98% of everything this plugin reported (9,244 of 9,473 findings) was in a
+ * file with no AWS anything in it** — `no-error-swallowing` alone contributed
+ * 5,543, firing on any `try/catch` in any file while its own description
+ * claimed to detect "empty catch blocks in Lambda handlers".
+ *
+ * The evidence is deliberately a **union**, because an import gate alone is the
+ * wrong gate here. Measured over the 12-repo Lambda corpus: 413 files export a
+ * handler and **184 of them (45%) import nothing AWS at all** — `aws-lambda` is
+ * a types package, a type-only import vanishes at runtime, and a plain JS
+ * handler imports nothing. Gating on imports would have silenced the plugin on
+ * nearly half of the real handlers. Conversely 441 files import an AWS SDK
+ * without exporting a handler, and they are still Lambda code.
+ *
+ * So: a handler export, or the `(event, context)` calling convention, or an AWS
+ * import. All three are local to the file — nothing is read from
+ * `serverless.yml`, `template.yaml` or `package.json`, so there is no project
+ * state to go stale and no dependency on lint order.
+ */
+export function fileIsLambda(ast: TSESTree.Program): boolean {
+  let found = false;
+
+  const visit = (node: TSESTree.Node): void => {
+    if (
+      (node.type === AST_NODE_TYPES.ImportDeclaration ||
+        node.type === AST_NODE_TYPES.ExportNamedDeclaration ||
+        node.type === AST_NODE_TYPES.ExportAllDeclaration) &&
+      node.source?.type === AST_NODE_TYPES.Literal &&
+      typeof node.source.value === 'string' &&
+      isAwsSpecifier(node.source.value)
+    ) {
+      found = true;
+      return;
+    }
+    if (
+      isAwsDynamicLoad(node) ||
+      declaresHandler(node) ||
+      hasHandlerSignature(node)
+    ) {
+      found = true;
+      return;
+    }
+    for (const key of Object.keys(node)) {
+      if (key === 'parent') continue;
+      const value = (node as unknown as Record<string, unknown>)[key];
+      if (Array.isArray(value)) {
+        for (const child of value) {
+          if (child && typeof (child as TSESTree.Node).type === 'string') {
+            visit(child as TSESTree.Node);
+            if (found) return;
+          }
+        }
+      } else if (
+        value &&
+        typeof value === 'object' &&
+        typeof (value as TSESTree.Node).type === 'string'
+      ) {
+        visit(value as TSESTree.Node);
+        if (found) return;
+      }
+    }
+  };
+
+  visit(ast);
+  return found;
+}

--- a/packages/eslint-plugin-lambda-security/src/utils/lambda-evidence.ts
+++ b/packages/eslint-plugin-lambda-security/src/utils/lambda-evidence.ts
@@ -56,11 +56,15 @@ function isAwsSpecifier(specifier: string): boolean {
  * `ImportExpression`, not a `CallExpression`, so the `require` check never sees
  * it.
  */
-function isAwsDynamicLoad(node: TSESTree.Node): boolean {
+function isAwsDynamicLoad(
+  node: TSESTree.Node,
+  requireIsShadowed: boolean,
+): boolean {
   const argument =
     node.type === AST_NODE_TYPES.ImportExpression
       ? node.source
-      : node.type === AST_NODE_TYPES.CallExpression &&
+      : !requireIsShadowed &&
+          node.type === AST_NODE_TYPES.CallExpression &&
           node.callee.type === AST_NODE_TYPES.Identifier &&
           node.callee.name === 'require'
         ? node.arguments[0]
@@ -157,8 +161,82 @@ function hasHandlerSignature(node: TSESTree.Node): boolean {
  * `serverless.yml`, `template.yaml` or `package.json`, so there is no project
  * state to go stale and no dependency on lint order.
  */
+/**
+ * Whether the file declares a binding named `require` anywhere.
+ *
+ * `function f(require) { require('aws-sdk'); }` is not module loading, and
+ * treating it as Lambda evidence would be this plugin committing the exact
+ * error it was just fixed for: taking a *name* as proof of an *interface*. When
+ * the name is bound locally the `require` arm is dropped; imports, dynamic
+ * `import()`, handler exports and the calling convention all still apply.
+ */
+function declaresRequireBinding(ast: TSESTree.Program): boolean {
+  let shadowed = false;
+  // No top guard: every recursive call site below already checks.
+  const scan = (node: TSESTree.Node): void => {
+    if (
+      (node.type === AST_NODE_TYPES.FunctionDeclaration ||
+        node.type === AST_NODE_TYPES.FunctionExpression ||
+        node.type === AST_NODE_TYPES.ArrowFunctionExpression) &&
+      node.params.some(
+        (p) => p.type === AST_NODE_TYPES.Identifier && p.name === 'require',
+      )
+    ) {
+      shadowed = true;
+      return;
+    }
+    if (
+      node.type === AST_NODE_TYPES.VariableDeclarator &&
+      node.id.type === AST_NODE_TYPES.Identifier &&
+      node.id.name === 'require'
+    ) {
+      shadowed = true;
+      return;
+    }
+    for (const key of Object.keys(node)) {
+      if (key === 'parent') continue;
+      const value = (node as unknown as Record<string, unknown>)[key];
+      if (Array.isArray(value)) {
+        for (const child of value) {
+          if (child && typeof (child as TSESTree.Node).type === 'string') {
+            scan(child as TSESTree.Node);
+            if (shadowed) return;
+          }
+        }
+      } else if (
+        value &&
+        typeof value === 'object' &&
+        typeof (value as TSESTree.Node).type === 'string'
+      ) {
+        scan(value as TSESTree.Node);
+        if (shadowed) return;
+      }
+    }
+  };
+  scan(ast);
+  return shadowed;
+}
+
+/**
+ * One evidence scan per file, not one per rule.
+ *
+ * `create` runs for each of the fourteen rules, so an uncached probe walks the
+ * whole AST fourteen times for every file — and the files paying that cost are
+ * mostly the non-Lambda ones the gate exists to skip cheaply.
+ */
+const cache = new WeakMap<TSESTree.Program, boolean>();
+
 export function fileIsLambda(ast: TSESTree.Program): boolean {
+  const cached = cache.get(ast);
+  if (cached !== undefined) return cached;
+  const result = computeIsLambda(ast);
+  cache.set(ast, result);
+  return result;
+}
+
+function computeIsLambda(ast: TSESTree.Program): boolean {
   let found = false;
+  const requireIsShadowed = declaresRequireBinding(ast);
 
   const visit = (node: TSESTree.Node): void => {
     if (
@@ -173,7 +251,7 @@ export function fileIsLambda(ast: TSESTree.Program): boolean {
       return;
     }
     if (
-      isAwsDynamicLoad(node) ||
+      isAwsDynamicLoad(node, requireIsShadowed) ||
       declaresHandler(node) ||
       hasHandlerSignature(node)
     ) {


### PR DESCRIPTION
## Summary

`eslint-plugin-lambda-security` had **no notion of whether a file was Lambda code**. `no-error-swallowing` fired on any `try/catch` anywhere — while its own description claimed to detect *"empty catch blocks in **Lambda handlers**"*. Four more rules (`no-env-logging`, `no-overly-permissive-iam-policy`, `no-permissive-cors-middy`, `no-secrets-in-env`) contain no Lambda reference at all, not even in prose.

Measured over **107,382 files across 108 repositories**:

| | findings | in a file with **no AWS anything** |
|---|---:|---:|
| before | 9,473 | **9,244 (98%)** |
| after | 723 | 500 † |

Reproducible in three lines — this is what the plugin said about a plain JSON helper:

```ts
export function parse(s: string) { try { return JSON.parse(s); } catch { return null; } }
// ⚠️ CWE-390 OWASP:A10-Mishandling CVSS:5 | Catch block swallows error
```

`no-error-swallowing` alone was 5,543 of the 9,244.

## An import gate is the wrong gate here — the corpus said so

The obvious fix (match imports, like the postgres and SQL gates) would have been **wrong**, and measuring the 12-repo Lambda corpus is what showed it:

| shape | files |
|---|---:|
| exports a `handler` | 413 |
| imports `aws-lambda` / `@aws-sdk/*` / `aws-sdk` / `@middy/*` | 670 |
| both | 229 |
| **handler-shaped, importing nothing AWS** | **184 — 45% of all handlers** |

`aws-lambda` is a *types* package; a type-only import vanishes at runtime and a plain JS handler imports nothing at all. An import gate would have silenced the plugin on nearly half the real handlers in the corpus. Conversely 441 files import an AWS SDK without exporting a handler — still Lambda code.

So the evidence is a **union**, every arm local to the file:

1. a **handler export** — `exports.handler`, `module.exports.handler`, `export const handler`, `export async function handler`, `export { x as handler }`
2. the **`(event, context[, callback])` calling convention** — in order, at least two parameters. One argument named `event` is every DOM listener ever written and is not evidence of anything.
3. an **import / `require` / dynamic `import()`** of `aws-lambda`, `aws-sdk`, `@aws-sdk/*`, `@middy/*`, `serverless`, `serverless-*`, `@aws-lambda-powertools/*`, `aws-xray-sdk`

A **locally bound `require` is not module loading**: `function f(require) { require('aws-sdk'); }` does not open the gate — that would be this plugin taking a *name* as proof of an *interface*, the exact error it is being fixed for.

Nothing is read from `serverless.yml`, `template.yaml` or `package.json` — no project state to go stale, no dependency on lint order. Gating by registering no visitors makes the non-Lambda case free rather than merely silent, and the probe is cached per `Program` so fourteen rules cost one scan.

† the residual 500 are, by construction, files the gate opened via **handler shape or calling convention** while the measurement probe (import-only) saw nothing — i.e. exactly the 45% an import gate would have lost.

## The cost was measured, not assumed

Every finding in the 768 in-SDK files was diffed before and after. **Exactly 4 were lost**, all in one file:

```
powertools-ts/packages/batch/src/processPartialResponse{,Sync}.ts  ×4
  l/no-unbounded-batch-processing
```

That is `@aws-lambda-powertools/batch` library code: it imports only relative paths (`./types.js`) and takes `(event, recordHandler, processor, options)`. Library code reached only through a wrapper is the deliberate, documented miss.

Two evidence arms exist **because the diff demanded them**, not on a hunch: bare `serverless` (8 findings) and dynamic `import()`, which is an `ImportExpression` the `require` check never saw (6 findings).

## Test plan

- [x] **Registry-wide lock** — `src/module-gate.lock.test.ts` sweeps *every* rule in `plugin.rules` over six real false-positive shapes from the corpus (a JSON helper, an Express route, a React component, a one-arg DOM listener, a config module, and a local module named `./aws-sdk`). A rule added later is covered the day it lands.
- [x] **Four positive controls**, because negatives alone would pass with the gate closed on everything: handler export alone, `(event, context)` alone, a type-only `aws-lambda` import, and the same catch block going silent with none of the three present.
- [x] **`Linter({ configType: 'flat' })`** — on this package's declared ESLint floor (8.40) a bare `new Linter()` still defaults to eslintrc, so the flat config would be ignored and every rule silently skipped. That is the vacuous pass this lock exists to catch.
- [x] **`src/utils/lambda-evidence.test.ts`** — the probe itself: every handler form, the near-misses (`handleRequest`, `handlers`, an unexported `handler`), the calling convention and its decoys, deep/scoped/relative/absolute/prefix-sharing specifiers, `require` and dynamic `import()` in every invalid form, and shadowed-`require` regressions.
- [x] **Fixtures wrapped, not edited** — a `lambda()` helper prefixes `code`, `output`, *and* `errors[].suggestions[].output` (autofix fixtures assert the whole file back). Test count **unchanged at 374** with the gate in place, 522 with the new suites, so nothing was silently skipped.
- [x] Suite green at the package's 100% coverage threshold: 19 files, 522 tests.

## After merge

Released as a **major** — any rule may now stay silent where it previously reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)