### PR TITLE
fix(bench): clone the repo the headline suite actually benchmarks

### DIFF
--- a/.github/workflows/weekly-benchmark.yml
+++ b/.github/workflows/weekly-benchmark.yml
@@ -75,6 +75,26 @@ jobs:
     # nothing here is rushed into a misleading fast number.
     timeout-minutes: 90
 
+    env:
+      # THE corpus. One list, read by the clone step and by the preflight that
+      # validates what we are about to benchmark — because the defect this
+      # replaced was two lists that had to agree with nothing linking them:
+      # the clones were pinned to the flagship manifest, ILB-Headline
+      # benchmarks nestjs, no manifest cites nestjs, so it was never cloned.
+      # Anything benchmarked must appear here.
+      CORPUS: |
+        next.js   https://github.com/vercel/next.js.git
+        supabase  https://github.com/supabase/supabase.git
+        lodash    https://github.com/lodash/lodash.git
+        shadcn-ui https://github.com/shadcn-ui/ui.git
+        payload   https://github.com/payloadcms/payload.git
+        vercel-ai https://github.com/vercel/ai.git
+        nestjs    https://github.com/nestjs/nest.git
+      # Both headline runs, as one list to validate against CORPUS. The second
+      # is hardcoded to shadcn-ui in its step; keep them in step.
+      HEADLINE_REPO: ${{ github.event.inputs.headline_repo || 'nestjs' }}
+      FRONTEND_REPO: shadcn-ui
+
     steps:
       # Pages is a single production surface and the commit step writes to
       # main, so a dispatch from a feature branch would publish that branch's
@@ -98,14 +118,37 @@ jobs:
       #
       # Pinned to the same repos the manifest references. A cache keeps the
       # weekly run from re-cloning ~5 large repos every Monday.
+      # Cheapest possible failure: no checkout of a corpus, no clone, no build.
+      # Runs BEFORE the cache and clone steps so a workflow_dispatch naming a
+      # repo nobody clones costs seconds rather than six shallow clones of
+      # multi-hundred-MB repositories.
+      - name: Preflight — every benchmarked repo is declared in CORPUS
+        run: |
+          set -euo pipefail
+          missing=""
+          for r in "$HEADLINE_REPO" "$FRONTEND_REPO"; do
+            printf '%s\n' "$CORPUS" | awk '{print $1}' | grep -qx "$r" || missing="$missing $r"
+          done
+          if [ -n "$missing" ]; then
+            echo "::error::Benchmarked repo(s) not declared in CORPUS:$missing. Add \"<name> <clone-url>\" to the CORPUS env at the top of this job — otherwise ILB-Headline exits 2 and no badge is rendered."
+            exit 1
+          fi
+          echo "✅ Every benchmarked repo is declared in CORPUS."
+
+      # v2: the key must change when CORPUS changes, or an exact-key hit
+      # restores a corpus missing the repo that was just added and Actions
+      # never updates an existing entry — so it would be re-cloned on every
+      # single run, forever. Hashing this workflow file covers that: CORPUS
+      # lives in it. `restore-keys` still gives a warm partial restore, and the
+      # clone step refreshes what it finds.
       - name: Restore OOS corpus cache
         id: oos-cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
           path: oos
-          key: oos-corpus-v1-${{ hashFiles('benchmarks/suites/ilb-flagship/manifest.json') }}
+          key: oos-corpus-v2-${{ hashFiles('benchmarks/suites/ilb-flagship/manifest.json', '.github/workflows/weekly-benchmark.yml') }}
           restore-keys: |
-            oos-corpus-v1-
+            oos-corpus-v2-
 
       - name: Shallow-clone OOS corpus
         run: |
@@ -126,42 +169,31 @@ jobs:
             echo "::endgroup::"
           }
           : > oos/COMMITS.txt
-          # The six the flagship manifest cites...
-          clone next.js   https://github.com/vercel/next.js.git
-          clone supabase  https://github.com/supabase/supabase.git
-          clone lodash    https://github.com/lodash/lodash.git
-          clone shadcn-ui https://github.com/shadcn-ui/ui.git
-          clone payload   https://github.com/payloadcms/payload.git
-          clone vercel-ai https://github.com/vercel/ai.git
-          # ...plus the headline suite's Node corpus, which no manifest
-          # references. ILB-Headline defaults to --repo=nestjs and this list was
-          # pinned to the flagship manifest alone, so nestjs was never cloned.
-          # It went unnoticed while three.js was here: the headline default was
-          # three.js, #454 removed it as a corpus we must not publish, and the
-          # very next cron died with `Repo not found: oos/nestjs` before
-          # rendering a single badge.
-          clone nestjs    https://github.com/nestjs/nest.git
+          printf '%s\n' "$CORPUS" | while read -r name url; do
+            [ -n "$name" ] || continue
+            clone "$name" "$url"
+          done
           echo "--- corpus commits ---"
           cat oos/COMMITS.txt
 
-      # Two lists that must agree — the clones above and the --repo arguments
-      # below — with nothing linking them. Assert here rather than discovering
-      # it 4 minutes into a build: the failure above was loud, but it surfaced
-      # only after cloning six large repos and building 31 packages.
-      - name: Verify every benchmarked repo is in the corpus
-        env:
-          HEADLINE_REPO: ${{ github.event.inputs.headline_repo || 'nestjs' }}
+      # A directory is not a checkout. `actions/cache` can restore a truncated
+      # or partially-written `oos/<repo>`, and the clone helper treats any
+      # existing path as cached — so a repo with no resolvable HEAD is scanned
+      # as though it were pinned, and whatever it happens to contain is
+      # published as a measurement. Resolve HEAD rather than test -d.
+      - name: Verify the benchmarked repos are real, pinned checkouts
         run: |
           set -euo pipefail
-          missing=""
-          for r in "$HEADLINE_REPO" shadcn-ui; do
-            [ -d "oos/$r" ] || missing="$missing $r"
+          bad=""
+          for r in "$HEADLINE_REPO" "$FRONTEND_REPO"; do
+            sha=$(git -C "oos/$r" rev-parse HEAD 2>/dev/null || true)
+            if [ -z "$sha" ]; then bad="$bad $r"; else echo "  $r @ $sha"; fi
           done
-          if [ -n "$missing" ]; then
-            echo "::error::Benchmarked repo(s) not in the corpus:$missing. Add a \`clone\` line for each in the step above — otherwise ILB-Headline exits 2 and no badge is rendered."
+          if [ -n "$bad" ]; then
+            echo "::error::Corpus path(s) with no resolvable git HEAD:$bad. A restored-but-broken checkout would be benchmarked as if pinned and published as a real measurement. Refusing to measure."
             exit 1
           fi
-          echo "✅ Every benchmarked repo is present in the corpus."
+          echo "✅ Every benchmarked repo is a pinned checkout."
 
       # Our plugins must be BUILT before benching: the oxlint JS-plugin shims
       # and the per-job configs load from each package's dist/. On a clean

--- a/.github/workflows/weekly-benchmark.yml
+++ b/.github/workflows/weekly-benchmark.yml
@@ -126,14 +126,42 @@ jobs:
             echo "::endgroup::"
           }
           : > oos/COMMITS.txt
+          # The six the flagship manifest cites...
           clone next.js   https://github.com/vercel/next.js.git
           clone supabase  https://github.com/supabase/supabase.git
           clone lodash    https://github.com/lodash/lodash.git
           clone shadcn-ui https://github.com/shadcn-ui/ui.git
           clone payload   https://github.com/payloadcms/payload.git
           clone vercel-ai https://github.com/vercel/ai.git
+          # ...plus the headline suite's Node corpus, which no manifest
+          # references. ILB-Headline defaults to --repo=nestjs and this list was
+          # pinned to the flagship manifest alone, so nestjs was never cloned.
+          # It went unnoticed while three.js was here: the headline default was
+          # three.js, #454 removed it as a corpus we must not publish, and the
+          # very next cron died with `Repo not found: oos/nestjs` before
+          # rendering a single badge.
+          clone nestjs    https://github.com/nestjs/nest.git
           echo "--- corpus commits ---"
           cat oos/COMMITS.txt
+
+      # Two lists that must agree — the clones above and the --repo arguments
+      # below — with nothing linking them. Assert here rather than discovering
+      # it 4 minutes into a build: the failure above was loud, but it surfaced
+      # only after cloning six large repos and building 31 packages.
+      - name: Verify every benchmarked repo is in the corpus
+        env:
+          HEADLINE_REPO: ${{ github.event.inputs.headline_repo || 'nestjs' }}
+        run: |
+          set -euo pipefail
+          missing=""
+          for r in "$HEADLINE_REPO" shadcn-ui; do
+            [ -d "oos/$r" ] || missing="$missing $r"
+          done
+          if [ -n "$missing" ]; then
+            echo "::error::Benchmarked repo(s) not in the corpus:$missing. Add a \`clone\` line for each in the step above — otherwise ILB-Headline exits 2 and no badge is rendered."
+            exit 1
+          fi
+          echo "✅ Every benchmarked repo is present in the corpus."
 
       # Our plugins must be BUILT before benching: the oxlint JS-plugin shims
       # and the per-job configs load from each package's dist/. On a clean


### PR DESCRIPTION
## What broke

The first weekly benchmark after #454 failed before rendering a single badge:

```
Repo not found: /home/runner/work/eslint/eslint/oos/nestjs
##[error]Process completed with exit code 2
```

Run: [31378731853](https://github.com/ofri-peretz/eslint/actions/runs/31378731853), 2026-08-10 10:20 UTC.

## Why

Two lists have to agree, and nothing links them:

| List | Contents | Set by |
|---|---|---|
| corpus clones | next.js, supabase, lodash, shadcn-ui, payload, vercel-ai | pinned to the flagship manifest |
| repos benchmarked | `${{ inputs.headline_repo \|\| 'nestjs' }}`, shadcn-ui | ILB-Headline steps |

`nestjs` is the headline suite's Node corpus. No manifest references it, so the clone step — explicitly "pinned to the same repos the manifest references" — never cloned it.

This was invisible while `three.js` was in the list: the headline default resolved to three.js, which *was* cloned. #454 removed three.js as a corpus we must not publish, which was right, and left the headline suite with no repo at all.

**Consequence:** the published badges still read `corpus: three.js`. Not because the fix didn't land, but because the run that would replace them exits 2 before the badge step. Every badge on the README has been serving the pre-#454 measurement since.

## The fix

- `clone nestjs https://github.com/nestjs/nest.git`.
- A preflight asserting every repo about to be benchmarked is in the corpus. The old failure was loud but late — it surfaced after cloning six large repos and building 31 packages. The preflight also catches a `workflow_dispatch` whose `headline_repo` input nobody clones.

## Verification

| Case | Expected | Result |
|---|---|---|
| nestjs absent (what happened) | blocks, names it | ✅ `missing: nestjs`, exit 1 |
| nestjs present (after fix) | passes | ✅ |
| dispatch names an uncloned repo | blocks, names it | ✅ `missing: vue-core`, exit 1 |
| `lint:workflows` | green | ✅ 34 files |

The OOS cache restores via `restore-keys`, so an old cache without nestjs self-heals: the clone helper clones any missing directory.

## After merge

Badges stay stale until a run succeeds — the next cron, or a manual dispatch. Dispatch publishes to production Pages and pushes to main, so that call is the maintainer's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Weekly benchmark runs now include the NestJS repository alongside the existing benchmark repositories.
  * Added preflight validation to confirm required benchmark repositories are available before execution.

* **Bug Fixes**
  * Benchmark runs now stop early with a clear error when required repositories are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->