### PR TITLE
fix(mongodb-security): close the relative-wrapper false negative

### DIFF
--- a/.changeset/mongo-relative-wrapper-fn.md
+++ b/.changeset/mongo-relative-wrapper-fn.md
@@ -1,0 +1,43 @@
+---
+'eslint-plugin-mongodb-security': patch
+---
+
+Close the relative-wrapper false negative in the MongoDB evidence gate
+
+The gate shipped in #491 documented one false negative and accepted it: a file
+that binds `mongoose` from a **relative** wrapper —
+`const mongoose = require('./config/mongoose')` — carries no package specifier,
+so every rule abstained. Accepting that was the wrong call. A security rule that
+silently stops reporting is precisely the failure this ecosystem exists to
+prevent, and "documented" does not make a false negative safe.
+
+The fix is a binding-name arm: an identifier bound as `mongoose` or `Mongoose`,
+whatever it was assigned from. The name is safe evidence in a way `db`,
+`collection` and `model` are not — those are generic English, `mongoose` is a
+product name. Measured over the corpus: **58 files bind that identifier, 57
+already import a Mongo package, and the 58th is exactly the missed file.** The
+arm opens the gate on one additional file and introduces no other.
+
+It is the *binding name* that counts, not the specifier, so
+`import db from './mongoose'` still does not qualify — a module path that merely
+ends in `/mongoose` is not evidence about what the file does.
+
+**Recall re-diffed over all 232 corpus files carrying Mongo evidence: 316 → 316
+against the pre-gate baseline — zero findings lost**, versus 315 with #491 as
+shipped. The recovered finding is `require-auth-mechanism` at
+`express-rest-boilerplate/src/index.js:9`.
+
+The lock's "a local module merely named mongoose" negative was the same shape as
+the false negative, so it has been **flipped into a positive control** and
+replaced with a sharper negative (a relative import whose local name is *not*
+`mongoose`).
+
+Two further gaps surfaced while restoring the coverage floor, both now locked:
+
+- `isMongoDynamicLoad` was a nested ternary; it is now early returns, so the
+  shadowed-`require` case is its own targeted line rather than a short-circuit
+  buried mid-expression.
+- with the name arm added, `const mongoose = require('mongoose')` is matched by
+  the **name** first and the walk stops, so the require-specifier path is only
+  reachable through a differently-named binding. That case
+  (`const db = require('mongoose')`) had no test and now does.

--- a/packages/eslint-plugin-mongodb-security/src/module-gate.lock.test.ts
+++ b/packages/eslint-plugin-mongodb-security/src/module-gate.lock.test.ts
@@ -71,9 +71,9 @@ const NON_MONGO_SOURCES: ReadonlyArray<readonly [string, string]> = [
      export function read(id: ObjectId) { return String(id); }`,
   ],
   [
-    'a local module merely named mongoose',
-    `import mongoose from './mongoose';
-     export const db = mongoose.connect('localhost');`,
+    'a relative import whose local name is NOT mongoose',
+    `import db from './mongoose';
+     export const conn = db.connect('localhost');`,
   ],
 ];
 
@@ -189,6 +189,27 @@ describe('MongoDB module gate', () => {
       expect(lint(code, 'no-hardcoded-connection-string').length).toBeGreaterThan(0);
     });
 
+    it('opens on a `mongoose` binding from a RELATIVE wrapper module', () => {
+      // This was a documented false negative when the gate first shipped:
+      // `const mongoose = require('./config/mongoose')` carries no package
+      // specifier. Measured over the corpus, 58 files bind this identifier,
+      // 57 already import a Mongo package, and the 58th was exactly the missed
+      // file — so the name is evidence, and it costs nothing.
+      const code = `const mongoose = require('./config/mongoose');
+      mongoose.connect();
+      ${dsn}`;
+      expect(lint(code, 'no-hardcoded-connection-string').length).toBeGreaterThan(0);
+    });
+
+    it("opens on require('mongoose') bound to a name that is NOT mongoose", () => {
+      // Distinct from the binding-name arm on purpose: with the name arm added,
+      // `const mongoose = require('mongoose')` is matched by the NAME first and
+      // the walk stops, so only a differently-named binding still exercises the
+      // require-specifier path.
+      const code = `const db = require('mongoose');\n${dsn}`;
+      expect(lint(code, 'no-hardcoded-connection-string').length).toBeGreaterThan(0);
+    });
+
     it('and stays silent on that same DSN-free file with no Mongo evidence', () => {
       expect(
         lint(`const uri = 'postgres://localhost/app';`, 'no-hardcoded-connection-string'),
@@ -199,6 +220,16 @@ describe('MongoDB module gate', () => {
   describe('a locally bound require is not module loading', () => {
     it('does not open the gate', () => {
       const code = `function wrap(require) { return require('mongoose'); }
+      export const q = { user: 1 };`;
+      expect(lint(code, 'no-hardcoded-connection-string')).toHaveLength(0);
+    });
+
+    it('a method named require on some object is not module loading either', () => {
+      // `loader.require('mongoose')` is a MemberExpression callee, not the
+      // global `require`. Treating it as a module load would be the same
+      // name-is-not-an-interface error the gate exists to correct.
+      const code = `const loader = getLoader();
+      loader.require('mongoose');
       export const q = { user: 1 };`;
       expect(lint(code, 'no-hardcoded-connection-string')).toHaveLength(0);
     });

--- a/packages/eslint-plugin-mongodb-security/src/utils/mongo-evidence.ts
+++ b/packages/eslint-plugin-mongodb-security/src/utils/mongo-evidence.ts
@@ -74,24 +74,39 @@ function bindsRequire(node: TSESTree.Node): boolean {
   return false;
 }
 
+/** A string literal whose value names a Mongo package. */
+function isMongoLiteral(node: TSESTree.Node | undefined): boolean {
+  return (
+    node?.type === AST_NODE_TYPES.Literal &&
+    typeof node.value === 'string' &&
+    isMongoSpecifier(node.value)
+  );
+}
+
+/**
+ * `require('mongoose')` and `await import('mongodb')`.
+ *
+ * Written as early returns rather than one nested ternary: each condition is
+ * then a branch a single test can target, and the shadowed-`require` case is
+ * visibly its own line rather than a short-circuit buried mid-expression.
+ */
 function isMongoDynamicLoad(
   node: TSESTree.Node,
   requireIsShadowed: boolean,
 ): boolean {
-  const argument =
-    node.type === AST_NODE_TYPES.ImportExpression
-      ? node.source
-      : !requireIsShadowed &&
-          node.type === AST_NODE_TYPES.CallExpression &&
-          node.callee.type === AST_NODE_TYPES.Identifier &&
-          node.callee.name === 'require'
-        ? node.arguments[0]
-        : undefined;
-  return (
-    argument?.type === AST_NODE_TYPES.Literal &&
-    typeof argument.value === 'string' &&
-    isMongoSpecifier(argument.value)
-  );
+  if (node.type === AST_NODE_TYPES.ImportExpression) {
+    return isMongoLiteral(node.source);
+  }
+  // A locally bound `require` is a parameter or variable, not module loading.
+  if (requireIsShadowed) return false;
+  if (node.type !== AST_NODE_TYPES.CallExpression) return false;
+  if (
+    node.callee.type !== AST_NODE_TYPES.Identifier ||
+    node.callee.name !== 'require'
+  ) {
+    return false;
+  }
+  return isMongoLiteral(node.arguments[0]);
 }
 
 /** `new Schema({...})` / `new mongoose.Schema({...})`. */
@@ -128,6 +143,42 @@ function isObjectIdEvidence(node: TSESTree.Node): boolean {
     node.callee.type === AST_NODE_TYPES.Identifier &&
     node.callee.name === 'ObjectId'
   );
+}
+
+/**
+ * A binding literally named `mongoose` / `Mongoose`, whatever it was assigned
+ * from.
+ *
+ * This arm exists to close the one false negative the previous gate shipped
+ * with: `const mongoose = require('./config/mongoose')` — a **relative** import
+ * of a local wrapper, which carries no package specifier for the import arm to
+ * find. That layout is common enough that documenting it as an accepted FN was
+ * the wrong call; a security rule that silently stops reporting is the failure
+ * this ecosystem exists to prevent.
+ *
+ * The name is safe evidence in a way `db`, `collection` and `model` are not —
+ * those are generic, `mongoose` is a product name. Measured over the corpus:
+ * **58 files bind this identifier, 57 already import a Mongo package, and the
+ * 58th is exactly the false negative.** The arm therefore opens the gate on one
+ * additional file and introduces no new one.
+ *
+ * A *relative import that merely ends in `/mongoose`* is deliberately not
+ * enough on its own — it is the binding name that is checked, so
+ * `import x from './mongoose'` where the local name is `x` still does not
+ * qualify.
+ */
+function bindsMongooseName(node: TSESTree.Node): boolean {
+  const named = (name: string): boolean =>
+    name === 'mongoose' || name === 'Mongoose';
+  if (node.type === AST_NODE_TYPES.VariableDeclarator) {
+    return node.id.type === AST_NODE_TYPES.Identifier && named(node.id.name);
+  }
+  if (node.type === AST_NODE_TYPES.ImportDefaultSpecifier ||
+      node.type === AST_NODE_TYPES.ImportNamespaceSpecifier ||
+      node.type === AST_NODE_TYPES.ImportSpecifier) {
+    return named(node.local.name);
+  }
+  return false;
 }
 
 /** `.lean()` — Mongoose's own query modifier, with no analogue elsewhere. */
@@ -244,6 +295,7 @@ function computeUsesMongo(ast: TSESTree.Program): boolean {
     }
     if (
       isImportEquals(node) ||
+      bindsMongooseName(node) ||
       isMongoDynamicLoad(node, requireIsShadowed) ||
       isSchemaConstruction(node) ||
       isObjectIdEvidence(node) ||


### PR DESCRIPTION
## Summary

#491 shipped the MongoDB evidence gate with **one documented false negative** and called it acceptable. It isn't. A security rule that silently stops reporting is exactly the failure mode this ecosystem exists to prevent, and documenting an FN does not make it safe. This closes it.

**The FN:** a file binding `mongoose` from a **relative** wrapper — `const mongoose = require('./config/mongoose')` — carries no package specifier, so every rule abstained.

**The fix:** a binding-name arm — an identifier bound as `mongoose`/`Mongoose`, whatever it was assigned from. The name is safe evidence in a way `db`, `collection` and `model` are not: those are generic English, `mongoose` is a product name.

Measured over the corpus: **58 files bind that identifier, 57 already import a Mongo package, and the 58th is exactly the missed file.** The arm opens the gate on one additional file and introduces no other.

It is the *binding name* that counts, not the specifier — `import db from './mongoose'` still does not qualify, because a module path ending in `/mongoose` says nothing about what the file does.

## Test plan

- [x] **Recall re-diffed over all 232 corpus files carrying Mongo evidence: 316 → 316 against the pre-gate baseline — zero findings lost**, versus 315 with #491 as shipped. The recovered finding is `require-auth-mechanism` at `express-rest-boilerplate/src/index.js:9`.
- [x] `vitest run`: **636 passed / 636**. Coverage **100 / 100 / 100 / 100**.
- [x] Pre-commit hooks green.

## Two further gaps found while restoring the coverage floor

Both were real holes in the lock, not coverage bookkeeping:

1. **`isMongoDynamicLoad` was a nested ternary.** Rewritten as early returns so the shadowed-`require` case is its own targeted line rather than a short-circuit buried mid-expression.
2. **The new name arm short-circuits the walk.** `const mongoose = require('mongoose')` is now matched by the *name* first, so the require-specifier path is only reachable through a differently-named binding. `const db = require('mongoose')` had no test at all — it does now.

## Note on the lock

The lock's `'a local module merely named mongoose'` **negative** was the same shape as the false negative — my own test was asserting the bug. It is flipped into a positive control and replaced with a sharper negative (a relative import whose local name is *not* `mongoose`).

## After merge

Applying the same standard to the gates already shipped: I'm auditing `vercel-ai-security` (#489) for the analogous wrapper-shaped FN, and the same question is open for `express-security` (#482) and `lambda-security` (#481), which predate this rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)