### PR TITLE
fix(postgresql-security): make require shadowing lexical in both gates

### DIFF
--- a/.changeset/lexical-require-shadowing.md
+++ b/.changeset/lexical-require-shadowing.md
@@ -1,0 +1,20 @@
+---
+'eslint-plugin-postgresql-security': patch
+'eslint-plugin-lambda-security': patch
+---
+
+Fix a false negative: `require` shadowing is now lexical, not file-wide
+
+Both module gates raised a single "this file shadows `require`" flag for the
+whole file. So `const client = require('pg'); function wrapper(require) {}` was
+read as fully shadowed: the real module load at module scope was ignored and
+every rule in the plugin abstained.
+
+That trades a false positive for a false negative, which is the worse trade —
+a security rule that silently stops reporting is the defect class that matters
+most.
+
+Shadowing now propagates down the walk and applies only inside the scope that
+binds the name: a function whose parameters include `require`, or a
+Program/BlockStatement whose direct body declares one. A `require()` outside
+that scope is module loading again.

--- a/packages/eslint-plugin-lambda-security/src/utils/lambda-evidence.test.ts
+++ b/packages/eslint-plugin-lambda-security/src/utils/lambda-evidence.test.ts
@@ -154,6 +154,22 @@ describe('fileIsLambda', () => {
       expect(isLambda(code)).toBe(false);
     });
 
+    // The regression a file-wide flag caused: a real `require('aws-sdk')` at module
+    // scope must survive an unrelated inner binding. Silencing all fourteen rules
+    // there trades a false positive for a false negative — the worse of the two.
+    it('an unshadowed require survives a shadowing binding elsewhere', () => {
+      expect(isLambda("const c = require('aws-sdk');\nfunction wrapper(require) {}")).toBe(true);
+      expect(isLambda("function wrapper(require) {}\nconst c = require('aws-sdk');")).toBe(true);
+      expect(
+        isLambda("function outer() { const c = require('aws-sdk'); }\nfunction w(require) {}"),
+      ).toBe(true);
+    });
+
+    it('shadowing applies only inside the scope that binds it', () => {
+      expect(isLambda("function f(require) { require('aws-sdk'); }")).toBe(false);
+      expect(isLambda("{ const require = (m) => m; require('aws-sdk'); }")).toBe(false);
+    });
+
     it('the other arms still apply when `require` is shadowed', () => {
       expect(
         isLambda("import type { H } from 'aws-lambda';\nfunction f(require) { require('aws-sdk'); }"),

--- a/packages/eslint-plugin-lambda-security/src/utils/lambda-evidence.ts
+++ b/packages/eslint-plugin-lambda-security/src/utils/lambda-evidence.ts
@@ -162,59 +162,44 @@ function hasHandlerSignature(node: TSESTree.Node): boolean {
  * state to go stale and no dependency on lint order.
  */
 /**
- * Whether the file declares a binding named `require` anywhere.
+ * Whether a scope-introducing node binds the name `require`.
  *
- * `function f(require) { require('aws-sdk'); }` is not module loading, and
- * treating it as Lambda evidence would be this plugin committing the exact
- * error it was just fixed for: taking a *name* as proof of an *interface*. When
- * the name is bound locally the `require` arm is dropped; imports, dynamic
- * `import()`, handler exports and the calling convention all still apply.
+ * `function f(require) { require('aws-sdk'); }` is not module loading, and taking it
+ * as evidence would be this plugin treating a *name* as proof of an
+ * *interface* — the error the gate exists to correct.
+ *
+ * Shadowing is **lexical**, propagated down the walk rather than computed once
+ * for the file. A file-wide flag reads
+ * `const c = require('aws-sdk'); function wrapper(require) {}` as fully shadowed and
+ * silences every rule — trading a false positive for a false negative, which is
+ * the worse of the two.
  */
-function declaresRequireBinding(ast: TSESTree.Program): boolean {
-  let shadowed = false;
-  // No top guard: every recursive call site below already checks.
-  const scan = (node: TSESTree.Node): void => {
-    if (
-      (node.type === AST_NODE_TYPES.FunctionDeclaration ||
-        node.type === AST_NODE_TYPES.FunctionExpression ||
-        node.type === AST_NODE_TYPES.ArrowFunctionExpression) &&
-      node.params.some(
-        (p) => p.type === AST_NODE_TYPES.Identifier && p.name === 'require',
-      )
-    ) {
-      shadowed = true;
-      return;
-    }
-    if (
-      node.type === AST_NODE_TYPES.VariableDeclarator &&
-      node.id.type === AST_NODE_TYPES.Identifier &&
-      node.id.name === 'require'
-    ) {
-      shadowed = true;
-      return;
-    }
-    for (const key of Object.keys(node)) {
-      if (key === 'parent') continue;
-      const value = (node as unknown as Record<string, unknown>)[key];
-      if (Array.isArray(value)) {
-        for (const child of value) {
-          if (child && typeof (child as TSESTree.Node).type === 'string') {
-            scan(child as TSESTree.Node);
-            if (shadowed) return;
-          }
-        }
-      } else if (
-        value &&
-        typeof value === 'object' &&
-        typeof (value as TSESTree.Node).type === 'string'
-      ) {
-        scan(value as TSESTree.Node);
-        if (shadowed) return;
-      }
-    }
-  };
-  scan(ast);
-  return shadowed;
+function bindsRequire(node: TSESTree.Node): boolean {
+  if (
+    node.type === AST_NODE_TYPES.FunctionDeclaration ||
+    node.type === AST_NODE_TYPES.FunctionExpression ||
+    node.type === AST_NODE_TYPES.ArrowFunctionExpression
+  ) {
+    return node.params.some(
+      (p) => p.type === AST_NODE_TYPES.Identifier && p.name === 'require',
+    );
+  }
+  // A `const require = …` shadows for the rest of the block it sits in, so the
+  // block — not the declarator — is where the flag is raised.
+  if (
+    node.type === AST_NODE_TYPES.Program ||
+    node.type === AST_NODE_TYPES.BlockStatement
+  ) {
+    return node.body.some(
+      (stmt) =>
+        stmt.type === AST_NODE_TYPES.VariableDeclaration &&
+        stmt.declarations.some(
+          (d) =>
+            d.id.type === AST_NODE_TYPES.Identifier && d.id.name === 'require',
+        ),
+    );
+  }
+  return false;
 }
 
 /**
@@ -236,9 +221,8 @@ export function fileIsLambda(ast: TSESTree.Program): boolean {
 
 function computeIsLambda(ast: TSESTree.Program): boolean {
   let found = false;
-  const requireIsShadowed = declaresRequireBinding(ast);
 
-  const visit = (node: TSESTree.Node): void => {
+  const visit = (node: TSESTree.Node, requireIsShadowed: boolean): void => {
     if (
       (node.type === AST_NODE_TYPES.ImportDeclaration ||
         node.type === AST_NODE_TYPES.ExportNamedDeclaration ||
@@ -258,13 +242,15 @@ function computeIsLambda(ast: TSESTree.Program): boolean {
       found = true;
       return;
     }
+    // Everything below this node is inside any scope it introduces.
+    const shadowedHere = requireIsShadowed || bindsRequire(node);
     for (const key of Object.keys(node)) {
       if (key === 'parent') continue;
       const value = (node as unknown as Record<string, unknown>)[key];
       if (Array.isArray(value)) {
         for (const child of value) {
           if (child && typeof (child as TSESTree.Node).type === 'string') {
-            visit(child as TSESTree.Node);
+            visit(child as TSESTree.Node, shadowedHere);
             if (found) return;
           }
         }
@@ -273,12 +259,12 @@ function computeIsLambda(ast: TSESTree.Program): boolean {
         typeof value === 'object' &&
         typeof (value as TSESTree.Node).type === 'string'
       ) {
-        visit(value as TSESTree.Node);
+        visit(value as TSESTree.Node, shadowedHere);
         if (found) return;
       }
     }
   };
 
-  visit(ast);
+  visit(ast, false);
   return found;
 }

--- a/packages/eslint-plugin-postgresql-security/src/utils/index.test.ts
+++ b/packages/eslint-plugin-postgresql-security/src/utils/index.test.ts
@@ -150,6 +150,22 @@ describe('fileUsesPostgres', () => {
       expect(uses(code)).toBe(false);
     });
 
+    // The regression a file-wide flag caused: a real `require('pg')` at module
+    // scope must survive an unrelated inner binding. Silencing all thirteen rules
+    // there trades a false positive for a false negative — the worse of the two.
+    it('an unshadowed require survives a shadowing binding elsewhere', () => {
+      expect(uses("const c = require('pg');\nfunction wrapper(require) {}")).toBe(true);
+      expect(uses("function wrapper(require) {}\nconst c = require('pg');")).toBe(true);
+      expect(
+        uses("function outer() { const c = require('pg'); }\nfunction w(require) {}"),
+      ).toBe(true);
+    });
+
+    it('shadowing applies only inside the scope that binds it', () => {
+      expect(uses("function f(require) { require('pg'); }")).toBe(false);
+      expect(uses("{ const require = (m) => m; require('pg'); }")).toBe(false);
+    });
+
     it('the other arms still apply when `require` is shadowed', () => {
       expect(uses("import { Pool } from 'pg';\nfunction f(require) { require('pg'); }")).toBe(true);
       expect(uses("const url = 'postgres://h/db';\nfunction f(require) { require('pg'); }")).toBe(true);

--- a/packages/eslint-plugin-postgresql-security/src/utils/index.ts
+++ b/packages/eslint-plugin-postgresql-security/src/utils/index.ts
@@ -87,61 +87,44 @@ function isPgConnectionString(node: TSESTree.Node): boolean {
 }
 
 /**
- * Whether the file declares a binding named `require` anywhere — a parameter,
- * a variable, a function.
+ * Whether a scope-introducing node binds the name `require`.
  *
- * `function f(require) { require('pg'); }` is not module loading, and treating
- * it as PostgreSQL evidence would be this plugin committing the exact error it
- * was just fixed for: taking a *name* as proof of an *interface*. When the name
- * is bound locally the `require` arm is dropped entirely; imports, DSNs, and
- * every other arm still apply.
+ * `function f(require) { require('pg'); }` is not module loading, and taking it
+ * as evidence would be this plugin treating a *name* as proof of an
+ * *interface* — the error the gate exists to correct.
+ *
+ * Shadowing is **lexical**, propagated down the walk rather than computed once
+ * for the file. A file-wide flag reads
+ * `const c = require('pg'); function wrapper(require) {}` as fully shadowed and
+ * silences every rule — trading a false positive for a false negative, which is
+ * the worse of the two.
  */
-function declaresRequireBinding(ast: TSESTree.Program): boolean {
-  let shadowed = false;
-  // As in `visit` below: no top guard, because every recursive call site here
-  // already checks, which would make it unreachable.
-  const scan = (node: TSESTree.Node): void => {
-    if (
-      (node.type === AST_NODE_TYPES.FunctionDeclaration ||
-        node.type === AST_NODE_TYPES.FunctionExpression ||
-        node.type === AST_NODE_TYPES.ArrowFunctionExpression) &&
-      node.params.some(
-        (p) => p.type === AST_NODE_TYPES.Identifier && p.name === 'require',
-      )
-    ) {
-      shadowed = true;
-      return;
-    }
-    if (
-      node.type === AST_NODE_TYPES.VariableDeclarator &&
-      node.id.type === AST_NODE_TYPES.Identifier &&
-      node.id.name === 'require'
-    ) {
-      shadowed = true;
-      return;
-    }
-    for (const key of Object.keys(node)) {
-      if (key === 'parent') continue;
-      const value = (node as unknown as Record<string, unknown>)[key];
-      if (Array.isArray(value)) {
-        for (const child of value) {
-          if (child && typeof (child as TSESTree.Node).type === 'string') {
-            scan(child as TSESTree.Node);
-            if (shadowed) return;
-          }
-        }
-      } else if (
-        value &&
-        typeof value === 'object' &&
-        typeof (value as TSESTree.Node).type === 'string'
-      ) {
-        scan(value as TSESTree.Node);
-        if (shadowed) return;
-      }
-    }
-  };
-  scan(ast);
-  return shadowed;
+function bindsRequire(node: TSESTree.Node): boolean {
+  if (
+    node.type === AST_NODE_TYPES.FunctionDeclaration ||
+    node.type === AST_NODE_TYPES.FunctionExpression ||
+    node.type === AST_NODE_TYPES.ArrowFunctionExpression
+  ) {
+    return node.params.some(
+      (p) => p.type === AST_NODE_TYPES.Identifier && p.name === 'require',
+    );
+  }
+  // A `const require = …` shadows for the rest of the block it sits in, so the
+  // block — not the declarator — is where the flag is raised.
+  if (
+    node.type === AST_NODE_TYPES.Program ||
+    node.type === AST_NODE_TYPES.BlockStatement
+  ) {
+    return node.body.some(
+      (stmt) =>
+        stmt.type === AST_NODE_TYPES.VariableDeclaration &&
+        stmt.declarations.some(
+          (d) =>
+            d.id.type === AST_NODE_TYPES.Identifier && d.id.name === 'require',
+        ),
+    );
+  }
+  return false;
 }
 
 /**
@@ -181,11 +164,10 @@ export function fileUsesPostgres(ast: TSESTree.Program): boolean {
 
 function computeUsesPostgres(ast: TSESTree.Program): boolean {
   let found = false;
-  const requireIsShadowed = declaresRequireBinding(ast);
 
   // No `if (found) return` guard at the top: every recursive call site below
   // already checks, so it would be unreachable.
-  const visit = (node: TSESTree.Node): void => {
+  const visit = (node: TSESTree.Node, requireIsShadowed: boolean): void => {
     if (
       (node.type === AST_NODE_TYPES.ImportDeclaration ||
         node.type === AST_NODE_TYPES.ExportNamedDeclaration ||
@@ -206,13 +188,15 @@ function computeUsesPostgres(ast: TSESTree.Program): boolean {
     }
     // `require` can sit anywhere — inside a function, a branch, an IIFE — so
     // the whole tree is walked rather than just the top-level statements.
+    // Everything below this node is inside any scope it introduces.
+    const shadowedHere = requireIsShadowed || bindsRequire(node);
     for (const key of Object.keys(node)) {
       if (key === 'parent') continue;
       const value = (node as unknown as Record<string, unknown>)[key];
       if (Array.isArray(value)) {
         for (const child of value) {
           if (child && typeof (child as TSESTree.Node).type === 'string') {
-            visit(child as TSESTree.Node);
+            visit(child as TSESTree.Node, shadowedHere);
             if (found) return;
           }
         }
@@ -221,12 +205,12 @@ function computeUsesPostgres(ast: TSESTree.Program): boolean {
         typeof (value as TSESTree.Node).type === 'string' &&
         typeof value === 'object'
       ) {
-        visit(value as TSESTree.Node);
+        visit(value as TSESTree.Node, shadowedHere);
         if (found) return;
       }
     }
   };
 
-  visit(ast);
+  visit(ast, false);
   return found;
 }


### PR DESCRIPTION
## Summary

A false negative in the two module gates already on `main` ([#479](https://github.com/ofri-peretz/eslint/pull/479), [#481](https://github.com/ofri-peretz/eslint/pull/481)), found while reviewing the express gate.

Both raised a **single, file-wide** "this file shadows `require`" flag. So this file was read as fully shadowed:

```js
const client = require('pg');      // ← real module load, at module scope
function wrapper(require) {}       // ← unrelated inner binding
```

The real `require('pg')` was ignored and **every rule in the plugin abstained**.

That trades a false positive for a false negative, which is the worse trade. A security rule that silently stops reporting is the defect class we care most about — and it is the same self-suppression shape these gates were written to avoid in the first place.

## The fix

Shadowing now propagates **down the walk** and applies only inside the scope that binds the name:

- a function whose parameters include `require`
- a `Program` / `BlockStatement` whose direct body declares one (the block, not the declarator, is where the flag is raised — a `const require = …` shadows the rest of *that block*)

A `require()` outside that scope is module loading again.

## Test plan

- [x] Three regression cases per plugin pinning the direction that regressed — an unshadowed `require` surviving a shadowing binding **before** it, **after** it, and in a **sibling function**.
- [x] Two per plugin pinning that shadowing still works *inside* the binding scope: `function f(require) { require('pg'); }` and `{ const require = (m) => m; require('pg'); }` both stay outside the gate.
- [x] Suites green at the 100% coverage threshold — postgresql 528 tests, lambda 524.

## After merge

Patch release for both. The express gate ([#482](https://github.com/ofri-peretz/eslint/pull/482)) carries the corrected form from the start, so no follow-up is needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)