### PR TITLE
fix(mongodb-security): abstain in files without local MongoDB evidence

### DIFF
--- a/.changeset/mongodb-evidence-gate.md
+++ b/.changeset/mongodb-evidence-gate.md
@@ -1,0 +1,74 @@
+---
+'eslint-plugin-mongodb-security': major
+---
+
+Every rule now abstains in files without local MongoDB evidence
+
+Measured over the corpus, **47% of everything this plugin reported (1,663 of
+3,542 findings) was in a file with no Mongo import**. The plugin already
+discriminated by *receiver* (`receiver.ts`), but that is a name heuristic:
+`userModel.findOne()` reads identically in a TypeORM repository and a Mongoose
+one. Grouping the off-SDK findings by repository, **73% sat in repositories with
+zero MongoDB anywhere** — twentyhq, strapi and cal.com are TypeORM and Prisma.
+The file-level question is the one the plugin could not ask.
+
+**This gate is a union, unlike vercel-ai's, and the corpus is why.** An
+import-only probe was right for the AI SDK because every no-import caller turned
+out to be a different vendor. Here the opposite risk dominates: the idiomatic
+Mongoose layout defines a model in one file and consumes it through a
+**relative** import, so a service calling `User.findOne()` has no package
+specifier to find.
+
+Evidence accepted, each chosen by measurement:
+
+- an import / `require` / dynamic `import()` / **`import x = require(...)`** of
+  `mongodb`, `mongoose`, `@nestjs/mongoose`, `@typegoose/typegoose`, `bson`,
+  `connect-mongo`, **or any `mongoose-*` / `*-mongoose` plugin**. The plugin
+  ecosystem matters: of the twelve corpus files containing `new Schema(` that a
+  four-package list placed "outside Mongo", **eleven were plugin consumers** —
+  `mongoose-paginate`, `passport-local-mongoose`, `mongoose-lean-virtuals`.
+- `new Schema(...)` / `new mongoose.Schema(...)`
+- `.lean()` — Mongoose's own query modifier, with no analogue elsewhere
+- `Types.ObjectId` and `new ObjectId(...)`
+- a `mongodb://` or `mongodb+srv://` connection string, anywhere in a literal or
+  template quasi
+
+Two obvious candidates were **rejected on evidence**:
+
+- `$set` / `$push` / `$inc` object keys look Mongo-specific and are not. `$push`
+  is `react-addons-update`'s immutability helper, `$set` is jQuery UI, and
+  `$addToSet` is Meteor's minimongo — all three appear in the corpus.
+- a **bare** `ObjectId` identifier is a type name in unrelated libraries, so only
+  the qualified and constructed forms count.
+
+A locally bound `require` is not module loading, and shadowing is **lexical**
+from the start — the file-wide flag that regressed express/postgres in #483 is
+not repeated. The probe is cached per `Program`, so sixteen rules cost one AST
+walk.
+
+**Recall cost measured, not assumed.** Every finding over all 232 corpus files
+carrying Mongo evidence, diffed before and after: **316 → 316**. The first run of
+that diff lost six findings and **caught two real defects in this gate**, both
+now fixed and locked: `import x = require('mongoose')` is a
+`TSImportEqualsDeclaration` rather than a `require` call and was invisible (three
+files, and DefinitelyTyped writes nearly every CommonJS test this way), and the
+DSN test was anchored to the start of the string so
+`'MONGODB_URL=mongodb://…'` did not count (two files).
+
+The single remaining difference is `express-rest-boilerplate/src/index.js`,
+where `mongoose` is a **relative** import of a local wrapper. The dropped report
+was `require-auth-mechanism` on `mongoose.connect()` — a zero-argument call that
+merely delegates. The genuine finding for that same defect is retained at the
+real connect site, `src/config/mongoose.js:26`, where
+`mongoose.connect(mongo.uri, {...})` specifies no auth mechanism. **Zero
+actionable findings lost.**
+
+That relative-wrapper shape is the gate's known false negative and it is
+deliberate: resolving one hop across files would give every rule project state
+that can go stale and a dependency on lint order, which no other probe in this
+ecosystem has.
+
+Locked by `src/module-gate.lock.test.ts` over the whole rule registry, with the
+TypeORM / Prisma / `react-addons-update` / jQuery shapes as negatives and ten
+positive controls — including the import-equals and unanchored-DSN cases the
+recall diff uncovered — so the suite cannot pass with the gate shut.

--- a/benchmarks/__tests__/sdk-gate-coverage.lock.test.ts
+++ b/benchmarks/__tests__/sdk-gate-coverage.lock.test.ts
@@ -74,7 +74,8 @@ const UNGATED: Readonly<Record<string, number>> = {
   // vercel-ai-security (was 1,738) is gated as of #489 and now ships
   // src/module-gate.lock.test.ts; re-measured on the same corpus it reports 0
   // off-SDK findings.
-  'mongodb-security': 1663,
+  // mongodb-security (was 1,663) is gated as of the mongo-evidence PR and now
+  // ships src/module-gate.lock.test.ts.
   'nestjs-security': 219,
   // Effectively gated already: `isJwtLibraryCall` requires the file to import a
   // JWT library, which took it from 702 off-SDK findings to 27. What it still

--- a/packages/eslint-plugin-mongodb-security/src/coverage-gaps.spec.ts
+++ b/packages/eslint-plugin-mongodb-security/src/coverage-gaps.spec.ts
@@ -39,6 +39,78 @@ import { requireLeanQueries } from './rules/require-lean-queries/index';
 import { requireProjection } from './rules/require-projection/index';
 import { requireSchemaValidation } from './rules/require-schema-validation/index';
 import { requireTlsConnection } from './rules/require-tls-connection/index';
+/**
+ * Every fixture imports mongoose, because the rules now abstain in files with
+ * no Mongo in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass
+ * vacuously on the gate instead of exercising the detection it was written
+ * for. `output` and errors[].suggestions[].output are prefixed too, since
+ * autofix fixtures assert the whole file back.
+ */
+// A SIDE-EFFECT import: satisfies the gate without reserving any binding, so
+// fixtures that already declare `mongoose`/`db` do not redeclare.
+const asMongo = (code: string): string => `import 'mongoose';\n${code}`;
+type MongoSuggestion = { output?: string | null };
+type MongoCase = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly MongoSuggestion[] } | string>;
+};
+const xmo = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asMongo(c) as T;
+    const test = c as MongoCase;
+    return {
+      ...c,
+      code: asMongo(test.code),
+      ...(typeof test.output === 'string' ? { output: asMongo(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !Array.isArray(e.suggestions)
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asMongo(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+/**
+ * The module gate reads `sourceCode.ast`, so a synthetic context needs a
+ * Program that actually contains Mongo — otherwise the rule correctly abstains
+ * and registers no listeners, and these branch tests would assert against a
+ * handler that no longer exists.
+ */
+/**
+ * The same evidence with NO `tokens` key at all. `TSESTree.Program.tokens` is
+ * typed optional, and the token-less branch below is the whole point of that
+ * test — handing it a `tokens: []` would satisfy the gate while silently
+ * skipping the `?? []` fallback it exists to exercise.
+ */
+const MONGO_PROGRAM_NO_TOKENS = {
+  type: 'Program',
+  body: [
+    { type: 'ImportDeclaration', specifiers: [], source: { type: 'Literal', value: 'mongoose' } },
+  ],
+};
+
+const MONGO_PROGRAM = {
+  type: 'Program',
+  body: [
+    { type: 'ImportDeclaration', specifiers: [], source: { type: 'Literal', value: 'mongoose' } },
+  ],
+  tokens: [],
+  comments: [],
+};
+
 
 const ruleTester = new RuleTester();
 
@@ -47,52 +119,52 @@ const ruleTester = new RuleTester();
 // ---------------------------------------------------------------------------
 
 ruleTester.run('no-bypass-middleware (coverage gaps)', noBypassMiddleware, {
-  valid: [
+  valid: xmo([
     // Computed member access — property is a Literal, not an Identifier,
     // so methodName resolves to null and the call is not flagged.
     `User['updateOne']({ _id: id });`,
-  ],
+  ]),
   invalid: [],
 });
 
 ruleTester.run('no-hardcoded-connection-string (coverage gaps)', noHardcodedConnectionString, {
-  valid: [
+  valid: xmo([
     // Template literal whose first quasi does not match the MongoDB URI pattern.
     'const greeting = `hello ${name}`;',
-  ],
+  ]),
   invalid: [],
 });
 
 ruleTester.run('no-hardcoded-credentials (coverage gaps)', noHardcodedCredentials, {
-  valid: [
+  valid: xmo([
     // Computed key (BinaryExpression) — keyName resolves to null, no report.
     `const opts = { ['pass' + 'word']: 'secret123' };`,
-  ],
-  invalid: [
+  ]),
+  invalid: xmo([
     // String-literal key — resolved via the Literal branch and reported.
     {
       code: `const opts = { 'password': 'secret123' };`,
       errors: [{ messageId: 'hardcodedCredentials' }],
     },
-  ],
+  ]),
 });
 
 ruleTester.run('no-operator-injection (coverage gaps)', noOperatorInjection, {
-  valid: [
+  valid: xmo([
     // Computed key (BinaryExpression) — keyName is null, early return.
     `const q = { ['$' + op]: req.body.value };`,
-  ],
-  invalid: [
+  ]),
+  invalid: xmo([
     // String-literal '$ne' key with user input value — Literal key branch.
     {
       code: `User.find({ age: { '$ne': req.body.value } });`,
       errors: [{ messageId: 'operatorInjection' }],
     },
-  ],
+  ]),
 });
 
 ruleTester.run('no-select-sensitive-fields (coverage gaps)', noSelectSensitiveFields, {
-  valid: [
+  valid: xmo([
     // Native driver: inclusion projection without sensitive fields is safe.
     `db.users.find({}, { projection: { name: 1 } });`,
     // Spread inside the projection object is skipped; inclusion still counts.
@@ -113,8 +185,8 @@ ruleTester.run('no-select-sensitive-fields (coverage gaps)', noSelectSensitiveFi
     `User.find({}).select(fields);`,
     // `.select('-password')` — sensitive field present but exclusion-prefixed.
     `User.find({}).select('-password');`,
-  ],
-  invalid: [
+  ]),
+  invalid: xmo([
     // Second argument is not an object — projection cannot be proven safe.
     {
       code: `const userSchema = new Schema({ email: String, password: String });\ndb.users.find({}, "name");`,
@@ -150,18 +222,18 @@ ruleTester.run('no-select-sensitive-fields (coverage gaps)', noSelectSensitiveFi
       code: `const userSchema = new Schema({ email: String, password: String });\ndb.users.find({}, { projection: { name: 'x' } });`,
       errors: [{ messageId: 'selectSensitiveFields' }],
     },
-  ],
+  ]),
 });
 
 ruleTester.run('no-unbounded-find (coverage gaps)', noUnboundedFind, {
-  valid: [
+  valid: xmo([
     // find() passed as an argument to a `.limit(...)` call — the chain walk
     // starts at a CallExpression whose callee is a `.limit` member expression.
     `q.limit(User.find({}));`,
     // Computed member access — methodName is null.
     `db.users['find']({});`,
-  ],
-  invalid: [
+  ]),
+  invalid: xmo([
     // Native-driver options object present but without a `limit` property.
     {
       code: `db.users.find({}, { skip: 5 });`,
@@ -170,11 +242,11 @@ ruleTester.run('no-unbounded-find (coverage gaps)', noUnboundedFind, {
         suggestions: [{ messageId: 'suggestionAddLimit', output: `db.users.find({}, { skip: 5 }).limit(100);` }],
       }],
     },
-  ],
+  ]),
 });
 
 ruleTester.run('no-unsafe-populate (coverage gaps)', noUnsafePopulate, {
-  valid: [
+  valid: xmo([
     // Member expression rooted at a call — getNodeSource returns '' for the object.
     `query.populate(getConfig().path);`,
     // Computed property — stringified as '[computed]', no user-input match.
@@ -185,12 +257,12 @@ ruleTester.run('no-unsafe-populate (coverage gaps)', noUnsafePopulate, {
     `query.populate({ ...opts });`,
     // String-literal 'path' key — keyName resolves to null, not inspected.
     `query.populate({ 'path': req.body.field });`,
-  ],
+  ]),
   invalid: [],
 });
 
 ruleTester.run('no-unsafe-query (coverage gaps)', noUnsafeQuery, {
-  valid: [
+  valid: xmo([
     // Plain function call — callee is not a member expression.
     `find({ name: req.body.name });`,
     // Computed member access — methodName is null.
@@ -206,8 +278,8 @@ ruleTester.run('no-unsafe-query (coverage gaps)', noUnsafeQuery, {
     // Concatenation of a literal and a plain identifier — no user input, not
     // an identifier value, so no report.
     `User.find({ name: 'a' + suffix });`,
-  ],
-  invalid: [
+  ]),
+  invalid: xmo([
     // Bare identifier value — reported with an $eq-wrapping suggestion.
     {
       code: `User.findOne({ username: username });`,
@@ -329,11 +401,11 @@ ruleTester.run('no-unsafe-query (coverage gaps)', noUnsafeQuery, {
         },
       ],
     },
-  ],
+  ]),
 });
 
 ruleTester.run('no-unsafe-regex-query (coverage gaps)', noUnsafeRegexQuery, {
-  valid: [
+  valid: xmo([
     // Computed member access — methodName is null.
     `User['find']({ name: { $regex: req.body.x } });`,
     // No arguments — query argument missing.
@@ -352,8 +424,8 @@ ruleTester.run('no-unsafe-regex-query (coverage gaps)', noUnsafeRegexQuery, {
     `User.find({ name: { $regex: new RegExp(config.pattern) } });`,
     // $regex member expression rooted at a call — getNodeSource returns ''.
     `User.find({ name: { $regex: getConfig().user.input } });`,
-  ],
-  invalid: [
+  ]),
+  invalid: xmo([
     // String-literal '$regex' key with user input — Literal key branch.
     {
       code: `User.find({ name: { '$regex': req.body.x } });`,
@@ -364,27 +436,27 @@ ruleTester.run('no-unsafe-regex-query (coverage gaps)', noUnsafeRegexQuery, {
       code: `User.find({ name: { $regex: req.body['x'] } });`,
       errors: [{ messageId: 'unsafeRegex' }],
     },
-  ],
+  ]),
 });
 
 ruleTester.run('no-unsafe-where (coverage gaps)', noUnsafeWhere, {
-  valid: [
+  valid: xmo([
     // Computed key (BinaryExpression) — keyName resolves to null.
     `const q = { ['$' + 'where']: 'this.a == 1' };`,
-  ],
+  ]),
   invalid: [],
 });
 
 ruleTester.run('require-auth-mechanism (coverage gaps)', requireAuthMechanism, {
-  valid: [
+  valid: xmo([
     // Computed member access — methodName is null.
     `mongoose['connect'](uri);`,
     // Options argument is not an object literal — not inspected.
     `mongoose.connect(uri, getOptions());`,
     // String-literal 'authMechanism' key is recognized.
     `mongoose.connect(uri, { 'authMechanism': 'SCRAM-SHA-256' });`,
-  ],
-  invalid: [
+  ]),
+  invalid: xmo([
     // Spread-only options — authMechanism cannot be proven present.
     {
       code: `mongoose.connect(uri, { ...opts });`,
@@ -395,33 +467,33 @@ ruleTester.run('require-auth-mechanism (coverage gaps)', requireAuthMechanism, {
       code: 'mongoose.connect(uri, { [`authMechanism`]: "SCRAM-SHA-256" });',
       errors: [{ messageId: 'requireAuthMechanism' }],
     },
-  ],
+  ]),
 });
 
 ruleTester.run('require-lean-queries (coverage gaps)', requireLeanQueries, {
-  valid: [
+  valid: xmo([
     // find() as an argument of a `.lean(...)` call — the chain walk starts at
     // a CallExpression whose callee is a `.lean` member expression.
     `helper.lean(User.find({}));`,
     // Computed member access — methodName is null.
     `User['find']({});`,
-  ],
+  ]),
   invalid: [],
 });
 
 ruleTester.run('require-projection (coverage gaps)', requireProjection, {
-  valid: [
+  valid: xmo([
     // find() as an argument of a `.select(...)` call — CallExpression branch
     // of hasChainedSelect.
     `helper.select(User.find({}));`,
     // Computed member access — methodName is null.
     `User['find']({});`,
-  ],
+  ]),
   invalid: [],
 });
 
 ruleTester.run('require-schema-validation (coverage gaps)', requireSchemaValidation, {
-  valid: [
+  valid: xmo([
     // No schema argument.
     `new Schema();`,
     // Schema argument is not an object literal.
@@ -430,8 +502,8 @@ ruleTester.run('require-schema-validation (coverage gaps)', requireSchemaValidat
     `new Schema({ ...base });`,
     // Object-style field without a `type` property is skipped.
     `new Schema({ name: { required: true } });`,
-  ],
-  invalid: [
+  ]),
+  invalid: xmo([
     // Spread inside the field definition is skipped by both scans; the field
     // has a type but no validation.
     {
@@ -444,11 +516,11 @@ ruleTester.run('require-schema-validation (coverage gaps)', requireSchemaValidat
       code: `new Schema({ name: { type: String, 'required': true } });`,
       errors: [{ messageId: 'requireSchemaValidation' }],
     },
-  ],
+  ]),
 });
 
 ruleTester.run('require-tls-connection (coverage gaps)', requireTlsConnection, {
-  valid: [
+  valid: xmo([
     // Computed member access — methodName is null.
     `mongoose['connect'](uri);`,
     // Zero arguments — nothing to report on.
@@ -460,8 +532,8 @@ ruleTester.run('require-tls-connection (coverage gaps)', requireTlsConnection, {
     // identifier keys while the repair lookup stripped quotes.
     `mongoose.connect(uri, { 'tls': true });`,
     `mongoose.connect(uri, { "ssl": true });`,
-  ],
-  invalid: [
+  ]),
+  invalid: xmo([
     // Spread-only options — tls cannot be proven present.
     {
       code: `mongoose.connect(uri, { ...opts });`,
@@ -478,7 +550,7 @@ ruleTester.run('require-tls-connection (coverage gaps)', requireTlsConnection, {
         suggestions: [{ messageId: 'suggestionAddTls', output: `mongoose.connect(uri, { 'tls': true });` }],
       }],
     },
-  ],
+  ]),
 });
 
 // ---------------------------------------------------------------------------
@@ -489,6 +561,7 @@ describe('no-hardcoded-connection-string — synthetic AST (Layer 2)', () => {
   it('ignores a TemplateLiteral with zero quasis (parser always emits >= 1)', () => {
     const { listeners, reports } = createWithMockContext(
       noHardcodedConnectionString as unknown as RuleLike,
+      { ast: MONGO_PROGRAM },
     );
     const templateLiteralListener = listeners.TemplateLiteral as (node: unknown) => void;
     templateLiteralListener({ type: 'TemplateLiteral', quasis: [], expressions: [] });
@@ -500,6 +573,7 @@ describe('no-unbounded-find — synthetic AST (Layer 2)', () => {
   it('reports when the chain walk hits a parent-less cursor (parser always roots at Program)', () => {
     const { listeners, reports } = createWithMockContext(
       noUnboundedFind as unknown as RuleLike,
+      { ast: MONGO_PROGRAM },
     );
     const callExpressionListener = listeners.CallExpression as (node: unknown) => void;
     const node = {
@@ -527,7 +601,7 @@ describe('no-select-sensitive-fields — a Program without tokens (Layer 2)', ()
   it('treats a token-less Program as "no sensitive field in view"', () => {
     const { listeners, reports } = createWithMockContext(
       noSelectSensitiveFields as unknown as RuleLike,
-      { ast: { type: 'Program', body: [] } },
+      { ast: MONGO_PROGRAM_NO_TOKENS },
     );
     const listener = listeners.CallExpression as (node: unknown) => void;
     listener({
@@ -586,7 +660,7 @@ describe('no-select-sensitive-fields — null sensitiveFields option (Layer 2)',
   it('falls back to the DEFAULT list for projections: safe inclusion projection stays silent', () => {
     const { listeners, reports } = createWithMockContext(
       noSelectSensitiveFields as unknown as RuleLike,
-      { options: [{ sensitiveFields: null }] },
+      { ast: MONGO_PROGRAM, options: [{ sensitiveFields: null }] },
     );
     const listener = listeners.CallExpression as (node: unknown) => void;
     listener(
@@ -598,7 +672,7 @@ describe('no-select-sensitive-fields — null sensitiveFields option (Layer 2)',
   it('falls back to the DEFAULT list for projections: including `password` still reports', () => {
     const { listeners, reports } = createWithMockContext(
       noSelectSensitiveFields as unknown as RuleLike,
-      { options: [{ sensitiveFields: null }] },
+      { ast: MONGO_PROGRAM, options: [{ sensitiveFields: null }] },
     );
     const listener = listeners.CallExpression as (node: unknown) => void;
     listener(
@@ -614,7 +688,7 @@ describe('no-select-sensitive-fields — null sensitiveFields option (Layer 2)',
   it('falls back to the DEFAULT list in .select() scans: selecting `password` reports on the select call', () => {
     const { listeners, reports } = createWithMockContext(
       noSelectSensitiveFields as unknown as RuleLike,
-      { options: [{ sensitiveFields: null }] },
+      { ast: MONGO_PROGRAM, options: [{ sensitiveFields: null }] },
     );
     const listener = listeners.CallExpression as (node: unknown) => void;
     const selectCall = {
@@ -636,7 +710,7 @@ describe('no-select-sensitive-fields — null sensitiveFields option (Layer 2)',
   it('falls back to the DEFAULT list in .select() scans: excluding `-password` stays silent', () => {
     const { listeners, reports } = createWithMockContext(
       noSelectSensitiveFields as unknown as RuleLike,
-      { options: [{ sensitiveFields: null }] },
+      { ast: MONGO_PROGRAM, options: [{ sensitiveFields: null }] },
     );
     const listener = listeners.CallExpression as (node: unknown) => void;
     const selectCall = {

--- a/packages/eslint-plugin-mongodb-security/src/module-gate.lock.test.ts
+++ b/packages/eslint-plugin-mongodb-security/src/module-gate.lock.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Regression lock: no rule in this plugin reports in a file with no MongoDB in
+ * it.
+ *
+ * Measured over the corpus, **47% of everything this plugin reported (1,663 of
+ * 3,542 findings) was in a file with no Mongo import**. The plugin already
+ * discriminated by *receiver* (`receiver.ts`), but that is a name heuristic:
+ * `userModel.findOne()` reads the same in a TypeORM repository as in a
+ * Mongoose one. This lock pins the file-level question.
+ *
+ * Written over the whole rule registry rather than per rule, so a rule added
+ * later is covered the day it lands.
+ */
+import { describe, it, expect } from 'vitest';
+import { Linter } from 'eslint';
+import parser from '@typescript-eslint/parser';
+import plugin from './index';
+
+const RULES = Object.keys(plugin.rules);
+
+/**
+ * Shapes that drew findings from this plugin across the corpus while having no
+ * MongoDB in them.
+ *
+ * The first three are real files: 73% of the off-SDK findings sat in
+ * repositories with **zero** Mongo anywhere — twentyhq, strapi and cal.com are
+ * TypeORM and Prisma. The last three are the operator/identifier collisions
+ * that the gate deliberately refuses to treat as evidence.
+ */
+const NON_MONGO_SOURCES: ReadonlyArray<readonly [string, string]> = [
+  [
+    'a TypeORM repository',
+    `import { Repository } from 'typeorm';
+     export class UserService {
+       constructor(private userModel: Repository<User>) {}
+       find(id: string) { return this.userModel.findOne({ where: { id } }); }
+     }`,
+  ],
+  [
+    'a Prisma client call',
+    `import { PrismaClient } from '@prisma/client';
+     const prisma = new PrismaClient();
+     export const get = (id: string) => prisma.user.findOne({ where: { id } });`,
+  ],
+  [
+    'a generic repository wrapper with a mongo-shaped name',
+    `export class Repo {
+       constructor(private collection: unknown) {}
+       async findOne(q: object) { return this.collection.findOne(q); }
+     }`,
+  ],
+  [
+    "react-addons-update's $push — not a Mongo operator",
+    `import update from 'react-addons-update';
+     const next = update(state, { items: { $push: [item] } });`,
+  ],
+  [
+    "jQuery UI's $set — not a Mongo operator",
+    `const options = { $set: { disabled: true }, $inc: { count: 1 } };
+     export default options;`,
+  ],
+  [
+    'a bare ObjectId type name from an unrelated library',
+    `import type { ObjectId } from 'bson-objectid-lookalike';
+     export function read(id: ObjectId) { return String(id); }`,
+  ],
+  [
+    'a local module merely named mongoose',
+    `import mongoose from './mongoose';
+     export const db = mongoose.connect('localhost');`,
+  ],
+];
+
+const lint = (code: string, rule: string): Linter.LintMessage[] => {
+  // `configType: 'flat'` is explicit: the declared ESLint floor still defaults
+  // `new Linter()` to eslintrc, where a flat config is ignored and every rule
+  // silently skipped — the vacuous pass this lock exists to catch.
+  const linter = new Linter({ configType: 'flat' });
+  return linter.verify(
+    code,
+    {
+      files: ['**/*.ts'],
+      languageOptions: {
+        parser: parser as unknown as Linter.Parser,
+        parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+      },
+      plugins: { xp: plugin as unknown as Linter.Plugin },
+      rules: { [`xp/${rule}`]: 'error' },
+    },
+    // Without a filename the Linter lints `<input>`, which matches no `files`
+    // entry, so every rule is skipped and every negative passes vacuously. The
+    // positive controls below are what catch that. `service.ts` rather than a
+    // test path, because several rules allow themselves in test files.
+    'service.ts',
+  );
+};
+
+describe('MongoDB module gate', () => {
+  it('the registry is non-empty, so the sweep below is not vacuous', () => {
+    expect(RULES.length).toBeGreaterThan(0);
+  });
+
+  describe.each(NON_MONGO_SOURCES)('%s', (_name, code) => {
+    it.each(RULES)('xp/%s reports nothing', (rule) => {
+      const messages = lint(code, rule);
+      // A parse or config error also produces zero *rule* findings, so it is
+      // asserted away rather than counted as a pass.
+      expect(messages.filter((m) => !m.ruleId)).toHaveLength(0);
+      expect(messages).toHaveLength(0);
+    });
+  });
+
+  describe('positive controls — the gate must open for real Mongo code', () => {
+    // The shape no-hardcoded-connection-string keys on.
+    const dsn = `const uri = 'mongodb://admin:hunter2@localhost:27017/app';`;
+
+    it('reports once the file imports mongoose', () => {
+      expect(
+        lint(`import mongoose from 'mongoose';\n${dsn}`, 'no-hardcoded-connection-string')
+          .length,
+      ).toBeGreaterThan(0);
+    });
+
+    it('reports on a mongodb:// literal with no import at all', () => {
+      // The DSN names the protocol; it is evidence in itself.
+      expect(lint(dsn, 'no-hardcoded-connection-string').length).toBeGreaterThan(0);
+    });
+
+    it('opens on a mongoose PLUGIN import, not just mongoose itself', () => {
+      // Eleven of the twelve corpus files holding `new Schema(` that a
+      // four-package list placed "outside Mongo" were exactly this.
+      expect(
+        lint(`import paginate from 'mongoose-paginate';\n${dsn}`, 'no-hardcoded-connection-string')
+          .length,
+      ).toBeGreaterThan(0);
+    });
+
+    it('opens on new Schema({...}) with no mongo import', () => {
+      const code = `const userSchema = new Schema({ name: String });\n${dsn}`;
+      expect(lint(code, 'no-hardcoded-connection-string').length).toBeGreaterThan(0);
+    });
+
+    it('opens on a .lean() query modifier', () => {
+      const code = `export const all = () => Model.find({}).lean();\n${dsn}`;
+      expect(lint(code, 'no-hardcoded-connection-string').length).toBeGreaterThan(0);
+    });
+
+    it('opens on Types.ObjectId', () => {
+      const code = `export const id = new Types.ObjectId();\n${dsn}`;
+      expect(lint(code, 'no-hardcoded-connection-string').length).toBeGreaterThan(0);
+    });
+
+    it("opens on a dynamic await import('mongodb')", () => {
+      // Lazily importing the driver inside a handler is idiomatic in
+      // serverless code; a gate that only saw static imports would abstain on
+      // exactly the files most likely to hold a connection string.
+      const code = `export async function handler() {
+        const { MongoClient } = await import('mongodb');
+        return MongoClient;
+      }
+      ${dsn}`;
+      expect(lint(code, 'no-hardcoded-connection-string').length).toBeGreaterThan(0);
+    });
+
+    it('opens on a mongodb:// template literal', () => {
+      const code = 'const uri = `mongodb://admin:hunter2@${host}:27017/app`;';
+      expect(lint(code, 'no-hardcoded-connection-string').length).toBeGreaterThan(0);
+    });
+
+    it("opens on TypeScript's import-equals form", () => {
+      // `import x = require('mongoose')` is a TSImportEqualsDeclaration, not a
+      // require CallExpression. DefinitelyTyped writes nearly every CommonJS
+      // type test this way; three corpus files were silenced until the recall
+      // diff caught it.
+      const code = `import mongoose = require('mongoose');\n${dsn}`;
+      expect(lint(code, 'no-hardcoded-connection-string').length).toBeGreaterThan(0);
+    });
+
+    it('opens on a DSN that is not at the start of the string', () => {
+      // Env-file generators write `MONGODB_URL=mongodb://...`; anchoring the
+      // match to the start of the literal silenced two corpus files.
+      const code = `const line = 'MONGODB_URL=mongodb://admin:hunter2@127.0.0.1/db';`;
+      expect(lint(code, 'no-hardcoded-connection-string').length).toBeGreaterThan(0);
+    });
+
+    it('and stays silent on that same DSN-free file with no Mongo evidence', () => {
+      expect(
+        lint(`const uri = 'postgres://localhost/app';`, 'no-hardcoded-connection-string'),
+      ).toHaveLength(0);
+    });
+  });
+
+  describe('a locally bound require is not module loading', () => {
+    it('does not open the gate', () => {
+      const code = `function wrap(require) { return require('mongoose'); }
+      export const q = { user: 1 };`;
+      expect(lint(code, 'no-hardcoded-connection-string')).toHaveLength(0);
+    });
+
+    it('but shadowing stays lexical — a real load elsewhere still opens it', () => {
+      // The file-wide-flag bug (#483) silenced the whole plugin here.
+      const code = `const mongoose = require('mongoose');
+      function wrap(require) { return require('x'); }
+      const uri = 'mongodb://admin:hunter2@localhost:27017/app';`;
+      expect(
+        lint(code, 'no-hardcoded-connection-string').length,
+      ).toBeGreaterThan(0);
+    });
+  });
+});

--- a/packages/eslint-plugin-mongodb-security/src/real-world-regressions.spec.ts
+++ b/packages/eslint-plugin-mongodb-security/src/real-world-regressions.spec.ts
@@ -21,6 +21,50 @@ import { noSelectSensitiveFields } from './rules/no-select-sensitive-fields/inde
 import { noUnboundedFind } from './rules/no-unbounded-find/index';
 import { requireAuthMechanism } from './rules/require-auth-mechanism/index';
 import { requireTlsConnection } from './rules/require-tls-connection/index';
+/**
+ * Every fixture imports mongoose, because the rules now abstain in files with
+ * no Mongo in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass
+ * vacuously on the gate instead of exercising the detection it was written
+ * for. `output` and errors[].suggestions[].output are prefixed too, since
+ * autofix fixtures assert the whole file back.
+ */
+// A SIDE-EFFECT import: satisfies the gate without reserving any binding, so
+// fixtures that already declare `mongoose`/`db` do not redeclare.
+const asMongo = (code: string): string => `import 'mongoose';\n${code}`;
+type MongoSuggestion = { output?: string | null };
+type MongoCase = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly MongoSuggestion[] } | string>;
+};
+const xmo = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asMongo(c) as T;
+    const test = c as MongoCase;
+    return {
+      ...c,
+      code: asMongo(test.code),
+      ...(typeof test.output === 'string' ? { output: asMongo(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !Array.isArray(e.suggestions)
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asMongo(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
 
 const ruleTester = new RuleTester();
 
@@ -30,7 +74,7 @@ const ruleTester = new RuleTester();
 
 describe('real-world FP regressions', () => {
   ruleTester.run('require-auth-mechanism', requireAuthMechanism, {
-    valid: [
+    valid: xmo([
       // src/infra/cache/redis/module.ts:18 — a Redis client.
       `import { createClient, RedisClientType } from 'redis';
        const client = createClient({ url: REDIS_URL }) as RedisClientType;
@@ -53,8 +97,8 @@ describe('real-world FP regressions', () => {
                mongoose.createConnection(container.getConnectionString(), { directConnection: true });`,
         filename: '/repo/src/utils/test/e2e/containers.ts',
       },
-    ],
-    invalid: [
+    ]),
+    invalid: xmo([
       // Still fires on the real thing: a Mongoose connection with no mechanism.
       {
         code: `import mongoose from 'mongoose';
@@ -68,7 +112,7 @@ describe('real-world FP regressions', () => {
                await client.connect();`,
         errors: [{ messageId: 'requireAuthMechanism' }],
       },
-    ],
+    ]),
   });
 
   // -------------------------------------------------------------------------
@@ -76,21 +120,21 @@ describe('real-world FP regressions', () => {
   // -------------------------------------------------------------------------
 
   ruleTester.run('require-tls-connection', requireTlsConnection, {
-    valid: [
+    valid: xmo([
       `await logger.connect(LogLevelEnum[LOG_LEVEL]);`,
       {
         code: `import mongoose from 'mongoose';
                mongoose.createConnection(container.getConnectionString(), { directConnection: true });`,
         filename: '/repo/src/utils/test/e2e/containers.ts',
       },
-    ],
-    invalid: [
+    ]),
+    invalid: xmo([
       {
         code: `import mongoose from 'mongoose';
                await mongoose.connect(MONGO_URL, { authMechanism: 'SCRAM-SHA-256' });`,
         errors: [{ messageId: 'requireTls', suggestions: 1 }],
       },
-    ],
+    ]),
   });
 
   // -------------------------------------------------------------------------
@@ -98,7 +142,7 @@ describe('real-world FP regressions', () => {
   // -------------------------------------------------------------------------
 
   ruleTester.run('no-unbounded-find', noUnboundedFind, {
-    valid: [
+    valid: xmo([
       // src/infra/logger/service.ts:48,82,119 — array literal + `.find(Boolean)`.
       `const level = [logLevel, 'trace']?.find(Boolean)?.toString();`,
       `this.logger.logger.debug([obj, gray(message)].find(Boolean), gray(message));`,
@@ -112,8 +156,8 @@ describe('real-world FP regressions', () => {
       // src/infra/repository/postgres/repository.ts:123 — TypeORM, not Mongo.
       `return this.repository.find();`,
       `return this.repository.find({ where: filter });`,
-    ],
-    invalid: [
+    ]),
+    invalid: xmo([
       // Still fires on a Mongoose model and on the native driver.
       {
         code: `const results = await this.model.find(filter);`,
@@ -134,7 +178,7 @@ describe('real-world FP regressions', () => {
         code: `const cats = await this.catModel.find({ age: 3 });`,
         errors: [{ messageId: 'unboundedFind', suggestions: 1 }],
       },
-    ],
+    ]),
   });
 
   // -------------------------------------------------------------------------
@@ -143,7 +187,7 @@ describe('real-world FP regressions', () => {
   // -------------------------------------------------------------------------
 
   ruleTester.run('no-select-sensitive-fields', noSelectSensitiveFields, {
-    valid: [
+    valid: xmo([
       // src/core/bird/use-cases/* — demo entities with no credential field.
       `const bird = await this.birdRepository.findById(id);`,
       `const cat = await this.catRepository.findById(id);`,
@@ -156,8 +200,8 @@ describe('real-world FP regressions', () => {
       // Array.prototype.find shares the method name.
       `const allowed = sortList.find((s) => s.name === key);`,
       `const status = [error.getStatus(), error['status']].find(Boolean);`,
-    ],
-    invalid: [
+    ]),
+    invalid: xmo([
       // Schema in view names a sensitive field — the claim is now grounded.
       {
         code: `const userSchema = new Schema({ email: String, password: String });
@@ -179,7 +223,7 @@ describe('real-world FP regressions', () => {
         options: [{ requireVisibleSensitiveField: false }],
         errors: [{ messageId: 'selectSensitiveFields' }],
       },
-    ],
+    ]),
   });
 
   // -------------------------------------------------------------------------
@@ -188,14 +232,14 @@ describe('real-world FP regressions', () => {
   // -------------------------------------------------------------------------
 
   ruleTester.run('no-bypass-middleware', noBypassMiddleware, {
-    valid: [
+    valid: xmo([
       // src/core/bird/use-cases/bird-update.ts:30 and siblings.
       `await this.birdRepository.updateOne({ id: entity.id }, entity.toObject());`,
       `await this.permissionRepository.updateOne({ id: entity.id }, entity.toObject());`,
       // TypeORM repository.
       `await this.repository.updateOne({ id }, patch);`,
-    ],
-    invalid: [
+    ]),
+    invalid: xmo([
       // src/infra/repository/mongo/repository.ts:207 — a real Mongoose model.
       {
         code: `const model = await this.model.findOneAndUpdate(filter, updated);`,
@@ -205,6 +249,6 @@ describe('real-world FP regressions', () => {
         code: `await User.updateMany({ active: false }, { $set: { archived: true } });`,
         errors: [{ messageId: 'bypassMiddleware' }],
       },
-    ],
+    ]),
   });
 });

--- a/packages/eslint-plugin-mongodb-security/src/rules/no-bypass-middleware/index.spec.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/no-bypass-middleware/index.spec.ts
@@ -1,10 +1,55 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { noBypassMiddleware } from '../no-bypass-middleware/index';
 
+/**
+ * Every fixture imports mongoose, because the rules now abstain in files with
+ * no Mongo in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass
+ * vacuously on the gate instead of exercising the detection it was written
+ * for. `output` and errors[].suggestions[].output are prefixed too, since
+ * autofix fixtures assert the whole file back.
+ */
+// A SIDE-EFFECT import: satisfies the gate without reserving any binding, so
+// fixtures that already declare `mongoose`/`db` do not redeclare.
+const asMongo = (code: string): string => `import 'mongoose';\n${code}`;
+type MongoSuggestion = { output?: string | null };
+type MongoCase = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly MongoSuggestion[] } | string>;
+};
+const xmo = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asMongo(c) as T;
+    const test = c as MongoCase;
+    return {
+      ...c,
+      code: asMongo(test.code),
+      ...(typeof test.output === 'string' ? { output: asMongo(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !Array.isArray(e.suggestions)
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asMongo(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 const ruleTester = new RuleTester();
 
 ruleTester.run('no-bypass-middleware', noBypassMiddleware, {
-  valid: [
+  valid: xmo([
     // findOne is safe (triggers middleware)
     `User.findOne({ _id: id });`,
     // save() triggers middleware
@@ -20,9 +65,9 @@ ruleTester.run('no-bypass-middleware', noBypassMiddleware, {
       code: `User.updateOne({ _id: id }, { $set: { active: false } });`,
       filename: 'user.test.ts',
     },
-  ],
+  ]),
 
-  invalid: [
+  invalid: xmo([
     // updateOne bypasses middleware
     {
       code: `User.updateOne({ _id: id }, { $set: { active: false } });`,
@@ -70,5 +115,5 @@ ruleTester.run('no-bypass-middleware', noBypassMiddleware, {
       options: [{ allowInTests: false }],
       errors: [{ messageId: 'bypassMiddleware' }],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-mongodb-security/src/rules/no-bypass-middleware/index.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/no-bypass-middleware/index.ts
@@ -13,6 +13,7 @@ import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
 import { AST_NODE_TYPES, createRule, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
 import { isTestFile } from '../../utils/paths';
 import { analyzeMongoScope } from '../../utils/receiver';
+import { fileUsesMongo } from '../../utils/mongo-evidence';
 
 type MessageIds = 'bypassMiddleware';
 export interface Options { allowInTests?: boolean; }
@@ -51,6 +52,14 @@ export const noBypassMiddleware = createRule<RuleOptions, MessageIds>({
   },
   defaultOptions: [{ allowInTests: true }],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>) {
+    // Every rule here is MongoDB-specific, and none of them could ask the
+    // file-level question: over the corpus, 47% of this plugin's findings were
+    // in files with no Mongo in them. `receiver.ts` discriminates by receiver
+    // NAME, which matches `userModel.findOne()` in a TypeORM repository just as
+    // well as in a Mongoose one. Registering no visitors is both the gate and
+    // the cheap path.
+    if (!fileUsesMongo(context.sourceCode.ast)) return {};
+
     const [options = {}] = context.options;
     const { allowInTests = true } = options as Options;
     const filename = context.filename;

--- a/packages/eslint-plugin-mongodb-security/src/rules/no-bypass-middleware/no-bypass-middleware.test.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/no-bypass-middleware/no-bypass-middleware.test.ts
@@ -10,6 +10,51 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { noBypassMiddleware } from './index';
 
+/**
+ * Every fixture imports mongoose, because the rules now abstain in files with
+ * no Mongo in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass
+ * vacuously on the gate instead of exercising the detection it was written
+ * for. `output` and errors[].suggestions[].output are prefixed too, since
+ * autofix fixtures assert the whole file back.
+ */
+// A SIDE-EFFECT import: satisfies the gate without reserving any binding, so
+// fixtures that already declare `mongoose`/`db` do not redeclare.
+const asMongo = (code: string): string => `import 'mongoose';\n${code}`;
+type MongoSuggestion = { output?: string | null };
+type MongoCase = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly MongoSuggestion[] } | string>;
+};
+const xmo = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asMongo(c) as T;
+    const test = c as MongoCase;
+    return {
+      ...c,
+      code: asMongo(test.code),
+      ...(typeof test.output === 'string' ? { output: asMongo(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !Array.isArray(e.suggestions)
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asMongo(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -27,7 +72,7 @@ const ruleTester = new RuleTester({
 describe('no-bypass-middleware', () => {
   describe('Valid Code', () => {
     ruleTester.run('valid - safe patterns', noBypassMiddleware, {
-      valid: [
+      valid: xmo([
         // Unrelated code should not trigger
         {
           code: `const x = 1;`,
@@ -50,7 +95,7 @@ describe('no-bypass-middleware', () => {
         {
           code: `const safe4 = process.env.DB_HOST;`,
         },
-      ],
+      ]),
       invalid: [],
     });
   });
@@ -58,13 +103,13 @@ describe('no-bypass-middleware', () => {
   describe('Invalid Code', () => {
     ruleTester.run('invalid - dangerous patterns', noBypassMiddleware, {
       valid: [],
-      invalid: [
+      invalid: xmo([
         // Triggers bypassMiddleware: bypasses mongoose middleware
         {
           code: `User.updateMany({ role: 'admin' }, { $set: { active: true } });`,
           errors: [{ messageId: 'bypassMiddleware' }],
         },
-      ],
+      ]),
     });
   });
 });

--- a/packages/eslint-plugin-mongodb-security/src/rules/no-debug-mode-production/index.spec.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/no-debug-mode-production/index.spec.ts
@@ -1,10 +1,55 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { noDebugModeProduction } from '../no-debug-mode-production/index';
 
+/**
+ * Every fixture imports mongoose, because the rules now abstain in files with
+ * no Mongo in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass
+ * vacuously on the gate instead of exercising the detection it was written
+ * for. `output` and errors[].suggestions[].output are prefixed too, since
+ * autofix fixtures assert the whole file back.
+ */
+// A SIDE-EFFECT import: satisfies the gate without reserving any binding, so
+// fixtures that already declare `mongoose`/`db` do not redeclare.
+const asMongo = (code: string): string => `import 'mongoose';\n${code}`;
+type MongoSuggestion = { output?: string | null };
+type MongoCase = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly MongoSuggestion[] } | string>;
+};
+const xmo = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asMongo(c) as T;
+    const test = c as MongoCase;
+    return {
+      ...c,
+      code: asMongo(test.code),
+      ...(typeof test.output === 'string' ? { output: asMongo(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !Array.isArray(e.suggestions)
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asMongo(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 const ruleTester = new RuleTester();
 
 ruleTester.run('no-debug-mode-production', noDebugModeProduction, {
-  valid: [
+  valid: xmo([
     // Debug set to false
     `mongoose.set('debug', false);`,
     // Debug based on env check
@@ -18,9 +63,9 @@ ruleTester.run('no-debug-mode-production', noDebugModeProduction, {
       code: `mongoose.set('debug', true);`,
       filename: 'setup.test.ts',
     },
-  ],
+  ]),
 
-  invalid: [
+  invalid: xmo([
     // mongoose.set('debug', true)
     {
       code: `mongoose.set('debug', true);`,
@@ -55,5 +100,5 @@ ruleTester.run('no-debug-mode-production', noDebugModeProduction, {
         suggestions: [{ messageId: 'suggestionGateOnNodeEnv', output: `mongoose.set('debug', process.env.NODE_ENV !== 'production');` }],
       }],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-mongodb-security/src/rules/no-debug-mode-production/index.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/no-debug-mode-production/index.ts
@@ -12,6 +12,7 @@
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
 import { AST_NODE_TYPES, createRule, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
 import { isTestFile } from '../../utils/paths';
+import { fileUsesMongo } from '../../utils/mongo-evidence';
 
 type MessageIds = 'debugModeProduction' | 'suggestionGateOnNodeEnv';
 export interface Options { allowInTests?: boolean; }
@@ -45,6 +46,14 @@ export const noDebugModeProduction = createRule<RuleOptions, MessageIds>({
   },
   defaultOptions: [{ allowInTests: true }],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>) {
+    // Every rule here is MongoDB-specific, and none of them could ask the
+    // file-level question: over the corpus, 47% of this plugin's findings were
+    // in files with no Mongo in them. `receiver.ts` discriminates by receiver
+    // NAME, which matches `userModel.findOne()` in a TypeORM repository just as
+    // well as in a Mongoose one. Registering no visitors is both the gate and
+    // the cheap path.
+    if (!fileUsesMongo(context.sourceCode.ast)) return {};
+
     const [options = {}] = context.options;
     const { allowInTests = true } = options as Options;
     const filename = context.filename;

--- a/packages/eslint-plugin-mongodb-security/src/rules/no-debug-mode-production/no-debug-mode-production.test.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/no-debug-mode-production/no-debug-mode-production.test.ts
@@ -10,6 +10,51 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { noDebugModeProduction } from './index';
 
+/**
+ * Every fixture imports mongoose, because the rules now abstain in files with
+ * no Mongo in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass
+ * vacuously on the gate instead of exercising the detection it was written
+ * for. `output` and errors[].suggestions[].output are prefixed too, since
+ * autofix fixtures assert the whole file back.
+ */
+// A SIDE-EFFECT import: satisfies the gate without reserving any binding, so
+// fixtures that already declare `mongoose`/`db` do not redeclare.
+const asMongo = (code: string): string => `import 'mongoose';\n${code}`;
+type MongoSuggestion = { output?: string | null };
+type MongoCase = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly MongoSuggestion[] } | string>;
+};
+const xmo = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asMongo(c) as T;
+    const test = c as MongoCase;
+    return {
+      ...c,
+      code: asMongo(test.code),
+      ...(typeof test.output === 'string' ? { output: asMongo(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !Array.isArray(e.suggestions)
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asMongo(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -27,7 +72,7 @@ const ruleTester = new RuleTester({
 describe('no-debug-mode-production', () => {
   describe('Valid Code', () => {
     ruleTester.run('valid - safe patterns', noDebugModeProduction, {
-      valid: [
+      valid: xmo([
         // Unrelated code should not trigger
         {
           code: `const x = 1;`,
@@ -50,7 +95,7 @@ describe('no-debug-mode-production', () => {
         {
           code: `const safe4 = process.env.DB_HOST;`,
         },
-      ],
+      ]),
       invalid: [],
     });
   });
@@ -58,7 +103,7 @@ describe('no-debug-mode-production', () => {
   describe('Invalid Code', () => {
     ruleTester.run('invalid - dangerous patterns', noDebugModeProduction, {
       valid: [],
-      invalid: [
+      invalid: xmo([
         // Triggers debugModeProduction: debug mode in production
         {
           code: `mongoose.set('debug', true);`,
@@ -67,13 +112,13 @@ describe('no-debug-mode-production', () => {
         suggestions: [{ messageId: 'suggestionGateOnNodeEnv', output: `mongoose.set('debug', process.env.NODE_ENV !== 'production');` }],
       }],
         },
-      ],
+      ]),
     });
   });
 describe('Suggestions', () => {
     ruleTester.run('suggestion - gates debug on NODE_ENV', noDebugModeProduction, {
       valid: [],
-      invalid: [
+      invalid: xmo([
         {
           code: `mongoose.set('debug', true);`,
           errors: [{
@@ -84,7 +129,7 @@ describe('Suggestions', () => {
             }],
           }],
         },
-      ],
+      ]),
     });
   });
 });

--- a/packages/eslint-plugin-mongodb-security/src/rules/no-hardcoded-connection-string/index.spec.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/no-hardcoded-connection-string/index.spec.ts
@@ -1,10 +1,55 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { noHardcodedConnectionString } from '../no-hardcoded-connection-string/index';
 
+/**
+ * Every fixture imports mongoose, because the rules now abstain in files with
+ * no Mongo in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass
+ * vacuously on the gate instead of exercising the detection it was written
+ * for. `output` and errors[].suggestions[].output are prefixed too, since
+ * autofix fixtures assert the whole file back.
+ */
+// A SIDE-EFFECT import: satisfies the gate without reserving any binding, so
+// fixtures that already declare `mongoose`/`db` do not redeclare.
+const asMongo = (code: string): string => `import 'mongoose';\n${code}`;
+type MongoSuggestion = { output?: string | null };
+type MongoCase = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly MongoSuggestion[] } | string>;
+};
+const xmo = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asMongo(c) as T;
+    const test = c as MongoCase;
+    return {
+      ...c,
+      code: asMongo(test.code),
+      ...(typeof test.output === 'string' ? { output: asMongo(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !Array.isArray(e.suggestions)
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asMongo(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 const ruleTester = new RuleTester();
 
 ruleTester.run('no-hardcoded-connection-string', noHardcodedConnectionString, {
-  valid: [
+  valid: xmo([
     // Environment variable reference
     `const uri = process.env.MONGODB_URI;`,
     // Variable (not a literal)
@@ -18,9 +63,9 @@ ruleTester.run('no-hardcoded-connection-string', noHardcodedConnectionString, {
       code: `const uri = 'mongodb://localhost:27017/test';`,
       filename: 'db.test.ts',
     },
-  ],
+  ]),
 
-  invalid: [
+  invalid: xmo([
     // Basic mongodb:// URI
     {
       code: `const uri = 'mongodb://localhost:27017/mydb';`,
@@ -48,5 +93,5 @@ ruleTester.run('no-hardcoded-connection-string', noHardcodedConnectionString, {
       options: [{ allowInTests: false }],
       errors: [{ messageId: 'hardcodedConnectionString' }],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-mongodb-security/src/rules/no-hardcoded-connection-string/index.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/no-hardcoded-connection-string/index.ts
@@ -12,6 +12,7 @@
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
 import { createRule, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
 import { isTestFile } from '../../utils/paths';
+import { fileUsesMongo } from '../../utils/mongo-evidence';
 
 type MessageIds = 'hardcodedConnectionString';
 export interface Options { allowInTests?: boolean; }
@@ -44,6 +45,14 @@ export const noHardcodedConnectionString = createRule<RuleOptions, MessageIds>({
   },
   defaultOptions: [{ allowInTests: true }],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>) {
+    // Every rule here is MongoDB-specific, and none of them could ask the
+    // file-level question: over the corpus, 47% of this plugin's findings were
+    // in files with no Mongo in them. `receiver.ts` discriminates by receiver
+    // NAME, which matches `userModel.findOne()` in a TypeORM repository just as
+    // well as in a Mongoose one. Registering no visitors is both the gate and
+    // the cheap path.
+    if (!fileUsesMongo(context.sourceCode.ast)) return {};
+
     const [options = {}] = context.options;
     const { allowInTests = true } = options as Options;
     const filename = context.filename;

--- a/packages/eslint-plugin-mongodb-security/src/rules/no-hardcoded-connection-string/no-hardcoded-connection-string.test.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/no-hardcoded-connection-string/no-hardcoded-connection-string.test.ts
@@ -10,6 +10,51 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { noHardcodedConnectionString } from './index';
 
+/**
+ * Every fixture imports mongoose, because the rules now abstain in files with
+ * no Mongo in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass
+ * vacuously on the gate instead of exercising the detection it was written
+ * for. `output` and errors[].suggestions[].output are prefixed too, since
+ * autofix fixtures assert the whole file back.
+ */
+// A SIDE-EFFECT import: satisfies the gate without reserving any binding, so
+// fixtures that already declare `mongoose`/`db` do not redeclare.
+const asMongo = (code: string): string => `import 'mongoose';\n${code}`;
+type MongoSuggestion = { output?: string | null };
+type MongoCase = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly MongoSuggestion[] } | string>;
+};
+const xmo = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asMongo(c) as T;
+    const test = c as MongoCase;
+    return {
+      ...c,
+      code: asMongo(test.code),
+      ...(typeof test.output === 'string' ? { output: asMongo(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !Array.isArray(e.suggestions)
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asMongo(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -27,7 +72,7 @@ const ruleTester = new RuleTester({
 describe('no-hardcoded-connection-string', () => {
   describe('Valid Code', () => {
     ruleTester.run('valid - safe patterns', noHardcodedConnectionString, {
-      valid: [
+      valid: xmo([
         // Unrelated code should not trigger
         {
           code: `const x = 1;`,
@@ -50,7 +95,7 @@ describe('no-hardcoded-connection-string', () => {
         {
           code: `const safe4 = process.env.DB_HOST;`,
         },
-      ],
+      ]),
       invalid: [],
     });
   });
@@ -58,13 +103,13 @@ describe('no-hardcoded-connection-string', () => {
   describe('Invalid Code', () => {
     ruleTester.run('invalid - dangerous patterns', noHardcodedConnectionString, {
       valid: [],
-      invalid: [
+      invalid: xmo([
         // Triggers hardcodedConnectionString: hardcoded connection string
         {
           code: `mongoose.connect('mongodb://user:pass@host:27017/db');`,
           errors: [{ messageId: 'hardcodedConnectionString' }],
         },
-      ],
+      ]),
     });
   });
 });

--- a/packages/eslint-plugin-mongodb-security/src/rules/no-hardcoded-credentials/index.spec.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/no-hardcoded-credentials/index.spec.ts
@@ -1,10 +1,55 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { noHardcodedCredentials } from '../no-hardcoded-credentials/index';
 
+/**
+ * Every fixture imports mongoose, because the rules now abstain in files with
+ * no Mongo in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass
+ * vacuously on the gate instead of exercising the detection it was written
+ * for. `output` and errors[].suggestions[].output are prefixed too, since
+ * autofix fixtures assert the whole file back.
+ */
+// A SIDE-EFFECT import: satisfies the gate without reserving any binding, so
+// fixtures that already declare `mongoose`/`db` do not redeclare.
+const asMongo = (code: string): string => `import 'mongoose';\n${code}`;
+type MongoSuggestion = { output?: string | null };
+type MongoCase = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly MongoSuggestion[] } | string>;
+};
+const xmo = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asMongo(c) as T;
+    const test = c as MongoCase;
+    return {
+      ...c,
+      code: asMongo(test.code),
+      ...(typeof test.output === 'string' ? { output: asMongo(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !Array.isArray(e.suggestions)
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asMongo(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 const ruleTester = new RuleTester();
 
 ruleTester.run('no-hardcoded-credentials', noHardcodedCredentials, {
-  valid: [
+  valid: xmo([
     // Environment variable
     `const opts = { user: process.env.DB_USER };`,
     // Variable reference
@@ -22,9 +67,9 @@ ruleTester.run('no-hardcoded-credentials', noHardcodedCredentials, {
       code: `const opts = { password: 'secret123' };`,
       filename: 'db.test.ts',
     },
-  ],
+  ]),
 
-  invalid: [
+  invalid: xmo([
     // Hardcoded password
     {
       code: `const opts = { password: 'secret123' };`,
@@ -65,5 +110,5 @@ ruleTester.run('no-hardcoded-credentials', noHardcodedCredentials, {
       options: [{ allowInTests: false }],
       errors: [{ messageId: 'hardcodedCredentials' }],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-mongodb-security/src/rules/no-hardcoded-credentials/index.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/no-hardcoded-credentials/index.ts
@@ -12,6 +12,7 @@
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
 import { AST_NODE_TYPES, createRule, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
 import { isTestFile } from '../../utils/paths';
+import { fileUsesMongo } from '../../utils/mongo-evidence';
 
 type MessageIds = 'hardcodedCredentials';
 export interface Options { allowInTests?: boolean; }
@@ -44,6 +45,14 @@ export const noHardcodedCredentials = createRule<RuleOptions, MessageIds>({
   },
   defaultOptions: [{ allowInTests: true }],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>) {
+    // Every rule here is MongoDB-specific, and none of them could ask the
+    // file-level question: over the corpus, 47% of this plugin's findings were
+    // in files with no Mongo in them. `receiver.ts` discriminates by receiver
+    // NAME, which matches `userModel.findOne()` in a TypeORM repository just as
+    // well as in a Mongoose one. Registering no visitors is both the gate and
+    // the cheap path.
+    if (!fileUsesMongo(context.sourceCode.ast)) return {};
+
     const [options = {}] = context.options;
     const { allowInTests = true } = options as Options;
     const filename = context.filename;

--- a/packages/eslint-plugin-mongodb-security/src/rules/no-hardcoded-credentials/no-hardcoded-credentials.test.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/no-hardcoded-credentials/no-hardcoded-credentials.test.ts
@@ -10,6 +10,51 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { noHardcodedCredentials } from './index';
 
+/**
+ * Every fixture imports mongoose, because the rules now abstain in files with
+ * no Mongo in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass
+ * vacuously on the gate instead of exercising the detection it was written
+ * for. `output` and errors[].suggestions[].output are prefixed too, since
+ * autofix fixtures assert the whole file back.
+ */
+// A SIDE-EFFECT import: satisfies the gate without reserving any binding, so
+// fixtures that already declare `mongoose`/`db` do not redeclare.
+const asMongo = (code: string): string => `import 'mongoose';\n${code}`;
+type MongoSuggestion = { output?: string | null };
+type MongoCase = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly MongoSuggestion[] } | string>;
+};
+const xmo = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asMongo(c) as T;
+    const test = c as MongoCase;
+    return {
+      ...c,
+      code: asMongo(test.code),
+      ...(typeof test.output === 'string' ? { output: asMongo(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !Array.isArray(e.suggestions)
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asMongo(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -27,7 +72,7 @@ const ruleTester = new RuleTester({
 describe('no-hardcoded-credentials', () => {
   describe('Valid Code', () => {
     ruleTester.run('valid - safe patterns', noHardcodedCredentials, {
-      valid: [
+      valid: xmo([
         // Unrelated code should not trigger
         {
           code: `const x = 1;`,
@@ -50,7 +95,7 @@ describe('no-hardcoded-credentials', () => {
           filename: 'test.spec.ts',
           options: [{"allowInTests":true}],
         },
-      ],
+      ]),
       invalid: [],
     });
   });
@@ -58,13 +103,13 @@ describe('no-hardcoded-credentials', () => {
   describe('Invalid Code', () => {
     ruleTester.run('invalid - dangerous patterns', noHardcodedCredentials, {
       valid: [],
-      invalid: [
+      invalid: xmo([
         // Triggers hardcodedCredentials: hardcoded credentials
         {
           code: `const opts = { username: "admin", password: "secret123" };`,
           errors: [{ messageId: 'hardcodedCredentials' }, { messageId: 'hardcodedCredentials' }],
         },
-      ],
+      ]),
     });
   });
 });

--- a/packages/eslint-plugin-mongodb-security/src/rules/no-operator-injection/index.spec.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/no-operator-injection/index.spec.ts
@@ -1,10 +1,55 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { noOperatorInjection } from '../no-operator-injection/index';
 
+/**
+ * Every fixture imports mongoose, because the rules now abstain in files with
+ * no Mongo in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass
+ * vacuously on the gate instead of exercising the detection it was written
+ * for. `output` and errors[].suggestions[].output are prefixed too, since
+ * autofix fixtures assert the whole file back.
+ */
+// A SIDE-EFFECT import: satisfies the gate without reserving any binding, so
+// fixtures that already declare `mongoose`/`db` do not redeclare.
+const asMongo = (code: string): string => `import 'mongoose';\n${code}`;
+type MongoSuggestion = { output?: string | null };
+type MongoCase = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly MongoSuggestion[] } | string>;
+};
+const xmo = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asMongo(c) as T;
+    const test = c as MongoCase;
+    return {
+      ...c,
+      code: asMongo(test.code),
+      ...(typeof test.output === 'string' ? { output: asMongo(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !Array.isArray(e.suggestions)
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asMongo(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 const ruleTester = new RuleTester();
 
 ruleTester.run('no-operator-injection', noOperatorInjection, {
-  valid: [
+  valid: xmo([
     // Static values in operators
     `User.find({ age: { $gt: 18 } });`,
     // No user input
@@ -18,9 +63,9 @@ ruleTester.run('no-operator-injection', noOperatorInjection, {
       code: `User.find({ age: { $ne: req.body.age } });`,
       filename: 'query.test.ts',
     },
-  ],
+  ]),
 
-  invalid: [
+  invalid: xmo([
     // $ne with user input
     {
       code: `User.find({ age: { $ne: req.body.age } });`,
@@ -53,5 +98,5 @@ ruleTester.run('no-operator-injection', noOperatorInjection, {
       options: [{ allowInTests: false }],
       errors: [{ messageId: 'operatorInjection' }],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-mongodb-security/src/rules/no-operator-injection/index.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/no-operator-injection/index.ts
@@ -14,6 +14,7 @@
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
 import { AST_NODE_TYPES, createRule, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
 import { isTestFile } from '../../utils/paths';
+import { fileUsesMongo } from '../../utils/mongo-evidence';
 
 type MessageIds = 'operatorInjection';
 export interface Options { allowInTests?: boolean; }
@@ -48,6 +49,14 @@ export const noOperatorInjection = createRule<RuleOptions, MessageIds>({
   },
   defaultOptions: [{ allowInTests: true }],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>) {
+    // Every rule here is MongoDB-specific, and none of them could ask the
+    // file-level question: over the corpus, 47% of this plugin's findings were
+    // in files with no Mongo in them. `receiver.ts` discriminates by receiver
+    // NAME, which matches `userModel.findOne()` in a TypeORM repository just as
+    // well as in a Mongoose one. Registering no visitors is both the gate and
+    // the cheap path.
+    if (!fileUsesMongo(context.sourceCode.ast)) return {};
+
     const [options = {}] = context.options;
     const { allowInTests = true } = options as Options;
     const filename = context.filename;

--- a/packages/eslint-plugin-mongodb-security/src/rules/no-operator-injection/no-operator-injection.test.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/no-operator-injection/no-operator-injection.test.ts
@@ -10,6 +10,51 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { noOperatorInjection } from './index';
 
+/**
+ * Every fixture imports mongoose, because the rules now abstain in files with
+ * no Mongo in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass
+ * vacuously on the gate instead of exercising the detection it was written
+ * for. `output` and errors[].suggestions[].output are prefixed too, since
+ * autofix fixtures assert the whole file back.
+ */
+// A SIDE-EFFECT import: satisfies the gate without reserving any binding, so
+// fixtures that already declare `mongoose`/`db` do not redeclare.
+const asMongo = (code: string): string => `import 'mongoose';\n${code}`;
+type MongoSuggestion = { output?: string | null };
+type MongoCase = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly MongoSuggestion[] } | string>;
+};
+const xmo = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asMongo(c) as T;
+    const test = c as MongoCase;
+    return {
+      ...c,
+      code: asMongo(test.code),
+      ...(typeof test.output === 'string' ? { output: asMongo(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !Array.isArray(e.suggestions)
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asMongo(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -27,7 +72,7 @@ const ruleTester = new RuleTester({
 describe('no-operator-injection', () => {
   describe('Valid Code', () => {
     ruleTester.run('valid - safe patterns', noOperatorInjection, {
-      valid: [
+      valid: xmo([
         // Unrelated code should not trigger
         {
           code: `const x = 1;`,
@@ -50,7 +95,7 @@ describe('no-operator-injection', () => {
         {
           code: `const safe4 = process.env.DB_HOST;`,
         },
-      ],
+      ]),
       invalid: [],
     });
   });
@@ -58,13 +103,13 @@ describe('no-operator-injection', () => {
   describe('Invalid Code', () => {
     ruleTester.run('invalid - dangerous patterns', noOperatorInjection, {
       valid: [],
-      invalid: [
+      invalid: xmo([
         // Triggers operatorInjection: operator from user input
         {
           code: `const filter = { $ne: req.body.value };`,
           errors: [{ messageId: 'operatorInjection' }],
         },
-      ],
+      ]),
     });
   });
 });

--- a/packages/eslint-plugin-mongodb-security/src/rules/no-select-sensitive-fields/index.spec.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/no-select-sensitive-fields/index.spec.ts
@@ -1,10 +1,55 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { noSelectSensitiveFields } from '../no-select-sensitive-fields/index';
 
+/**
+ * Every fixture imports mongoose, because the rules now abstain in files with
+ * no Mongo in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass
+ * vacuously on the gate instead of exercising the detection it was written
+ * for. `output` and errors[].suggestions[].output are prefixed too, since
+ * autofix fixtures assert the whole file back.
+ */
+// A SIDE-EFFECT import: satisfies the gate without reserving any binding, so
+// fixtures that already declare `mongoose`/`db` do not redeclare.
+const asMongo = (code: string): string => `import 'mongoose';\n${code}`;
+type MongoSuggestion = { output?: string | null };
+type MongoCase = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly MongoSuggestion[] } | string>;
+};
+const xmo = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asMongo(c) as T;
+    const test = c as MongoCase;
+    return {
+      ...c,
+      code: asMongo(test.code),
+      ...(typeof test.output === 'string' ? { output: asMongo(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !Array.isArray(e.suggestions)
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asMongo(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 const ruleTester = new RuleTester();
 
 ruleTester.run('no-select-sensitive-fields', noSelectSensitiveFields, {
-  valid: [
+  valid: xmo([
     // Query with .select() excluding sensitive fields
     `User.find({}).select("-password -refreshToken");`,
     // Query with .select() returning only safe fields
@@ -22,9 +67,9 @@ ruleTester.run('no-select-sensitive-fields', noSelectSensitiveFields, {
     `User.findOne({ email }).select("-password -secret");`,
     // findById with select
     `User.findById(id).select("name");`,
-  ],
+  ]),
 
-  invalid: [
+  invalid: xmo([
     // find without .select(), schema in view
     {
       code: `const userSchema = new Schema({ email: String, password: String });\nUser.find({});`,
@@ -52,5 +97,5 @@ ruleTester.run('no-select-sensitive-fields', noSelectSensitiveFields, {
       options: [{ allowInTests: false }],
       errors: [{ messageId: 'selectSensitiveFields' }],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-mongodb-security/src/rules/no-select-sensitive-fields/index.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/no-select-sensitive-fields/index.ts
@@ -13,6 +13,7 @@ import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
 import { AST_NODE_TYPES, createRule, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
 import { isTestFile } from '../../utils/paths';
 import { analyzeMongoScope } from '../../utils/receiver';
+import { fileUsesMongo } from '../../utils/mongo-evidence';
 
 type MessageIds = 'selectSensitiveFields';
 export interface Options {
@@ -63,6 +64,14 @@ export const noSelectSensitiveFields = createRule<RuleOptions, MessageIds>({
   },
   defaultOptions: [{ allowInTests: true, sensitiveFields: DEFAULT_SENSITIVE_FIELDS, requireVisibleSensitiveField: true }],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>) {
+    // Every rule here is MongoDB-specific, and none of them could ask the
+    // file-level question: over the corpus, 47% of this plugin's findings were
+    // in files with no Mongo in them. `receiver.ts` discriminates by receiver
+    // NAME, which matches `userModel.findOne()` in a TypeORM repository just as
+    // well as in a Mongoose one. Registering no visitors is both the gate and
+    // the cheap path.
+    if (!fileUsesMongo(context.sourceCode.ast)) return {};
+
     const [options = {}] = context.options;
     const {
       allowInTests = true,

--- a/packages/eslint-plugin-mongodb-security/src/rules/no-select-sensitive-fields/no-select-sensitive-fields.test.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/no-select-sensitive-fields/no-select-sensitive-fields.test.ts
@@ -10,6 +10,51 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { noSelectSensitiveFields } from './index';
 
+/**
+ * Every fixture imports mongoose, because the rules now abstain in files with
+ * no Mongo in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass
+ * vacuously on the gate instead of exercising the detection it was written
+ * for. `output` and errors[].suggestions[].output are prefixed too, since
+ * autofix fixtures assert the whole file back.
+ */
+// A SIDE-EFFECT import: satisfies the gate without reserving any binding, so
+// fixtures that already declare `mongoose`/`db` do not redeclare.
+const asMongo = (code: string): string => `import 'mongoose';\n${code}`;
+type MongoSuggestion = { output?: string | null };
+type MongoCase = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly MongoSuggestion[] } | string>;
+};
+const xmo = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asMongo(c) as T;
+    const test = c as MongoCase;
+    return {
+      ...c,
+      code: asMongo(test.code),
+      ...(typeof test.output === 'string' ? { output: asMongo(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !Array.isArray(e.suggestions)
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asMongo(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -27,7 +72,7 @@ const ruleTester = new RuleTester({
 describe('no-select-sensitive-fields', () => {
   describe('Valid Code', () => {
     ruleTester.run('valid - safe patterns', noSelectSensitiveFields, {
-      valid: [
+      valid: xmo([
         // Unrelated code should not trigger
         {
           code: `const x = 1;`,
@@ -50,7 +95,7 @@ describe('no-select-sensitive-fields', () => {
         {
           code: `const safe4 = process.env.DB_HOST;`,
         },
-      ],
+      ]),
       invalid: [],
     });
   });
@@ -58,13 +103,13 @@ describe('no-select-sensitive-fields', () => {
   describe('Invalid Code', () => {
     ruleTester.run('invalid - dangerous patterns', noSelectSensitiveFields, {
       valid: [],
-      invalid: [
+      invalid: xmo([
         // Triggers selectSensitiveFields: user input in query
         {
           code: `const userSchema = new Schema({ email: String, password: String });\ndb.users.find({ username: req.body.username });`,
           errors: [{ messageId: 'selectSensitiveFields' }],
         },
-      ],
+      ]),
     });
   });
 });

--- a/packages/eslint-plugin-mongodb-security/src/rules/no-unbounded-find/index.spec.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/no-unbounded-find/index.spec.ts
@@ -1,10 +1,55 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { noUnboundedFind } from '../no-unbounded-find/index';
 
+/**
+ * Every fixture imports mongoose, because the rules now abstain in files with
+ * no Mongo in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass
+ * vacuously on the gate instead of exercising the detection it was written
+ * for. `output` and errors[].suggestions[].output are prefixed too, since
+ * autofix fixtures assert the whole file back.
+ */
+// A SIDE-EFFECT import: satisfies the gate without reserving any binding, so
+// fixtures that already declare `mongoose`/`db` do not redeclare.
+const asMongo = (code: string): string => `import 'mongoose';\n${code}`;
+type MongoSuggestion = { output?: string | null };
+type MongoCase = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly MongoSuggestion[] } | string>;
+};
+const xmo = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asMongo(c) as T;
+    const test = c as MongoCase;
+    return {
+      ...c,
+      code: asMongo(test.code),
+      ...(typeof test.output === 'string' ? { output: asMongo(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !Array.isArray(e.suggestions)
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asMongo(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 const ruleTester = new RuleTester();
 
 ruleTester.run('no-unbounded-find', noUnboundedFind, {
-  valid: [
+  valid: xmo([
     // find with limit chained
     `User.find({}).limit(100);`,
     // Not a member expression
@@ -22,9 +67,9 @@ ruleTester.run('no-unbounded-find', noUnboundedFind, {
     `db.collection('u').find({ a: 1 }, { projection: { _id: 1 } }).select('-password').limit(100).toArray();`,
     // Native driver: limit option in 2nd arg
     `db.collection('u').find({ a: 1 }, { limit: 50 });`,
-  ],
+  ]),
 
-  invalid: [
+  invalid: xmo([
     // find without limit
     {
       code: `User.find({});`,
@@ -59,5 +104,5 @@ ruleTester.run('no-unbounded-find', noUnboundedFind, {
         suggestions: [{ messageId: 'suggestionAddLimit', output: `User.find({}).limit(100);` }],
       }],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-mongodb-security/src/rules/no-unbounded-find/index.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/no-unbounded-find/index.ts
@@ -13,6 +13,7 @@ import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
 import { AST_NODE_TYPES, createRule, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
 import { isTestFile } from '../../utils/paths';
 import { analyzeMongoScope } from '../../utils/receiver';
+import { fileUsesMongo } from '../../utils/mongo-evidence';
 
 type MessageIds = 'unboundedFind' | 'suggestionAddLimit';
 export interface Options { allowInTests?: boolean; }
@@ -51,6 +52,14 @@ export const noUnboundedFind = createRule<RuleOptions, MessageIds>({
   },
   defaultOptions: [{ allowInTests: true }],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>) {
+    // Every rule here is MongoDB-specific, and none of them could ask the
+    // file-level question: over the corpus, 47% of this plugin's findings were
+    // in files with no Mongo in them. `receiver.ts` discriminates by receiver
+    // NAME, which matches `userModel.findOne()` in a TypeORM repository just as
+    // well as in a Mongoose one. Registering no visitors is both the gate and
+    // the cheap path.
+    if (!fileUsesMongo(context.sourceCode.ast)) return {};
+
     const [options = {}] = context.options;
     const { allowInTests = true } = options as Options;
     const filename = context.filename;

--- a/packages/eslint-plugin-mongodb-security/src/rules/no-unbounded-find/no-unbounded-find.test.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/no-unbounded-find/no-unbounded-find.test.ts
@@ -10,6 +10,51 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { noUnboundedFind } from './index';
 
+/**
+ * Every fixture imports mongoose, because the rules now abstain in files with
+ * no Mongo in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass
+ * vacuously on the gate instead of exercising the detection it was written
+ * for. `output` and errors[].suggestions[].output are prefixed too, since
+ * autofix fixtures assert the whole file back.
+ */
+// A SIDE-EFFECT import: satisfies the gate without reserving any binding, so
+// fixtures that already declare `mongoose`/`db` do not redeclare.
+const asMongo = (code: string): string => `import 'mongoose';\n${code}`;
+type MongoSuggestion = { output?: string | null };
+type MongoCase = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly MongoSuggestion[] } | string>;
+};
+const xmo = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asMongo(c) as T;
+    const test = c as MongoCase;
+    return {
+      ...c,
+      code: asMongo(test.code),
+      ...(typeof test.output === 'string' ? { output: asMongo(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !Array.isArray(e.suggestions)
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asMongo(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -27,7 +72,7 @@ const ruleTester = new RuleTester({
 describe('no-unbounded-find', () => {
   describe('Valid Code', () => {
     ruleTester.run('valid - safe patterns', noUnboundedFind, {
-      valid: [
+      valid: xmo([
         // Unrelated code should not trigger
         {
           code: `const x = 1;`,
@@ -50,7 +95,7 @@ describe('no-unbounded-find', () => {
         {
           code: `const safe4 = process.env.DB_HOST;`,
         },
-      ],
+      ]),
       invalid: [],
     });
   });
@@ -58,7 +103,7 @@ describe('no-unbounded-find', () => {
   describe('Invalid Code', () => {
     ruleTester.run('invalid - dangerous patterns', noUnboundedFind, {
       valid: [],
-      invalid: [
+      invalid: xmo([
         // Triggers unboundedFind: unbounded find without limit
         {
           code: `const results = await Model.find({});`,
@@ -67,13 +112,13 @@ describe('no-unbounded-find', () => {
         suggestions: [{ messageId: 'suggestionAddLimit', output: `const results = await Model.find({}).limit(100);` }],
       }],
         },
-      ],
+      ]),
     });
   });
 describe('Suggestions', () => {
     ruleTester.run('suggestion - appends .limit(100)', noUnboundedFind, {
       valid: [],
-      invalid: [
+      invalid: xmo([
         {
           code: `const docs = await Model.find({ active: true });`,
           errors: [{
@@ -84,7 +129,7 @@ describe('Suggestions', () => {
             }],
           }],
         },
-      ],
+      ]),
     });
   });
 });

--- a/packages/eslint-plugin-mongodb-security/src/rules/no-unsafe-populate/index.spec.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/no-unsafe-populate/index.spec.ts
@@ -1,10 +1,55 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { noUnsafePopulate } from '../no-unsafe-populate/index';
 
+/**
+ * Every fixture imports mongoose, because the rules now abstain in files with
+ * no Mongo in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass
+ * vacuously on the gate instead of exercising the detection it was written
+ * for. `output` and errors[].suggestions[].output are prefixed too, since
+ * autofix fixtures assert the whole file back.
+ */
+// A SIDE-EFFECT import: satisfies the gate without reserving any binding, so
+// fixtures that already declare `mongoose`/`db` do not redeclare.
+const asMongo = (code: string): string => `import 'mongoose';\n${code}`;
+type MongoSuggestion = { output?: string | null };
+type MongoCase = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly MongoSuggestion[] } | string>;
+};
+const xmo = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asMongo(c) as T;
+    const test = c as MongoCase;
+    return {
+      ...c,
+      code: asMongo(test.code),
+      ...(typeof test.output === 'string' ? { output: asMongo(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !Array.isArray(e.suggestions)
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asMongo(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 const ruleTester = new RuleTester();
 
 ruleTester.run('no-unsafe-populate', noUnsafePopulate, {
-  valid: [
+  valid: xmo([
     // Static string path
     `User.findOne({}).populate("posts");`,
     // Static string path with select
@@ -22,9 +67,9 @@ ruleTester.run('no-unsafe-populate', noUnsafePopulate, {
       code: `User.findOne({}).populate(req.body.field);`,
       filename: 'user.test.ts',
     },
-  ],
+  ]),
 
-  invalid: [
+  invalid: xmo([
     // Direct user input
     {
       code: `User.findOne({}).populate(req.body.field);`,
@@ -57,5 +102,5 @@ ruleTester.run('no-unsafe-populate', noUnsafePopulate, {
       options: [{ allowInTests: false }],
       errors: [{ messageId: 'unsafePopulate' }],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-mongodb-security/src/rules/no-unsafe-populate/index.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/no-unsafe-populate/index.ts
@@ -12,6 +12,7 @@
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
 import { AST_NODE_TYPES, createRule, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
 import { isTestFile } from '../../utils/paths';
+import { fileUsesMongo } from '../../utils/mongo-evidence';
 
 type MessageIds = 'unsafePopulate';
 export interface Options { allowInTests?: boolean; }
@@ -69,6 +70,14 @@ export const noUnsafePopulate = createRule<RuleOptions, MessageIds>({
   },
   defaultOptions: [{ allowInTests: true }],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>) {
+    // Every rule here is MongoDB-specific, and none of them could ask the
+    // file-level question: over the corpus, 47% of this plugin's findings were
+    // in files with no Mongo in them. `receiver.ts` discriminates by receiver
+    // NAME, which matches `userModel.findOne()` in a TypeORM repository just as
+    // well as in a Mongoose one. Registering no visitors is both the gate and
+    // the cheap path.
+    if (!fileUsesMongo(context.sourceCode.ast)) return {};
+
     const [options = {}] = context.options;
     const { allowInTests = true } = options as Options;
     const filename = context.filename;

--- a/packages/eslint-plugin-mongodb-security/src/rules/no-unsafe-populate/no-unsafe-populate.test.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/no-unsafe-populate/no-unsafe-populate.test.ts
@@ -10,6 +10,51 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { noUnsafePopulate } from './index';
 
+/**
+ * Every fixture imports mongoose, because the rules now abstain in files with
+ * no Mongo in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass
+ * vacuously on the gate instead of exercising the detection it was written
+ * for. `output` and errors[].suggestions[].output are prefixed too, since
+ * autofix fixtures assert the whole file back.
+ */
+// A SIDE-EFFECT import: satisfies the gate without reserving any binding, so
+// fixtures that already declare `mongoose`/`db` do not redeclare.
+const asMongo = (code: string): string => `import 'mongoose';\n${code}`;
+type MongoSuggestion = { output?: string | null };
+type MongoCase = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly MongoSuggestion[] } | string>;
+};
+const xmo = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asMongo(c) as T;
+    const test = c as MongoCase;
+    return {
+      ...c,
+      code: asMongo(test.code),
+      ...(typeof test.output === 'string' ? { output: asMongo(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !Array.isArray(e.suggestions)
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asMongo(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -27,7 +72,7 @@ const ruleTester = new RuleTester({
 describe('no-unsafe-populate', () => {
   describe('Valid Code', () => {
     ruleTester.run('valid - safe patterns', noUnsafePopulate, {
-      valid: [
+      valid: xmo([
         // Unrelated code should not trigger
         {
           code: `const x = 1;`,
@@ -50,7 +95,7 @@ describe('no-unsafe-populate', () => {
         {
           code: `const safe4 = process.env.DB_HOST;`,
         },
-      ],
+      ]),
       invalid: [],
     });
   });
@@ -58,13 +103,13 @@ describe('no-unsafe-populate', () => {
   describe('Invalid Code', () => {
     ruleTester.run('invalid - dangerous patterns', noUnsafePopulate, {
       valid: [],
-      invalid: [
+      invalid: xmo([
         // Triggers unsafePopulate: user-controlled populate
         {
           code: `User.find().populate(req.query.field);`,
           errors: [{ messageId: 'unsafePopulate' }],
         },
-      ],
+      ]),
     });
   });
 });

--- a/packages/eslint-plugin-mongodb-security/src/rules/no-unsafe-query/index.spec.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/no-unsafe-query/index.spec.ts
@@ -1,6 +1,51 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { noUnsafeQuery } from './index';
 
+/**
+ * Every fixture imports mongoose, because the rules now abstain in files with
+ * no Mongo in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass
+ * vacuously on the gate instead of exercising the detection it was written
+ * for. `output` and errors[].suggestions[].output are prefixed too, since
+ * autofix fixtures assert the whole file back.
+ */
+// A SIDE-EFFECT import: satisfies the gate without reserving any binding, so
+// fixtures that already declare `mongoose`/`db` do not redeclare.
+const asMongo = (code: string): string => `import 'mongoose';\n${code}`;
+type MongoSuggestion = { output?: string | null };
+type MongoCase = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly MongoSuggestion[] } | string>;
+};
+const xmo = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asMongo(c) as T;
+    const test = c as MongoCase;
+    return {
+      ...c,
+      code: asMongo(test.code),
+      ...(typeof test.output === 'string' ? { output: asMongo(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !Array.isArray(e.suggestions)
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asMongo(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 const ruleTester = new RuleTester();
 
 /**
@@ -30,7 +75,7 @@ function createInvalidCase(
 }
 
 ruleTester.run('no-unsafe-query', noUnsafeQuery, {
-  valid: [
+  valid: xmo([
     // =================================================================
     // TRUE NEGATIVES: Safe patterns that should NOT trigger
     // =================================================================
@@ -110,9 +155,9 @@ ruleTester.run('no-unsafe-query', noUnsafeQuery, {
       code: `User.customFindMethod({ email: req.body.email })`,
       options: [{ additionalMethods: ['otherMethod'] }],
     },
-  ],
+  ]),
 
-  invalid: [
+  invalid: xmo([
     // =================================================================
     // TRUE POSITIVES: Vulnerable patterns that MUST trigger
     // =================================================================
@@ -248,5 +293,5 @@ ruleTester.run('no-unsafe-query', noUnsafeQuery, {
       `User.customFind({ email: { $eq: req.body.email } })`,
       { options: [{ additionalMethods: ['customFind'] }] }
     ),
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-mongodb-security/src/rules/no-unsafe-query/index.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/no-unsafe-query/index.ts
@@ -20,6 +20,7 @@ import {
   MessageIcons,
 } from '@interlace/eslint-devkit';
 import { isTestFile } from '../../utils/paths';
+import { fileUsesMongo } from '../../utils/mongo-evidence';
 
 type MessageIds = 'unsafeQuery' | 'suggestionUseEq';
 
@@ -201,6 +202,14 @@ export const noUnsafeQuery = createRule<RuleOptions, MessageIds>({
     context: TSESLint.RuleContext<MessageIds, RuleOptions>,
     [options = {}]
   ) {
+    // Every rule here is MongoDB-specific, and none of them could ask the
+    // file-level question: over the corpus, 47% of this plugin's findings were
+    // in files with no Mongo in them. `receiver.ts` discriminates by receiver
+    // NAME, which matches `userModel.findOne()` in a TypeORM repository just as
+    // well as in a Mongoose one. Registering no visitors is both the gate and
+    // the cheap path.
+    if (!fileUsesMongo(context.sourceCode.ast)) return {};
+
     const { allowInTests = true, additionalMethods = [] } = options as Options;
     const filename = context.filename;
     const inTestFile = isTestFile(filename);

--- a/packages/eslint-plugin-mongodb-security/src/rules/no-unsafe-query/no-unsafe-query.test.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/no-unsafe-query/no-unsafe-query.test.ts
@@ -10,6 +10,51 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { noUnsafeQuery } from './index';
 
+/**
+ * Every fixture imports mongoose, because the rules now abstain in files with
+ * no Mongo in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass
+ * vacuously on the gate instead of exercising the detection it was written
+ * for. `output` and errors[].suggestions[].output are prefixed too, since
+ * autofix fixtures assert the whole file back.
+ */
+// A SIDE-EFFECT import: satisfies the gate without reserving any binding, so
+// fixtures that already declare `mongoose`/`db` do not redeclare.
+const asMongo = (code: string): string => `import 'mongoose';\n${code}`;
+type MongoSuggestion = { output?: string | null };
+type MongoCase = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly MongoSuggestion[] } | string>;
+};
+const xmo = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asMongo(c) as T;
+    const test = c as MongoCase;
+    return {
+      ...c,
+      code: asMongo(test.code),
+      ...(typeof test.output === 'string' ? { output: asMongo(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !Array.isArray(e.suggestions)
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asMongo(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -27,7 +72,7 @@ const ruleTester = new RuleTester({
 describe('no-unsafe-query', () => {
   describe('Valid Code', () => {
     ruleTester.run('valid - safe patterns', noUnsafeQuery, {
-      valid: [
+      valid: xmo([
         // Unrelated code should not trigger
         {
           code: `const x = 1;`,
@@ -50,7 +95,7 @@ describe('no-unsafe-query', () => {
           filename: 'test.spec.ts',
           options: [{"allowInTests":true}],
         },
-      ],
+      ]),
       invalid: [],
     });
   });
@@ -58,7 +103,7 @@ describe('no-unsafe-query', () => {
   describe('Invalid Code', () => {
     ruleTester.run('invalid - dangerous patterns', noUnsafeQuery, {
       valid: [],
-      invalid: [
+      invalid: xmo([
         // Triggers unsafeQuery: user input in query
         {
           code: `db.users.find({ username: req.body.username });`,
@@ -67,7 +112,7 @@ describe('no-unsafe-query', () => {
             suggestions: [{ messageId: 'suggestionUseEq', output: `db.users.find({ username: { $eq: req.body.username } });` }],
           }],
         },
-      ],
+      ]),
     });
   });
 });

--- a/packages/eslint-plugin-mongodb-security/src/rules/no-unsafe-regex-query/index.spec.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/no-unsafe-regex-query/index.spec.ts
@@ -1,10 +1,55 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { noUnsafeRegexQuery } from '../no-unsafe-regex-query/index';
 
+/**
+ * Every fixture imports mongoose, because the rules now abstain in files with
+ * no Mongo in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass
+ * vacuously on the gate instead of exercising the detection it was written
+ * for. `output` and errors[].suggestions[].output are prefixed too, since
+ * autofix fixtures assert the whole file back.
+ */
+// A SIDE-EFFECT import: satisfies the gate without reserving any binding, so
+// fixtures that already declare `mongoose`/`db` do not redeclare.
+const asMongo = (code: string): string => `import 'mongoose';\n${code}`;
+type MongoSuggestion = { output?: string | null };
+type MongoCase = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly MongoSuggestion[] } | string>;
+};
+const xmo = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asMongo(c) as T;
+    const test = c as MongoCase;
+    return {
+      ...c,
+      code: asMongo(test.code),
+      ...(typeof test.output === 'string' ? { output: asMongo(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !Array.isArray(e.suggestions)
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asMongo(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 const ruleTester = new RuleTester();
 
 ruleTester.run('no-unsafe-regex-query', noUnsafeRegexQuery, {
-  valid: [
+  valid: xmo([
     // Static regex
     `User.find({ name: { $regex: /^john/i } });`,
     // Static string regex
@@ -20,9 +65,9 @@ ruleTester.run('no-unsafe-regex-query', noUnsafeRegexQuery, {
       code: `User.find({ name: { $regex: req.body.search } });`,
       filename: 'search.test.ts',
     },
-  ],
+  ]),
 
-  invalid: [
+  invalid: xmo([
     // User input in $regex
     {
       code: `User.find({ name: { $regex: req.body.search } });`,
@@ -50,5 +95,5 @@ ruleTester.run('no-unsafe-regex-query', noUnsafeRegexQuery, {
       options: [{ allowInTests: false }],
       errors: [{ messageId: 'unsafeRegex' }],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-mongodb-security/src/rules/no-unsafe-regex-query/index.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/no-unsafe-regex-query/index.ts
@@ -12,6 +12,7 @@
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
 import { AST_NODE_TYPES, createRule, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
 import { isTestFile } from '../../utils/paths';
+import { fileUsesMongo } from '../../utils/mongo-evidence';
 
 type MessageIds = 'unsafeRegex';
 export interface Options { allowInTests?: boolean; }
@@ -75,6 +76,14 @@ export const noUnsafeRegexQuery = createRule<RuleOptions, MessageIds>({
   },
   defaultOptions: [{ allowInTests: true }],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>) {
+    // Every rule here is MongoDB-specific, and none of them could ask the
+    // file-level question: over the corpus, 47% of this plugin's findings were
+    // in files with no Mongo in them. `receiver.ts` discriminates by receiver
+    // NAME, which matches `userModel.findOne()` in a TypeORM repository just as
+    // well as in a Mongoose one. Registering no visitors is both the gate and
+    // the cheap path.
+    if (!fileUsesMongo(context.sourceCode.ast)) return {};
+
     const [options = {}] = context.options;
     const { allowInTests = true } = options as Options;
     const filename = context.filename;

--- a/packages/eslint-plugin-mongodb-security/src/rules/no-unsafe-regex-query/no-unsafe-regex-query.test.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/no-unsafe-regex-query/no-unsafe-regex-query.test.ts
@@ -10,6 +10,51 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { noUnsafeRegexQuery } from './index';
 
+/**
+ * Every fixture imports mongoose, because the rules now abstain in files with
+ * no Mongo in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass
+ * vacuously on the gate instead of exercising the detection it was written
+ * for. `output` and errors[].suggestions[].output are prefixed too, since
+ * autofix fixtures assert the whole file back.
+ */
+// A SIDE-EFFECT import: satisfies the gate without reserving any binding, so
+// fixtures that already declare `mongoose`/`db` do not redeclare.
+const asMongo = (code: string): string => `import 'mongoose';\n${code}`;
+type MongoSuggestion = { output?: string | null };
+type MongoCase = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly MongoSuggestion[] } | string>;
+};
+const xmo = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asMongo(c) as T;
+    const test = c as MongoCase;
+    return {
+      ...c,
+      code: asMongo(test.code),
+      ...(typeof test.output === 'string' ? { output: asMongo(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !Array.isArray(e.suggestions)
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asMongo(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -27,7 +72,7 @@ const ruleTester = new RuleTester({
 describe('no-unsafe-regex-query', () => {
   describe('Valid Code', () => {
     ruleTester.run('valid - safe patterns', noUnsafeRegexQuery, {
-      valid: [
+      valid: xmo([
         // Unrelated code should not trigger
         {
           code: `const x = 1;`,
@@ -50,7 +95,7 @@ describe('no-unsafe-regex-query', () => {
           filename: 'test.spec.ts',
           options: [{"allowInTests":true}],
         },
-      ],
+      ]),
       invalid: [],
     });
   });
@@ -58,13 +103,13 @@ describe('no-unsafe-regex-query', () => {
   describe('Invalid Code', () => {
     ruleTester.run('invalid - dangerous patterns', noUnsafeRegexQuery, {
       valid: [],
-      invalid: [
+      invalid: xmo([
         // Triggers unsafeRegex: user input in $regex operator
         {
           code: `db.users.find({ name: { $regex: req.body.pattern } });`,
           errors: [{ messageId: 'unsafeRegex' }],
         },
-      ],
+      ]),
     });
   });
 });

--- a/packages/eslint-plugin-mongodb-security/src/rules/no-unsafe-where/index.spec.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/no-unsafe-where/index.spec.ts
@@ -1,10 +1,55 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { noUnsafeWhere } from '../no-unsafe-where/index';
 
+/**
+ * Every fixture imports mongoose, because the rules now abstain in files with
+ * no Mongo in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass
+ * vacuously on the gate instead of exercising the detection it was written
+ * for. `output` and errors[].suggestions[].output are prefixed too, since
+ * autofix fixtures assert the whole file back.
+ */
+// A SIDE-EFFECT import: satisfies the gate without reserving any binding, so
+// fixtures that already declare `mongoose`/`db` do not redeclare.
+const asMongo = (code: string): string => `import 'mongoose';\n${code}`;
+type MongoSuggestion = { output?: string | null };
+type MongoCase = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly MongoSuggestion[] } | string>;
+};
+const xmo = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asMongo(c) as T;
+    const test = c as MongoCase;
+    return {
+      ...c,
+      code: asMongo(test.code),
+      ...(typeof test.output === 'string' ? { output: asMongo(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !Array.isArray(e.suggestions)
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asMongo(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 const ruleTester = new RuleTester();
 
 ruleTester.run('no-unsafe-where', noUnsafeWhere, {
-  valid: [
+  valid: xmo([
     // Normal query operators
     `User.find({ age: { $gt: 18 } });`,
     // Standard Mongoose where (field-based)
@@ -16,9 +61,9 @@ ruleTester.run('no-unsafe-where', noUnsafeWhere, {
       code: `User.find({ $where: 'this.age > 18' });`,
       filename: 'query.test.ts',
     },
-  ],
+  ]),
 
-  invalid: [
+  invalid: xmo([
     // $where in query object (string property)
     {
       code: `User.find({ $where: 'this.age > 18' });`,
@@ -46,5 +91,5 @@ ruleTester.run('no-unsafe-where', noUnsafeWhere, {
       options: [{ allowInTests: false }],
       errors: [{ messageId: 'unsafeWhere' }],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-mongodb-security/src/rules/no-unsafe-where/index.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/no-unsafe-where/index.ts
@@ -14,6 +14,7 @@
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
 import { AST_NODE_TYPES, createRule, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
 import { isTestFile } from '../../utils/paths';
+import { fileUsesMongo } from '../../utils/mongo-evidence';
 
 type MessageIds = 'unsafeWhere';
 export interface Options { allowInTests?: boolean; }
@@ -46,6 +47,14 @@ export const noUnsafeWhere = createRule<RuleOptions, MessageIds>({
   },
   defaultOptions: [{ allowInTests: true }],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>) {
+    // Every rule here is MongoDB-specific, and none of them could ask the
+    // file-level question: over the corpus, 47% of this plugin's findings were
+    // in files with no Mongo in them. `receiver.ts` discriminates by receiver
+    // NAME, which matches `userModel.findOne()` in a TypeORM repository just as
+    // well as in a Mongoose one. Registering no visitors is both the gate and
+    // the cheap path.
+    if (!fileUsesMongo(context.sourceCode.ast)) return {};
+
     const [options = {}] = context.options;
     const { allowInTests = true } = options as Options;
     const filename = context.filename;

--- a/packages/eslint-plugin-mongodb-security/src/rules/no-unsafe-where/no-unsafe-where.test.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/no-unsafe-where/no-unsafe-where.test.ts
@@ -10,6 +10,51 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { noUnsafeWhere } from './index';
 
+/**
+ * Every fixture imports mongoose, because the rules now abstain in files with
+ * no Mongo in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass
+ * vacuously on the gate instead of exercising the detection it was written
+ * for. `output` and errors[].suggestions[].output are prefixed too, since
+ * autofix fixtures assert the whole file back.
+ */
+// A SIDE-EFFECT import: satisfies the gate without reserving any binding, so
+// fixtures that already declare `mongoose`/`db` do not redeclare.
+const asMongo = (code: string): string => `import 'mongoose';\n${code}`;
+type MongoSuggestion = { output?: string | null };
+type MongoCase = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly MongoSuggestion[] } | string>;
+};
+const xmo = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asMongo(c) as T;
+    const test = c as MongoCase;
+    return {
+      ...c,
+      code: asMongo(test.code),
+      ...(typeof test.output === 'string' ? { output: asMongo(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !Array.isArray(e.suggestions)
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asMongo(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -27,7 +72,7 @@ const ruleTester = new RuleTester({
 describe('no-unsafe-where', () => {
   describe('Valid Code', () => {
     ruleTester.run('valid - safe patterns', noUnsafeWhere, {
-      valid: [
+      valid: xmo([
         // Unrelated code should not trigger
         {
           code: `const x = 1;`,
@@ -54,7 +99,7 @@ describe('no-unsafe-where', () => {
           filename: 'test.spec.ts',
           options: [{"allowInTests":true}],
         },
-      ],
+      ]),
       invalid: [],
     });
   });
@@ -62,13 +107,13 @@ describe('no-unsafe-where', () => {
   describe('Invalid Code', () => {
     ruleTester.run('invalid - dangerous patterns', noUnsafeWhere, {
       valid: [],
-      invalid: [
+      invalid: xmo([
         // Triggers unsafeWhere: $where enables RCE
         {
           code: `db.users.find({ $where: 'this.age > 18' });`,
           errors: [{ messageId: 'unsafeWhere' }],
         },
-      ],
+      ]),
     });
   });
 });

--- a/packages/eslint-plugin-mongodb-security/src/rules/require-auth-mechanism/index.spec.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/require-auth-mechanism/index.spec.ts
@@ -1,10 +1,55 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { requireAuthMechanism } from '../require-auth-mechanism/index';
 
+/**
+ * Every fixture imports mongoose, because the rules now abstain in files with
+ * no Mongo in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass
+ * vacuously on the gate instead of exercising the detection it was written
+ * for. `output` and errors[].suggestions[].output are prefixed too, since
+ * autofix fixtures assert the whole file back.
+ */
+// A SIDE-EFFECT import: satisfies the gate without reserving any binding, so
+// fixtures that already declare `mongoose`/`db` do not redeclare.
+const asMongo = (code: string): string => `import 'mongoose';\n${code}`;
+type MongoSuggestion = { output?: string | null };
+type MongoCase = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly MongoSuggestion[] } | string>;
+};
+const xmo = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asMongo(c) as T;
+    const test = c as MongoCase;
+    return {
+      ...c,
+      code: asMongo(test.code),
+      ...(typeof test.output === 'string' ? { output: asMongo(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !Array.isArray(e.suggestions)
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asMongo(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 const ruleTester = new RuleTester();
 
 ruleTester.run('require-auth-mechanism', requireAuthMechanism, {
-  valid: [
+  valid: xmo([
     // With authMechanism
     `mongoose.connect(uri, { authMechanism: "SCRAM-SHA-256" });`,
     // createConnection with authMechanism
@@ -18,9 +63,9 @@ ruleTester.run('require-auth-mechanism', requireAuthMechanism, {
       code: `mongoose.connect(uri);`,
       filename: 'db.test.ts',
     },
-  ],
+  ]),
 
-  invalid: [
+  invalid: xmo([
     // No options at all
     {
       code: `mongoose.connect(uri);`,
@@ -48,5 +93,5 @@ ruleTester.run('require-auth-mechanism', requireAuthMechanism, {
       options: [{ allowInTests: false }],
       errors: [{ messageId: 'requireAuthMechanism' }],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-mongodb-security/src/rules/require-auth-mechanism/index.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/require-auth-mechanism/index.ts
@@ -13,6 +13,7 @@ import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
 import { AST_NODE_TYPES, createRule, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
 import { isTestFile } from '../../utils/paths';
 import { analyzeMongoScope } from '../../utils/receiver';
+import { fileUsesMongo } from '../../utils/mongo-evidence';
 
 type MessageIds = 'requireAuthMechanism';
 export interface Options { allowInTests?: boolean; }
@@ -46,6 +47,14 @@ export const requireAuthMechanism = createRule<RuleOptions, MessageIds>({
   },
   defaultOptions: [{ allowInTests: true }],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>) {
+    // Every rule here is MongoDB-specific, and none of them could ask the
+    // file-level question: over the corpus, 47% of this plugin's findings were
+    // in files with no Mongo in them. `receiver.ts` discriminates by receiver
+    // NAME, which matches `userModel.findOne()` in a TypeORM repository just as
+    // well as in a Mongoose one. Registering no visitors is both the gate and
+    // the cheap path.
+    if (!fileUsesMongo(context.sourceCode.ast)) return {};
+
     const [options = {}] = context.options;
     const { allowInTests = true } = options as Options;
     const filename = context.filename;

--- a/packages/eslint-plugin-mongodb-security/src/rules/require-auth-mechanism/require-auth-mechanism.test.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/require-auth-mechanism/require-auth-mechanism.test.ts
@@ -10,6 +10,51 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { requireAuthMechanism } from './index';
 
+/**
+ * Every fixture imports mongoose, because the rules now abstain in files with
+ * no Mongo in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass
+ * vacuously on the gate instead of exercising the detection it was written
+ * for. `output` and errors[].suggestions[].output are prefixed too, since
+ * autofix fixtures assert the whole file back.
+ */
+// A SIDE-EFFECT import: satisfies the gate without reserving any binding, so
+// fixtures that already declare `mongoose`/`db` do not redeclare.
+const asMongo = (code: string): string => `import 'mongoose';\n${code}`;
+type MongoSuggestion = { output?: string | null };
+type MongoCase = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly MongoSuggestion[] } | string>;
+};
+const xmo = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asMongo(c) as T;
+    const test = c as MongoCase;
+    return {
+      ...c,
+      code: asMongo(test.code),
+      ...(typeof test.output === 'string' ? { output: asMongo(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !Array.isArray(e.suggestions)
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asMongo(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -27,7 +72,7 @@ const ruleTester = new RuleTester({
 describe('require-auth-mechanism', () => {
   describe('Valid Code', () => {
     ruleTester.run('valid - safe patterns', requireAuthMechanism, {
-      valid: [
+      valid: xmo([
         // Unrelated code should not trigger
         {
           code: `const x = 1;`,
@@ -54,7 +99,7 @@ describe('require-auth-mechanism', () => {
           filename: 'test.spec.ts',
           options: [{"allowInTests":true}],
         },
-      ],
+      ]),
       invalid: [],
     });
   });
@@ -62,13 +107,13 @@ describe('require-auth-mechanism', () => {
   describe('Invalid Code', () => {
     ruleTester.run('invalid - dangerous patterns', requireAuthMechanism, {
       valid: [],
-      invalid: [
+      invalid: xmo([
         // Triggers requireAuthMechanism: no auth mechanism
         {
           code: `mongoose.connect(uri, { });`,
           errors: [{ messageId: 'requireAuthMechanism' }],
         },
-      ],
+      ]),
     });
   });
 });

--- a/packages/eslint-plugin-mongodb-security/src/rules/require-lean-queries/index.spec.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/require-lean-queries/index.spec.ts
@@ -1,10 +1,55 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { requireLeanQueries } from '../require-lean-queries/index';
 
+/**
+ * Every fixture imports mongoose, because the rules now abstain in files with
+ * no Mongo in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass
+ * vacuously on the gate instead of exercising the detection it was written
+ * for. `output` and errors[].suggestions[].output are prefixed too, since
+ * autofix fixtures assert the whole file back.
+ */
+// A SIDE-EFFECT import: satisfies the gate without reserving any binding, so
+// fixtures that already declare `mongoose`/`db` do not redeclare.
+const asMongo = (code: string): string => `import 'mongoose';\n${code}`;
+type MongoSuggestion = { output?: string | null };
+type MongoCase = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly MongoSuggestion[] } | string>;
+};
+const xmo = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asMongo(c) as T;
+    const test = c as MongoCase;
+    return {
+      ...c,
+      code: asMongo(test.code),
+      ...(typeof test.output === 'string' ? { output: asMongo(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !Array.isArray(e.suggestions)
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asMongo(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 const ruleTester = new RuleTester();
 
 ruleTester.run('require-lean-queries', requireLeanQueries, {
-  valid: [
+  valid: xmo([
     // With .lean()
     `User.find({}).lean();`,
     // findOne with .lean()
@@ -22,9 +67,9 @@ ruleTester.run('require-lean-queries', requireLeanQueries, {
       code: `User.find({});`,
       filename: 'user.test.ts',
     },
-  ],
+  ]),
 
-  invalid: [
+  invalid: xmo([
     // find without .lean()
     {
       code: `User.find({});`,
@@ -67,5 +112,5 @@ ruleTester.run('require-lean-queries', requireLeanQueries, {
         suggestions: [{ messageId: 'suggestionAddLean', output: `User.find({}).lean();` }],
       }],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-mongodb-security/src/rules/require-lean-queries/index.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/require-lean-queries/index.ts
@@ -13,6 +13,7 @@ import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
 import { AST_NODE_TYPES, createRule, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
 import { isTestFile } from '../../utils/paths';
 import { analyzeMongoScope } from '../../utils/receiver';
+import { fileUsesMongo } from '../../utils/mongo-evidence';
 
 type MessageIds = 'useLean' | 'suggestionAddLean';
 export interface Options { allowInTests?: boolean; }
@@ -74,6 +75,14 @@ export const requireLeanQueries = createRule<RuleOptions, MessageIds>({
   },
   defaultOptions: [{ allowInTests: true }],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>) {
+    // Every rule here is MongoDB-specific, and none of them could ask the
+    // file-level question: over the corpus, 47% of this plugin's findings were
+    // in files with no Mongo in them. `receiver.ts` discriminates by receiver
+    // NAME, which matches `userModel.findOne()` in a TypeORM repository just as
+    // well as in a Mongoose one. Registering no visitors is both the gate and
+    // the cheap path.
+    if (!fileUsesMongo(context.sourceCode.ast)) return {};
+
     const [options = {}] = context.options;
     const { allowInTests = true } = options as Options;
     const filename = context.filename;

--- a/packages/eslint-plugin-mongodb-security/src/rules/require-lean-queries/require-lean-queries.test.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/require-lean-queries/require-lean-queries.test.ts
@@ -10,6 +10,51 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { requireLeanQueries } from './index';
 
+/**
+ * Every fixture imports mongoose, because the rules now abstain in files with
+ * no Mongo in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass
+ * vacuously on the gate instead of exercising the detection it was written
+ * for. `output` and errors[].suggestions[].output are prefixed too, since
+ * autofix fixtures assert the whole file back.
+ */
+// A SIDE-EFFECT import: satisfies the gate without reserving any binding, so
+// fixtures that already declare `mongoose`/`db` do not redeclare.
+const asMongo = (code: string): string => `import 'mongoose';\n${code}`;
+type MongoSuggestion = { output?: string | null };
+type MongoCase = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly MongoSuggestion[] } | string>;
+};
+const xmo = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asMongo(c) as T;
+    const test = c as MongoCase;
+    return {
+      ...c,
+      code: asMongo(test.code),
+      ...(typeof test.output === 'string' ? { output: asMongo(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !Array.isArray(e.suggestions)
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asMongo(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -27,7 +72,7 @@ const ruleTester = new RuleTester({
 describe('require-lean-queries', () => {
   describe('Valid Code', () => {
     ruleTester.run('valid - safe patterns', requireLeanQueries, {
-      valid: [
+      valid: xmo([
         // Array.prototype.find — the receiver is not a Mongo handle. Ungated,
         // this rule reported every `.find()` in every codebase: 115 findings on
         // the Interlace repo alone, which contains no MongoDB. It ships in
@@ -62,7 +107,7 @@ describe('require-lean-queries', () => {
         {
           code: `const safe4 = process.env.DB_HOST;`,
         },
-      ],
+      ]),
       invalid: [],
     });
   });
@@ -70,7 +115,7 @@ describe('require-lean-queries', () => {
   describe('Invalid Code', () => {
     ruleTester.run('invalid - dangerous patterns', requireLeanQueries, {
       valid: [],
-      invalid: [
+      invalid: xmo([
         // Triggers useLean: read query without .lean()
         {
           code: `const docs = await Model.find({ active: true });`,
@@ -79,13 +124,13 @@ describe('require-lean-queries', () => {
         suggestions: [{ messageId: 'suggestionAddLean', output: `const docs = await Model.find({ active: true }).lean();` }],
       }],
         },
-      ],
+      ]),
     });
   });
 describe('Suggestions', () => {
     ruleTester.run('suggestion - appends .lean()', requireLeanQueries, {
       valid: [],
-      invalid: [
+      invalid: xmo([
         {
           code: `const docs = await Model.find({ active: true });`,
           errors: [{
@@ -96,7 +141,7 @@ describe('Suggestions', () => {
             }],
           }],
         },
-      ],
+      ]),
     });
   });
 });

--- a/packages/eslint-plugin-mongodb-security/src/rules/require-projection/index.spec.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/require-projection/index.spec.ts
@@ -1,10 +1,55 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { requireProjection } from '../require-projection/index';
 
+/**
+ * Every fixture imports mongoose, because the rules now abstain in files with
+ * no Mongo in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass
+ * vacuously on the gate instead of exercising the detection it was written
+ * for. `output` and errors[].suggestions[].output are prefixed too, since
+ * autofix fixtures assert the whole file back.
+ */
+// A SIDE-EFFECT import: satisfies the gate without reserving any binding, so
+// fixtures that already declare `mongoose`/`db` do not redeclare.
+const asMongo = (code: string): string => `import 'mongoose';\n${code}`;
+type MongoSuggestion = { output?: string | null };
+type MongoCase = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly MongoSuggestion[] } | string>;
+};
+const xmo = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asMongo(c) as T;
+    const test = c as MongoCase;
+    return {
+      ...c,
+      code: asMongo(test.code),
+      ...(typeof test.output === 'string' ? { output: asMongo(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !Array.isArray(e.suggestions)
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asMongo(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 const ruleTester = new RuleTester();
 
 ruleTester.run('require-projection', requireProjection, {
-  valid: [
+  valid: xmo([
     // find with inline projection
     `User.find({}, { name: 1, email: 1 });`,
     // findOne with inline projection
@@ -24,9 +69,9 @@ ruleTester.run('require-projection', requireProjection, {
       code: `User.find({});`,
       filename: 'user.test.ts',
     },
-  ],
+  ]),
 
-  invalid: [
+  invalid: xmo([
     // find without projection
     {
       code: `User.find({});`,
@@ -54,5 +99,5 @@ ruleTester.run('require-projection', requireProjection, {
       options: [{ allowInTests: false }],
       errors: [{ messageId: 'requireProjection' }],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-mongodb-security/src/rules/require-projection/index.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/require-projection/index.ts
@@ -13,6 +13,7 @@ import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
 import { AST_NODE_TYPES, createRule, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
 import { isTestFile } from '../../utils/paths';
 import { analyzeMongoScope } from '../../utils/receiver';
+import { fileUsesMongo } from '../../utils/mongo-evidence';
 
 type MessageIds = 'requireProjection';
 export interface Options { allowInTests?: boolean; }
@@ -72,6 +73,14 @@ export const requireProjection = createRule<RuleOptions, MessageIds>({
   },
   defaultOptions: [{ allowInTests: true }],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>) {
+    // Every rule here is MongoDB-specific, and none of them could ask the
+    // file-level question: over the corpus, 47% of this plugin's findings were
+    // in files with no Mongo in them. `receiver.ts` discriminates by receiver
+    // NAME, which matches `userModel.findOne()` in a TypeORM repository just as
+    // well as in a Mongoose one. Registering no visitors is both the gate and
+    // the cheap path.
+    if (!fileUsesMongo(context.sourceCode.ast)) return {};
+
     const [options = {}] = context.options;
     const { allowInTests = true } = options as Options;
     const filename = context.filename;

--- a/packages/eslint-plugin-mongodb-security/src/rules/require-projection/require-projection.test.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/require-projection/require-projection.test.ts
@@ -10,6 +10,51 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { requireProjection } from './index';
 
+/**
+ * Every fixture imports mongoose, because the rules now abstain in files with
+ * no Mongo in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass
+ * vacuously on the gate instead of exercising the detection it was written
+ * for. `output` and errors[].suggestions[].output are prefixed too, since
+ * autofix fixtures assert the whole file back.
+ */
+// A SIDE-EFFECT import: satisfies the gate without reserving any binding, so
+// fixtures that already declare `mongoose`/`db` do not redeclare.
+const asMongo = (code: string): string => `import 'mongoose';\n${code}`;
+type MongoSuggestion = { output?: string | null };
+type MongoCase = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly MongoSuggestion[] } | string>;
+};
+const xmo = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asMongo(c) as T;
+    const test = c as MongoCase;
+    return {
+      ...c,
+      code: asMongo(test.code),
+      ...(typeof test.output === 'string' ? { output: asMongo(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !Array.isArray(e.suggestions)
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asMongo(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -27,7 +72,7 @@ const ruleTester = new RuleTester({
 describe('require-projection', () => {
   describe('Valid Code', () => {
     ruleTester.run('valid - safe patterns', requireProjection, {
-      valid: [
+      valid: xmo([
         // Array.prototype.find — the receiver is not a Mongo handle. Ungated,
         // this rule reported every `.find()` in every codebase: 115 findings on
         // the Interlace repo alone, which contains no MongoDB. It ships in
@@ -62,7 +107,7 @@ describe('require-projection', () => {
         {
           code: `const safe4 = process.env.DB_HOST;`,
         },
-      ],
+      ]),
       invalid: [],
     });
   });
@@ -70,13 +115,13 @@ describe('require-projection', () => {
   describe('Invalid Code', () => {
     ruleTester.run('invalid - dangerous patterns', requireProjection, {
       valid: [],
-      invalid: [
+      invalid: xmo([
         // Triggers requireProjection: user input in query
         {
           code: `db.users.find({ username: req.body.username });`,
           errors: [{ messageId: 'requireProjection' }],
         },
-      ],
+      ]),
     });
   });
 });

--- a/packages/eslint-plugin-mongodb-security/src/rules/require-schema-validation/index.spec.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/require-schema-validation/index.spec.ts
@@ -1,10 +1,55 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { requireSchemaValidation } from '../require-schema-validation/index';
 
+/**
+ * Every fixture imports mongoose, because the rules now abstain in files with
+ * no Mongo in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass
+ * vacuously on the gate instead of exercising the detection it was written
+ * for. `output` and errors[].suggestions[].output are prefixed too, since
+ * autofix fixtures assert the whole file back.
+ */
+// A SIDE-EFFECT import: satisfies the gate without reserving any binding, so
+// fixtures that already declare `mongoose`/`db` do not redeclare.
+const asMongo = (code: string): string => `import 'mongoose';\n${code}`;
+type MongoSuggestion = { output?: string | null };
+type MongoCase = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly MongoSuggestion[] } | string>;
+};
+const xmo = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asMongo(c) as T;
+    const test = c as MongoCase;
+    return {
+      ...c,
+      code: asMongo(test.code),
+      ...(typeof test.output === 'string' ? { output: asMongo(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !Array.isArray(e.suggestions)
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asMongo(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 const ruleTester = new RuleTester();
 
 ruleTester.run('require-schema-validation', requireSchemaValidation, {
-  valid: [
+  valid: xmo([
     // Field with required validation
     `new Schema({ name: { type: String, required: true } });`,
     // Field with enum validation
@@ -26,9 +71,9 @@ ruleTester.run('require-schema-validation', requireSchemaValidation, {
     },
     // minlength/maxlength
     `new Schema({ name: { type: String, minlength: 2, maxlength: 100 } });`,
-  ],
+  ]),
 
-  invalid: [
+  invalid: xmo([
     // Field with type but no validation
     {
       code: `new Schema({ name: { type: String } });`,
@@ -59,5 +104,5 @@ ruleTester.run('require-schema-validation', requireSchemaValidation, {
       options: [{ allowInTests: false }],
       errors: [{ messageId: 'requireSchemaValidation' }],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-mongodb-security/src/rules/require-schema-validation/index.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/require-schema-validation/index.ts
@@ -12,6 +12,7 @@
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
 import { AST_NODE_TYPES, createRule, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
 import { isTestFile } from '../../utils/paths';
+import { fileUsesMongo } from '../../utils/mongo-evidence';
 
 type MessageIds = 'requireSchemaValidation';
 export interface Options { allowInTests?: boolean; }
@@ -48,6 +49,14 @@ export const requireSchemaValidation = createRule<RuleOptions, MessageIds>({
   },
   defaultOptions: [{ allowInTests: true }],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>) {
+    // Every rule here is MongoDB-specific, and none of them could ask the
+    // file-level question: over the corpus, 47% of this plugin's findings were
+    // in files with no Mongo in them. `receiver.ts` discriminates by receiver
+    // NAME, which matches `userModel.findOne()` in a TypeORM repository just as
+    // well as in a Mongoose one. Registering no visitors is both the gate and
+    // the cheap path.
+    if (!fileUsesMongo(context.sourceCode.ast)) return {};
+
     const [options = {}] = context.options;
     const { allowInTests = true } = options as Options;
     const filename = context.filename;

--- a/packages/eslint-plugin-mongodb-security/src/rules/require-schema-validation/require-schema-validation.test.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/require-schema-validation/require-schema-validation.test.ts
@@ -10,6 +10,51 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { requireSchemaValidation } from './index';
 
+/**
+ * Every fixture imports mongoose, because the rules now abstain in files with
+ * no Mongo in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass
+ * vacuously on the gate instead of exercising the detection it was written
+ * for. `output` and errors[].suggestions[].output are prefixed too, since
+ * autofix fixtures assert the whole file back.
+ */
+// A SIDE-EFFECT import: satisfies the gate without reserving any binding, so
+// fixtures that already declare `mongoose`/`db` do not redeclare.
+const asMongo = (code: string): string => `import 'mongoose';\n${code}`;
+type MongoSuggestion = { output?: string | null };
+type MongoCase = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly MongoSuggestion[] } | string>;
+};
+const xmo = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asMongo(c) as T;
+    const test = c as MongoCase;
+    return {
+      ...c,
+      code: asMongo(test.code),
+      ...(typeof test.output === 'string' ? { output: asMongo(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !Array.isArray(e.suggestions)
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asMongo(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -27,7 +72,7 @@ const ruleTester = new RuleTester({
 describe('require-schema-validation', () => {
   describe('Valid Code', () => {
     ruleTester.run('valid - safe patterns', requireSchemaValidation, {
-      valid: [
+      valid: xmo([
         // Unrelated code should not trigger
         {
           code: `const x = 1;`,
@@ -50,7 +95,7 @@ describe('require-schema-validation', () => {
         {
           code: `const safe4 = process.env.DB_HOST;`,
         },
-      ],
+      ]),
       invalid: [],
     });
   });
@@ -58,13 +103,13 @@ describe('require-schema-validation', () => {
   describe('Invalid Code', () => {
     ruleTester.run('invalid - dangerous patterns', requireSchemaValidation, {
       valid: [],
-      invalid: [
+      invalid: xmo([
         // Triggers requireSchemaValidation: schema field without validation
         {
           code: `const schema = new Schema({ name: { type: String } });`,
           errors: [{ messageId: 'requireSchemaValidation' }],
         },
-      ],
+      ]),
     });
   });
 });

--- a/packages/eslint-plugin-mongodb-security/src/rules/require-tls-connection/index.spec.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/require-tls-connection/index.spec.ts
@@ -1,10 +1,55 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { requireTlsConnection } from '../require-tls-connection/index';
 
+/**
+ * Every fixture imports mongoose, because the rules now abstain in files with
+ * no Mongo in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass
+ * vacuously on the gate instead of exercising the detection it was written
+ * for. `output` and errors[].suggestions[].output are prefixed too, since
+ * autofix fixtures assert the whole file back.
+ */
+// A SIDE-EFFECT import: satisfies the gate without reserving any binding, so
+// fixtures that already declare `mongoose`/`db` do not redeclare.
+const asMongo = (code: string): string => `import 'mongoose';\n${code}`;
+type MongoSuggestion = { output?: string | null };
+type MongoCase = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly MongoSuggestion[] } | string>;
+};
+const xmo = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asMongo(c) as T;
+    const test = c as MongoCase;
+    return {
+      ...c,
+      code: asMongo(test.code),
+      ...(typeof test.output === 'string' ? { output: asMongo(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !Array.isArray(e.suggestions)
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asMongo(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 const ruleTester = new RuleTester();
 
 ruleTester.run('require-tls-connection', requireTlsConnection, {
-  valid: [
+  valid: xmo([
     // TLS enabled
     `mongoose.connect(uri, { tls: true });`,
     // SSL enabled
@@ -20,9 +65,9 @@ ruleTester.run('require-tls-connection', requireTlsConnection, {
       code: `mongoose.connect('mongodb://localhost:27017/test');`,
       filename: 'db.test.ts',
     },
-  ],
+  ]),
 
-  invalid: [
+  invalid: xmo([
     // No options at all
     {
       code: `mongoose.connect(uri);`,
@@ -65,5 +110,5 @@ ruleTester.run('require-tls-connection', requireTlsConnection, {
         suggestions: [{ messageId: 'suggestionAddTls', output: `mongoose.connect(uri, { tls: true });` }],
       }],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-mongodb-security/src/rules/require-tls-connection/index.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/require-tls-connection/index.ts
@@ -13,6 +13,7 @@ import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
 import { AST_NODE_TYPES, createRule, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
 import { isTestFile } from '../../utils/paths';
 import { analyzeMongoScope } from '../../utils/receiver';
+import { fileUsesMongo } from '../../utils/mongo-evidence';
 
 type MessageIds = 'requireTls' | 'suggestionAddTls';
 export interface Options { allowInTests?: boolean; }
@@ -48,6 +49,14 @@ export const requireTlsConnection = createRule<RuleOptions, MessageIds>({
   },
   defaultOptions: [{ allowInTests: true }],
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>) {
+    // Every rule here is MongoDB-specific, and none of them could ask the
+    // file-level question: over the corpus, 47% of this plugin's findings were
+    // in files with no Mongo in them. `receiver.ts` discriminates by receiver
+    // NAME, which matches `userModel.findOne()` in a TypeORM repository just as
+    // well as in a Mongoose one. Registering no visitors is both the gate and
+    // the cheap path.
+    if (!fileUsesMongo(context.sourceCode.ast)) return {};
+
     const [options = {}] = context.options;
     const { allowInTests = true } = options as Options;
     const filename = context.filename;

--- a/packages/eslint-plugin-mongodb-security/src/rules/require-tls-connection/require-tls-connection.test.ts
+++ b/packages/eslint-plugin-mongodb-security/src/rules/require-tls-connection/require-tls-connection.test.ts
@@ -10,6 +10,51 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { requireTlsConnection } from './index';
 
+/**
+ * Every fixture imports mongoose, because the rules now abstain in files with
+ * no Mongo in them. Wrapping the arrays rather than editing each fixture means
+ * one cannot be left behind — a fixture missing the import would pass
+ * vacuously on the gate instead of exercising the detection it was written
+ * for. `output` and errors[].suggestions[].output are prefixed too, since
+ * autofix fixtures assert the whole file back.
+ */
+// A SIDE-EFFECT import: satisfies the gate without reserving any binding, so
+// fixtures that already declare `mongoose`/`db` do not redeclare.
+const asMongo = (code: string): string => `import 'mongoose';\n${code}`;
+type MongoSuggestion = { output?: string | null };
+type MongoCase = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly MongoSuggestion[] } | string>;
+};
+const xmo = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asMongo(c) as T;
+    const test = c as MongoCase;
+    return {
+      ...c,
+      code: asMongo(test.code),
+      ...(typeof test.output === 'string' ? { output: asMongo(test.output) } : {}),
+      ...(test.errors
+        ? {
+            errors: test.errors.map((e) =>
+              typeof e === 'string' || !Array.isArray(e.suggestions)
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asMongo(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -27,7 +72,7 @@ const ruleTester = new RuleTester({
 describe('require-tls-connection', () => {
   describe('Valid Code', () => {
     ruleTester.run('valid - safe patterns', requireTlsConnection, {
-      valid: [
+      valid: xmo([
         // Unrelated code should not trigger
         {
           code: `const x = 1;`,
@@ -66,7 +111,7 @@ describe('require-tls-connection', () => {
           filename: 'test.spec.ts',
           options: [{"allowInTests":true}],
         },
-      ],
+      ]),
       invalid: [],
     });
   });
@@ -74,7 +119,7 @@ describe('require-tls-connection', () => {
   describe('Invalid Code', () => {
     ruleTester.run('invalid - dangerous patterns', requireTlsConnection, {
       valid: [],
-      invalid: [
+      invalid: xmo([
         // Triggers requireTls: no TLS configured
         {
           code: `mongoose.connect('mongodb://localhost/db', { useNewUrlParser: true });`,
@@ -83,13 +128,13 @@ describe('require-tls-connection', () => {
         suggestions: [{ messageId: 'suggestionAddTls', output: `mongoose.connect('mongodb://localhost/db', { useNewUrlParser: true, tls: true });` }],
       }],
         },
-      ],
+      ]),
     });
   });
 describe('Suggestions', () => {
     ruleTester.run('suggestion - adds tls: true', requireTlsConnection, {
       valid: [],
-      invalid: [
+      invalid: xmo([
         // Existing options object: merge the property in.
         {
           code: `mongoose.connect('mongodb://localhost/db', { useNewUrlParser: true });`,
@@ -128,7 +173,7 @@ describe('Suggestions', () => {
           code: `mongoose.connect('mongodb://localhost/db', connectOptions);`,
           errors: [{ messageId: 'requireTls', suggestions: [] }],
         },
-      ],
+      ]),
     });
   });
 });

--- a/packages/eslint-plugin-mongodb-security/src/utils/mongo-evidence.ts
+++ b/packages/eslint-plugin-mongodb-security/src/utils/mongo-evidence.ts
@@ -1,0 +1,280 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+import type { TSESTree } from '@interlace/eslint-devkit';
+import { AST_NODE_TYPES } from '@interlace/eslint-devkit';
+
+/**
+ * Packages that put a MongoDB or Mongoose handle in a file.
+ *
+ * The plugin ecosystem is included by pattern, not just the four core packages.
+ * Mongoose plugins are consumed as `mongoose-paginate`, `mongoose-delete`,
+ * `mongoose-lean-virtuals`, `passport-local-mongoose` and so on, and a file
+ * that imports one is unambiguously a Mongoose file even when it never imports
+ * `mongoose` itself. Measured on the corpus this is not a hypothetical: of the
+ * twelve files containing `new Schema(` that the four-package list placed
+ * outside Mongo, **eleven were exactly these plugin consumers**.
+ */
+const MONGO_PACKAGES: ReadonlySet<string> = new Set([
+  'mongodb',
+  'mongoose',
+  '@nestjs/mongoose',
+  '@typegoose/typegoose',
+  'mongodb-client-encryption',
+  'bson',
+  'connect-mongo',
+]);
+
+/** `mongoose-paginate`, `passport-local-mongoose`, `@types/mongoose`. */
+const MONGO_PACKAGE_PATTERN = /(^|[-@/])mongoose($|[-/])|^mongodb-/;
+
+function isMongoSpecifier(specifier: string): boolean {
+  if (specifier.startsWith('.') || specifier.startsWith('/')) return false;
+  const parts = specifier.split('/');
+  const root = specifier.startsWith('@')
+    ? parts.slice(0, 2).join('/')
+    : parts[0];
+  return MONGO_PACKAGES.has(root) || MONGO_PACKAGE_PATTERN.test(root);
+}
+
+/**
+ * Whether a scope-introducing node binds the name `require`.
+ *
+ * Lexical, propagated down the walk — never a file-wide flag. See #483: a
+ * file-wide flag reads `const m = require('mongoose'); function w(require) {}`
+ * as fully shadowed and silences every rule in the plugin, which converts a
+ * false positive into a false negative.
+ */
+function bindsRequire(node: TSESTree.Node): boolean {
+  if (
+    node.type === AST_NODE_TYPES.FunctionDeclaration ||
+    node.type === AST_NODE_TYPES.FunctionExpression ||
+    node.type === AST_NODE_TYPES.ArrowFunctionExpression
+  ) {
+    return node.params.some(
+      (p) => p.type === AST_NODE_TYPES.Identifier && p.name === 'require',
+    );
+  }
+  if (
+    node.type === AST_NODE_TYPES.Program ||
+    node.type === AST_NODE_TYPES.BlockStatement
+  ) {
+    return node.body.some(
+      (stmt) =>
+        stmt.type === AST_NODE_TYPES.VariableDeclaration &&
+        stmt.declarations.some(
+          (d) =>
+            d.id.type === AST_NODE_TYPES.Identifier && d.id.name === 'require',
+        ),
+    );
+  }
+  return false;
+}
+
+function isMongoDynamicLoad(
+  node: TSESTree.Node,
+  requireIsShadowed: boolean,
+): boolean {
+  const argument =
+    node.type === AST_NODE_TYPES.ImportExpression
+      ? node.source
+      : !requireIsShadowed &&
+          node.type === AST_NODE_TYPES.CallExpression &&
+          node.callee.type === AST_NODE_TYPES.Identifier &&
+          node.callee.name === 'require'
+        ? node.arguments[0]
+        : undefined;
+  return (
+    argument?.type === AST_NODE_TYPES.Literal &&
+    typeof argument.value === 'string' &&
+    isMongoSpecifier(argument.value)
+  );
+}
+
+/** `new Schema({...})` / `new mongoose.Schema({...})`. */
+function isSchemaConstruction(node: TSESTree.Node): boolean {
+  if (node.type !== AST_NODE_TYPES.NewExpression) return false;
+  const { callee } = node;
+  if (callee.type === AST_NODE_TYPES.Identifier) return callee.name === 'Schema';
+  return (
+    callee.type === AST_NODE_TYPES.MemberExpression &&
+    callee.property.type === AST_NODE_TYPES.Identifier &&
+    callee.property.name === 'Schema'
+  );
+}
+
+/**
+ * `Types.ObjectId` and `new ObjectId(...)`.
+ *
+ * The **qualified** and **constructed** forms only. A bare `ObjectId`
+ * identifier is a type name in a dozen unrelated libraries; `Types.ObjectId` is
+ * Mongoose's own namespace and `new ObjectId()` is the BSON constructor.
+ */
+function isObjectIdEvidence(node: TSESTree.Node): boolean {
+  if (
+    node.type === AST_NODE_TYPES.MemberExpression &&
+    node.object.type === AST_NODE_TYPES.Identifier &&
+    node.object.name === 'Types' &&
+    node.property.type === AST_NODE_TYPES.Identifier &&
+    node.property.name === 'ObjectId'
+  ) {
+    return true;
+  }
+  return (
+    node.type === AST_NODE_TYPES.NewExpression &&
+    node.callee.type === AST_NODE_TYPES.Identifier &&
+    node.callee.name === 'ObjectId'
+  );
+}
+
+/** `.lean()` — Mongoose's own query modifier, with no analogue elsewhere. */
+function isLeanCall(node: TSESTree.Node): boolean {
+  return (
+    node.type === AST_NODE_TYPES.CallExpression &&
+    node.callee.type === AST_NODE_TYPES.MemberExpression &&
+    node.callee.property.type === AST_NODE_TYPES.Identifier &&
+    node.callee.property.name === 'lean' &&
+    node.arguments.length === 0
+  );
+}
+
+/**
+ * A `mongodb://` or `mongodb+srv://` connection string, **anywhere in the
+ * string** rather than only at its start.
+ *
+ * Anchoring to the start looked tidier and lost real files: env-file
+ * generators write `'MONGODB_URL=mongodb://127.0.0.1/db'` and
+ * `` `\nMONGODB_URL=mongodb://localhost:27017/dbname` ``, both of which name
+ * the protocol just as plainly as a bare DSN. Two corpus files were silenced
+ * by the anchor before the recall diff caught it.
+ */
+const MONGO_DSN = /mongodb(\+srv)?:\/\//;
+
+function isConnectionString(node: TSESTree.Node): boolean {
+  if (
+    node.type === AST_NODE_TYPES.Literal &&
+    typeof node.value === 'string' &&
+    MONGO_DSN.test(node.value)
+  ) {
+    return true;
+  }
+  return (
+    node.type === AST_NODE_TYPES.TemplateLiteral &&
+    node.quasis.some((q) => MONGO_DSN.test(q.value.raw))
+  );
+}
+
+/**
+ * `import mongoose = require('mongoose')` — TypeScript's import-equals form.
+ *
+ * Not a `CallExpression`: the AST is a `TSImportEqualsDeclaration` whose
+ * `moduleReference` is a `TSExternalModuleReference` wrapping the literal, so
+ * the `require`-call arm never sees it. DefinitelyTyped writes almost every
+ * CommonJS type test this way, and three corpus files were silenced by the
+ * omission until the recall diff surfaced them.
+ */
+function isImportEquals(node: TSESTree.Node): boolean {
+  return (
+    node.type === AST_NODE_TYPES.TSImportEqualsDeclaration &&
+    node.moduleReference.type === AST_NODE_TYPES.TSExternalModuleReference &&
+    node.moduleReference.expression.type === AST_NODE_TYPES.Literal &&
+    typeof node.moduleReference.expression.value === 'string' &&
+    isMongoSpecifier(node.moduleReference.expression.value)
+  );
+}
+
+const cache = new WeakMap<TSESTree.Program, boolean>();
+
+/**
+ * Whether this file has MongoDB or Mongoose in it.
+ *
+ * Measured over the corpus, **47% of everything this plugin reported (1,663 of
+ * 3,542 findings) was in a file with no Mongo import**. The plugin already
+ * discriminates by *receiver* (see `receiver.ts`), but that is a name
+ * heuristic: `userModel.findOne()` matches it just as well in a TypeORM
+ * repository as in a Mongoose one. The file-level question is the one it could
+ * not ask.
+ *
+ * **This gate is a union, unlike vercel-ai's, and the corpus is why.** An
+ * import-only probe was correct for the AI SDK because every no-import caller
+ * turned out to be a different vendor. Here the opposite risk dominates: the
+ * idiomatic Mongoose layout defines a model in one file and consumes it through
+ * a **relative** import, so a service calling `User.findOne()` has no package
+ * specifier to find. Silencing those is a false negative in a security plugin.
+ *
+ * The non-import arms were each chosen by measurement, and two obvious
+ * candidates were **rejected**:
+ *
+ *   - `$set` / `$push` / `$inc` object keys look Mongo-specific and are not.
+ *     `$push` is `react-addons-update`'s immutability helper, `$set` is jQuery
+ *     UI, and `$addToSet` is Meteor's minimongo. All three appear in the corpus.
+ *   - a bare `ObjectId` identifier is a type name in unrelated libraries, so
+ *     only the qualified `Types.ObjectId` and constructed `new ObjectId()`
+ *     forms count.
+ *
+ * Everything accepted is local to the file: nothing is read from
+ * `package.json`, nothing is resolved across files, so there is no project
+ * state to go stale and no dependency on lint order.
+ */
+export function fileUsesMongo(ast: TSESTree.Program): boolean {
+  const cached = cache.get(ast);
+  if (cached !== undefined) return cached;
+  const result = computeUsesMongo(ast);
+  cache.set(ast, result);
+  return result;
+}
+
+function computeUsesMongo(ast: TSESTree.Program): boolean {
+  let found = false;
+
+  const visit = (node: TSESTree.Node, requireIsShadowed: boolean): void => {
+    if (
+      (node.type === AST_NODE_TYPES.ImportDeclaration ||
+        node.type === AST_NODE_TYPES.ExportNamedDeclaration ||
+        node.type === AST_NODE_TYPES.ExportAllDeclaration) &&
+      node.source?.type === AST_NODE_TYPES.Literal &&
+      typeof node.source.value === 'string' &&
+      isMongoSpecifier(node.source.value)
+    ) {
+      found = true;
+      return;
+    }
+    if (
+      isImportEquals(node) ||
+      isMongoDynamicLoad(node, requireIsShadowed) ||
+      isSchemaConstruction(node) ||
+      isObjectIdEvidence(node) ||
+      isLeanCall(node) ||
+      isConnectionString(node)
+    ) {
+      found = true;
+      return;
+    }
+    const shadowedHere = requireIsShadowed || bindsRequire(node);
+    for (const key of Object.keys(node)) {
+      if (key === 'parent') continue;
+      const value = (node as unknown as Record<string, unknown>)[key];
+      if (Array.isArray(value)) {
+        for (const child of value) {
+          if (child && typeof (child as TSESTree.Node).type === 'string') {
+            visit(child as TSESTree.Node, shadowedHere);
+            if (found) return;
+          }
+        }
+      } else if (
+        value &&
+        typeof value === 'object' &&
+        typeof (value as TSESTree.Node).type === 'string'
+      ) {
+        visit(value as TSESTree.Node, shadowedHere);
+        if (found) return;
+      }
+    }
+  };
+
+  visit(ast, false);
+  return found;
+}


### PR DESCRIPTION
## Summary

Item 6b of NEXT-LEVEL-PLAN.md — the second-largest off-SDK offender, after #489.

- **Gates all 16 rules** on local MongoDB evidence. **47% of this plugin's findings (1,663 of 3,542) were in files with no Mongo import.** The plugin already discriminated by *receiver* ([receiver.ts](packages/eslint-plugin-mongodb-security/src/utils/receiver.ts)), but that is a name heuristic — `userModel.findOne()` reads identically in a TypeORM repository. Grouping the off-SDK findings by repo, **73% sat in repositories with zero MongoDB anywhere**: twentyhq, strapi and cal.com are TypeORM and Prisma.
- **A union gate, deliberately unlike #489's imports-only one.** For the AI SDK every no-import caller turned out to be a different vendor. Here the opposite risk dominates: Mongoose models are defined in one file and consumed through a *relative* import, so the calling service has no package specifier to find. Silencing those would be a false negative.
- **The mongoose plugin ecosystem counts as evidence.** Of the 12 corpus files containing `new Schema(` that a four-package list placed "outside Mongo", **11 were plugin consumers** — `mongoose-paginate`, `passport-local-mongoose`, `mongoose-lean-virtuals`.
- **Two candidates rejected on evidence:** `$set`/`$push`/`$inc` are *not* Mongo-exclusive (`$push` is `react-addons-update`, `$set` is jQuery UI, `$addToSet` is Meteor — all three in the corpus), and a bare `ObjectId` identifier is a type name in unrelated libraries, so only `Types.ObjectId` and `new ObjectId()` count.

## Test plan

- [x] `vitest run`: **633 passed / 633**, 37 files. Baseline **507**; the delta is exactly the new lock tests — zero pre-existing tests lost.
- [x] Coverage **100 / 100 / 100 / 100**.
- [x] `npm run oxlint` — 0 errors. `npm run typecheck` (tsgo whole-graph) — clean.
- [x] Pre-commit hooks green.
- [x] **Recall diff over all 232 corpus files carrying Mongo evidence: 316 → 316.**

### The recall diff caught two real defects in this gate

Worth calling out, because the first run lost six findings and the cause was mine, not the plugin's:

1. **`import x = require('mongoose')` was invisible.** That is a `TSImportEqualsDeclaration` whose module reference is a `TSExternalModuleReference` — not a `require` `CallExpression`, so the dynamic-load arm never saw it. Three files. DefinitelyTyped writes nearly every CommonJS type test this way.
2. **The DSN test was anchored to the start of the string**, so `'MONGODB_URL=mongodb://127.0.0.1/db'` did not count. Two files, both env-file generators.

Both fixed and locked as positive controls.

### The one remaining difference, and why it is not a loss

`express-rest-boilerplate/src/index.js` does `require('./config/mongoose')` — a **relative** import of a local wrapper. The dropped report was `require-auth-mechanism` on `mongoose.connect()`, a **zero-argument call that merely delegates**. The genuine finding for that same defect is retained at the real connect site, `src/config/mongoose.js:26`, where `mongoose.connect(mongo.uri, {...})` specifies no auth mechanism. **Zero actionable findings lost.**

That relative-wrapper shape is the gate's known false negative, and it is deliberate: resolving one hop across files would give every rule project state that can go stale and a dependency on lint order, which no other probe in this ecosystem has.

## Notes for the reviewer

- The `xmo()` fixture wrapper guards `Array.isArray(e.suggestions)`. One fixture carries a non-array `suggestions`, which threw at module scope and **silently removed that file's 38 tests from the count** — invisible except through the before/after comparison. Same class of failure #482 documented.
- Seven synthetic-AST contexts now receive a Mongo-bearing `Program`. The token-less one deliberately gets a variant with **no `tokens` key at all**: handing it `tokens: []` would satisfy the gate while skipping the `?? []` fallback that test exists to exercise.
- `mongodb-security` leaves `UNGATED` in `sdk-gate-coverage.lock.test.ts` — the ratchet going red the moment the plugin shipped a gate is it working as designed.

## After merge

`nestjs-security` (219 off-SDK) is the last ungated plugin in item 6; after that the seven SQL plugins owe registry locks, and the four AI-SDK plugins owe locks to keep their measured zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)