### PR TITLE
fix(express-security): abstain in files without local Express evidence

### DIFF
--- a/.changeset/express-evidence-gate.md
+++ b/.changeset/express-evidence-gate.md
@@ -1,0 +1,33 @@
+---
+'eslint-plugin-express-security': major
+---
+
+Every rule now abstains in files without local Express evidence
+
+The plugin had no notion of whether a file had Express in it. Measured over
+**107,382 files across 108 repositories**: 5,921 findings, of which **4,450
+(75%) were in files with no Express import** — `no-missing-csrf-protection`
+alone contributed 3,556.
+
+Every rule now requires local evidence: an import / `require` / dynamic
+`import()` of `express`, **or** a `(req, res, next)` middleware signature.
+
+The signature arm is deliberately the **three-argument** form only. Two-argument
+`(req, res)` is shared with `node:http`, Next.js API routes and other servers,
+so accepting it would re-import the false positives this change removes. The
+three-argument form with a trailing `next` is the Connect/Express middleware
+contract and essentially nothing else. Error-handling middleware
+`(err, req, res, next)` matches on the tail.
+
+The import arm alone was not enough: over the 12-repo Express corpus, 68 of 114
+files containing a `(req, res)`-shaped function (60%) import no `express` —
+route modules routinely receive `app` or `router` from their caller.
+
+After the change the same corpus yields 1,480 findings instead of 5,921, and
+**no recall is lost**: diffed across all 1,003 files that import `express`,
+findings are identical before and after (1,554 → 1,554, zero lost). The 44
+remaining findings outside an `express` import are, by construction, files the
+gate opened on the middleware signature.
+
+This is a **major** bump: any rule may now stay silent where it previously
+reported.

--- a/packages/eslint-plugin-express-security/src/module-gate.lock.test.ts
+++ b/packages/eslint-plugin-express-security/src/module-gate.lock.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Regression lock: no rule in this plugin reports in a file with no Express in
+ * it.
+ *
+ * Measured over 107,382 files in 108 repositories, **75% of everything this
+ * plugin reported (4,450 of 5,921 findings) was in a file with no Express
+ * import** — `no-missing-csrf-protection` alone contributed 3,556.
+ *
+ * Written over the whole rule registry rather than per rule, so a rule added
+ * later is covered the day it lands: it will fail here until it is gated too.
+ * Revert the gate in any single rule and this test goes red.
+ */
+import { describe, it, expect } from 'vitest';
+import { Linter } from 'eslint';
+import parser from '@typescript-eslint/parser';
+import plugin from './index';
+
+const RULES = Object.keys(plugin.rules);
+
+/**
+ * Shapes that drew findings from this plugin across the corpus while having no
+ * Express in them. The `node:http` and Next.js cases matter most: both use the
+ * two-argument `(req, res)` form, which is exactly why the gate's signature arm
+ * requires the three-argument middleware contract instead.
+ */
+const NON_EXPRESS_SOURCES: ReadonlyArray<readonly [string, string]> = [
+  [
+    'a node:http server',
+    `import http from 'node:http';
+     http.createServer((req, res) => {
+       res.writeHead(200, { 'Access-Control-Allow-Origin': '*' });
+       res.end(req.url);
+     }).listen(3000);`,
+  ],
+  [
+    'a Next.js API route',
+    `export default function handler(req, res) {
+       res.setHeader('Access-Control-Allow-Origin', '*');
+       res.json({ path: req.query.path });
+     }`,
+  ],
+  [
+    'a Fastify server',
+    `import fastify from 'fastify';
+     const app = fastify();
+     app.get('/users', async (request, reply) => reply.send({ ok: true }));`,
+  ],
+  [
+    'a React component',
+    `export default function Panel({ items }) {
+       return items.map((i) => i.name).join(', ');
+     }`,
+  ],
+  [
+    'a config module',
+    `export const config = {
+       cookie: { secure: false, httpOnly: false },
+       cors: { origin: '*' },
+     };`,
+  ],
+  [
+    'a local module merely named express',
+    `import express from './express';
+     const app = express();
+     app.use((req, res) => res.send('x'));`,
+  ],
+];
+
+const lint = (code: string, rule: string): Linter.LintMessage[] => {
+  // The declared ESLint floor for this package is 8.40, where `new Linter()`
+  // still defaults to eslintrc — a flat config would be ignored there and every
+  // rule silently skipped, which is the vacuous pass this lock exists to catch.
+  const linter = new Linter({ configType: 'flat' });
+  return linter.verify(
+    code,
+    {
+      files: ['**/*.ts'],
+      languageOptions: {
+        parser: parser as unknown as Linter.Parser,
+        parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+      },
+      plugins: { xp: plugin as unknown as Linter.Plugin },
+      rules: { [`xp/${rule}`]: 'error' },
+    },
+    // Without a filename the Linter lints `<input>`, which matches no `files`
+    // entry — so every rule is skipped and every negative below passes without
+    // running a rule at all. The positive controls below are what catch that.
+    'server.ts',
+  );
+};
+
+describe('Express module gate', () => {
+  it('the registry is non-empty, so the sweep below is not vacuous', () => {
+    expect(RULES.length).toBeGreaterThan(0);
+  });
+
+  describe.each(NON_EXPRESS_SOURCES)('%s', (_name, code) => {
+    it.each(RULES)('xp/%s reports nothing', (rule) => {
+      const messages = lint(code, rule);
+      // A parse or config error also produces zero *rule* findings, so it is
+      // asserted away rather than counted as a pass.
+      expect(messages.filter((m) => !m.ruleId)).toHaveLength(0);
+      expect(messages).toHaveLength(0);
+    });
+  });
+
+  describe('positive controls — the gate must open for real Express code', () => {
+    // `app.use(cors({ origin: '*' }))` is the shape no-permissive-cors keys on.
+    const permissive = `app.use(cors({ origin: '*', credentials: true }));`;
+
+    it('reports once the file imports express', () => {
+      const code = `import express from 'express';
+        import cors from 'cors';
+        const app = express();
+        ${permissive}`;
+      expect(lint(code, 'no-permissive-cors').length).toBeGreaterThan(0);
+    });
+
+    it('reports on the (req, res, next) middleware contract with no express import', () => {
+      const code = `import cors from 'cors';
+        export function setup(app) { ${permissive} }
+        export function guard(req, res, next) { next(); }`;
+      expect(lint(code, 'no-permissive-cors').length).toBeGreaterThan(0);
+    });
+
+    it('and stays silent on that same call with neither present', () => {
+      const code = `import cors from 'cors';
+        export function setup(app) { ${permissive} }`;
+      expect(lint(code, 'no-permissive-cors')).toHaveLength(0);
+    });
+  });
+});

--- a/packages/eslint-plugin-express-security/src/rules/no-client-controlled-authorization/index.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-client-controlled-authorization/index.ts
@@ -36,6 +36,7 @@
  */
 
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
+import { fileUsesExpress } from '../../utils/express-evidence';
 import {
   AST_NODE_TYPES,
   createRule,
@@ -243,6 +244,12 @@ export const noClientControlledAuthorization = createRule<
   },
   defaultOptions: [{}],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>, [options]) {
+    // Every rule here is Express-specific, and none of them knew it: over
+    // 107,382 files, 75% of this plugin's findings were in files with no
+    // Express import. Registering no visitors is both the gate and the cheap
+    // path — a file with no Express in it does no work.
+    if (!fileUsesExpress(context.sourceCode.ast)) return {};
+
     const { extraProperties } = options as Options;
     const extra = new Set(
       (extraProperties ?? []).map((name) => name.toLowerCase()),

--- a/packages/eslint-plugin-express-security/src/rules/no-client-controlled-authorization/no-client-controlled-authorization.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-client-controlled-authorization/no-client-controlled-authorization.test.ts
@@ -3,6 +3,49 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { noClientControlledAuthorization } from './index';
 
+/**
+ * Every fixture imports express, because the rules now abstain in files with no
+ * Express in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass vacuously
+ * on the gate instead of exercising the detection it was written for. `output`
+ * and errors[].suggestions[].output are prefixed too, since autofix fixtures
+ * assert the whole file back.
+ */
+const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const xp = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asExpress(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asExpress(test.code),
+      ...(typeof test.output === 'string' ? { output: asExpress(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asExpress(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -17,7 +60,7 @@ describe('no-client-controlled-authorization', () => {
     'no-client-controlled-authorization',
     noClientControlledAuthorization,
     {
-      valid: [
+      valid: xp([
         // THE safe pattern — the attribute comes from the verified principal
         { code: `if (req.user.role === 'admin') { grant(); }` },
         {
@@ -52,8 +95,8 @@ describe('no-client-controlled-authorization', () => {
         // Dynamic property name — not analysed
         { code: `if (req.body[field] === 'admin') { grant(); }` },
         { code: `if (req.body[0] === 'admin') { grant(); }` },
-      ],
-      invalid: [
+      ]),
+      invalid: xp([
         // Role straight off the request body
         {
           code: `if (req.body.role === 'admin') { deleteEverything(); }`,
@@ -122,7 +165,7 @@ describe('no-client-controlled-authorization', () => {
           options: [{ extraProperties: ['plan'] }],
           errors: [{ messageId: 'clientControlledAuthorization' as const }],
         },
-      ],
+      ]),
     },
   );
 });

--- a/packages/eslint-plugin-express-security/src/rules/no-client-controlled-authorization/no-client-controlled-authorization.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-client-controlled-authorization/no-client-controlled-authorization.test.ts
@@ -11,7 +11,10 @@ import { noClientControlledAuthorization } from './index';
  * and errors[].suggestions[].output are prefixed too, since autofix fixtures
  * assert the whole file back.
  */
-const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+// A SIDE-EFFECT import: it satisfies the gate without reserving the `express`
+// binding. Several fixtures already declare `const express = require('express')`
+// at module level, and a default import would redeclare it.
+const asExpress = (code: string): string => `import 'express';\n${code}`;
 type Suggestion = { output?: string | null };
 type Case = {
   code: string;

--- a/packages/eslint-plugin-express-security/src/rules/no-cors-credentials-wildcard/index.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-cors-credentials-wildcard/index.ts
@@ -15,6 +15,7 @@
  * @see https://cwe.mitre.org/data/definitions/942.html
  */
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
+import { fileUsesExpress } from '../../utils/express-evidence';
 import {
   formatLLMMessage,
   MessageIcons,
@@ -167,6 +168,12 @@ export const noCorsCredentialsWildcard = createRule<RuleOptions, MessageIds>({
     },
   ],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>, [options]) {
+    // Every rule here is Express-specific, and none of them knew it: over
+    // 107,382 files, 75% of this plugin's findings were in files with no
+    // Express import. Registering no visitors is both the gate and the cheap
+    // path — a file with no Express in it does no work.
+    if (!fileUsesExpress(context.sourceCode.ast)) return {};
+
     const { allowInTests = false } = options as Options;
 
     const filename = context.filename;

--- a/packages/eslint-plugin-express-security/src/rules/no-cors-credentials-wildcard/no-cors-credentials-wildcard.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-cors-credentials-wildcard/no-cors-credentials-wildcard.test.ts
@@ -2,6 +2,49 @@ import { RuleTester } from '@typescript-eslint/rule-tester';
 import * as vitest from 'vitest';
 import { noCorsCredentialsWildcard } from './index';
 
+/**
+ * Every fixture imports express, because the rules now abstain in files with no
+ * Express in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass vacuously
+ * on the gate instead of exercising the detection it was written for. `output`
+ * and errors[].suggestions[].output are prefixed too, since autofix fixtures
+ * assert the whole file back.
+ */
+const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const xp = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asExpress(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asExpress(test.code),
+      ...(typeof test.output === 'string' ? { output: asExpress(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asExpress(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = vitest.afterAll;
 RuleTester.it = vitest.it;
 RuleTester.itOnly = vitest.it.only;
@@ -15,7 +58,7 @@ const ruleTester = new RuleTester({
 });
 
 ruleTester.run('no-cors-credentials-wildcard', noCorsCredentialsWildcard, {
-  valid: [
+  valid: xp([
     // Safe: explicit origin with credentials
     {
       code: `
@@ -66,8 +109,8 @@ ruleTester.run('no-cors-credentials-wildcard', noCorsCredentialsWildcard, {
         app.use(helmet());
       `,
     },
-  ],
-  invalid: [
+  ]),
+  invalid: xp([
     // Critical: wildcard origin with credentials: true
     {
       code: `
@@ -118,7 +161,7 @@ ruleTester.run('no-cors-credentials-wildcard', noCorsCredentialsWildcard, {
       `,
       errors: [{ messageId: 'credentialsWildcard' }],
     },
-  ],
+  ]),
 });
 
 // ---------------------------------------------------------------------------
@@ -128,7 +171,7 @@ ruleTester.run(
   'no-cors-credentials-wildcard (coverage wave)',
   noCorsCredentialsWildcard,
   {
-    valid: [
+    valid: xp([
       // cors() with no arguments — nothing to inspect
       { code: `cors();` },
       // cors(identifier) — config is not an inline object literal
@@ -147,8 +190,8 @@ ruleTester.run(
       {
         code: `app.use(cors({ origin: 'https://a.com', credentials: true }));`,
       },
-    ],
-    invalid: [
+    ]),
+    invalid: xp([
       // allowInTests: true but NON-test filename — still reported
       {
         code: `app.use(cors({ origin: '*', credentials: true }));`,
@@ -161,6 +204,6 @@ ruleTester.run(
         code: `cors({ origin: true, credentials: true });`,
         errors: [{ messageId: 'credentialsWildcard' }],
       },
-    ],
+    ]),
   },
 );

--- a/packages/eslint-plugin-express-security/src/rules/no-cors-credentials-wildcard/no-cors-credentials-wildcard.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-cors-credentials-wildcard/no-cors-credentials-wildcard.test.ts
@@ -10,7 +10,10 @@ import { noCorsCredentialsWildcard } from './index';
  * and errors[].suggestions[].output are prefixed too, since autofix fixtures
  * assert the whole file back.
  */
-const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+// A SIDE-EFFECT import: it satisfies the gate without reserving the `express`
+// binding. Several fixtures already declare `const express = require('express')`
+// at module level, and a default import would redeclare it.
+const asExpress = (code: string): string => `import 'express';\n${code}`;
 type Suggestion = { output?: string | null };
 type Case = {
   code: string;

--- a/packages/eslint-plugin-express-security/src/rules/no-disabled-helmet-protections/index.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-disabled-helmet-protections/index.ts
@@ -35,6 +35,7 @@
  */
 
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
+import { fileUsesExpress } from '../../utils/express-evidence';
 import {
   AST_NODE_TYPES,
   createRule,
@@ -136,6 +137,12 @@ export const noDisabledHelmetProtections = createRule<RuleOptions, MessageIds>({
   },
   defaultOptions: [{}],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>, [options]) {
+    // Every rule here is Express-specific, and none of them knew it: over
+    // 107,382 files, 75% of this plugin's findings were in files with no
+    // Express import. Registering no visitors is both the gate and the cheap
+    // path — a file with no Express in it does no work.
+    if (!fileUsesExpress(context.sourceCode.ast)) return {};
+
     const { allowDisabled } = options as Options;
     const allowed = new Set(allowDisabled ?? []);
 

--- a/packages/eslint-plugin-express-security/src/rules/no-disabled-helmet-protections/no-disabled-helmet-protections.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-disabled-helmet-protections/no-disabled-helmet-protections.test.ts
@@ -3,6 +3,49 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { noDisabledHelmetProtections } from './index';
 
+/**
+ * Every fixture imports express, because the rules now abstain in files with no
+ * Express in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass vacuously
+ * on the gate instead of exercising the detection it was written for. `output`
+ * and errors[].suggestions[].output are prefixed too, since autofix fixtures
+ * assert the whole file back.
+ */
+const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const xp = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asExpress(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asExpress(test.code),
+      ...(typeof test.output === 'string' ? { output: asExpress(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asExpress(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -17,7 +60,7 @@ describe('no-disabled-helmet-protections', () => {
     'no-disabled-helmet-protections',
     noDisabledHelmetProtections,
     {
-      valid: [
+      valid: xp([
         // THE safe pattern — helmet with its defaults
         { code: `app.use(helmet());` },
         // Customising a protection (object, not false) keeps the header
@@ -55,8 +98,8 @@ describe('no-disabled-helmet-protections', () => {
           code: `app.use(helmet({ contentSecurityPolicy: false }));`,
           options: [{ allowDisabled: ['contentSecurityPolicy'] }],
         },
-      ],
-      invalid: [
+      ]),
+      invalid: xp([
         // CSP off — the SonarJS S5728 case
         {
           code: `app.use(helmet({ contentSecurityPolicy: false }));`,
@@ -230,7 +273,7 @@ describe('no-disabled-helmet-protections', () => {
             },
           ],
         },
-      ],
+      ]),
     },
   );
 });

--- a/packages/eslint-plugin-express-security/src/rules/no-disabled-helmet-protections/no-disabled-helmet-protections.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-disabled-helmet-protections/no-disabled-helmet-protections.test.ts
@@ -11,7 +11,10 @@ import { noDisabledHelmetProtections } from './index';
  * and errors[].suggestions[].output are prefixed too, since autofix fixtures
  * assert the whole file back.
  */
-const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+// A SIDE-EFFECT import: it satisfies the gate without reserving the `express`
+// binding. Several fixtures already declare `const express = require('express')`
+// at module level, and a default import would redeclare it.
+const asExpress = (code: string): string => `import 'express';\n${code}`;
 type Suggestion = { output?: string | null };
 type Case = {
   code: string;

--- a/packages/eslint-plugin-express-security/src/rules/no-error-details-in-response/index.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-error-details-in-response/index.ts
@@ -40,6 +40,7 @@
  */
 
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
+import { fileUsesExpress } from '../../utils/express-evidence';
 import {
   AST_NODE_TYPES,
   createRule,
@@ -122,6 +123,12 @@ export const noErrorDetailsInResponse = createRule<RuleOptions, MessageIds>({
   },
   defaultOptions: [{}],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>, [options]) {
+    // Every rule here is Express-specific, and none of them knew it: over
+    // 107,382 files, 75% of this plugin's findings were in files with no
+    // Express import. Registering no visitors is both the gate and the cheap
+    // path — a file with no Express in it does no work.
+    if (!fileUsesExpress(context.sourceCode.ast)) return {};
+
     const { allowMessage, allowInDev } = options as Options;
     const messageAllowed = allowMessage ?? true;
     const devAllowed = allowInDev ?? false;

--- a/packages/eslint-plugin-express-security/src/rules/no-error-details-in-response/no-error-details-in-response.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-error-details-in-response/no-error-details-in-response.test.ts
@@ -3,6 +3,49 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { noErrorDetailsInResponse } from './index';
 
+/**
+ * Every fixture imports express, because the rules now abstain in files with no
+ * Express in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass vacuously
+ * on the gate instead of exercising the detection it was written for. `output`
+ * and errors[].suggestions[].output are prefixed too, since autofix fixtures
+ * assert the whole file back.
+ */
+const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const xp = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asExpress(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asExpress(test.code),
+      ...(typeof test.output === 'string' ? { output: asExpress(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asExpress(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -14,7 +57,7 @@ const ruleTester = new RuleTester({
 
 describe('no-error-details-in-response', () => {
   ruleTester.run('no-error-details-in-response', noErrorDetailsInResponse, {
-    valid: [
+    valid: xp([
       // Benchmark corpus: CWE-209/safe/generic-error-response.js (FP-lock)
       {
         code: `
@@ -111,8 +154,8 @@ module.exports = app;
         `,
         options: [{ allowInDev: true }],
       },
-    ],
-    invalid: [
+    ]),
+    invalid: xp([
       // Benchmark corpus: CWE-209/vulnerable/error-object-in-json.js
       {
         code: `
@@ -234,7 +277,7 @@ module.exports = app;
         code: `try { work(); } catch (err) { reply.send(err); }`,
         errors: [{ messageId: 'errorDetailsExposed' }],
       },
-    ],
+    ]),
   });
 });
 
@@ -245,7 +288,7 @@ ruleTester.run(
   'no-error-details-in-response (coverage wave)',
   noErrorDetailsInResponse,
   {
-    valid: [
+    valid: xp([
       // Function with no params entered while no frames are active
       { code: `register(() => { done(); });` },
       // Destructured first param
@@ -265,8 +308,8 @@ ruleTester.run(
         `,
         options: [{ allowInDev: true }],
       },
-    ],
-    invalid: [
+    ]),
+    invalid: xp([
       // Nested frames: catch inside an error-first function — both bindings
       {
         code: `
@@ -329,6 +372,6 @@ ruleTester.run(
           },
         ],
       },
-    ],
+    ]),
   },
 );

--- a/packages/eslint-plugin-express-security/src/rules/no-error-details-in-response/no-error-details-in-response.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-error-details-in-response/no-error-details-in-response.test.ts
@@ -11,7 +11,10 @@ import { noErrorDetailsInResponse } from './index';
  * and errors[].suggestions[].output are prefixed too, since autofix fixtures
  * assert the whole file back.
  */
-const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+// A SIDE-EFFECT import: it satisfies the gate without reserving the `express`
+// binding. Several fixtures already declare `const express = require('express')`
+// at module level, and a default import would redeclare it.
+const asExpress = (code: string): string => `import 'express';\n${code}`;
 type Suggestion = { output?: string | null };
 type Case = {
   code: string;

--- a/packages/eslint-plugin-express-security/src/rules/no-exposed-debug-endpoints/index.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-exposed-debug-endpoints/index.ts
@@ -14,6 +14,7 @@ import {
   MessageIcons,
 } from '@interlace/eslint-devkit';
 import type { TSESTree } from '@interlace/eslint-devkit';
+import { fileUsesExpress } from '../../utils/express-evidence';
 
 type MessageIds = 'violationDetected';
 
@@ -91,6 +92,12 @@ export const noExposedDebugEndpoints = createRule<RuleOptions, MessageIds>({
   },
   defaultOptions: [{}],
   create(context) {
+    // Every rule here is Express-specific, and none of them knew it: over
+    // 107,382 files, 75% of this plugin's findings were in files with no
+    // Express import. Registering no visitors is both the gate and the cheap
+    // path — a file with no Express in it does no work.
+    if (!fileUsesExpress(context.sourceCode.ast)) return {};
+
     const options = context.options[0] || {};
     const debugPaths = options.endpoints || DEFAULT_DEBUG_PATHS;
     const ignoreFiles = options.ignoreFiles || [];

--- a/packages/eslint-plugin-express-security/src/rules/no-exposed-debug-endpoints/no-exposed-debug-endpoints.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-exposed-debug-endpoints/no-exposed-debug-endpoints.test.ts
@@ -13,7 +13,10 @@ import { noExposedDebugEndpoints } from './index';
  * and errors[].suggestions[].output are prefixed too, since autofix fixtures
  * assert the whole file back.
  */
-const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+// A SIDE-EFFECT import: it satisfies the gate without reserving the `express`
+// binding. Several fixtures already declare `const express = require('express')`
+// at module level, and a default import would redeclare it.
+const asExpress = (code: string): string => `import 'express';\n${code}`;
 type Suggestion = { output?: string | null };
 type Case = {
   code: string;

--- a/packages/eslint-plugin-express-security/src/rules/no-exposed-debug-endpoints/no-exposed-debug-endpoints.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-exposed-debug-endpoints/no-exposed-debug-endpoints.test.ts
@@ -5,6 +5,49 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { noExposedDebugEndpoints } from './index';
 
+/**
+ * Every fixture imports express, because the rules now abstain in files with no
+ * Express in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass vacuously
+ * on the gate instead of exercising the detection it was written for. `output`
+ * and errors[].suggestions[].output are prefixed too, since autofix fixtures
+ * assert the whole file back.
+ */
+const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const xp = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asExpress(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asExpress(test.code),
+      ...(typeof test.output === 'string' ? { output: asExpress(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asExpress(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 const ruleTester = new RuleTester({
   languageOptions: {
     ecmaVersion: 2022,
@@ -13,7 +56,7 @@ const ruleTester = new RuleTester({
 });
 
 ruleTester.run('no-exposed-debug-endpoints', noExposedDebugEndpoints, {
-  valid: [
+  valid: xp([
     'const x = 42;',
     'const flag = true;',
     'function noop() {}',
@@ -22,9 +65,9 @@ ruleTester.run('no-exposed-debug-endpoints', noExposedDebugEndpoints, {
     { code: "router.post('/login', authenticate)" },
     // Non-route code
     { code: 'const x = 1' },
-  ],
+  ]),
 
-  invalid: [
+  invalid: xp([
     // Debug endpoints (now caught once)
     {
       code: "app.get('/debug', debugHandler)",
@@ -48,7 +91,7 @@ ruleTester.run('no-exposed-debug-endpoints', noExposedDebugEndpoints, {
       code: "router.route('/test').get(handler)",
       errors: [{ messageId: 'violationDetected' }],
     },
-  ],
+  ]),
 });
 
 // ---------------------------------------------------------------------------
@@ -63,7 +106,7 @@ ruleTester.run(
   'no-exposed-debug-endpoints (bare literals)',
   noExposedDebugEndpoints,
   {
-    valid: [
+    valid: xp([
       // constant declarations
       { code: "const ADMIN_PATH = '/admin';" },
       { code: "const path = '/debug';" },
@@ -82,7 +125,7 @@ ruleTester.run(
       { code: "app.get('/safe', '/debug');" },
       // non-express object with a matching method name
       { code: "fetchClient.get('/admin');" },
-    ],
+    ]),
     invalid: [],
   },
 );
@@ -94,7 +137,7 @@ ruleTester.run(
   'no-exposed-debug-endpoints (coverage wave)',
   noExposedDebugEndpoints,
   {
-    valid: [
+    valid: xp([
       // ignoreFiles matching the current filename disables the rule
       {
         code: `app.get('/debug', handler);`,
@@ -118,8 +161,8 @@ ruleTester.run(
       { code: `handler('/admin');` },
       // literal only *contains* a debug path, in a safe position
       { code: `const x = '/debugging-guide';` },
-    ],
-    invalid: [
+    ]),
+    invalid: xp([
       // path containing a debug segment is still a route registration
       {
         code: `app.use('/admin/panel', adminRouter);`,
@@ -138,6 +181,6 @@ ruleTester.run(
         filename: '/project/src/server.ts',
         errors: [{ messageId: 'violationDetected' }],
       },
-    ],
+    ]),
   },
 );

--- a/packages/eslint-plugin-express-security/src/rules/no-express-unsafe-regex-route/index.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-express-unsafe-regex-route/index.ts
@@ -16,6 +16,7 @@
  * @see https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS
  */
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
+import { fileUsesExpress } from '../../utils/express-evidence';
 import {
   formatLLMMessage,
   MessageIcons,
@@ -141,6 +142,12 @@ export const noExpressUnsafeRegexRoute = createRule<RuleOptions, MessageIds>({
   },
   defaultOptions: [{ allowInTests: false }],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>, [options]) {
+    // Every rule here is Express-specific, and none of them knew it: over
+    // 107,382 files, 75% of this plugin's findings were in files with no
+    // Express import. Registering no visitors is both the gate and the cheap
+    // path — a file with no Express in it does no work.
+    if (!fileUsesExpress(context.sourceCode.ast)) return {};
+
     const { allowInTests = false } = options as Options;
 
     const filename = context.filename;

--- a/packages/eslint-plugin-express-security/src/rules/no-express-unsafe-regex-route/no-express-unsafe-regex-route.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-express-unsafe-regex-route/no-express-unsafe-regex-route.test.ts
@@ -1,10 +1,53 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { noExpressUnsafeRegexRoute } from './index';
 
+/**
+ * Every fixture imports express, because the rules now abstain in files with no
+ * Express in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass vacuously
+ * on the gate instead of exercising the detection it was written for. `output`
+ * and errors[].suggestions[].output are prefixed too, since autofix fixtures
+ * assert the whole file back.
+ */
+const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const xp = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asExpress(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asExpress(test.code),
+      ...(typeof test.output === 'string' ? { output: asExpress(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asExpress(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 const ruleTester = new RuleTester();
 
 ruleTester.run('no-express-unsafe-regex-route', noExpressUnsafeRegexRoute, {
-  valid: [
+  valid: xp([
     // Simple string routes
     {
       code: `app.get('/api/users', handler)`,
@@ -35,8 +78,8 @@ ruleTester.run('no-express-unsafe-regex-route', noExpressUnsafeRegexRoute, {
       filename: 'test.spec.ts',
       options: [{ allowInTests: true }],
     },
-  ],
-  invalid: [
+  ]),
+  invalid: xp([
     // Vulnerable regex: nested quantifiers - simpler pattern
     {
       code: `app.get(/(a+)+/, handler)`,
@@ -89,7 +132,7 @@ ruleTester.run('no-express-unsafe-regex-route', noExpressUnsafeRegexRoute, {
       code: `app.get(new RegExp('(a+)+'), handler)`,
       errors: [{ messageId: 'unsafeRegexRoute' }],
     },
-  ],
+  ]),
 });
 
 // ---------------------------------------------------------------------------
@@ -99,7 +142,7 @@ ruleTester.run(
   'no-express-unsafe-regex-route (coverage wave)',
   noExpressUnsafeRegexRoute,
   {
-    valid: [
+    valid: xp([
       // callee is not a member expression
       { code: `get('/users/:id', handler);` },
       // computed member access — property is a Literal, not an Identifier
@@ -124,8 +167,8 @@ ruleTester.run(
         options: [{ allowInTests: true }],
         filename: 'routes.spec.ts',
       },
-    ],
-    invalid: [
+    ]),
+    invalid: xp([
       // allowInTests: true but non-test filename — still reported
       {
         code: `app.get(/(a+)+$/, handler);`,
@@ -133,6 +176,6 @@ ruleTester.run(
         filename: 'routes.ts',
         errors: [{ messageId: 'unsafeRegexRoute' }],
       },
-    ],
+    ]),
   },
 );

--- a/packages/eslint-plugin-express-security/src/rules/no-express-unsafe-regex-route/no-express-unsafe-regex-route.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-express-unsafe-regex-route/no-express-unsafe-regex-route.test.ts
@@ -9,7 +9,10 @@ import { noExpressUnsafeRegexRoute } from './index';
  * and errors[].suggestions[].output are prefixed too, since autofix fixtures
  * assert the whole file back.
  */
-const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+// A SIDE-EFFECT import: it satisfies the gate without reserving the `express`
+// binding. Several fixtures already declare `const express = require('express')`
+// at module level, and a default import would redeclare it.
+const asExpress = (code: string): string => `import 'express';\n${code}`;
 type Suggestion = { output?: string | null };
 type Case = {
   code: string;

--- a/packages/eslint-plugin-express-security/src/rules/no-graphql-introspection-production/index.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-graphql-introspection-production/index.ts
@@ -13,6 +13,7 @@
  * @see https://cheatsheetseries.owasp.org/cheatsheets/GraphQL_Cheat_Sheet.html
  */
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
+import { fileUsesExpress } from '../../utils/express-evidence';
 import {
   formatLLMMessage,
   MessageIcons,
@@ -132,6 +133,12 @@ export const noGraphqlIntrospectionProduction = createRule<
     },
   ],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>, [options]) {
+    // Every rule here is Express-specific, and none of them knew it: over
+    // 107,382 files, 75% of this plugin's findings were in files with no
+    // Express import. Registering no visitors is both the gate and the cheap
+    // path — a file with no Express in it does no work.
+    if (!fileUsesExpress(context.sourceCode.ast)) return {};
+
     const { allowInTests = true } = options as Options;
 
     const filename = context.filename;

--- a/packages/eslint-plugin-express-security/src/rules/no-graphql-introspection-production/no-graphql-introspection-production.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-graphql-introspection-production/no-graphql-introspection-production.test.ts
@@ -13,7 +13,10 @@ import * as vitest from 'vitest';
  * and errors[].suggestions[].output are prefixed too, since autofix fixtures
  * assert the whole file back.
  */
-const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+// A SIDE-EFFECT import: it satisfies the gate without reserving the `express`
+// binding. Several fixtures already declare `const express = require('express')`
+// at module level, and a default import would redeclare it.
+const asExpress = (code: string): string => `import 'express';\n${code}`;
 type Suggestion = { output?: string | null };
 type Case = {
   code: string;

--- a/packages/eslint-plugin-express-security/src/rules/no-graphql-introspection-production/no-graphql-introspection-production.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-graphql-introspection-production/no-graphql-introspection-production.test.ts
@@ -5,6 +5,49 @@ import { RuleTester } from '@typescript-eslint/rule-tester';
 import { noGraphqlIntrospectionProduction } from './index';
 import * as vitest from 'vitest';
 
+/**
+ * Every fixture imports express, because the rules now abstain in files with no
+ * Express in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass vacuously
+ * on the gate instead of exercising the detection it was written for. `output`
+ * and errors[].suggestions[].output are prefixed too, since autofix fixtures
+ * assert the whole file back.
+ */
+const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const xp = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asExpress(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asExpress(test.code),
+      ...(typeof test.output === 'string' ? { output: asExpress(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asExpress(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = vitest.afterAll;
 RuleTester.it = vitest.it;
 RuleTester.itOnly = vitest.it.only;
@@ -21,7 +64,7 @@ ruleTester.run(
   'no-graphql-introspection-production',
   noGraphqlIntrospectionProduction,
   {
-    valid: [
+    valid: xp([
       // Introspection disabled
       {
         code: `
@@ -81,8 +124,8 @@ ruleTester.run(
         options: [{ allowInTests: true }],
         filename: 'server.test.ts',
       },
-    ],
-    invalid: [
+    ]),
+    invalid: xp([
       // Introspection explicitly enabled
       {
         code: `
@@ -112,7 +155,7 @@ ruleTester.run(
           },
         ],
       },
-    ],
+    ]),
   },
 );
 
@@ -123,7 +166,7 @@ ruleTester.run(
   'no-graphql-introspection-production (coverage wave)',
   noGraphqlIntrospectionProduction,
   {
-    valid: [
+    valid: xp([
       // graphqlHTTP with no config argument
       { code: `graphqlHTTP();` },
       // graphqlHTTP with a non-object config
@@ -146,8 +189,8 @@ ruleTester.run(
       { code: `new foo.Bar()();` },
       // production guard via isProduction naming
       { code: `new ApolloServer({ introspection: !isProduction });` },
-    ],
-    invalid: [
+    ]),
+    invalid: xp([
       // plain createServer() call with introspection enabled
       {
         code: `createServer({ introspection: true });`,
@@ -163,6 +206,6 @@ ruleTester.run(
         code: `graphqlHTTP({ introspection: true });`,
         errors: [{ messageId: 'graphqlIntrospection' }],
       },
-    ],
+    ]),
   },
 );

--- a/packages/eslint-plugin-express-security/src/rules/no-host-header-in-links/index.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-host-header-in-links/index.ts
@@ -36,6 +36,7 @@
  */
 
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
+import { fileUsesExpress } from '../../utils/express-evidence';
 import {
   AST_NODE_TYPES,
   createRule,
@@ -124,6 +125,12 @@ export const noHostHeaderInLinks = createRule<RuleOptions, MessageIds>({
   },
   defaultOptions: [{}],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>, [options]) {
+    // Every rule here is Express-specific, and none of them knew it: over
+    // 107,382 files, 75% of this plugin's findings were in files with no
+    // Express import. Registering no visitors is both the gate and the cheap
+    // path — a file with no Express in it does no work.
+    if (!fileUsesExpress(context.sourceCode.ast)) return {};
+
     const { allowedHosts, checkMailCallees } = options as Options;
     const allowed = allowedHosts ?? [];
     const mailCallees = new Set(checkMailCallees ?? ['sendMail', 'send']);

--- a/packages/eslint-plugin-express-security/src/rules/no-host-header-in-links/no-host-header-in-links.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-host-header-in-links/no-host-header-in-links.test.ts
@@ -11,7 +11,10 @@ import { noHostHeaderInLinks } from './index';
  * and errors[].suggestions[].output are prefixed too, since autofix fixtures
  * assert the whole file back.
  */
-const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+// A SIDE-EFFECT import: it satisfies the gate without reserving the `express`
+// binding. Several fixtures already declare `const express = require('express')`
+// at module level, and a default import would redeclare it.
+const asExpress = (code: string): string => `import 'express';\n${code}`;
 type Suggestion = { output?: string | null };
 type Case = {
   code: string;

--- a/packages/eslint-plugin-express-security/src/rules/no-host-header-in-links/no-host-header-in-links.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-host-header-in-links/no-host-header-in-links.test.ts
@@ -3,6 +3,49 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { noHostHeaderInLinks } from './index';
 
+/**
+ * Every fixture imports express, because the rules now abstain in files with no
+ * Express in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass vacuously
+ * on the gate instead of exercising the detection it was written for. `output`
+ * and errors[].suggestions[].output are prefixed too, since autofix fixtures
+ * assert the whole file back.
+ */
+const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const xp = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asExpress(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asExpress(test.code),
+      ...(typeof test.output === 'string' ? { output: asExpress(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asExpress(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -14,7 +57,7 @@ const ruleTester = new RuleTester({
 
 describe('no-host-header-in-links', () => {
   ruleTester.run('no-host-header-in-links', noHostHeaderInLinks, {
-    valid: [
+    valid: xp([
       // Benchmark corpus: CWE-640/safe/reset-link-config-origin.js (FP-lock)
       {
         code: `
@@ -83,8 +126,8 @@ module.exports = app;
       { code: `notify('host ' + req.headers.host);` },
       // Computed (non-Identifier) callee property, no URL marker
       { code: `obj['send']('host: ' + req.headers.host);` },
-    ],
-    invalid: [
+    ]),
+    invalid: xp([
       // Benchmark corpus: CWE-640/vulnerable/reset-link-host-header.js
       {
         code: `
@@ -231,7 +274,7 @@ module.exports = app;
         ].join('\n'),
         errors: [{ messageId: 'hostHeaderInLink' }],
       },
-    ],
+    ]),
   });
 });
 
@@ -239,7 +282,7 @@ module.exports = app;
 // Coverage wave: exhaustive branch coverage for helper predicates
 // ---------------------------------------------------------------------------
 ruleTester.run('no-host-header-in-links (coverage wave)', noHostHeaderInLinks, {
-  valid: [
+  valid: xp([
     // Non-'+' binary operator
     { code: `const n = 1 - 2;` },
     // '+' with numeric literals only (non-string Literal operand)
@@ -290,8 +333,8 @@ ruleTester.run('no-host-header-in-links (coverage wave)', noHostHeaderInLinks, {
       ].join('\n'),
       options: [{ allowedHosts: ['app.example.com'] }],
     },
-  ],
-  invalid: [
+  ]),
+  invalid: xp([
     // Direct host read as a mail-call argument via member callee
     {
       code: 'mailer.send(`link: ${req.headers.host}/go`);',
@@ -321,5 +364,5 @@ ruleTester.run('no-host-header-in-links (coverage wave)', noHostHeaderInLinks, {
         },
       ],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-express-security/src/rules/no-idor-resource-access/index.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-idor-resource-access/index.ts
@@ -45,6 +45,7 @@ import {
   MessageIcons,
 } from '@interlace/eslint-devkit';
 import { isClientRequestMember, readsPrincipal, walk } from '../../utils';
+import { fileUsesExpress } from '../../utils/express-evidence';
 
 type MessageIds = 'unscopedResourceLookup';
 
@@ -150,6 +151,12 @@ export const noIdorResourceAccess = createRule<RuleOptions, MessageIds>({
   },
   defaultOptions: [{}],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>, [options]) {
+    // Every rule here is Express-specific, and none of them knew it: over
+    // 107,382 files, 75% of this plugin's findings were in files with no
+    // Express import. Registering no visitors is both the gate and the cheap
+    // path — a file with no Express in it does no work.
+    if (!fileUsesExpress(context.sourceCode.ast)) return {};
+
     const { lookupMethods } = options as Options;
     const lookups = new Set(lookupMethods ?? DEFAULT_LOOKUP_METHODS);
 

--- a/packages/eslint-plugin-express-security/src/rules/no-idor-resource-access/no-idor-resource-access.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-idor-resource-access/no-idor-resource-access.test.ts
@@ -3,6 +3,49 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { noIdorResourceAccess } from './index';
 
+/**
+ * Every fixture imports express, because the rules now abstain in files with no
+ * Express in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass vacuously
+ * on the gate instead of exercising the detection it was written for. `output`
+ * and errors[].suggestions[].output are prefixed too, since autofix fixtures
+ * assert the whole file back.
+ */
+const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const xp = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asExpress(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asExpress(test.code),
+      ...(typeof test.output === 'string' ? { output: asExpress(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asExpress(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -14,7 +57,7 @@ const ruleTester = new RuleTester({
 
 describe('no-idor-resource-access', () => {
   ruleTester.run('no-idor-resource-access', noIdorResourceAccess, {
-    valid: [
+    valid: xp([
       // THE safe pattern — the query is scoped to the principal
       {
         code: `
@@ -87,8 +130,8 @@ describe('no-idor-resource-access', () => {
         code: `app.get('/x/:id', (req, res) => Invoice.findById(req.params.id).then(send));`,
         options: [{ lookupMethods: ['fetchById'] }],
       },
-    ],
-    invalid: [
+    ]),
+    invalid: xp([
       // The textbook IDOR
       {
         code: `app.get('/invoices/:id', (req, res) => Invoice.findById(req.params.id).then((doc) => res.json(doc)));`,
@@ -148,6 +191,6 @@ describe('no-idor-resource-access', () => {
         options: [{ lookupMethods: ['fetchById'] }],
         errors: [{ messageId: 'unscopedResourceLookup' as const }],
       },
-    ],
+    ]),
   });
 });

--- a/packages/eslint-plugin-express-security/src/rules/no-idor-resource-access/no-idor-resource-access.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-idor-resource-access/no-idor-resource-access.test.ts
@@ -11,7 +11,10 @@ import { noIdorResourceAccess } from './index';
  * and errors[].suggestions[].output are prefixed too, since autofix fixtures
  * assert the whole file back.
  */
-const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+// A SIDE-EFFECT import: it satisfies the gate without reserving the `express`
+// binding. Several fixtures already declare `const express = require('express')`
+// at module level, and a default import would redeclare it.
+const asExpress = (code: string): string => `import 'express';\n${code}`;
 type Suggestion = { output?: string | null };
 type Case = {
   code: string;

--- a/packages/eslint-plugin-express-security/src/rules/no-insecure-cookie-options/index.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-insecure-cookie-options/index.ts
@@ -13,6 +13,7 @@
  * @see https://owasp.org/www-community/controls/SecureCookieAttribute
  */
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
+import { fileUsesExpress } from '../../utils/express-evidence';
 import {
   formatLLMMessage,
   MessageIcons,
@@ -156,6 +157,12 @@ export const noInsecureCookieOptions = createRule<RuleOptions, MessageIds>({
     },
   ],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>, [options]) {
+    // Every rule here is Express-specific, and none of them knew it: over
+    // 107,382 files, 75% of this plugin's findings were in files with no
+    // Express import. Registering no visitors is both the gate and the cheap
+    // path — a file with no Express in it does no work.
+    if (!fileUsesExpress(context.sourceCode.ast)) return {};
+
     const { allowInTests = false } = options as Options;
 
     const filename = context.filename;

--- a/packages/eslint-plugin-express-security/src/rules/no-insecure-cookie-options/no-insecure-cookie-options.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-insecure-cookie-options/no-insecure-cookie-options.test.ts
@@ -12,7 +12,10 @@ import * as vitest from 'vitest';
  * and errors[].suggestions[].output are prefixed too, since autofix fixtures
  * assert the whole file back.
  */
-const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+// A SIDE-EFFECT import: it satisfies the gate without reserving the `express`
+// binding. Several fixtures already declare `const express = require('express')`
+// at module level, and a default import would redeclare it.
+const asExpress = (code: string): string => `import 'express';\n${code}`;
 type Suggestion = { output?: string | null };
 type Case = {
   code: string;

--- a/packages/eslint-plugin-express-security/src/rules/no-insecure-cookie-options/no-insecure-cookie-options.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-insecure-cookie-options/no-insecure-cookie-options.test.ts
@@ -4,6 +4,48 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { noInsecureCookieOptions } from './index';
 import * as vitest from 'vitest';
+/**
+ * Every fixture imports express, because the rules now abstain in files with no
+ * Express in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass vacuously
+ * on the gate instead of exercising the detection it was written for. `output`
+ * and errors[].suggestions[].output are prefixed too, since autofix fixtures
+ * assert the whole file back.
+ */
+const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const xp = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asExpress(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asExpress(test.code),
+      ...(typeof test.output === 'string' ? { output: asExpress(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asExpress(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
 
 RuleTester.afterAll = vitest.afterAll;
 RuleTester.it = vitest.it;
@@ -18,7 +60,7 @@ const ruleTester = new RuleTester({
 });
 
 ruleTester.run('no-insecure-cookie-options', noInsecureCookieOptions, {
-  valid: [
+  valid: xp([
     // Fully secure cookie
     {
       code: `
@@ -53,8 +95,8 @@ ruleTester.run('no-insecure-cookie-options', noInsecureCookieOptions, {
         obj.notCookie('session', token);
       `,
     },
-  ],
-  invalid: [
+  ]),
+  invalid: xp([
     // No options at all
     {
       code: `
@@ -142,7 +184,7 @@ ruleTester.run('no-insecure-cookie-options', noInsecureCookieOptions, {
         },
       ],
     },
-  ],
+  ]),
 });
 
 // ---------------------------------------------------------------------------
@@ -152,11 +194,13 @@ import { describe, expect, it } from 'vitest';
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
 import { checkCookieOptions } from './index';
 
+
+
 ruleTester.run(
   'no-insecure-cookie-options (coverage wave)',
   noInsecureCookieOptions,
   {
-    valid: [
+    valid: xp([
       // requireHttpOnly: false — httpOnly check skipped
       {
         code: `res.cookie('a', 'b', { secure: true, sameSite: 'strict' });`,
@@ -174,15 +218,15 @@ ruleTester.run(
       },
       // options argument is not an object literal
       { code: `res.cookie('a', 'b', cookieOptions);` },
-    ],
-    invalid: [
+    ]),
+    invalid: xp([
       // custom acceptableSameSiteValues rejects 'lax'
       {
         code: `res.cookie('a', 'b', { httpOnly: true, secure: true, sameSite: 'lax' });`,
         options: [{ acceptableSameSiteValues: ['strict'] }],
         errors: [{ messageId: 'insecureCookie' }],
       },
-    ],
+    ]),
   },
 );
 

--- a/packages/eslint-plugin-express-security/src/rules/no-missing-cors-check/index.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-missing-cors-check/index.ts
@@ -15,6 +15,7 @@
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
 import { formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
 import { createRule } from '@interlace/eslint-devkit';
+import { fileUsesExpress } from '../../utils/express-evidence';
 
 type MessageIds =
   'missingCorsCheck' | 'useOriginValidation' | 'useCorsMiddleware';
@@ -123,6 +124,12 @@ export const noMissingCorsCheck = createRule<RuleOptions, MessageIds>({
     },
   ],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>, [options]) {
+    // Every rule here is Express-specific, and none of them knew it: over
+    // 107,382 files, 75% of this plugin's findings were in files with no
+    // Express import. Registering no visitors is both the gate and the cheap
+    // path — a file with no Express in it does no work.
+    if (!fileUsesExpress(context.sourceCode.ast)) return {};
+
     const {
       allowInTests = false,
       trustedLibraries: corsTrustedLibraries = [],

--- a/packages/eslint-plugin-express-security/src/rules/no-missing-cors-check/no-missing-cors-check.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-missing-cors-check/no-missing-cors-check.test.ts
@@ -14,7 +14,10 @@ import { noMissingCorsCheck } from './index';
  * and errors[].suggestions[].output are prefixed too, since autofix fixtures
  * assert the whole file back.
  */
-const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+// A SIDE-EFFECT import: it satisfies the gate without reserving the `express`
+// binding. Several fixtures already declare `const express = require('express')`
+// at module level, and a default import would redeclare it.
+const asExpress = (code: string): string => `import 'express';\n${code}`;
 type Suggestion = { output?: string | null };
 type Case = {
   code: string;

--- a/packages/eslint-plugin-express-security/src/rules/no-missing-cors-check/no-missing-cors-check.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-missing-cors-check/no-missing-cors-check.test.ts
@@ -6,6 +6,48 @@ import { RuleTester } from '@typescript-eslint/rule-tester';
 import * as vitest from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { noMissingCorsCheck } from './index';
+/**
+ * Every fixture imports express, because the rules now abstain in files with no
+ * Express in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass vacuously
+ * on the gate instead of exercising the detection it was written for. `output`
+ * and errors[].suggestions[].output are prefixed too, since autofix fixtures
+ * assert the whole file back.
+ */
+const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const xp = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asExpress(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asExpress(test.code),
+      ...(typeof test.output === 'string' ? { output: asExpress(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asExpress(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
 
 // Configure RuleTester for Vitest
 RuleTester.afterAll = vitest.afterAll;
@@ -30,7 +72,7 @@ const ruleTester = new RuleTester({
 vitest.describe('no-missing-cors-check', () => {
   vitest.describe('Valid Code', () => {
     ruleTester.run('valid - proper CORS validation', noMissingCorsCheck, {
-      valid: [
+      valid: xp([
         // CORS with origin validation
         {
           code: `
@@ -64,7 +106,7 @@ vitest.describe('no-missing-cors-check', () => {
           code: 'app.use(cors({ origin: safeOrigin }));',
           options: [{ ignorePatterns: ['safeOrigin'] }],
         },
-      ],
+      ]),
       invalid: [],
     });
   });
@@ -72,7 +114,7 @@ vitest.describe('no-missing-cors-check', () => {
   vitest.describe('Invalid Code - Wildcard Origin', () => {
     ruleTester.run('invalid - wildcard CORS origin', noMissingCorsCheck, {
       valid: [],
-      invalid: [
+      invalid: xp([
         {
           code: 'app.use(cors({ origin: "*" }));',
           errors: [
@@ -91,14 +133,14 @@ vitest.describe('no-missing-cors-check', () => {
             },
           ],
         },
-      ],
+      ]),
     });
   });
 
   vitest.describe('Invalid Code - CORS Headers', () => {
     ruleTester.run('invalid - wildcard CORS header', noMissingCorsCheck, {
       valid: [],
-      invalid: [
+      invalid: xp([
         {
           code: 'res.setHeader("Access-Control-Allow-Origin", "*");',
           errors: [
@@ -115,20 +157,20 @@ vitest.describe('no-missing-cors-check', () => {
             },
           ],
         },
-      ],
+      ]),
     });
   });
 
   vitest.describe('Options', () => {
     ruleTester.run('options - allowInTests', noMissingCorsCheck, {
-      valid: [
+      valid: xp([
         {
           code: 'app.use(cors({ origin: "*" }));',
           filename: 'test.spec.ts',
           options: [{ allowInTests: true }],
         },
-      ],
-      invalid: [
+      ]),
+      invalid: xp([
         {
           code: 'app.use(cors({ origin: "*" }));',
           filename: 'server.ts',
@@ -139,37 +181,37 @@ vitest.describe('no-missing-cors-check', () => {
             },
           ],
         },
-      ],
+      ]),
     });
 
     ruleTester.run(
       'options - ignorePatterns with invalid regex',
       noMissingCorsCheck,
       {
-        valid: [
+        valid: xp([
           {
             code: 'app.use(cors({ origin: testOrigin }));',
             options: [{ ignorePatterns: ['['] }], // Invalid regex should be caught
           },
-        ],
+        ]),
         invalid: [],
       },
     );
 
     ruleTester.run('options - trustedLibraries', noMissingCorsCheck, {
-      valid: [
+      valid: xp([
         {
           code: 'app.use(myCors({ origin: "*" }));',
           options: [{ trustedLibraries: ['myCors'] }],
         },
-      ],
+      ]),
       invalid: [],
     });
   });
 
   vitest.describe('Edge Cases', () => {
     ruleTester.run('edge cases - non-wildcard literal', noMissingCorsCheck, {
-      valid: [
+      valid: xp([
         {
           code: 'app.use(cors({ origin: "https://example.com" }));',
         },
@@ -179,19 +221,19 @@ vitest.describe('no-missing-cors-check', () => {
         {
           code: 'app.use(cors({ origin: true }));',
         },
-      ],
+      ]),
       invalid: [],
     });
 
     ruleTester.run('edge cases - non-CORS context', noMissingCorsCheck, {
-      valid: [
+      valid: xp([
         {
           code: 'const config = { origin: "*" };',
         },
         {
           code: 'const data = { allowedOrigins: "*" };',
         },
-      ],
+      ]),
       invalid: [],
     });
 
@@ -199,11 +241,11 @@ vitest.describe('no-missing-cors-check', () => {
       'edge cases - CORS config object validation',
       noMissingCorsCheck,
       {
-        valid: [
+        valid: xp([
           {
             code: 'app.use(cors({ origin: allowedOrigins, credentials: true }));',
           },
-        ],
+        ]),
         invalid: [],
       },
     );
@@ -212,14 +254,14 @@ vitest.describe('no-missing-cors-check', () => {
       'edge cases - setHeader with non-wildcard',
       noMissingCorsCheck,
       {
-        valid: [
+        valid: xp([
           {
             code: 'res.setHeader("Access-Control-Allow-Origin", origin);',
           },
           {
             code: 'res.setHeader("Content-Type", "*");',
           },
-        ],
+        ]),
         invalid: [],
       },
     );
@@ -228,14 +270,14 @@ vitest.describe('no-missing-cors-check', () => {
       'edge cases - header with non-Access-Control',
       noMissingCorsCheck,
       {
-        valid: [
+        valid: xp([
           {
             code: 'res.setHeader("Content-Type", "*");',
           },
           {
             code: 'res.header("Content-Type", "*");',
           },
-        ],
+        ]),
         invalid: [],
       },
     );
@@ -244,14 +286,14 @@ vitest.describe('no-missing-cors-check', () => {
       'edge cases - callExpression without use method',
       noMissingCorsCheck,
       {
-        valid: [
+        valid: xp([
           {
             code: 'app.get("/api", handler);',
           },
           {
             code: 'router.post("/users", controller);',
           },
-        ],
+        ]),
         invalid: [],
       },
     );
@@ -261,7 +303,7 @@ vitest.describe('no-missing-cors-check', () => {
       noMissingCorsCheck,
       {
         valid: [],
-        invalid: [
+        invalid: xp([
           {
             code: 'app.use(cors({ origin: "*", allowedOrigins: ["https://example.com"] }));',
             errors: [
@@ -270,7 +312,7 @@ vitest.describe('no-missing-cors-check', () => {
               },
             ],
           },
-        ],
+        ]),
       },
     );
 
@@ -279,7 +321,7 @@ vitest.describe('no-missing-cors-check', () => {
       noMissingCorsCheck,
       {
         valid: [],
-        invalid: [
+        invalid: xp([
           {
             code: 'const config = { origin: "*" }; app.use(cors(config));',
             errors: [
@@ -288,7 +330,7 @@ vitest.describe('no-missing-cors-check', () => {
               },
             ],
           },
-        ],
+        ]),
       },
     );
 
@@ -296,12 +338,12 @@ vitest.describe('no-missing-cors-check', () => {
       'edge cases - literal with ignorePatterns',
       noMissingCorsCheck,
       {
-        valid: [
+        valid: xp([
           {
             code: 'app.use(cors({ origin: "*" }));',
             options: [{ ignorePatterns: ['\\*'] }],
           },
-        ],
+        ]),
         invalid: [],
       },
     );
@@ -311,7 +353,7 @@ vitest.describe('no-missing-cors-check', () => {
       noMissingCorsCheck,
       {
         valid: [],
-        invalid: [
+        invalid: xp([
           {
             code: 'cors({ origin: "*" });',
             errors: [
@@ -320,7 +362,7 @@ vitest.describe('no-missing-cors-check', () => {
               },
             ],
           },
-        ],
+        ]),
       },
     );
 
@@ -329,7 +371,7 @@ vitest.describe('no-missing-cors-check', () => {
       noMissingCorsCheck,
       {
         valid: [],
-        invalid: [
+        invalid: xp([
           {
             code: 'app.use(cors({ allowedOrigins: "*" }));',
             errors: [
@@ -338,7 +380,7 @@ vitest.describe('no-missing-cors-check', () => {
               },
             ],
           },
-        ],
+        ]),
       },
     );
 
@@ -346,12 +388,12 @@ vitest.describe('no-missing-cors-check', () => {
       'edge cases - memberExpression with ignorePatterns',
       noMissingCorsCheck,
       {
-        valid: [
+        valid: xp([
           {
             code: 'safeRes.setHeader("Access-Control-Allow-Origin", "*");',
             options: [{ ignorePatterns: ['safeRes'] }],
           },
-        ],
+        ]),
         invalid: [],
       },
     );
@@ -361,7 +403,7 @@ vitest.describe('no-missing-cors-check', () => {
       noMissingCorsCheck,
       {
         valid: [],
-        invalid: [
+        invalid: xp([
           {
             code: `
             const corsConfig = { origin: "*" };
@@ -373,7 +415,7 @@ vitest.describe('no-missing-cors-check', () => {
               },
             ],
           },
-        ],
+        ]),
       },
     );
 
@@ -382,7 +424,7 @@ vitest.describe('no-missing-cors-check', () => {
       noMissingCorsCheck,
       {
         valid: [],
-        invalid: [
+        invalid: xp([
           {
             code: 'enable(cors({ origin: "*" }));',
             errors: [
@@ -391,7 +433,7 @@ vitest.describe('no-missing-cors-check', () => {
               },
             ],
           },
-        ],
+        ]),
       },
     );
 
@@ -400,7 +442,7 @@ vitest.describe('no-missing-cors-check', () => {
       noMissingCorsCheck,
       {
         valid: [],
-        invalid: [
+        invalid: xp([
           {
             code: `
             const myConfig = { origin: "*" };
@@ -412,7 +454,7 @@ vitest.describe('no-missing-cors-check', () => {
               },
             ],
           },
-        ],
+        ]),
       },
     );
 
@@ -420,11 +462,11 @@ vitest.describe('no-missing-cors-check', () => {
       'edge cases - variable not found, traverse to root (line 432)',
       noMissingCorsCheck,
       {
-        valid: [
+        valid: xp([
           {
             code: 'app.use(cors(unknownVar));',
           },
-        ],
+        ]),
         invalid: [],
       },
     );
@@ -434,7 +476,7 @@ vitest.describe('no-missing-cors-check', () => {
       noMissingCorsCheck,
       {
         valid: [],
-        invalid: [
+        invalid: xp([
           {
             code: `
             function setupCors() {
@@ -448,7 +490,7 @@ vitest.describe('no-missing-cors-check', () => {
               },
             ],
           },
-        ],
+        ]),
       },
     );
   });
@@ -460,8 +502,10 @@ vitest.describe('no-missing-cors-check', () => {
 import { expect } from 'vitest';
 import { createWithMockContext } from '@interlace/eslint-devkit';
 
+
+
 ruleTester.run('no-missing-cors-check (coverage wave)', noMissingCorsCheck, {
-  valid: [
+  valid: xp([
     // wildcard in an object with no CORS context at all
     { code: `const config = { origin: '*' };` },
     // config variable declared without an initializer
@@ -508,8 +552,8 @@ ruleTester.run('no-missing-cors-check (coverage wave)', noMissingCorsCheck, {
       code: `app.use(cors('*'));`,
       options: [{ ignorePatterns: ['\\*'] }],
     },
-  ],
-  invalid: [
+  ]),
+  invalid: xp([
     // wildcard literal passed directly to cors() — actual CORS context
     {
       code: `app.use(cors('*'));`,
@@ -550,7 +594,7 @@ ruleTester.run('no-missing-cors-check (coverage wave)', noMissingCorsCheck, {
       code: `res.setHeader('Access-Control-Allow-Origin', '*');`,
       errors: [{ messageId: 'missingCorsCheck' }],
     },
-  ],
+  ]),
 });
 
 // Layer 2: synthetic AST — a parser always parents nodes up to Program, so the
@@ -562,6 +606,21 @@ vitest.describe('no-missing-cors-check (layer 2: synthetic AST)', () => {
     () => {
       const { listeners, reports } = createWithMockContext(noMissingCorsCheck, {
         sourceText: 'app.use(cors(config))',
+        // This test drives listeners directly, so the file it stands for must
+        // carry the same Express evidence a real one would — otherwise the rule
+        // registers no listeners and the gap under test is never reached.
+        ast: {
+          type: 'Program',
+          body: [
+            {
+              type: 'ImportDeclaration',
+              source: { type: 'Literal', value: 'express' },
+              specifiers: [],
+            },
+          ],
+          tokens: [],
+          comments: [],
+        } as never,
       });
       const node = {
         type: 'CallExpression',

--- a/packages/eslint-plugin-express-security/src/rules/no-missing-csrf-protection/index.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-missing-csrf-protection/index.ts
@@ -19,6 +19,7 @@ import {
   MessageIcons,
 } from '@interlace/eslint-devkit';
 import { createRule } from '@interlace/eslint-devkit';
+import { fileUsesExpress } from '../../utils/express-evidence';
 
 type MessageIds = 'missingCsrfProtection' | 'addCsrfValidation';
 
@@ -145,6 +146,12 @@ export const noMissingCsrfProtection = createRule<RuleOptions, MessageIds>({
     },
   ],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>, [options]) {
+    // Every rule here is Express-specific, and none of them knew it: over
+    // 107,382 files, 75% of this plugin's findings were in files with no
+    // Express import. Registering no visitors is both the gate and the cheap
+    // path — a file with no Express in it does no work.
+    if (!fileUsesExpress(context.sourceCode.ast)) return {};
+
     const {
       allowInTests = false,
       csrfMiddlewarePatterns,

--- a/packages/eslint-plugin-express-security/src/rules/no-missing-csrf-protection/no-missing-csrf-protection.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-missing-csrf-protection/no-missing-csrf-protection.test.ts
@@ -7,6 +7,49 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { noMissingCsrfProtection } from './index';
 
+/**
+ * Every fixture imports express, because the rules now abstain in files with no
+ * Express in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass vacuously
+ * on the gate instead of exercising the detection it was written for. `output`
+ * and errors[].suggestions[].output are prefixed too, since autofix fixtures
+ * assert the whole file back.
+ */
+const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const xp = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asExpress(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asExpress(test.code),
+      ...(typeof test.output === 'string' ? { output: asExpress(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asExpress(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -28,7 +71,7 @@ const ruleTester = new RuleTester({
 describe('no-missing-csrf-protection', () => {
   describe('Valid Code', () => {
     ruleTester.run('valid - CSRF protection present', noMissingCsrfProtection, {
-      valid: [
+      valid: xp([
         // CSRF middleware in route chain
         {
           code: 'app.post("/api/users", csrf(), handler);',
@@ -52,7 +95,7 @@ describe('no-missing-csrf-protection', () => {
           filename: 'test.spec.ts',
           options: [{ allowInTests: true }],
         },
-      ],
+      ]),
       invalid: [],
     });
   });
@@ -60,7 +103,7 @@ describe('no-missing-csrf-protection', () => {
   describe('Invalid Code - Missing CSRF', () => {
     ruleTester.run('invalid - POST without CSRF', noMissingCsrfProtection, {
       valid: [],
-      invalid: [
+      invalid: xp([
         {
           code: 'app.post("/api/users", handler);',
           errors: [
@@ -100,12 +143,12 @@ describe('no-missing-csrf-protection', () => {
             },
           ],
         },
-      ],
+      ]),
     });
 
     ruleTester.run('invalid - PUT without CSRF', noMissingCsrfProtection, {
       valid: [],
-      invalid: [
+      invalid: xp([
         {
           code: 'app.put("/api/users/:id", handler);',
           errors: [
@@ -125,12 +168,12 @@ describe('no-missing-csrf-protection', () => {
             },
           ],
         },
-      ],
+      ]),
     });
 
     ruleTester.run('invalid - DELETE without CSRF', noMissingCsrfProtection, {
       valid: [],
-      invalid: [
+      invalid: xp([
         {
           code: 'app.delete("/api/users/:id", handler);',
           errors: [
@@ -150,12 +193,12 @@ describe('no-missing-csrf-protection', () => {
             },
           ],
         },
-      ],
+      ]),
     });
 
     ruleTester.run('invalid - PATCH without CSRF', noMissingCsrfProtection, {
       valid: [],
-      invalid: [
+      invalid: xp([
         {
           code: 'app.patch("/api/users/:id", handler);',
           errors: [
@@ -175,13 +218,13 @@ describe('no-missing-csrf-protection', () => {
             },
           ],
         },
-      ],
+      ]),
     });
   });
 
   describe('Options', () => {
     ruleTester.run('options - ignorePatterns', noMissingCsrfProtection, {
-      valid: [
+      valid: xp([
         // Valid ignorePattern - pattern must match the call text
         {
           code: 'app.post("/api/internal", handler);',
@@ -192,17 +235,17 @@ describe('no-missing-csrf-protection', () => {
           code: 'app.post("/api/internal", handler);',
           options: [{ ignorePatterns: ['internal'] }],
         },
-      ],
+      ]),
       invalid: [],
     });
 
     ruleTester.run('options - custom CSRF patterns', noMissingCsrfProtection, {
-      valid: [
+      valid: xp([
         {
           code: 'app.post("/api/users", customCsrf(), handler);',
           options: [{ csrfMiddlewarePatterns: ['customCsrf'] }],
         },
-      ],
+      ]),
       invalid: [],
     });
 
@@ -210,12 +253,12 @@ describe('no-missing-csrf-protection', () => {
       'options - custom protected methods',
       noMissingCsrfProtection,
       {
-        valid: [
+        valid: xp([
           {
             code: 'app.options("/api/users", handler);', // OPTIONS not protected by default
           },
-        ],
-        invalid: [
+        ]),
+        invalid: xp([
           {
             code: 'app.options("/api/users", handler);',
             options: [{ protectedMethods: ['options'] }],
@@ -231,7 +274,7 @@ describe('no-missing-csrf-protection', () => {
               },
             ],
           },
-        ],
+        ]),
       },
     );
   });
@@ -244,7 +287,7 @@ ruleTester.run(
   'no-missing-csrf-protection (coverage wave)',
   noMissingCsrfProtection,
   {
-    valid: [
+    valid: xp([
       // fewer than two arguments — not a route registration
       { code: `app.post('/incomplete');` },
       // invalid regex ignore pattern falls back to substring matching (matches '(')
@@ -262,8 +305,8 @@ ruleTester.run(
         code: `app.get('/read', handler);`,
         options: [{ protectedMethods: ['post'] }],
       },
-    ],
-    invalid: [
+    ]),
+    invalid: xp([
       // invalid regex ignore pattern that does not match as a substring either
       {
         code: `app.post('/b', handler);`,
@@ -295,6 +338,6 @@ ruleTester.run(
           },
         ],
       },
-    ],
+    ]),
   },
 );

--- a/packages/eslint-plugin-express-security/src/rules/no-missing-csrf-protection/no-missing-csrf-protection.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-missing-csrf-protection/no-missing-csrf-protection.test.ts
@@ -15,7 +15,10 @@ import { noMissingCsrfProtection } from './index';
  * and errors[].suggestions[].output are prefixed too, since autofix fixtures
  * assert the whole file back.
  */
-const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+// A SIDE-EFFECT import: it satisfies the gate without reserving the `express`
+// binding. Several fixtures already declare `const express = require('express')`
+// at module level, and a default import would redeclare it.
+const asExpress = (code: string): string => `import 'express';\n${code}`;
 type Suggestion = { output?: string | null };
 type Case = {
   code: string;

--- a/packages/eslint-plugin-express-security/src/rules/no-missing-security-headers/index.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-missing-security-headers/index.ts
@@ -15,6 +15,7 @@
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
 import { formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
 import { createRule } from '@interlace/eslint-devkit';
+import { fileUsesExpress } from '../../utils/express-evidence';
 
 type MessageIds =
   | 'missingSecurityHeader'
@@ -226,6 +227,12 @@ export const noMissingSecurityHeaders = createRule<RuleOptions, MessageIds>({
     },
   ],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>, [options]) {
+    // Every rule here is Express-specific, and none of them knew it: over
+    // 107,382 files, 75% of this plugin's findings were in files with no
+    // Express import. Registering no visitors is both the gate and the cheap
+    // path — a file with no Express in it does no work.
+    if (!fileUsesExpress(context.sourceCode.ast)) return {};
+
     const {
       requiredHeaders = DEFAULT_REQUIRED_HEADERS,
       ignoreInTests = true,

--- a/packages/eslint-plugin-express-security/src/rules/no-missing-security-headers/no-missing-security-headers.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-missing-security-headers/no-missing-security-headers.test.ts
@@ -15,7 +15,10 @@ import { noMissingSecurityHeaders } from './index';
  * and errors[].suggestions[].output are prefixed too, since autofix fixtures
  * assert the whole file back.
  */
-const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+// A SIDE-EFFECT import: it satisfies the gate without reserving the `express`
+// binding. Several fixtures already declare `const express = require('express')`
+// at module level, and a default import would redeclare it.
+const asExpress = (code: string): string => `import 'express';\n${code}`;
 type Suggestion = { output?: string | null };
 type Case = {
   code: string;

--- a/packages/eslint-plugin-express-security/src/rules/no-missing-security-headers/no-missing-security-headers.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-missing-security-headers/no-missing-security-headers.test.ts
@@ -7,6 +7,49 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { noMissingSecurityHeaders } from './index';
 
+/**
+ * Every fixture imports express, because the rules now abstain in files with no
+ * Express in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass vacuously
+ * on the gate instead of exercising the detection it was written for. `output`
+ * and errors[].suggestions[].output are prefixed too, since autofix fixtures
+ * assert the whole file back.
+ */
+const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const xp = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asExpress(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asExpress(test.code),
+      ...(typeof test.output === 'string' ? { output: asExpress(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asExpress(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -23,7 +66,7 @@ const ruleTester = new RuleTester({
 describe('no-missing-security-headers', () => {
   describe('Valid Code', () => {
     ruleTester.run('valid - security headers set', noMissingSecurityHeaders, {
-      valid: [
+      valid: xp([
         // All required headers
         {
           code: `
@@ -38,7 +81,7 @@ describe('no-missing-security-headers', () => {
           filename: 'test.spec.ts',
           options: [{ ignoreInTests: true }],
         },
-      ],
+      ]),
       invalid: [],
     });
   });
@@ -46,7 +89,7 @@ describe('no-missing-security-headers', () => {
   describe('Invalid Code - Missing Security Headers', () => {
     ruleTester.run('invalid - missing headers', noMissingSecurityHeaders, {
       valid: [],
-      invalid: [
+      invalid: xp([
         {
           code: 'res.setHeader("X-Custom", "value");',
           errors: [{ messageId: 'missingSecurityHeader' }],
@@ -55,43 +98,43 @@ describe('no-missing-security-headers', () => {
           code: 'res.setHeader("Content-Security-Policy", "default-src self");',
           errors: [{ messageId: 'missingSecurityHeader' }], // Missing other headers
         },
-      ],
+      ]),
     });
   });
 
   describe('Options', () => {
     ruleTester.run('options - ignoreInTests', noMissingSecurityHeaders, {
-      valid: [
+      valid: xp([
         {
           code: 'res.setHeader("X-Custom", "value");',
           filename: 'test.spec.ts',
           options: [{ ignoreInTests: true }],
         },
-      ],
-      invalid: [
+      ]),
+      invalid: xp([
         {
           code: 'res.setHeader("X-Custom", "value");',
           filename: 'test.spec.ts',
           options: [{ ignoreInTests: false }],
           errors: [{ messageId: 'missingSecurityHeader' }],
         },
-      ],
+      ]),
     });
 
     ruleTester.run('options - requiredHeaders', noMissingSecurityHeaders, {
-      valid: [
+      valid: xp([
         {
           code: 'res.setHeader("Custom-Header", "value");',
           options: [{ requiredHeaders: ['Custom-Header'] }],
         },
-      ],
-      invalid: [
+      ]),
+      invalid: xp([
         {
           code: 'res.setHeader("Other-Header", "value");',
           options: [{ requiredHeaders: ['Custom-Header'] }],
           errors: [{ messageId: 'missingSecurityHeader' }],
         },
-      ],
+      ]),
     });
   });
 });
@@ -103,7 +146,7 @@ ruleTester.run(
   'no-missing-security-headers (coverage wave)',
   noMissingSecurityHeaders,
   {
-    valid: [
+    valid: xp([
       // bare call — callee is not a member expression
       { code: `setHeader('X-Frame-Options', 'DENY');` },
       // member method that is not a header setter
@@ -118,8 +161,8 @@ ruleTester.run(
         }
       `,
       },
-    ],
-    invalid: [
+    ]),
+    invalid: xp([
       // res.set() without arguments — header name is unknown, all headers missing
       { code: `res.set();`, errors: [{ messageId: 'missingSecurityHeader' }] },
       // dynamic header name cannot be tracked
@@ -146,7 +189,7 @@ ruleTester.run(
         code: `app.get('/a', (req, res) => { res.setHeader('X-Frame-Options', 'DENY'); });`,
         errors: [{ messageId: 'missingSecurityHeader' }],
       },
-    ],
+    ]),
   },
 );
 
@@ -159,7 +202,7 @@ ruleTester.run(
   'no-missing-security-headers (callee must be a response)',
   noMissingSecurityHeaders,
   {
-    valid: [
+    valid: xp([
       // the reported false positives
       { code: `url.searchParams.set('page', '2');` },
       { code: `app.set('view engine', 'ejs');` },
@@ -186,8 +229,8 @@ ruleTester.run(
       // a non-header header name collected from a non-response receiver must not
       // satisfy the requirement — no response call here at all, so no report
       { code: `myMap.set('Content-Security-Policy', 'x');` },
-    ],
-    invalid: [
+    ]),
+    invalid: xp([
       // response aliases are still checked
       {
         code: `reply.header('X-Frame-Options', 'DENY');`,
@@ -213,6 +256,6 @@ ruleTester.run(
       `,
         errors: [{ messageId: 'missingSecurityHeader' }],
       },
-    ],
+    ]),
   },
 );

--- a/packages/eslint-plugin-express-security/src/rules/no-permissive-cors/index.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-permissive-cors/index.ts
@@ -13,6 +13,7 @@
  * @see https://owasp.org/www-community/attacks/CORS_OriginHeaderScrutiny
  */
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
+import { fileUsesExpress } from '../../utils/express-evidence';
 import {
   formatLLMMessage,
   MessageIcons,
@@ -193,6 +194,12 @@ export const noPermissiveCors = createRule<RuleOptions, MessageIds>({
     },
   ],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>, [options]) {
+    // Every rule here is Express-specific, and none of them knew it: over
+    // 107,382 files, 75% of this plugin's findings were in files with no
+    // Express import. Registering no visitors is both the gate and the cheap
+    // path — a file with no Express in it does no work.
+    if (!fileUsesExpress(context.sourceCode.ast)) return {};
+
     const { allowInTests = false, allowOriginTrue = false } =
       options as Options;
 

--- a/packages/eslint-plugin-express-security/src/rules/no-permissive-cors/no-permissive-cors.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-permissive-cors/no-permissive-cors.test.ts
@@ -14,7 +14,10 @@ import { noPermissiveCors } from './index';
  * and errors[].suggestions[].output are prefixed too, since autofix fixtures
  * assert the whole file back.
  */
-const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+// A SIDE-EFFECT import: it satisfies the gate without reserving the `express`
+// binding. Several fixtures already declare `const express = require('express')`
+// at module level, and a default import would redeclare it.
+const asExpress = (code: string): string => `import 'express';\n${code}`;
 type Suggestion = { output?: string | null };
 type Case = {
   code: string;

--- a/packages/eslint-plugin-express-security/src/rules/no-permissive-cors/no-permissive-cors.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-permissive-cors/no-permissive-cors.test.ts
@@ -6,6 +6,49 @@ import { RuleTester } from '@typescript-eslint/rule-tester';
 import { describe, it, afterAll } from 'vitest';
 import { noPermissiveCors } from './index';
 
+/**
+ * Every fixture imports express, because the rules now abstain in files with no
+ * Express in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass vacuously
+ * on the gate instead of exercising the detection it was written for. `output`
+ * and errors[].suggestions[].output are prefixed too, since autofix fixtures
+ * assert the whole file back.
+ */
+const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const xp = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asExpress(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asExpress(test.code),
+      ...(typeof test.output === 'string' ? { output: asExpress(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asExpress(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -21,7 +64,7 @@ const ruleTester = new RuleTester({
 describe('no-permissive-cors', () => {
   describe('Valid Code', () => {
     ruleTester.run('valid - restricted origins', noPermissiveCors, {
-      valid: [
+      valid: xp([
         // CORS with specific origin whitelist
         {
           code: `
@@ -79,7 +122,7 @@ describe('no-permissive-cors', () => {
             app.use(notCors({ origin: '*' }));
           `,
         },
-      ],
+      ]),
       invalid: [],
     });
   });
@@ -87,7 +130,7 @@ describe('no-permissive-cors', () => {
   describe('Invalid Code', () => {
     ruleTester.run('invalid - permissive origins', noPermissiveCors, {
       valid: [],
-      invalid: [
+      invalid: xp([
         // Wildcard origin
         {
           code: `
@@ -128,7 +171,7 @@ describe('no-permissive-cors', () => {
           code: `const corsMiddleware = cors({ origin: '*' });`,
           errors: [{ messageId: 'permissiveCors' }],
         },
-      ],
+      ]),
     });
   });
 });
@@ -137,7 +180,7 @@ describe('no-permissive-cors', () => {
 // Coverage wave: previously untested branches (annotation-debt removal)
 // ---------------------------------------------------------------------------
 ruleTester.run('no-permissive-cors (coverage wave)', noPermissiveCors, {
-  valid: [
+  valid: xp([
     // app.use(cors(identifier)) — config is not an inline object
     { code: `app.use(cors(corsOptions));` },
     // standalone cors(identifier)
@@ -149,13 +192,13 @@ ruleTester.run('no-permissive-cors (coverage wave)', noPermissiveCors, {
       code: `cors({ origin: 'https://a.com', credentials: true });`,
       options: [{ allowOriginTrue: true }],
     },
-  ],
-  invalid: [
+  ]),
+  invalid: xp([
     // credentials: true + origin: true is still flagged even with allowOriginTrue
     {
       code: `cors({ origin: true, credentials: true });`,
       options: [{ allowOriginTrue: true }],
       errors: [{ messageId: 'permissiveCors' }],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-express-security/src/rules/no-permissive-trust-proxy/index.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-permissive-trust-proxy/index.ts
@@ -29,6 +29,7 @@
  */
 
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
+import { fileUsesExpress } from '../../utils/express-evidence';
 import {
   AST_NODE_TYPES,
   createRule,
@@ -117,6 +118,12 @@ export const noPermissiveTrustProxy = createRule<RuleOptions, MessageIds>({
   },
   defaultOptions: [{}],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>, [options]) {
+    // Every rule here is Express-specific, and none of them knew it: over
+    // 107,382 files, 75% of this plugin's findings were in files with no
+    // Express import. Registering no visitors is both the gate and the cheap
+    // path — a file with no Express in it does no work.
+    if (!fileUsesExpress(context.sourceCode.ast)) return {};
+
     const { hopCount } = options as Options;
     const hops = hopCount ?? 1;
 

--- a/packages/eslint-plugin-express-security/src/rules/no-permissive-trust-proxy/no-permissive-trust-proxy.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-permissive-trust-proxy/no-permissive-trust-proxy.test.ts
@@ -3,6 +3,49 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { noPermissiveTrustProxy } from './index';
 
+/**
+ * Every fixture imports express, because the rules now abstain in files with no
+ * Express in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass vacuously
+ * on the gate instead of exercising the detection it was written for. `output`
+ * and errors[].suggestions[].output are prefixed too, since autofix fixtures
+ * assert the whole file back.
+ */
+const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const xp = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asExpress(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asExpress(test.code),
+      ...(typeof test.output === 'string' ? { output: asExpress(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asExpress(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -14,7 +57,7 @@ const ruleTester = new RuleTester({
 
 describe('no-permissive-trust-proxy', () => {
   ruleTester.run('no-permissive-trust-proxy', noPermissiveTrustProxy, {
-    valid: [
+    valid: xp([
       // THE safe patterns — name the proxies you actually run behind
       { code: `app.set('trust proxy', 1);` },
       { code: `app.set('trust proxy', 'loopback');` },
@@ -35,8 +78,8 @@ describe('no-permissive-trust-proxy', () => {
       { code: `app[method]('trust proxy', true);` },
       { code: `app['set']('trust proxy', true);` },
       { code: `app().set('trust proxy', true);` },
-    ],
-    invalid: [
+    ]),
+    invalid: xp([
       // Unconditional trust — the classic rate-limit bypass
       {
         code: `app.set('trust proxy', true);`,
@@ -112,6 +155,6 @@ describe('no-permissive-trust-proxy', () => {
           },
         ],
       },
-    ],
+    ]),
   });
 });

--- a/packages/eslint-plugin-express-security/src/rules/no-permissive-trust-proxy/no-permissive-trust-proxy.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-permissive-trust-proxy/no-permissive-trust-proxy.test.ts
@@ -11,7 +11,10 @@ import { noPermissiveTrustProxy } from './index';
  * and errors[].suggestions[].output are prefixed too, since autofix fixtures
  * assert the whole file back.
  */
-const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+// A SIDE-EFFECT import: it satisfies the gate without reserving the `express`
+// binding. Several fixtures already declare `const express = require('express')`
+// at module level, and a default import would redeclare it.
+const asExpress = (code: string): string => `import 'express';\n${code}`;
 type Suggestion = { output?: string | null };
 type Case = {
   code: string;

--- a/packages/eslint-plugin-express-security/src/rules/no-sensitive-data-in-query/index.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-sensitive-data-in-query/index.ts
@@ -37,6 +37,7 @@
  */
 
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
+import { fileUsesExpress } from '../../utils/express-evidence';
 import {
   AST_NODE_TYPES,
   createRule,
@@ -163,6 +164,12 @@ export const noSensitiveDataInQuery = createRule<RuleOptions, MessageIds>({
   },
   defaultOptions: [{}],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>, [options]) {
+    // Every rule here is Express-specific, and none of them knew it: over
+    // 107,382 files, 75% of this plugin's findings were in files with no
+    // Express import. Registering no visitors is both the gate and the cheap
+    // path — a file with no Express in it does no work.
+    if (!fileUsesExpress(context.sourceCode.ast)) return {};
+
     const { sensitiveParams, extraPatterns, allowedParams } =
       options as Options;
     const terms = [...DEFAULT_SENSITIVE, ...(sensitiveParams ?? [])].map(

--- a/packages/eslint-plugin-express-security/src/rules/no-sensitive-data-in-query/no-sensitive-data-in-query.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-sensitive-data-in-query/no-sensitive-data-in-query.test.ts
@@ -3,6 +3,49 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { noSensitiveDataInQuery } from './index';
 
+/**
+ * Every fixture imports express, because the rules now abstain in files with no
+ * Express in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass vacuously
+ * on the gate instead of exercising the detection it was written for. `output`
+ * and errors[].suggestions[].output are prefixed too, since autofix fixtures
+ * assert the whole file back.
+ */
+const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const xp = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asExpress(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asExpress(test.code),
+      ...(typeof test.output === 'string' ? { output: asExpress(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asExpress(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -14,7 +57,7 @@ const ruleTester = new RuleTester({
 
 describe('no-sensitive-data-in-query', () => {
   ruleTester.run('no-sensitive-data-in-query', noSensitiveDataInQuery, {
-    valid: [
+    valid: xp([
       // Benchmark corpus: CWE-598/safe/login-via-body-post.js (FP-lock)
       {
         code: `
@@ -85,8 +128,8 @@ module.exports = app;
       // Computed query access is not resolvable (documented false negative)
       { code: `const z = req.query[key];` },
       { code: `const w = req['query'].password;` },
-    ],
-    invalid: [
+    ]),
+    invalid: xp([
       // Benchmark corpus: CWE-598/vulnerable/login-via-query.js
       {
         code: `
@@ -229,7 +272,7 @@ module.exports = app;
         code: `const t = req.query._token;`,
         errors: [{ messageId: 'sensitiveQueryParam' }],
       },
-    ],
+    ]),
   });
 });
 
@@ -240,7 +283,7 @@ ruleTester.run(
   'no-sensitive-data-in-query (coverage wave)',
   noSensitiveDataInQuery,
   {
-    valid: [
+    valid: xp([
       // VariableDeclarator: id is a plain identifier (not a pattern)
       { code: `const q = req.query;` },
       // VariableDeclarator: array pattern
@@ -269,8 +312,8 @@ ruleTester.run(
       {
         code: `class C { #query = {}; check(req) { return req.#query.password; } }`,
       },
-    ],
-    invalid: [
+    ]),
+    invalid: xp([
       // Sensitive read used as a call argument (expression position)
       {
         code: `lookup(req.query.card);`,
@@ -283,6 +326,6 @@ ruleTester.run(
           { messageId: 'sensitiveQueryParam', data: { name: 'serviceApiKey' } },
         ],
       },
-    ],
+    ]),
   },
 );

--- a/packages/eslint-plugin-express-security/src/rules/no-sensitive-data-in-query/no-sensitive-data-in-query.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-sensitive-data-in-query/no-sensitive-data-in-query.test.ts
@@ -11,7 +11,10 @@ import { noSensitiveDataInQuery } from './index';
  * and errors[].suggestions[].output are prefixed too, since autofix fixtures
  * assert the whole file back.
  */
-const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+// A SIDE-EFFECT import: it satisfies the gate without reserving the `express`
+// binding. Several fixtures already declare `const express = require('express')`
+// at module level, and a default import would redeclare it.
+const asExpress = (code: string): string => `import 'express';\n${code}`;
 type Suggestion = { output?: string | null };
 type Case = {
   code: string;

--- a/packages/eslint-plugin-express-security/src/rules/no-static-root-exposure/index.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-static-root-exposure/index.ts
@@ -32,6 +32,7 @@
  */
 
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
+import { fileUsesExpress } from '../../utils/express-evidence';
 import {
   AST_NODE_TYPES,
   createRule,
@@ -155,6 +156,12 @@ export const noStaticRootExposure = createRule<RuleOptions, MessageIds>({
   },
   defaultOptions: [{}],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>, [options]) {
+    // Every rule here is Express-specific, and none of them knew it: over
+    // 107,382 files, 75% of this plugin's findings were in files with no
+    // Express import. Registering no visitors is both the gate and the cheap
+    // path — a file with no Express in it does no work.
+    if (!fileUsesExpress(context.sourceCode.ast)) return {};
+
     const { allowedRoots } = options as Options;
     const roots = new Set(allowedRoots ?? DEFAULT_ALLOWED_ROOTS);
     const suggestionRoot =

--- a/packages/eslint-plugin-express-security/src/rules/no-static-root-exposure/no-static-root-exposure.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-static-root-exposure/no-static-root-exposure.test.ts
@@ -11,7 +11,10 @@ import { noStaticRootExposure } from './index';
  * and errors[].suggestions[].output are prefixed too, since autofix fixtures
  * assert the whole file back.
  */
-const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+// A SIDE-EFFECT import: it satisfies the gate without reserving the `express`
+// binding. Several fixtures already declare `const express = require('express')`
+// at module level, and a default import would redeclare it.
+const asExpress = (code: string): string => `import 'express';\n${code}`;
 type Suggestion = { output?: string | null };
 type Case = {
   code: string;

--- a/packages/eslint-plugin-express-security/src/rules/no-static-root-exposure/no-static-root-exposure.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-static-root-exposure/no-static-root-exposure.test.ts
@@ -3,6 +3,49 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { noStaticRootExposure } from './index';
 
+/**
+ * Every fixture imports express, because the rules now abstain in files with no
+ * Express in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass vacuously
+ * on the gate instead of exercising the detection it was written for. `output`
+ * and errors[].suggestions[].output are prefixed too, since autofix fixtures
+ * assert the whole file back.
+ */
+const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const xp = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asExpress(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asExpress(test.code),
+      ...(typeof test.output === 'string' ? { output: asExpress(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asExpress(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -14,7 +57,7 @@ const ruleTester = new RuleTester({
 
 describe('no-static-root-exposure', () => {
   ruleTester.run('no-static-root-exposure', noStaticRootExposure, {
-    valid: [
+    valid: xp([
       // THE safe pattern (corpus FP-lock: CWE-548/safe/static-public-dir.js)
       {
         code: `
@@ -62,8 +105,8 @@ describe('no-static-root-exposure', () => {
       { code: `express.json();` },
       { code: `fastify.static('.');` },
       { code: `app.use(express.static(path.join(__dirname, 'public')));` },
-    ],
-    invalid: [
+    ]),
+    invalid: xp([
       // Corpus fixture (verbatim): CWE-548/vulnerable/static-root-dirname.js
       {
         code: `
@@ -287,7 +330,7 @@ describe('no-static-root-exposure', () => {
         `,
         errors: [{ messageId: 'directoryListing' }],
       },
-    ],
+    ]),
   });
 });
 
@@ -298,7 +341,7 @@ ruleTester.run(
   'no-static-root-exposure (coverage wave)',
   noStaticRootExposure,
   {
-    valid: [
+    valid: xp([
       // express.static with no argument — nothing to analyze
       { code: `express.static();` },
       // non-string literal root
@@ -333,8 +376,8 @@ ruleTester.run(
       { code: `const x = require(moduleName);` }, // non-literal module
       { code: `const morgan = require('morgan');` }, // different module
       { code: `import express from 'express';` }, // different import source
-    ],
-    invalid: [
+    ]),
+    invalid: xp([
       // empty-string root
       {
         code: `express.static('');`,
@@ -459,6 +502,6 @@ ruleTester.run(
       `,
         errors: [{ messageId: 'directoryListing' }],
       },
-    ],
+    ]),
   },
 );

--- a/packages/eslint-plugin-express-security/src/rules/no-unsafe-csp-directives/index.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-unsafe-csp-directives/index.ts
@@ -35,6 +35,7 @@
  */
 
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
+import { fileUsesExpress } from '../../utils/express-evidence';
 import {
   AST_NODE_TYPES,
   createRule,
@@ -214,6 +215,12 @@ export const noUnsafeCspDirectives = createRule<RuleOptions, MessageIds>({
   },
   defaultOptions: [{}],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>, [options]) {
+    // Every rule here is Express-specific, and none of them knew it: over
+    // 107,382 files, 75% of this plugin's findings were in files with no
+    // Express import. Registering no visitors is both the gate and the cheap
+    // path — a file with no Express in it does no work.
+    if (!fileUsesExpress(context.sourceCode.ast)) return {};
+
     const { checkStyleSrc } = options as Options;
     const withStyle = checkStyleSrc ?? true;
 

--- a/packages/eslint-plugin-express-security/src/rules/no-unsafe-csp-directives/no-unsafe-csp-directives.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-unsafe-csp-directives/no-unsafe-csp-directives.test.ts
@@ -3,6 +3,49 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { noUnsafeCspDirectives } from './index';
 
+/**
+ * Every fixture imports express, because the rules now abstain in files with no
+ * Express in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass vacuously
+ * on the gate instead of exercising the detection it was written for. `output`
+ * and errors[].suggestions[].output are prefixed too, since autofix fixtures
+ * assert the whole file back.
+ */
+const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const xp = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asExpress(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asExpress(test.code),
+      ...(typeof test.output === 'string' ? { output: asExpress(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asExpress(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -14,7 +57,7 @@ const ruleTester = new RuleTester({
 
 describe('no-unsafe-csp-directives', () => {
   ruleTester.run('no-unsafe-csp-directives', noUnsafeCspDirectives, {
-    valid: [
+    valid: xp([
       // THE safe pattern — self-only sources, explicit frame-ancestors
       {
         code: `
@@ -111,8 +154,8 @@ describe('no-unsafe-csp-directives', () => {
       {
         code: `app.use(helmet({ contentSecurityPolicy: { directives: { 1: ['*'] } } }));`,
       },
-    ],
-    invalid: [
+    ]),
+    invalid: xp([
       // 'unsafe-inline' in script-src — the SonarJS S5728 case
       {
         code: `app.use(helmet({ contentSecurityPolicy: { directives: { scriptSrc: ["'self'", "'unsafe-inline'"] } } }));`,
@@ -258,6 +301,6 @@ describe('no-unsafe-csp-directives', () => {
           },
         ],
       },
-    ],
+    ]),
   });
 });

--- a/packages/eslint-plugin-express-security/src/rules/no-unsafe-csp-directives/no-unsafe-csp-directives.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-unsafe-csp-directives/no-unsafe-csp-directives.test.ts
@@ -11,7 +11,10 @@ import { noUnsafeCspDirectives } from './index';
  * and errors[].suggestions[].output are prefixed too, since autofix fixtures
  * assert the whole file back.
  */
-const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+// A SIDE-EFFECT import: it satisfies the gate without reserving the `express`
+// binding. Several fixtures already declare `const express = require('express')`
+// at module level, and a default import would redeclare it.
+const asExpress = (code: string): string => `import 'express';\n${code}`;
 type Suggestion = { output?: string | null };
 type Case = {
   code: string;

--- a/packages/eslint-plugin-express-security/src/rules/no-user-controlled-redirect/index.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-user-controlled-redirect/index.ts
@@ -33,6 +33,7 @@
  */
 
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
+import { fileUsesExpress } from '../../utils/express-evidence';
 import {
   AST_NODE_TYPES,
   createRule,
@@ -109,6 +110,12 @@ export const noUserControlledRedirect = createRule<RuleOptions, MessageIds>({
   },
   defaultOptions: [{}],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>, [options]) {
+    // Every rule here is Express-specific, and none of them knew it: over
+    // 107,382 files, 75% of this plugin's findings were in files with no
+    // Express import. Registering no visitors is both the gate and the cheap
+    // path — a file with no Express in it does no work.
+    if (!fileUsesExpress(context.sourceCode.ast)) return {};
+
     const { responseObjects, requestObjects } = options as Options;
     const extraResNames = new Set(responseObjects ?? []);
     const extraReqNames = new Set(requestObjects ?? []);

--- a/packages/eslint-plugin-express-security/src/rules/no-user-controlled-redirect/no-user-controlled-redirect.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-user-controlled-redirect/no-user-controlled-redirect.test.ts
@@ -3,6 +3,49 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { noUserControlledRedirect } from './index';
 
+/**
+ * Every fixture imports express, because the rules now abstain in files with no
+ * Express in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass vacuously
+ * on the gate instead of exercising the detection it was written for. `output`
+ * and errors[].suggestions[].output are prefixed too, since autofix fixtures
+ * assert the whole file back.
+ */
+const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const xp = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asExpress(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asExpress(test.code),
+      ...(typeof test.output === 'string' ? { output: asExpress(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asExpress(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -14,7 +57,7 @@ const ruleTester = new RuleTester({
 
 describe('no-user-controlled-redirect', () => {
   ruleTester.run('no-user-controlled-redirect', noUserControlledRedirect, {
-    valid: [
+    valid: xp([
       // Literal redirect — always safe
       { code: `res.redirect('/dashboard');` },
       { code: `res.redirect(301, '/login');` },
@@ -38,8 +81,8 @@ describe('no-user-controlled-redirect', () => {
       { code: `res.json({ url: req.body.url });` },
       // Numeric status code + literal target
       { code: `response.redirect(302, '/logout');` },
-    ],
-    invalid: [
+    ]),
+    invalid: xp([
       // Direct req.query access
       {
         code: `res.redirect(req.query.returnUrl);`,
@@ -92,7 +135,7 @@ describe('no-user-controlled-redirect', () => {
         options: [{ responseObjects: ['reply'], requestObjects: ['ctx'] }],
         errors: [{ messageId: 'openRedirect', data: { source: 'req.query' } }],
       },
-    ],
+    ]),
   });
 });
 
@@ -103,7 +146,7 @@ ruleTester.run(
   'no-user-controlled-redirect (coverage wave)',
   noUserControlledRedirect,
   {
-    valid: [
+    valid: xp([
       // bare call — callee is not a member expression
       { code: `redirect(req.query.url);` },
       // computed member access on the response object
@@ -126,8 +169,8 @@ ruleTester.run(
       { code: `res.redirect(req['query']);` },
       // safe literal
       { code: `res.redirect('/home');` },
-    ],
-    invalid: [
+    ]),
+    invalid: xp([
       {
         code: `reply.redirect(req.query.url);`,
         errors: [{ messageId: 'openRedirect' }],
@@ -162,6 +205,6 @@ ruleTester.run(
         code: `res.redirect(req.body['to']);`,
         errors: [{ messageId: 'openRedirect' }],
       },
-    ],
+    ]),
   },
 );

--- a/packages/eslint-plugin-express-security/src/rules/no-user-controlled-redirect/no-user-controlled-redirect.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-user-controlled-redirect/no-user-controlled-redirect.test.ts
@@ -11,7 +11,10 @@ import { noUserControlledRedirect } from './index';
  * and errors[].suggestions[].output are prefixed too, since autofix fixtures
  * assert the whole file back.
  */
-const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+// A SIDE-EFFECT import: it satisfies the gate without reserving the `express`
+// binding. Several fixtures already declare `const express = require('express')`
+// at module level, and a default import would redeclare it.
+const asExpress = (code: string): string => `import 'express';\n${code}`;
 type Suggestion = { output?: string | null };
 type Case = {
   code: string;

--- a/packages/eslint-plugin-express-security/src/rules/no-user-controlled-render-locals/index.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-user-controlled-render-locals/index.ts
@@ -35,6 +35,7 @@
  */
 
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
+import { fileUsesExpress } from '../../utils/express-evidence';
 import {
   AST_NODE_TYPES,
   createRule,
@@ -126,6 +127,12 @@ export const noUserControlledRenderLocals = createRule<RuleOptions, MessageIds>(
     },
     defaultOptions: [{}],
     create(context: TSESLint.RuleContext<MessageIds, RuleOptions>, [options]) {
+      // Every rule here is Express-specific, and none of them knew it: over
+      // 107,382 files, 75% of this plugin's findings were in files with no
+      // Express import. Registering no visitors is both the gate and the cheap
+      // path — a file with no Express in it does no work.
+      if (!fileUsesExpress(context.sourceCode.ast)) return {};
+
       const { allowSanitizers } = options as Options;
       const sanitizers = new Set(allowSanitizers ?? []);
 

--- a/packages/eslint-plugin-express-security/src/rules/no-user-controlled-render-locals/no-user-controlled-render-locals.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-user-controlled-render-locals/no-user-controlled-render-locals.test.ts
@@ -3,6 +3,49 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { noUserControlledRenderLocals } from './index';
 
+/**
+ * Every fixture imports express, because the rules now abstain in files with no
+ * Express in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass vacuously
+ * on the gate instead of exercising the detection it was written for. `output`
+ * and errors[].suggestions[].output are prefixed too, since autofix fixtures
+ * assert the whole file back.
+ */
+const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const xp = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asExpress(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asExpress(test.code),
+      ...(typeof test.output === 'string' ? { output: asExpress(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asExpress(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -17,7 +60,7 @@ describe('no-user-controlled-render-locals', () => {
     'no-user-controlled-render-locals',
     noUserControlledRenderLocals,
     {
-      valid: [
+      valid: xp([
         // Static locals — always safe
         { code: `res.render('home');` },
         { code: `res.render('home', { title: 'Welcome' });` },
@@ -88,8 +131,8 @@ describe('no-user-controlled-render-locals', () => {
         // Static view names
         { code: `res.render('pages/' + page);` },
         { code: 'res.render(`pages/${page}`);' },
-      ],
-      invalid: [
+      ]),
+      invalid: xp([
         // Corpus fixture (verbatim): CWE-073/vulnerable/render-body-spread.js
         {
           code: `
@@ -306,7 +349,7 @@ describe('no-user-controlled-render-locals', () => {
             { messageId: 'unsafeRenderLocals', data: { source: 'req.query' } },
           ],
         },
-      ],
+      ]),
     },
   );
 });
@@ -318,7 +361,7 @@ ruleTester.run(
   'no-user-controlled-render-locals (coverage wave)',
   noUserControlledRenderLocals,
   {
-    valid: [
+    valid: xp([
       // REGRESSION: a name-keyed tracking map leaked the first handler's origin
       // into the second, flagging a `locals` that was never user-controlled.
       {
@@ -395,8 +438,8 @@ ruleTester.run(
       `,
         options: [{ allowSanitizers: ['pick'] }],
       },
-    ],
-    invalid: [
+    ]),
+    invalid: xp([
       // sanitizer-callee scan: callee is itself a CallExpression → not a sanitizer
       {
         code: `res.render('v', factory()(req.body));`,
@@ -522,6 +565,6 @@ ruleTester.run(
           { messageId: 'unsafeRenderLocals', data: { source: 'req.query' } },
         ],
       },
-    ],
+    ]),
   },
 );

--- a/packages/eslint-plugin-express-security/src/rules/no-user-controlled-render-locals/no-user-controlled-render-locals.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/no-user-controlled-render-locals/no-user-controlled-render-locals.test.ts
@@ -11,7 +11,10 @@ import { noUserControlledRenderLocals } from './index';
  * and errors[].suggestions[].output are prefixed too, since autofix fixtures
  * assert the whole file back.
  */
-const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+// A SIDE-EFFECT import: it satisfies the gate without reserving the `express`
+// binding. Several fixtures already declare `const express = require('express')`
+// at module level, and a default import would redeclare it.
+const asExpress = (code: string): string => `import 'express';\n${code}`;
 type Suggestion = { output?: string | null };
 type Case = {
   code: string;

--- a/packages/eslint-plugin-express-security/src/rules/require-case-insensitive-path-guard/index.ts
+++ b/packages/eslint-plugin-express-security/src/rules/require-case-insensitive-path-guard/index.ts
@@ -44,6 +44,7 @@
  */
 
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
+import { fileUsesExpress } from '../../utils/express-evidence';
 import {
   AST_NODE_TYPES,
   createRule,
@@ -152,6 +153,12 @@ export const requireCaseInsensitivePathGuard = createRule<
   },
   defaultOptions: [{}],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>, [options]) {
+    // Every rule here is Express-specific, and none of them knew it: over
+    // 107,382 files, 75% of this plugin's findings were in files with no
+    // Express import. Registering no visitors is both the gate and the cheap
+    // path — a file with no Express in it does no work.
+    if (!fileUsesExpress(context.sourceCode.ast)) return {};
+
     const { protectedPaths, checkAllPaths } = options as Options;
     const patterns = (protectedPaths ?? DEFAULT_PROTECTED_PATHS).map((p) =>
       p.toLowerCase(),

--- a/packages/eslint-plugin-express-security/src/rules/require-case-insensitive-path-guard/require-case-insensitive-path-guard.coverage.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/require-case-insensitive-path-guard/require-case-insensitive-path-guard.coverage.test.ts
@@ -18,7 +18,10 @@ import { requireCaseInsensitivePathGuard } from './index';
  * and errors[].suggestions[].output are prefixed too, since autofix fixtures
  * assert the whole file back.
  */
-const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+// A SIDE-EFFECT import: it satisfies the gate without reserving the `express`
+// binding. Several fixtures already declare `const express = require('express')`
+// at module level, and a default import would redeclare it.
+const asExpress = (code: string): string => `import 'express';\n${code}`;
 type Suggestion = { output?: string | null };
 type Case = {
   code: string;

--- a/packages/eslint-plugin-express-security/src/rules/require-case-insensitive-path-guard/require-case-insensitive-path-guard.coverage.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/require-case-insensitive-path-guard/require-case-insensitive-path-guard.coverage.test.ts
@@ -10,6 +10,49 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { requireCaseInsensitivePathGuard } from './index';
 
+/**
+ * Every fixture imports express, because the rules now abstain in files with no
+ * Express in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass vacuously
+ * on the gate instead of exercising the detection it was written for. `output`
+ * and errors[].suggestions[].output are prefixed too, since autofix fixtures
+ * assert the whole file back.
+ */
+const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const xp = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asExpress(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asExpress(test.code),
+      ...(typeof test.output === 'string' ? { output: asExpress(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asExpress(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -24,7 +67,7 @@ describe('require-case-insensitive-path-guard (branch coverage)', () => {
     'require-case-insensitive-path-guard (branch coverage)',
     requireCaseInsensitivePathGuard,
     {
-      valid: [
+      valid: xp([
         // Bare call — callee is not a member expression
         { code: `startsWith('/admin');` },
         // Computed guard method — property is not an Identifier
@@ -51,8 +94,8 @@ describe('require-case-insensitive-path-guard (branch coverage)', () => {
         { code: `if (5 === req.path) deny();` },
         // Path on both sides — no string literal to compare against
         { code: `if (req.path === req.url) deny();` },
-      ],
-      invalid: [
+      ]),
+      invalid: xp([
         // request alias through the equality path (isRequestIdent 'request')
         {
           code: `if (request.url === '/api/private') deny();`,
@@ -68,7 +111,7 @@ describe('require-case-insensitive-path-guard (branch coverage)', () => {
             },
           ],
         },
-      ],
+      ]),
     },
   );
 });

--- a/packages/eslint-plugin-express-security/src/rules/require-case-insensitive-path-guard/require-case-insensitive-path-guard.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/require-case-insensitive-path-guard/require-case-insensitive-path-guard.test.ts
@@ -11,7 +11,10 @@ import { requireCaseInsensitivePathGuard } from './index';
  * and errors[].suggestions[].output are prefixed too, since autofix fixtures
  * assert the whole file back.
  */
-const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+// A SIDE-EFFECT import: it satisfies the gate without reserving the `express`
+// binding. Several fixtures already declare `const express = require('express')`
+// at module level, and a default import would redeclare it.
+const asExpress = (code: string): string => `import 'express';\n${code}`;
 type Suggestion = { output?: string | null };
 type Case = {
   code: string;

--- a/packages/eslint-plugin-express-security/src/rules/require-case-insensitive-path-guard/require-case-insensitive-path-guard.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/require-case-insensitive-path-guard/require-case-insensitive-path-guard.test.ts
@@ -3,6 +3,49 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { requireCaseInsensitivePathGuard } from './index';
 
+/**
+ * Every fixture imports express, because the rules now abstain in files with no
+ * Express in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass vacuously
+ * on the gate instead of exercising the detection it was written for. `output`
+ * and errors[].suggestions[].output are prefixed too, since autofix fixtures
+ * assert the whole file back.
+ */
+const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const xp = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asExpress(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asExpress(test.code),
+      ...(typeof test.output === 'string' ? { output: asExpress(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asExpress(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -17,7 +60,7 @@ describe('require-case-insensitive-path-guard', () => {
     'require-case-insensitive-path-guard',
     requireCaseInsensitivePathGuard,
     {
-      valid: [
+      valid: xp([
         // Normalized before comparing — the canonical safe pattern
         { code: `if (req.path.toLowerCase().startsWith('/admin')) deny();` },
         { code: `if (req.url.toUpperCase() === '/ADMIN') deny();` },
@@ -72,8 +115,8 @@ app.get(/^\\/admin\\/users$/i, async (req, res) => {
 module.exports = app;
         `,
         },
-      ],
-      invalid: [
+      ]),
+      invalid: xp([
         // REGRESSION: manual `'...'` quoting emitted invalid JS when the
         // rewritten literal itself contained a quote.
         {
@@ -356,7 +399,7 @@ module.exports = app;
             },
           ],
         },
-      ],
+      ]),
     },
   );
 
@@ -365,14 +408,14 @@ module.exports = app;
     'require-case-insensitive-path-guard (protectedPaths option)',
     requireCaseInsensitivePathGuard,
     {
-      valid: [
+      valid: xp([
         // '/admin' no longer protected once the set is replaced
         {
           code: `if (req.path.startsWith('/admin')) deny();`,
           options: [{ protectedPaths: ['secret'] }],
         },
-      ],
-      invalid: [
+      ]),
+      invalid: xp([
         {
           code: `if (req.path.startsWith('/secret')) deny();`,
           options: [{ protectedPaths: ['secret'] }],
@@ -388,7 +431,7 @@ module.exports = app;
             },
           ],
         },
-      ],
+      ]),
     },
   );
 
@@ -397,7 +440,7 @@ module.exports = app;
     'require-case-insensitive-path-guard (checkAllPaths option)',
     requireCaseInsensitivePathGuard,
     {
-      valid: [
+      valid: xp([
         // Normalized guards stay valid even with checkAllPaths
         {
           code: `if (req.path.toLowerCase().startsWith('/health')) skip();`,
@@ -407,8 +450,8 @@ module.exports = app;
           code: `if (req.path.match(/^\\/health/i)) skip();`,
           options: [{ checkAllPaths: true }],
         },
-      ],
-      invalid: [
+      ]),
+      invalid: xp([
         {
           code: `if (req.path.startsWith('/health')) skip();`,
           options: [{ checkAllPaths: true }],
@@ -454,7 +497,7 @@ module.exports = app;
             },
           ],
         },
-      ],
+      ]),
     },
   );
 });

--- a/packages/eslint-plugin-express-security/src/rules/require-csrf-protection/index.ts
+++ b/packages/eslint-plugin-express-security/src/rules/require-csrf-protection/index.ts
@@ -13,6 +13,7 @@
  * @see https://owasp.org/www-community/attacks/csrf
  */
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
+import { fileUsesExpress } from '../../utils/express-evidence';
 import {
   formatLLMMessage,
   MessageIcons,
@@ -199,6 +200,12 @@ export const requireCsrfProtection = createRule<RuleOptions, MessageIds>({
     },
   ],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>, [options]) {
+    // Every rule here is Express-specific, and none of them knew it: over
+    // 107,382 files, 75% of this plugin's findings were in files with no
+    // Express import. Registering no visitors is both the gate and the cheap
+    // path — a file with no Express in it does no work.
+    if (!fileUsesExpress(context.sourceCode.ast)) return {};
+
     const {
       allowInTests = false,
       protectedMethods = DEFAULT_PROTECTED_METHODS,

--- a/packages/eslint-plugin-express-security/src/rules/require-csrf-protection/require-csrf-protection.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/require-csrf-protection/require-csrf-protection.test.ts
@@ -7,6 +7,49 @@ import { RuleTester } from '@typescript-eslint/rule-tester';
 import { requireCsrfProtection } from './index';
 import * as vitest from 'vitest';
 
+/**
+ * Every fixture imports express, because the rules now abstain in files with no
+ * Express in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass vacuously
+ * on the gate instead of exercising the detection it was written for. `output`
+ * and errors[].suggestions[].output are prefixed too, since autofix fixtures
+ * assert the whole file back.
+ */
+const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const xp = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asExpress(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asExpress(test.code),
+      ...(typeof test.output === 'string' ? { output: asExpress(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asExpress(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = vitest.afterAll;
 RuleTester.it = vitest.it;
 RuleTester.itOnly = vitest.it.only;
@@ -20,7 +63,7 @@ const ruleTester = new RuleTester({
 });
 
 ruleTester.run('require-csrf-protection', requireCsrfProtection, {
-  valid: [
+  valid: xp([
     // ============================================
     // GLOBAL CSRF MIDDLEWARE PATTERNS
     // ============================================
@@ -220,9 +263,9 @@ ruleTester.run('require-csrf-protection', requireCsrfProtection, {
         app.post('/secure', handler);
       `,
     },
-  ],
+  ]),
 
-  invalid: [
+  invalid: xp([
     // ============================================
     // MISSING CSRF - SHOULD FLAG
     // ============================================
@@ -304,7 +347,7 @@ ruleTester.run('require-csrf-protection', requireCsrfProtection, {
       options: [{ allowInTests: false }],
       errors: [{ messageId: 'missingCsrf' }],
     },
-  ],
+  ]),
 });
 
 // ---------------------------------------------------------------------------
@@ -314,7 +357,7 @@ ruleTester.run(
   'require-csrf-protection (coverage wave)',
   requireCsrfProtection,
   {
-    valid: [
+    valid: xp([
       // lusca.csrf() recognized as global CSRF middleware
       { code: `app.use(lusca.csrf()); app.post('/transfer', handler);` },
       // member callee that is not lusca.csrf
@@ -341,8 +384,8 @@ ruleTester.run(
       },
       // csurf-named identifier middleware sets the global flag
       { code: `app.use(csurfMiddleware); app.post('/transfer', handler);` },
-    ],
-    invalid: [
+    ]),
+    invalid: xp([
       // non-CSRF middleware identifiers do not set the global flag
       {
         code: `app.use(logger); app.post('/transfer', handler);`,
@@ -364,6 +407,6 @@ ruleTester.run(
         code: `express.Router().post('/t', handler);`,
         errors: [{ messageId: 'missingCsrf' }],
       },
-    ],
+    ]),
   },
 );

--- a/packages/eslint-plugin-express-security/src/rules/require-csrf-protection/require-csrf-protection.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/require-csrf-protection/require-csrf-protection.test.ts
@@ -15,7 +15,10 @@ import * as vitest from 'vitest';
  * and errors[].suggestions[].output are prefixed too, since autofix fixtures
  * assert the whole file back.
  */
-const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+// A SIDE-EFFECT import: it satisfies the gate without reserving the `express`
+// binding. Several fixtures already declare `const express = require('express')`
+// at module level, and a default import would redeclare it.
+const asExpress = (code: string): string => `import 'express';\n${code}`;
 type Suggestion = { output?: string | null };
 type Case = {
   code: string;

--- a/packages/eslint-plugin-express-security/src/rules/require-express-body-parser-limits/index.ts
+++ b/packages/eslint-plugin-express-security/src/rules/require-express-body-parser-limits/index.ts
@@ -16,6 +16,7 @@
  * @see https://expressjs.com/en/4x/api.html#express.json
  */
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
+import { fileUsesExpress } from '../../utils/express-evidence';
 import {
   formatLLMMessage,
   MessageIcons,
@@ -166,6 +167,12 @@ export const requireExpressBodyParserLimits = createRule<
     },
   ],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>, [options]) {
+    // Every rule here is Express-specific, and none of them knew it: over
+    // 107,382 files, 75% of this plugin's findings were in files with no
+    // Express import. Registering no visitors is both the gate and the cheap
+    // path — a file with no Express in it does no work.
+    if (!fileUsesExpress(context.sourceCode.ast)) return {};
+
     const { allowInTests = false, excessiveLimits = DEFAULT_EXCESSIVE_LIMITS } =
       options as Options;
 

--- a/packages/eslint-plugin-express-security/src/rules/require-express-body-parser-limits/require-express-body-parser-limits.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/require-express-body-parser-limits/require-express-body-parser-limits.test.ts
@@ -1,13 +1,56 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { requireExpressBodyParserLimits } from './index';
 
+/**
+ * Every fixture imports express, because the rules now abstain in files with no
+ * Express in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass vacuously
+ * on the gate instead of exercising the detection it was written for. `output`
+ * and errors[].suggestions[].output are prefixed too, since autofix fixtures
+ * assert the whole file back.
+ */
+const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const xp = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asExpress(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asExpress(test.code),
+      ...(typeof test.output === 'string' ? { output: asExpress(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asExpress(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 const ruleTester = new RuleTester();
 
 ruleTester.run(
   'require-express-body-parser-limits',
   requireExpressBodyParserLimits,
   {
-    valid: [
+    valid: xp([
       // With explicit limit
       {
         code: `express.json({ limit: '100kb' })`,
@@ -45,8 +88,8 @@ ruleTester.run(
         filename: 'test.spec.ts',
         options: [{ allowInTests: true }],
       },
-    ],
-    invalid: [
+    ]),
+    invalid: xp([
       // No options - missing limit
       {
         code: `express.json()`,
@@ -177,7 +220,7 @@ ruleTester.run(
           },
         ],
       },
-    ],
+    ]),
   },
 );
 
@@ -188,7 +231,7 @@ ruleTester.run(
   'require-express-body-parser-limits (coverage wave)',
   requireExpressBodyParserLimits,
   {
-    valid: [
+    valid: xp([
       // bare call — callee is not a member expression
       { code: `json({ limit: '1mb' });` },
       // deep member — object is not an identifier
@@ -207,8 +250,8 @@ ruleTester.run(
       { code: `express.json({ limit: MAX_BODY });` },
       // reasonable string limit
       { code: `express.json({ limit: '100kb' });` },
-    ],
-    invalid: [
+    ]),
+    invalid: xp([
       // no options at all — suggestion rewrites the whole call
       {
         code: `express.json();`,
@@ -247,6 +290,6 @@ ruleTester.run(
         options: [{ excessiveLimits: ['5gb'] }],
         errors: [{ messageId: 'excessiveLimit' }],
       },
-    ],
+    ]),
   },
 );

--- a/packages/eslint-plugin-express-security/src/rules/require-express-body-parser-limits/require-express-body-parser-limits.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/require-express-body-parser-limits/require-express-body-parser-limits.test.ts
@@ -9,7 +9,10 @@ import { requireExpressBodyParserLimits } from './index';
  * and errors[].suggestions[].output are prefixed too, since autofix fixtures
  * assert the whole file back.
  */
-const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+// A SIDE-EFFECT import: it satisfies the gate without reserving the `express`
+// binding. Several fixtures already declare `const express = require('express')`
+// at module level, and a default import would redeclare it.
+const asExpress = (code: string): string => `import 'express';\n${code}`;
 type Suggestion = { output?: string | null };
 type Case = {
   code: string;

--- a/packages/eslint-plugin-express-security/src/rules/require-helmet/index.ts
+++ b/packages/eslint-plugin-express-security/src/rules/require-helmet/index.ts
@@ -14,6 +14,7 @@
  * @see https://owasp.org/www-project-secure-headers/
  */
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
+import { fileUsesExpress } from '../../utils/express-evidence';
 import {
   formatLLMMessage,
   MessageIcons,
@@ -167,6 +168,12 @@ export const requireHelmet = createRule<RuleOptions, MessageIds>({
     },
   ],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>, [options]) {
+    // Every rule here is Express-specific, and none of them knew it: over
+    // 107,382 files, 75% of this plugin's findings were in files with no
+    // Express import. Registering no visitors is both the gate and the cheap
+    // path — a file with no Express in it does no work.
+    if (!fileUsesExpress(context.sourceCode.ast)) return {};
+
     const {
       allowInTests = false,
       alternativeMiddleware = [],

--- a/packages/eslint-plugin-express-security/src/rules/require-helmet/require-helmet.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/require-helmet/require-helmet.test.ts
@@ -13,7 +13,10 @@ import * as vitest from 'vitest';
  * and errors[].suggestions[].output are prefixed too, since autofix fixtures
  * assert the whole file back.
  */
-const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+// A SIDE-EFFECT import: it satisfies the gate without reserving the `express`
+// binding. Several fixtures already declare `const express = require('express')`
+// at module level, and a default import would redeclare it.
+const asExpress = (code: string): string => `import 'express';\n${code}`;
 type Suggestion = { output?: string | null };
 type Case = {
   code: string;

--- a/packages/eslint-plugin-express-security/src/rules/require-helmet/require-helmet.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/require-helmet/require-helmet.test.ts
@@ -5,6 +5,49 @@ import { RuleTester } from '@typescript-eslint/rule-tester';
 import { requireHelmet } from './index';
 import * as vitest from 'vitest';
 
+/**
+ * Every fixture imports express, because the rules now abstain in files with no
+ * Express in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass vacuously
+ * on the gate instead of exercising the detection it was written for. `output`
+ * and errors[].suggestions[].output are prefixed too, since autofix fixtures
+ * assert the whole file back.
+ */
+const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const xp = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asExpress(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asExpress(test.code),
+      ...(typeof test.output === 'string' ? { output: asExpress(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asExpress(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = vitest.afterAll;
 RuleTester.it = vitest.it;
 RuleTester.itOnly = vitest.it.only;
@@ -18,7 +61,7 @@ const ruleTester = new RuleTester({
 });
 
 ruleTester.run('require-helmet', requireHelmet, {
-  valid: [
+  valid: xp([
     {
       // ToniR7/express-typescript-starter: the app is created here and helmet
       // is registered in `utils/appInitialization.ts`. Once the binding is handed
@@ -104,8 +147,8 @@ ruleTester.run('require-helmet', requireHelmet, {
       `,
       options: [{ assumeHelmetMiddleware: true }],
     },
-  ],
-  invalid: [
+  ]),
+  invalid: xp([
     {
       // `express()` with no binding at all — there is nothing to follow, so the
       // escape hatch must not engage and the missing middleware is still a
@@ -170,14 +213,14 @@ ruleTester.run('require-helmet', requireHelmet, {
         },
       ],
     },
-  ],
+  ]),
 });
 
 // ---------------------------------------------------------------------------
 // Coverage wave: previously untested branches (annotation-debt removal)
 // ---------------------------------------------------------------------------
 ruleTester.run('require-helmet (coverage wave)', requireHelmet, {
-  valid: [
+  valid: xp([
     // app.use(helmet) — identifier reference without a call
     { code: `const app = express(); app.use(helmet);` },
     // call-of-a-call that is not require('express')()
@@ -193,8 +236,8 @@ ruleTester.run('require-helmet (coverage wave)', requireHelmet, {
       code: `const app = express(); app.use(secureHeaders);`,
       options: [{ alternativeMiddleware: ['secureHeaders'] }],
     },
-  ],
-  invalid: [
+  ]),
+  invalid: xp([
     // require('express')() pattern creates an app without helmet
     {
       code: `const app = require('express')(); app.listen(3000);`,
@@ -210,5 +253,5 @@ ruleTester.run('require-helmet (coverage wave)', requireHelmet, {
       code: `const app = express(); app.use('/api', apiRouter);`,
       errors: [{ messageId: 'missingHelmet' }],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-express-security/src/rules/require-query-type-guard/index.ts
+++ b/packages/eslint-plugin-express-security/src/rules/require-query-type-guard/index.ts
@@ -42,6 +42,7 @@
  */
 
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
+import { fileUsesExpress } from '../../utils/express-evidence';
 import {
   AST_NODE_TYPES,
   createRule,
@@ -136,6 +137,12 @@ export const requireQueryTypeGuard = createRule<RuleOptions, MessageIds>({
   },
   defaultOptions: [{}],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>, [options]) {
+    // Every rule here is Express-specific, and none of them knew it: over
+    // 107,382 files, 75% of this plugin's findings were in files with no
+    // Express import. Registering no visitors is both the gate and the cheap
+    // path — a file with no Express in it does no work.
+    if (!fileUsesExpress(context.sourceCode.ast)) return {};
+
     const { coercers, validators } = options as Options;
     const coercerNames = new Set(coercers ?? ['String']);
     const validatorNames = new Set(validators ?? ['parse', 'safeParse']);

--- a/packages/eslint-plugin-express-security/src/rules/require-query-type-guard/require-query-type-guard.coverage.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/require-query-type-guard/require-query-type-guard.coverage.test.ts
@@ -10,6 +10,49 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { requireQueryTypeGuard } from './index';
 
+/**
+ * Every fixture imports express, because the rules now abstain in files with no
+ * Express in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass vacuously
+ * on the gate instead of exercising the detection it was written for. `output`
+ * and errors[].suggestions[].output are prefixed too, since autofix fixtures
+ * assert the whole file back.
+ */
+const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const xp = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asExpress(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asExpress(test.code),
+      ...(typeof test.output === 'string' ? { output: asExpress(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asExpress(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -24,7 +67,7 @@ describe('require-query-type-guard (branch coverage)', () => {
     'require-query-type-guard (branch coverage)',
     requireQueryTypeGuard,
     {
-      valid: [
+      valid: xp([
         // --- CallExpression bails ---
         // Bare call — callee is not a member expression
         { code: `trim();` },
@@ -86,8 +129,8 @@ describe('require-query-type-guard (branch coverage)', () => {
           }
         `,
         },
-      ],
-      invalid: [
+      ]),
+      invalid: xp([
         // Safe-call check: callee is neither identifier nor member (IIFE)
         {
           code: `let v = req.query.q; v = ((x) => x)(v); v.trim();`,
@@ -163,7 +206,7 @@ describe('require-query-type-guard (branch coverage)', () => {
             },
           ],
         },
-      ],
+      ]),
     },
   );
 });

--- a/packages/eslint-plugin-express-security/src/rules/require-query-type-guard/require-query-type-guard.coverage.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/require-query-type-guard/require-query-type-guard.coverage.test.ts
@@ -18,7 +18,10 @@ import { requireQueryTypeGuard } from './index';
  * and errors[].suggestions[].output are prefixed too, since autofix fixtures
  * assert the whole file back.
  */
-const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+// A SIDE-EFFECT import: it satisfies the gate without reserving the `express`
+// binding. Several fixtures already declare `const express = require('express')`
+// at module level, and a default import would redeclare it.
+const asExpress = (code: string): string => `import 'express';\n${code}`;
 type Suggestion = { output?: string | null };
 type Case = {
   code: string;

--- a/packages/eslint-plugin-express-security/src/rules/require-query-type-guard/require-query-type-guard.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/require-query-type-guard/require-query-type-guard.test.ts
@@ -11,7 +11,10 @@ import { requireQueryTypeGuard } from './index';
  * and errors[].suggestions[].output are prefixed too, since autofix fixtures
  * assert the whole file back.
  */
-const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+// A SIDE-EFFECT import: it satisfies the gate without reserving the `express`
+// binding. Several fixtures already declare `const express = require('express')`
+// at module level, and a default import would redeclare it.
+const asExpress = (code: string): string => `import 'express';\n${code}`;
 type Suggestion = { output?: string | null };
 type Case = {
   code: string;

--- a/packages/eslint-plugin-express-security/src/rules/require-query-type-guard/require-query-type-guard.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/require-query-type-guard/require-query-type-guard.test.ts
@@ -3,6 +3,49 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { requireQueryTypeGuard } from './index';
 
+/**
+ * Every fixture imports express, because the rules now abstain in files with no
+ * Express in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass vacuously
+ * on the gate instead of exercising the detection it was written for. `output`
+ * and errors[].suggestions[].output are prefixed too, since autofix fixtures
+ * assert the whole file back.
+ */
+const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const xp = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asExpress(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asExpress(test.code),
+      ...(typeof test.output === 'string' ? { output: asExpress(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asExpress(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -14,7 +57,7 @@ const ruleTester = new RuleTester({
 
 describe('require-query-type-guard', () => {
   ruleTester.run('require-query-type-guard', requireQueryTypeGuard, {
-    valid: [
+    valid: xp([
       // Coerced at the source — String() init is never tracked
       { code: `const name = String(req.query.name); name.replace(/x/g, '');` },
       // Inline typeof guard on the member itself
@@ -91,8 +134,8 @@ app.get('/search', async (req, res) => {
 module.exports = app;
         `,
       },
-    ],
-    invalid: [
+    ]),
+    invalid: xp([
       // Direct member call — the classic shape, with String() suggestion
       {
         code: `req.query.name.replace(/x/g, '');`,
@@ -434,12 +477,12 @@ module.exports = app;
           },
         ],
       },
-    ],
+    ]),
   });
 
   // Options: custom coercers / validators
   ruleTester.run('require-query-type-guard (options)', requireQueryTypeGuard, {
-    valid: [
+    valid: xp([
       // Custom coercer accepted in a reassignment
       {
         code: `let v = req.query.q; v = toStr(v); v.trim();`,
@@ -455,8 +498,8 @@ module.exports = app;
         code: `let v = req.query.q; v = validate(v); v.trim();`,
         options: [{ validators: ['validate'] }],
       },
-    ],
-    invalid: [
+    ]),
+    invalid: xp([
       // Replacing coercers drops the String default
       {
         code: `let v = req.query.q; v = String(v); v.trim();`,
@@ -489,6 +532,6 @@ module.exports = app;
           },
         ],
       },
-    ],
+    ]),
   });
 });

--- a/packages/eslint-plugin-express-security/src/rules/require-rate-limiting/index.ts
+++ b/packages/eslint-plugin-express-security/src/rules/require-rate-limiting/index.ts
@@ -13,6 +13,7 @@
  * @see https://owasp.org/www-community/controls/Blocking_Brute_Force_Attacks
  */
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
+import { fileUsesExpress } from '../../utils/express-evidence';
 import {
   formatLLMMessage,
   MessageIcons,
@@ -145,6 +146,12 @@ export const requireRateLimiting = createRule<RuleOptions, MessageIds>({
     },
   ],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>, [options]) {
+    // Every rule here is Express-specific, and none of them knew it: over
+    // 107,382 files, 75% of this plugin's findings were in files with no
+    // Express import. Registering no visitors is both the gate and the cheap
+    // path — a file with no Express in it does no work.
+    if (!fileUsesExpress(context.sourceCode.ast)) return {};
+
     const {
       allowInTests = false,
       alternativeMiddleware = [],

--- a/packages/eslint-plugin-express-security/src/rules/require-rate-limiting/require-rate-limiting.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/require-rate-limiting/require-rate-limiting.test.ts
@@ -13,7 +13,10 @@ import * as vitest from 'vitest';
  * and errors[].suggestions[].output are prefixed too, since autofix fixtures
  * assert the whole file back.
  */
-const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+// A SIDE-EFFECT import: it satisfies the gate without reserving the `express`
+// binding. Several fixtures already declare `const express = require('express')`
+// at module level, and a default import would redeclare it.
+const asExpress = (code: string): string => `import 'express';\n${code}`;
 type Suggestion = { output?: string | null };
 type Case = {
   code: string;

--- a/packages/eslint-plugin-express-security/src/rules/require-rate-limiting/require-rate-limiting.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/require-rate-limiting/require-rate-limiting.test.ts
@@ -5,6 +5,49 @@ import { RuleTester } from '@typescript-eslint/rule-tester';
 import { requireRateLimiting } from './index';
 import * as vitest from 'vitest';
 
+/**
+ * Every fixture imports express, because the rules now abstain in files with no
+ * Express in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass vacuously
+ * on the gate instead of exercising the detection it was written for. `output`
+ * and errors[].suggestions[].output are prefixed too, since autofix fixtures
+ * assert the whole file back.
+ */
+const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const xp = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asExpress(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asExpress(test.code),
+      ...(typeof test.output === 'string' ? { output: asExpress(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asExpress(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = vitest.afterAll;
 RuleTester.it = vitest.it;
 RuleTester.itOnly = vitest.it.only;
@@ -18,7 +61,7 @@ const ruleTester = new RuleTester({
 });
 
 ruleTester.run('require-rate-limiting', requireRateLimiting, {
-  valid: [
+  valid: xp([
     {
       // ToniR7/express-typescript-starter: the app is created here and the rate limiter
       // is registered in `utils/appInitialization.ts`. Once the binding is handed
@@ -92,8 +135,8 @@ ruleTester.run('require-rate-limiting', requireRateLimiting, {
       `,
       options: [{ assumeRateLimiting: true }],
     },
-  ],
-  invalid: [
+  ]),
+  invalid: xp([
     {
       // `express()` with no binding at all — there is nothing to follow, so the
       // escape hatch must not engage and the missing middleware is still a
@@ -131,20 +174,20 @@ ruleTester.run('require-rate-limiting', requireRateLimiting, {
         },
       ],
     },
-  ],
+  ]),
 });
 
 // ---------------------------------------------------------------------------
 // Coverage wave: previously untested branches (annotation-debt removal)
 // ---------------------------------------------------------------------------
 ruleTester.run('require-rate-limiting (coverage wave)', requireRateLimiting, {
-  valid: [
+  valid: xp([
     // rate-limiter referenced as an identifier without a call
     { code: `const app = express(); app.use(rateLimiter);` },
     // rate-limiter factory call
     { code: `const app = express(); app.use(limiter());` },
-  ],
-  invalid: [
+  ]),
+  invalid: xp([
     // identifier middleware that is not a rate limiter
     {
       code: `const app = express(); app.use(logger);`,
@@ -155,5 +198,5 @@ ruleTester.run('require-rate-limiting (coverage wave)', requireRateLimiting, {
       code: `const app = express(); app.use(morgan());`,
       errors: [{ messageId: 'missingRateLimiting' }],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-express-security/src/rules/require-route-authentication/index.ts
+++ b/packages/eslint-plugin-express-security/src/rules/require-route-authentication/index.ts
@@ -43,6 +43,7 @@ import {
   MessageIcons,
 } from '@interlace/eslint-devkit';
 import { readsPrincipal } from '../../utils';
+import { fileUsesExpress } from '../../utils/express-evidence';
 
 type MessageIds = 'missingAuthentication';
 
@@ -202,6 +203,12 @@ export const requireRouteAuthentication = createRule<RuleOptions, MessageIds>({
   },
   defaultOptions: [{}],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>, [options]) {
+    // Every rule here is Express-specific, and none of them knew it: over
+    // 107,382 files, 75% of this plugin's findings were in files with no
+    // Express import. Registering no visitors is both the gate and the cheap
+    // path — a file with no Express in it does no work.
+    if (!fileUsesExpress(context.sourceCode.ast)) return {};
+
     const { criticalPaths, publicPaths, authMiddleware } = options as Options;
     const critical = (criticalPaths ?? DEFAULT_CRITICAL_PATHS).map((p) =>
       p.toLowerCase(),

--- a/packages/eslint-plugin-express-security/src/rules/require-route-authentication/require-route-authentication.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/require-route-authentication/require-route-authentication.test.ts
@@ -11,7 +11,10 @@ import { requireRouteAuthentication } from './index';
  * and errors[].suggestions[].output are prefixed too, since autofix fixtures
  * assert the whole file back.
  */
-const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+// A SIDE-EFFECT import: it satisfies the gate without reserving the `express`
+// binding. Several fixtures already declare `const express = require('express')`
+// at module level, and a default import would redeclare it.
+const asExpress = (code: string): string => `import 'express';\n${code}`;
 type Suggestion = { output?: string | null };
 type Case = {
   code: string;

--- a/packages/eslint-plugin-express-security/src/rules/require-route-authentication/require-route-authentication.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/require-route-authentication/require-route-authentication.test.ts
@@ -3,6 +3,49 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { requireRouteAuthentication } from './index';
 
+/**
+ * Every fixture imports express, because the rules now abstain in files with no
+ * Express in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass vacuously
+ * on the gate instead of exercising the detection it was written for. `output`
+ * and errors[].suggestions[].output are prefixed too, since autofix fixtures
+ * assert the whole file back.
+ */
+const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const xp = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asExpress(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asExpress(test.code),
+      ...(typeof test.output === 'string' ? { output: asExpress(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asExpress(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -14,7 +57,7 @@ const ruleTester = new RuleTester({
 
 describe('require-route-authentication', () => {
   ruleTester.run('require-route-authentication', requireRouteAuthentication, {
-    valid: [
+    valid: xp([
       // THE safe pattern — auth middleware in the chain
       { code: `app.post('/account/password', requireAuth, changePassword);` },
       { code: `router.delete('/users/:id', authenticate, removeUser);` },
@@ -86,8 +129,8 @@ describe('require-route-authentication', () => {
           app.post('/users', createUser);
         `,
       },
-    ],
-    invalid: [
+    ]),
+    invalid: xp([
       // REGRESSION: a path-scoped mount is not global auth. `app.use('/public', ...)`
       // guards /public only — before this lock it switched the rule off file-wide.
       {
@@ -176,6 +219,6 @@ describe('require-route-authentication', () => {
         code: `app.post('/users', (req, res) => createUser(getReq().user));`,
         errors: [{ messageId: 'missingAuthentication' as const }],
       },
-    ],
+    ]),
   });
 });

--- a/packages/eslint-plugin-express-security/src/rules/require-strict-transport-security/index.ts
+++ b/packages/eslint-plugin-express-security/src/rules/require-strict-transport-security/index.ts
@@ -34,6 +34,7 @@
  */
 
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
+import { fileUsesExpress } from '../../utils/express-evidence';
 import {
   AST_NODE_TYPES,
   createRule,
@@ -173,6 +174,12 @@ export const requireStrictTransportSecurity = createRule<
   },
   defaultOptions: [{}],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>, [options]) {
+    // Every rule here is Express-specific, and none of them knew it: over
+    // 107,382 files, 75% of this plugin's findings were in files with no
+    // Express import. Registering no visitors is both the gate and the cheap
+    // path — a file with no Express in it does no work.
+    if (!fileUsesExpress(context.sourceCode.ast)) return {};
+
     const { minMaxAge, requireSubDomains } = options as Options;
     const minimum = minMaxAge ?? DEFAULT_MIN_MAX_AGE;
     const wantSubDomains = requireSubDomains ?? true;

--- a/packages/eslint-plugin-express-security/src/rules/require-strict-transport-security/require-strict-transport-security.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/require-strict-transport-security/require-strict-transport-security.test.ts
@@ -11,7 +11,10 @@ import { requireStrictTransportSecurity } from './index';
  * and errors[].suggestions[].output are prefixed too, since autofix fixtures
  * assert the whole file back.
  */
-const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+// A SIDE-EFFECT import: it satisfies the gate without reserving the `express`
+// binding. Several fixtures already declare `const express = require('express')`
+// at module level, and a default import would redeclare it.
+const asExpress = (code: string): string => `import 'express';\n${code}`;
 type Suggestion = { output?: string | null };
 type Case = {
   code: string;

--- a/packages/eslint-plugin-express-security/src/rules/require-strict-transport-security/require-strict-transport-security.test.ts
+++ b/packages/eslint-plugin-express-security/src/rules/require-strict-transport-security/require-strict-transport-security.test.ts
@@ -3,6 +3,49 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { requireStrictTransportSecurity } from './index';
 
+/**
+ * Every fixture imports express, because the rules now abstain in files with no
+ * Express in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass vacuously
+ * on the gate instead of exercising the detection it was written for. `output`
+ * and errors[].suggestions[].output are prefixed too, since autofix fixtures
+ * assert the whole file back.
+ */
+const asExpress = (code: string): string => `import express from 'express';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const xp = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asExpress(c) as T;
+    const test = c as Case;
+    return {
+      ...c,
+      code: asExpress(test.code),
+      ...(typeof test.output === 'string' ? { output: asExpress(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asExpress(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -17,7 +60,7 @@ describe('require-strict-transport-security', () => {
     'require-strict-transport-security',
     requireStrictTransportSecurity,
     {
-      valid: [
+      valid: xp([
         // Helmet defaults (365 days, includeSubDomains) — nothing to report
         { code: `app.use(helmet());` },
         { code: `app.use(helmet({ noSniff: true }));` },
@@ -71,8 +114,8 @@ describe('require-strict-transport-security', () => {
         { code: `app.use(getHelmet().hsts({ maxAge: 1 }));` },
         { code: `app.use(helmet(config));` },
         { code: `const mw = helmet();` },
-      ],
-      invalid: [
+      ]),
+      invalid: xp([
         // HSTS switched off entirely (helmet ≤6 spelling)
         {
           code: `app.use(helmet({ hsts: false }));`,
@@ -154,7 +197,7 @@ describe('require-strict-transport-security', () => {
             { messageId: 'subdomainsExcluded' as const },
           ],
         },
-      ],
+      ]),
     },
   );
 });

--- a/packages/eslint-plugin-express-security/src/utils/express-evidence.test.ts
+++ b/packages/eslint-plugin-express-security/src/utils/express-evidence.test.ts
@@ -99,6 +99,31 @@ describe('fileUsesExpress', () => {
       expect(usesExpress(code)).toBe(false);
     });
 
+    // The regression the file-wide flag caused: a real `require('express')` at
+    // module scope must survive an unrelated inner binding. Silencing all 28
+    // rules there trades a false positive for a false negative — the worse of
+    // the two.
+    it('an unshadowed require survives a shadowing binding elsewhere', () => {
+      expect(
+        usesExpress("const express = require('express');\nfunction wrapper(require) {}"),
+      ).toBe(true);
+      expect(
+        usesExpress("function wrapper(require) {}\nconst express = require('express');"),
+      ).toBe(true);
+      expect(
+        usesExpress("function outer() { const express = require('express'); }\nfunction w(require) {}"),
+      ).toBe(true);
+    });
+
+    it('shadowing applies only inside the scope that binds it', () => {
+      // Inner call is shadowed; there is no other evidence, so the file is out.
+      expect(usesExpress("function f(require) { require('express'); }")).toBe(false);
+      // A block-scoped `const require` shadows the rest of that block only.
+      expect(
+        usesExpress("{ const require = (m) => m; require('express'); }"),
+      ).toBe(false);
+    });
+
     it('the other arms still apply when `require` is shadowed', () => {
       expect(
         usesExpress("import express from 'express';\nfunction f(require) { require('express'); }"),

--- a/packages/eslint-plugin-express-security/src/utils/express-evidence.test.ts
+++ b/packages/eslint-plugin-express-security/src/utils/express-evidence.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Tests for the Express evidence probe.
+ *
+ * Every rule in this plugin abstains unless `fileUsesExpress` says the file has
+ * Express in it, so a bug here is a bug in all twenty-eight at once — silently,
+ * in whichever direction the bug leans.
+ */
+import { describe, it, expect } from 'vitest';
+import { parse } from '@typescript-eslint/parser';
+import { fileUsesExpress } from './express-evidence';
+
+const usesExpress = (code: string): boolean =>
+  fileUsesExpress(parse(code, { sourceType: 'module', range: true }));
+
+describe('fileUsesExpress', () => {
+  describe('imports and requires', () => {
+    it.each([
+      "import express from 'express';",
+      "import { Router } from 'express';",
+      "import type { Request } from 'express-serve-static-core';",
+      "const express = require('express');",
+      "const app = (await import('express')).default();",
+      "export { Router } from 'express';",
+      "export * from 'express';",
+      "import 'express';",
+    ])('%s → true', (code) => {
+      expect(usesExpress(code)).toBe(true);
+    });
+
+    it.each([
+      ["import fastify from 'fastify';", 'a different framework'],
+      ["import koa from 'koa';", 'koa'],
+      // Middleware is usable with any Connect-style server; importing it is not
+      // evidence that this file has an Express app in it.
+      ["import helmet from 'helmet';", 'middleware, not the framework'],
+      ["import cors from 'cors';", 'middleware, not the framework'],
+      ["import x from './express';", 'a relative path spelling the package'],
+      ["import x from '/express';", 'an absolute path'],
+      ["import x from 'express-rate-limit';", 'a package sharing the prefix'],
+      // Exercises the scoped-package root path: `@types/express` is types, not
+      // a runtime Express, so the root is compared and rejected.
+      ["import type { Request } from '@types/express';", 'a scoped types package'],
+      ["import x from '@company/express-utils';", 'a scoped package with express in the name'],
+      ["require('./express');", 'a relative require'],
+      ['require(name);', 'a non-literal require'],
+      ['require();', 'a require with no arguments'],
+      ['require(123);', 'a non-string literal'],
+      ['notRequire("express");', 'a differently named function'],
+      ["await import('./express');", 'a relative dynamic import'],
+    ])('%s → false (%s)', (code) => {
+      expect(usesExpress(code)).toBe(false);
+    });
+  });
+
+  describe('the (req, res, next) middleware contract', () => {
+    // 68 of 114 files with a (req,res)-shaped function in the Express corpus
+    // (60%) import no express — route modules receive `app`/`router` from their
+    // caller, so the import arm alone would miss most of them.
+    it.each([
+      'export function auth(req, res, next) { next(); }',
+      'const auth = (req, res, next) => next();',
+      'const auth = function (request, response, next) { next(); };',
+      // Error-handling middleware is (err, req, res, next) — four parameters,
+      // which is why the tail is matched rather than a fixed length.
+      'function onError(err, req, res, next) { next(err); }',
+    ])('%s → true', (code) => {
+      expect(usesExpress(code)).toBe(true);
+    });
+
+    // The two-argument form is shared with node:http, Next.js API routes and
+    // several other servers. Accepting it would re-import the very
+    // false-positive problem this gate removes.
+    it.each([
+      ['http.createServer((req, res) => res.end());', 'node:http'],
+      ['export default function handler(req, res) { res.json({}); }', 'a Next.js API route'],
+      ['const f = (req, res) => res.send("x");', 'a bare two-arg function'],
+      ['function f(req, next) {}', 'the wrong second parameter'],
+      ['function f(a, b, next) {}', 'the wrong first two parameters'],
+      ['function f(req, res, done) {}', 'a trailing parameter that is not `next`'],
+      ['function f(req, res, next, extra, more) {}', 'too many parameters'],
+      ['function f({ req }, res, next) {}', 'a destructured parameter'],
+    ])('%s → false (%s)', (code) => {
+      expect(usesExpress(code)).toBe(false);
+    });
+  });
+
+  describe('a locally bound `require` is not module loading', () => {
+    it.each([
+      "function f(require) { require('express'); }",
+      "const load = (require) => require('express');",
+      "const require = (m) => m; require('express');",
+    ])('%s → false', (code) => {
+      expect(usesExpress(code)).toBe(false);
+    });
+
+    it('the other arms still apply when `require` is shadowed', () => {
+      expect(
+        usesExpress("import express from 'express';\nfunction f(require) { require('express'); }"),
+      ).toBe(true);
+      expect(
+        usesExpress("function mw(req, res, next) { next(); }\nfunction f(require) { require('express'); }"),
+      ).toBe(true);
+    });
+  });
+
+  describe('files with no Express at all', () => {
+    it('an empty file', () => {
+      expect(usesExpress('')).toBe(false);
+    });
+
+    it.each([
+      'export default function Button() { return null; }',
+      'export const config = { retries: 3 };',
+      'export const handler = async (event, context) => ({ statusCode: 200 });',
+      'await mongoose.connect(uri);',
+    ])('%s stays outside the gate', (code) => {
+      expect(usesExpress(code)).toBe(false);
+    });
+  });
+
+  it('the result is cached per Program, so twenty-eight rules cost one scan', () => {
+    const ast = parse("import express from 'express';", {
+      sourceType: 'module',
+      range: true,
+    });
+    expect(fileUsesExpress(ast)).toBe(true);
+    expect(fileUsesExpress(ast)).toBe(true);
+  });
+});

--- a/packages/eslint-plugin-express-security/src/utils/express-evidence.ts
+++ b/packages/eslint-plugin-express-security/src/utils/express-evidence.ts
@@ -1,0 +1,225 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+import type { TSESTree } from '@interlace/eslint-devkit';
+import { AST_NODE_TYPES } from '@interlace/eslint-devkit';
+
+/**
+ * Packages that put an Express application in a file.
+ *
+ * Deliberately short. Middleware packages (`helmet`, `cors`, `body-parser`)
+ * are *usable* with Express but are not Express, and several work with any
+ * Connect-style server — importing one is not evidence that this file has an
+ * Express app in it.
+ */
+const EXPRESS_PACKAGES: ReadonlySet<string> = new Set([
+  'express',
+  'express-serve-static-core',
+]);
+
+/** `req`/`request`, then `res`/`response`, then `next`. */
+const REQ_NAMES: ReadonlySet<string> = new Set(['req', 'request']);
+const RES_NAMES: ReadonlySet<string> = new Set(['res', 'response']);
+
+function isExpressSpecifier(specifier: string): boolean {
+  if (specifier.startsWith('.') || specifier.startsWith('/')) return false;
+  const parts = specifier.split('/');
+  const root = specifier.startsWith('@')
+    ? parts.slice(0, 2).join('/')
+    : parts[0];
+  return EXPRESS_PACKAGES.has(root);
+}
+
+/**
+ * Whether the file declares a binding named `require` anywhere.
+ *
+ * `function f(require) { require('express'); }` is not module loading. Taking
+ * it as evidence would be this plugin treating a *name* as proof of an
+ * *interface* — the error the gate exists to correct.
+ */
+function declaresRequireBinding(ast: TSESTree.Program): boolean {
+  let shadowed = false;
+  // No top guard: every recursive call site below already checks.
+  const scan = (node: TSESTree.Node): void => {
+    if (
+      (node.type === AST_NODE_TYPES.FunctionDeclaration ||
+        node.type === AST_NODE_TYPES.FunctionExpression ||
+        node.type === AST_NODE_TYPES.ArrowFunctionExpression) &&
+      node.params.some(
+        (p) => p.type === AST_NODE_TYPES.Identifier && p.name === 'require',
+      )
+    ) {
+      shadowed = true;
+      return;
+    }
+    if (
+      node.type === AST_NODE_TYPES.VariableDeclarator &&
+      node.id.type === AST_NODE_TYPES.Identifier &&
+      node.id.name === 'require'
+    ) {
+      shadowed = true;
+      return;
+    }
+    for (const key of Object.keys(node)) {
+      if (key === 'parent') continue;
+      const value = (node as unknown as Record<string, unknown>)[key];
+      if (Array.isArray(value)) {
+        for (const child of value) {
+          if (child && typeof (child as TSESTree.Node).type === 'string') {
+            scan(child as TSESTree.Node);
+            if (shadowed) return;
+          }
+        }
+      } else if (
+        value &&
+        typeof value === 'object' &&
+        typeof (value as TSESTree.Node).type === 'string'
+      ) {
+        scan(value as TSESTree.Node);
+        if (shadowed) return;
+      }
+    }
+  };
+  scan(ast);
+  return shadowed;
+}
+
+/** `require('express')` and `await import('express')`. */
+function isExpressDynamicLoad(
+  node: TSESTree.Node,
+  requireIsShadowed: boolean,
+): boolean {
+  const argument =
+    node.type === AST_NODE_TYPES.ImportExpression
+      ? node.source
+      : !requireIsShadowed &&
+          node.type === AST_NODE_TYPES.CallExpression &&
+          node.callee.type === AST_NODE_TYPES.Identifier &&
+          node.callee.name === 'require'
+        ? node.arguments[0]
+        : undefined;
+  return (
+    argument?.type === AST_NODE_TYPES.Literal &&
+    typeof argument.value === 'string' &&
+    isExpressSpecifier(argument.value)
+  );
+}
+
+/**
+ * A function taking `(req, res, next)` — the Connect/Express middleware
+ * contract.
+ *
+ * **Three parameters, not two.** The two-argument `(req, res)` form is shared
+ * with `node:http` (`createServer((req, res) => …)`), Next.js API routes and
+ * several other servers, so accepting it would re-import the exact
+ * false-positive problem this gate exists to remove. The three-argument form
+ * with a trailing `next` is Connect-style middleware and essentially nothing
+ * else.
+ */
+function hasMiddlewareSignature(node: TSESTree.Node): boolean {
+  if (
+    node.type !== AST_NODE_TYPES.FunctionDeclaration &&
+    node.type !== AST_NODE_TYPES.FunctionExpression &&
+    node.type !== AST_NODE_TYPES.ArrowFunctionExpression
+  ) {
+    return false;
+  }
+  const params = node.params;
+  // An error-handling middleware is `(err, req, res, next)` — four parameters,
+  // which is why the tail is matched rather than a fixed length.
+  if (params.length !== 3 && params.length !== 4) return false;
+  const tail = params.slice(-3);
+  if (tail.some((p) => p.type !== AST_NODE_TYPES.Identifier)) return false;
+  const [first, second, third] = tail as TSESTree.Identifier[];
+  return (
+    REQ_NAMES.has(first.name) &&
+    RES_NAMES.has(second.name) &&
+    third.name === 'next'
+  );
+}
+
+/**
+ * One evidence scan per file, not one per rule.
+ *
+ * `create` runs for each of the twenty-eight rules, so an uncached probe walks
+ * the whole AST twenty-eight times per file — and the files paying that cost
+ * are mostly the non-Express ones the gate exists to skip cheaply.
+ */
+const cache = new WeakMap<TSESTree.Program, boolean>();
+
+/**
+ * Whether this file has Express in it.
+ *
+ * Every rule in this plugin is gated on it. Measured over 107,382 files across
+ * 108 repositories, **75% of everything this plugin reported (4,450 of 5,921
+ * findings) was in a file with no Express import** — `no-missing-csrf-protection`
+ * alone contributed 3,556.
+ *
+ * The evidence is a union, because an import gate alone is not enough: over the
+ * 12-repo Express corpus, 68 of 114 files containing a `(req, res)`-shaped
+ * function (60%) import no `express` — route modules routinely receive `app` or
+ * `router` from their caller.
+ *
+ * So: an `express` import / `require` / dynamic `import()`, or a
+ * `(req, res, next)` middleware signature. Both are local to the file — nothing
+ * is read from `package.json` and nothing is resolved across files, so there is
+ * no project state to go stale and no dependency on lint order.
+ */
+export function fileUsesExpress(ast: TSESTree.Program): boolean {
+  const cached = cache.get(ast);
+  if (cached !== undefined) return cached;
+  const result = computeUsesExpress(ast);
+  cache.set(ast, result);
+  return result;
+}
+
+function computeUsesExpress(ast: TSESTree.Program): boolean {
+  let found = false;
+  const requireIsShadowed = declaresRequireBinding(ast);
+
+  const visit = (node: TSESTree.Node): void => {
+    if (
+      (node.type === AST_NODE_TYPES.ImportDeclaration ||
+        node.type === AST_NODE_TYPES.ExportNamedDeclaration ||
+        node.type === AST_NODE_TYPES.ExportAllDeclaration) &&
+      node.source?.type === AST_NODE_TYPES.Literal &&
+      typeof node.source.value === 'string' &&
+      isExpressSpecifier(node.source.value)
+    ) {
+      found = true;
+      return;
+    }
+    if (
+      isExpressDynamicLoad(node, requireIsShadowed) ||
+      hasMiddlewareSignature(node)
+    ) {
+      found = true;
+      return;
+    }
+    for (const key of Object.keys(node)) {
+      if (key === 'parent') continue;
+      const value = (node as unknown as Record<string, unknown>)[key];
+      if (Array.isArray(value)) {
+        for (const child of value) {
+          if (child && typeof (child as TSESTree.Node).type === 'string') {
+            visit(child as TSESTree.Node);
+            if (found) return;
+          }
+        }
+      } else if (
+        value &&
+        typeof value === 'object' &&
+        typeof (value as TSESTree.Node).type === 'string'
+      ) {
+        visit(value as TSESTree.Node);
+        if (found) return;
+      }
+    }
+  };
+
+  visit(ast);
+  return found;
+}

--- a/packages/eslint-plugin-express-security/src/utils/express-evidence.ts
+++ b/packages/eslint-plugin-express-security/src/utils/express-evidence.ts
@@ -34,57 +34,44 @@ function isExpressSpecifier(specifier: string): boolean {
 }
 
 /**
- * Whether the file declares a binding named `require` anywhere.
+ * Whether a scope-introducing node binds the name `require`.
  *
- * `function f(require) { require('express'); }` is not module loading. Taking
- * it as evidence would be this plugin treating a *name* as proof of an
+ * `function f(require) { require('express'); }` is not module loading, and
+ * taking it as evidence would be this plugin treating a *name* as proof of an
  * *interface* — the error the gate exists to correct.
+ *
+ * Shadowing is **lexical**, propagated down the walk rather than computed once
+ * for the file. A file-wide flag reads
+ * `const express = require('express'); function wrapper(require) {}` as fully
+ * shadowed and silences all twenty-eight rules — trading a false positive for a
+ * false negative, which is the worse of the two.
  */
-function declaresRequireBinding(ast: TSESTree.Program): boolean {
-  let shadowed = false;
-  // No top guard: every recursive call site below already checks.
-  const scan = (node: TSESTree.Node): void => {
-    if (
-      (node.type === AST_NODE_TYPES.FunctionDeclaration ||
-        node.type === AST_NODE_TYPES.FunctionExpression ||
-        node.type === AST_NODE_TYPES.ArrowFunctionExpression) &&
-      node.params.some(
-        (p) => p.type === AST_NODE_TYPES.Identifier && p.name === 'require',
-      )
-    ) {
-      shadowed = true;
-      return;
-    }
-    if (
-      node.type === AST_NODE_TYPES.VariableDeclarator &&
-      node.id.type === AST_NODE_TYPES.Identifier &&
-      node.id.name === 'require'
-    ) {
-      shadowed = true;
-      return;
-    }
-    for (const key of Object.keys(node)) {
-      if (key === 'parent') continue;
-      const value = (node as unknown as Record<string, unknown>)[key];
-      if (Array.isArray(value)) {
-        for (const child of value) {
-          if (child && typeof (child as TSESTree.Node).type === 'string') {
-            scan(child as TSESTree.Node);
-            if (shadowed) return;
-          }
-        }
-      } else if (
-        value &&
-        typeof value === 'object' &&
-        typeof (value as TSESTree.Node).type === 'string'
-      ) {
-        scan(value as TSESTree.Node);
-        if (shadowed) return;
-      }
-    }
-  };
-  scan(ast);
-  return shadowed;
+function bindsRequire(node: TSESTree.Node): boolean {
+  if (
+    node.type === AST_NODE_TYPES.FunctionDeclaration ||
+    node.type === AST_NODE_TYPES.FunctionExpression ||
+    node.type === AST_NODE_TYPES.ArrowFunctionExpression
+  ) {
+    return node.params.some(
+      (p) => p.type === AST_NODE_TYPES.Identifier && p.name === 'require',
+    );
+  }
+  // A `const require = …` shadows for the rest of the block it sits in, so the
+  // block — not the declarator — is where the flag is raised.
+  if (
+    node.type === AST_NODE_TYPES.Program ||
+    node.type === AST_NODE_TYPES.BlockStatement
+  ) {
+    return node.body.some(
+      (stmt) =>
+        stmt.type === AST_NODE_TYPES.VariableDeclaration &&
+        stmt.declarations.some(
+          (d) =>
+            d.id.type === AST_NODE_TYPES.Identifier && d.id.name === 'require',
+        ),
+    );
+  }
+  return false;
 }
 
 /** `require('express')` and `await import('express')`. */
@@ -178,9 +165,8 @@ export function fileUsesExpress(ast: TSESTree.Program): boolean {
 
 function computeUsesExpress(ast: TSESTree.Program): boolean {
   let found = false;
-  const requireIsShadowed = declaresRequireBinding(ast);
 
-  const visit = (node: TSESTree.Node): void => {
+  const visit = (node: TSESTree.Node, requireIsShadowed: boolean): void => {
     if (
       (node.type === AST_NODE_TYPES.ImportDeclaration ||
         node.type === AST_NODE_TYPES.ExportNamedDeclaration ||
@@ -199,13 +185,15 @@ function computeUsesExpress(ast: TSESTree.Program): boolean {
       found = true;
       return;
     }
+    // Everything below this node is inside any scope it introduces.
+    const shadowedHere = requireIsShadowed || bindsRequire(node);
     for (const key of Object.keys(node)) {
       if (key === 'parent') continue;
       const value = (node as unknown as Record<string, unknown>)[key];
       if (Array.isArray(value)) {
         for (const child of value) {
           if (child && typeof (child as TSESTree.Node).type === 'string') {
-            visit(child as TSESTree.Node);
+            visit(child as TSESTree.Node, shadowedHere);
             if (found) return;
           }
         }
@@ -214,12 +202,12 @@ function computeUsesExpress(ast: TSESTree.Program): boolean {
         typeof value === 'object' &&
         typeof (value as TSESTree.Node).type === 'string'
       ) {
-        visit(value as TSESTree.Node);
+        visit(value as TSESTree.Node, shadowedHere);
         if (found) return;
       }
     }
   };
 
-  visit(ast);
+  visit(ast, false);
   return found;
 }


### PR DESCRIPTION
## Summary

`eslint-plugin-express-security` had **no notion of whether a file had Express in it**. Measured over **107,382 files across 108 repositories**:

| | findings | in a file with **no** `express` import |
|---|---:|---:|
| before | 5,921 | **4,450 (75%)** |
| after | 1,480 | 44 † |

`no-missing-csrf-protection` alone contributed **3,556** of the 4,450.

## The design decision: three arguments, not two

The obvious gate (match imports) is **not enough** here, and the corpus says so — over the 12-repo Express corpus:

| shape | files | of which **no** `express` import |
|---|---:|---:|
| imports / requires `express` | 274 | — |
| a `(req, res[, next])` function | 114 | **68 (60%)** |
| a **3-arg `(req, res, next)`** function | 69 | **47 (68%)** |

Route modules routinely receive `app` or `router` from their caller and import nothing. So the gate needs a signature arm — but **the two-argument form must not be it**:

- `(req, res)` is `node:http`'s `createServer` callback, a Next.js API route, and several other servers. Accepting it would re-import the exact false positives this change removes.
- `(req, res, next)` is the **Connect/Express middleware contract** and essentially nothing else. Error-handling middleware `(err, req, res, next)` matches on the tail.

**The gate:** an import / `require` / dynamic `import()` of `express` or `express-serve-static-core`, matched on the package root and never relative — **or** a `(req, res, next)` middleware signature.

**Middleware packages are deliberately not evidence.** `helmet`, `cors` and `body-parser` work with any Connect-style server; importing one says nothing about whether *this file* has an Express app in it.

A locally bound `require` is not module loading — `function f(require) { require('express'); }` does not open the gate. The probe is cached per `Program`, so twenty-eight rules cost one AST walk rather than twenty-eight.

† the 44 residual findings outside an `express` import are, by construction, files the gate opened on the **middleware signature** — i.e. exactly what the import-only measurement probe cannot see.

## Recall cost: measured at zero

Every finding was diffed across **all 1,003 corpus files that import `express`**, before and after, same rules, same file set, only the plugin differing:

```
before=1554  after=1554  lost=0
```

## Test plan

- [x] **Registry-wide lock** — `src/module-gate.lock.test.ts` sweeps *every* rule in `plugin.rules` over six non-Express shapes. Two of them are the ones that matter most: a **`node:http` server** and a **Next.js API route**, both using the two-argument `(req, res)` form the signature arm must reject. Plus Fastify, a React component, a config module, and a local module named `./express`.
- [x] **Three positive controls**, without which the suite passes with the gate shut on everything: reports with an `express` import, reports on `(req, res, next)` with *no* import, and stays silent with neither.
- [x] **`Linter({ configType: 'flat' })`** — on this package's declared ESLint floor (8.40) a bare `new Linter()` still defaults to eslintrc, so the flat config would be ignored and every rule silently skipped.
- [x] **`src/utils/express-evidence.test.ts`** — the probe itself: every import form, middleware vs framework packages, scoped/relative/absolute/prefix-sharing specifiers, the 3-arg and 4-arg signatures and their decoys (`(req, next)`, `(req, res, done)`, destructured params, too many params), shadowed `require`, and the per-`Program` cache.
- [x] **Fixtures wrapped, not edited** — an `xp()` helper prefixes `code`, `output`, and `errors[].suggestions[].output`. Test count **unchanged at 1,062** with the gate in place, 1,279 with the new suites.
  *Two files needed the helper moved above their first use: inserting it after the last `import` put it below the usage and threw `ReferenceError`, which vitest reports as a **file-level** failure that silently removes that file's tests from the total. Comparing counts to the 1,062 baseline is what caught it.*
- [x] Suite green at the package's 100% coverage threshold: 33 files, 1,279 tests.

## After merge

Released as a **major** — any rule may now stay silent where it previously reported.

Fourth in the series after [#478](https://github.com/ofri-peretz/eslint/pull/478), [#479](https://github.com/ofri-peretz/eslint/pull/479) and [#481](https://github.com/ofri-peretz/eslint/pull/481). Across the four, off-SDK reporting outside the react plugins goes **18,835 → 561 (−97%)**, at a total measured recall cost of **4 findings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Express security rules now analyze files only when recognizable Express usage is present.
  * Files for other frameworks, Node HTTP applications, configuration, or unrelated code are ignored.
  * Express usage can be identified through imports, requires, dynamic imports, or middleware signatures.

* **Bug Fixes**
  * Reduced false-positive security findings in non-Express files.
  * Preserved existing security checks for confirmed Express applications.

* **Tests**
  * Added broad coverage for Express detection, framework exclusions, shadowed imports, and middleware patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->