### PR TITLE
fix(workspace): close two false-negative classes in every SDK-evidence gate

### DIFF
--- a/.changeset/gate-fn-audit.md
+++ b/.changeset/gate-fn-audit.md
@@ -1,0 +1,54 @@
+---
+'eslint-plugin-express-security': patch
+'eslint-plugin-lambda-security': patch
+'eslint-plugin-postgresql-security': patch
+'eslint-plugin-vercel-ai-security': patch
+---
+
+Close two false-negative classes across every SDK-evidence gate
+
+A full false-negative audit ran every gated plugin twice over the 107-repository
+corpus — once with the gates forced open, once as shipped — and compared the
+**6,686 findings the gates silence across 5,235 files**. Of those files, 134 were
+flagged as suspect (the SDK *is* imported but the gate closed anyway), and two
+real defect classes came out of verifying them one by one.
+
+**1. TypeScript's import-equals form was invisible to four of the five gates.**
+`import express = require('express')` is a `TSImportEqualsDeclaration` whose
+module reference is a `TSExternalModuleReference` — not a `require`
+`CallExpression` — so the dynamic-load arm never saw it. **82 corpus files
+written this way for Express alone had every rule in the plugin silenced.** Only
+`mongodb-security` handled it, and only because an earlier audit forced the
+issue. Now handled by express, lambda, postgresql and vercel-ai too.
+
+**2. Deno's module specifiers were unrecognisable to all five.**
+`npm:@aws-sdk/client-bedrock-runtime` and
+`https://deno.land/x/postgres@v0.17.0/mod.ts` are ordinary SDK imports in Deno
+and Supabase Edge Functions; the prefix made the specifier unmatchable and the
+whole plugin abstained on real SDK code. Both forms are now normalised before
+the package test.
+
+**`postgresql-security` also had no dynamic `import()` arm at all** — alone
+among the five — so a file that lazily loads its driver was silenced entirely.
+Every other gate has carried that arm since #481.
+
+**Measured, not assumed.** Re-sweeping the same 119,271 files with the fixes:
+**198 findings recovered across 88 files** (196 express, 1 postgres, 1 lambda)
+and **zero regressions** — nothing that reported before is silenced now.
+
+The two non-Express recoveries are the clearest illustration of what was broken:
+`no-missing-authorization-check` on a Supabase Edge Function calling Bedrock, and
+`no-missing-client-release` on a Deno postgres pool driver. Both are real
+serverless code that the ecosystem was blind to.
+
+Verification also **ruled out** four groups the generous probe flagged, rather
+than widening the gates to swallow them: `@serverless/*` and
+`@aws-lambda-powertools/*` hits were the frameworks' own source (one specifier
+was inside a JSDoc `@example` block), and `@payloadcms/db-mongodb` /
+`@medusajs/deps/pg` were type-only imports of adapter packages in files that
+never touch the driver.
+
+Each new arm ships a positive control in the plugin's `module-gate.lock.test.ts`
+— import-equals, `npm:`, and `deno.land/x` for every gate, plus the dynamic
+`import()` case for postgres — so none of them can regress silently. All four
+packages remain at 100% statements / branches / functions / lines.

--- a/packages/eslint-plugin-express-security/src/module-gate.lock.test.ts
+++ b/packages/eslint-plugin-express-security/src/module-gate.lock.test.ts
@@ -129,6 +129,31 @@ describe('Express module gate', () => {
       expect(lint(code, 'no-permissive-cors').length).toBeGreaterThan(0);
     });
 
+    it("opens on TypeScript's import-equals form", () => {
+      // `import express = require('express')` is a TSImportEqualsDeclaration,
+      // not a require CallExpression. The false-negative audit found 82 corpus
+      // files written this way with every rule in the plugin silenced.
+      const code = `import express = require('express');
+        import cors from 'cors';
+        const app = express();
+        ${permissive}`;
+      expect(lint(code, 'no-permissive-cors').length).toBeGreaterThan(0);
+    });
+
+    it("opens on Deno's npm: specifier", () => {
+      const code = `import express from 'npm:express';
+        import cors from 'cors';
+        ${permissive}`;
+      expect(lint(code, 'no-permissive-cors').length).toBeGreaterThan(0);
+    });
+
+    it('opens on a deno.land/x URL import', () => {
+      const code = `import express from 'https://deno.land/x/express@v1.0.0/mod.ts';
+        import cors from 'cors';
+        ${permissive}`;
+      expect(lint(code, 'no-permissive-cors').length).toBeGreaterThan(0);
+    });
+
     it('and stays silent on that same call with neither present', () => {
       const code = `import cors from 'cors';
         export function setup(app) { ${permissive} }`;

--- a/packages/eslint-plugin-express-security/src/utils/express-evidence.ts
+++ b/packages/eslint-plugin-express-security/src/utils/express-evidence.ts
@@ -24,7 +24,26 @@ const EXPRESS_PACKAGES: ReadonlySet<string> = new Set([
 const REQ_NAMES: ReadonlySet<string> = new Set(['req', 'request']);
 const RES_NAMES: ReadonlySet<string> = new Set(['res', 'response']);
 
+/**
+ * Strip the module-resolution prefixes Deno adds, so a Deno/Supabase Edge
+ * Function is judged on the package it actually loads.
+ *
+ * `npm:@aws-sdk/client-s3` and
+ * `https://deno.land/x/postgres@v0.17.0/mod.ts` are ordinary SDK imports
+ * written in Deno's specifier syntax. Both were silenced by every gate in the
+ * ecosystem until the false-negative audit found them in
+ * supabase/examples/**: the prefix made the specifier unrecognisable and the
+ * whole plugin abstained on real SDK code.
+ */
+function normalizeSpecifier(specifier: string): string {
+  if (specifier.startsWith('npm:')) return specifier.slice(4);
+  const deno = /^https?:\/\/deno\.land\/x\/([^@/]+)/.exec(specifier);
+  if (deno) return deno[1];
+  return specifier;
+}
+
 function isExpressSpecifier(specifier: string): boolean {
+  specifier = normalizeSpecifier(specifier);
   if (specifier.startsWith('.') || specifier.startsWith('/')) return false;
   const parts = specifier.split('/');
   const root = specifier.startsWith('@')
@@ -32,6 +51,26 @@ function isExpressSpecifier(specifier: string): boolean {
     : parts[0];
   return EXPRESS_PACKAGES.has(root);
 }
+
+/**
+ * `import express = require('express')` — TypeScript's import-equals form.
+ *
+ * Not a `CallExpression`: the AST is a `TSImportEqualsDeclaration` whose
+ * `moduleReference` is a `TSExternalModuleReference` wrapping the literal, so
+ * the `require`-call arm never sees it. The false-negative audit found **82
+ * corpus files** written this way for Express alone — DefinitelyTyped uses it
+ * for nearly every CommonJS type test — with every rule in the plugin silenced.
+ */
+function isImportEqualsLoad(node: TSESTree.Node): boolean {
+  return (
+    node.type === AST_NODE_TYPES.TSImportEqualsDeclaration &&
+    node.moduleReference.type === AST_NODE_TYPES.TSExternalModuleReference &&
+    node.moduleReference.expression.type === AST_NODE_TYPES.Literal &&
+    typeof node.moduleReference.expression.value === 'string' &&
+    isExpressSpecifier(node.moduleReference.expression.value)
+  );
+}
+
 
 /**
  * Whether a scope-introducing node binds the name `require`.
@@ -179,6 +218,7 @@ function computeUsesExpress(ast: TSESTree.Program): boolean {
       return;
     }
     if (
+      isImportEqualsLoad(node) ||
       isExpressDynamicLoad(node, requireIsShadowed) ||
       hasMiddlewareSignature(node)
     ) {

--- a/packages/eslint-plugin-lambda-security/src/module-gate.lock.test.ts
+++ b/packages/eslint-plugin-lambda-security/src/module-gate.lock.test.ts
@@ -114,6 +114,23 @@ describe('Lambda module gate', () => {
   describe('positive controls — the gate must open for real Lambda code', () => {
     const swallowing = `try { riskyOperation(); } catch (error) {}`;
 
+    it("opens on TypeScript's import-equals form", () => {
+      const code = `import AWS = require('aws-sdk');\nconst run = () => { ${swallowing} };`;
+      expect(lint(code, 'no-error-swallowing').length).toBeGreaterThan(0);
+    });
+
+    it('opens on a deno.land/x URL import', () => {
+      const code = `import { S3 } from 'https://deno.land/x/aws-sdk@v3.0.0/mod.ts';\nconst run = () => { ${swallowing} };`;
+      expect(lint(code, 'no-error-swallowing').length).toBeGreaterThan(0);
+    });
+
+    it("opens on Deno's npm: specifier", () => {
+      // supabase/examples/**/image_gen/index.ts imports
+      // 'npm:@aws-sdk/client-bedrock-runtime'; the prefix silenced the plugin.
+      const code = `import { BedrockRuntimeClient } from 'npm:@aws-sdk/client-bedrock-runtime';\nconst run = () => { ${swallowing} };`;
+      expect(lint(code, 'no-error-swallowing').length).toBeGreaterThan(0);
+    });
+
     it('reports once the file exports a handler, with no AWS import at all', () => {
       const code = `export const handler = async (event) => { ${swallowing} };`;
       expect(lint(code, 'no-error-swallowing').length).toBeGreaterThan(0);

--- a/packages/eslint-plugin-lambda-security/src/utils/lambda-evidence.ts
+++ b/packages/eslint-plugin-lambda-security/src/utils/lambda-evidence.ts
@@ -37,7 +37,26 @@ const AWS_PREFIXES: readonly string[] = [
 /** The Lambda calling convention, in the order the runtime passes them. */
 const HANDLER_PARAMS: readonly string[] = ['event', 'context', 'callback'];
 
+/**
+ * Strip the module-resolution prefixes Deno adds, so a Deno/Supabase Edge
+ * Function is judged on the package it actually loads.
+ *
+ * `npm:@aws-sdk/client-s3` and
+ * `https://deno.land/x/postgres@v0.17.0/mod.ts` are ordinary SDK imports
+ * written in Deno's specifier syntax. Both were silenced by every gate in the
+ * ecosystem until the false-negative audit found them in
+ * supabase/examples/**: the prefix made the specifier unrecognisable and the
+ * whole plugin abstained on real SDK code.
+ */
+function normalizeSpecifier(specifier: string): string {
+  if (specifier.startsWith('npm:')) return specifier.slice(4);
+  const deno = /^https?:\/\/deno\.land\/x\/([^@/]+)/.exec(specifier);
+  if (deno) return deno[1];
+  return specifier;
+}
+
 function isAwsSpecifier(specifier: string): boolean {
+  specifier = normalizeSpecifier(specifier);
   if (specifier.startsWith('.') || specifier.startsWith('/')) return false;
   if (AWS_PACKAGES.has(specifier)) return true;
   const parts = specifier.split('/');
@@ -47,6 +66,26 @@ function isAwsSpecifier(specifier: string): boolean {
   if (AWS_PACKAGES.has(root)) return true;
   return AWS_PREFIXES.some((prefix) => specifier.startsWith(prefix));
 }
+
+/**
+ * `import express = require('express')` — TypeScript's import-equals form.
+ *
+ * Not a `CallExpression`: the AST is a `TSImportEqualsDeclaration` whose
+ * `moduleReference` is a `TSExternalModuleReference` wrapping the literal, so
+ * the `require`-call arm never sees it. The false-negative audit found **82
+ * corpus files** written this way for Express alone — DefinitelyTyped uses it
+ * for nearly every CommonJS type test — with every rule in the plugin silenced.
+ */
+function isImportEqualsLoad(node: TSESTree.Node): boolean {
+  return (
+    node.type === AST_NODE_TYPES.TSImportEqualsDeclaration &&
+    node.moduleReference.type === AST_NODE_TYPES.TSExternalModuleReference &&
+    node.moduleReference.expression.type === AST_NODE_TYPES.Literal &&
+    typeof node.moduleReference.expression.value === 'string' &&
+    isAwsSpecifier(node.moduleReference.expression.value)
+  );
+}
+
 
 /**
  * `require('aws-sdk')` and `await import('aws-sdk')` — the two dynamic forms.
@@ -235,6 +274,7 @@ function computeIsLambda(ast: TSESTree.Program): boolean {
       return;
     }
     if (
+      isImportEqualsLoad(node) ||
       isAwsDynamicLoad(node, requireIsShadowed) ||
       declaresHandler(node) ||
       hasHandlerSignature(node)

--- a/packages/eslint-plugin-postgresql-security/src/module-gate.lock.test.ts
+++ b/packages/eslint-plugin-postgresql-security/src/module-gate.lock.test.ts
@@ -120,6 +120,32 @@ describe('PostgreSQL module gate', () => {
     expect(lint(code, 'no-unsafe-query').length).toBeGreaterThan(0);
   });
 
+  it("opens on TypeScript's import-equals form", () => {
+    const code = `import pg = require('pg');
+      client.query('SELECT * FROM users WHERE id = ' + id);`;
+    expect(lint(code, 'no-unsafe-query').length).toBeGreaterThan(0);
+  });
+
+  it('opens on a dynamic import() of the driver', () => {
+    // This gate had no ImportExpression arm at all, alone among the five.
+    const code = `const { Pool } = await import('pg');
+      client.query('SELECT * FROM users WHERE id = ' + id);`;
+    expect(lint(code, 'no-unsafe-query').length).toBeGreaterThan(0);
+  });
+
+  it("opens on Deno's npm: specifier", () => {
+    const code = `import pg from 'npm:pg';
+      client.query('SELECT * FROM users WHERE id = ' + id);`;
+    expect(lint(code, 'no-unsafe-query').length).toBeGreaterThan(0);
+  });
+
+  it("opens on a Deno deno.land/x URL import", () => {
+    // supabase/examples/edge-functions/**/DenoPostgresDriver.ts
+    const code = `import { Pool } from 'https://deno.land/x/postgres@v0.17.0/mod.ts';
+      client.query('SELECT * FROM users WHERE id = ' + id);`;
+    expect(lint(code, 'no-unsafe-query').length).toBeGreaterThan(0);
+  });
+
   it('and stays silent on that same query with the import removed', () => {
     const code = `client.query('SELECT * FROM users WHERE id = ' + id);`;
     expect(lint(code, 'no-unsafe-query')).toHaveLength(0);

--- a/packages/eslint-plugin-postgresql-security/src/utils/index.ts
+++ b/packages/eslint-plugin-postgresql-security/src/utils/index.ts
@@ -41,7 +41,26 @@ const PG_MODULE_SET: ReadonlySet<string> = new Set(PG_MODULES);
  * count. A relative specifier is never a package and is rejected outright —
  * otherwise `'./pg'` would satisfy the gate in a repo that has no `pg`.
  */
+/**
+ * Strip the module-resolution prefixes Deno adds, so a Deno/Supabase Edge
+ * Function is judged on the package it actually loads.
+ *
+ * `npm:@aws-sdk/client-s3` and
+ * `https://deno.land/x/postgres@v0.17.0/mod.ts` are ordinary SDK imports
+ * written in Deno's specifier syntax. Both were silenced by every gate in the
+ * ecosystem until the false-negative audit found them in
+ * supabase/examples/**: the prefix made the specifier unrecognisable and the
+ * whole plugin abstained on real SDK code.
+ */
+function normalizeSpecifier(specifier: string): string {
+  if (specifier.startsWith('npm:')) return specifier.slice(4);
+  const deno = /^https?:\/\/deno\.land\/x\/([^@/]+)/.exec(specifier);
+  if (deno) return deno[1];
+  return specifier;
+}
+
 function isPgSpecifier(specifier: string): boolean {
+  specifier = normalizeSpecifier(specifier);
   if (specifier.startsWith('.') || specifier.startsWith('/')) return false;
   const parts = specifier.split('/');
   const root = specifier.startsWith('@')
@@ -50,7 +69,43 @@ function isPgSpecifier(specifier: string): boolean {
   return PG_MODULE_SET.has(root);
 }
 
+/**
+ * `import express = require('express')` — TypeScript's import-equals form.
+ *
+ * Not a `CallExpression`: the AST is a `TSImportEqualsDeclaration` whose
+ * `moduleReference` is a `TSExternalModuleReference` wrapping the literal, so
+ * the `require`-call arm never sees it. The false-negative audit found **82
+ * corpus files** written this way for Express alone — DefinitelyTyped uses it
+ * for nearly every CommonJS type test — with every rule in the plugin silenced.
+ */
+function isImportEqualsLoad(node: TSESTree.Node): boolean {
+  return (
+    node.type === AST_NODE_TYPES.TSImportEqualsDeclaration &&
+    node.moduleReference.type === AST_NODE_TYPES.TSExternalModuleReference &&
+    node.moduleReference.expression.type === AST_NODE_TYPES.Literal &&
+    typeof node.moduleReference.expression.value === 'string' &&
+    isPgSpecifier(node.moduleReference.expression.value)
+  );
+}
+
+
 /** `require('pg')` — the CommonJS half of the same evidence. */
+/**
+ * `await import('pg')` — the dynamic form.
+ *
+ * This gate had no `ImportExpression` arm at all, alone among the five: a file
+ * that lazily loads its driver was silenced entirely. Every other gate in the
+ * ecosystem has carried this arm since #481.
+ */
+function isPgDynamicImport(node: TSESTree.Node): boolean {
+  return (
+    node.type === AST_NODE_TYPES.ImportExpression &&
+    node.source.type === AST_NODE_TYPES.Literal &&
+    typeof node.source.value === 'string' &&
+    isPgSpecifier(node.source.value)
+  );
+}
+
 function isPgRequire(node: TSESTree.Node): boolean {
   if (node.type !== AST_NODE_TYPES.CallExpression) return false;
   if (
@@ -180,6 +235,8 @@ function computeUsesPostgres(ast: TSESTree.Program): boolean {
       return;
     }
     if (
+      isImportEqualsLoad(node) ||
+      isPgDynamicImport(node) ||
       (!requireIsShadowed && isPgRequire(node)) ||
       isPgConnectionString(node)
     ) {

--- a/packages/eslint-plugin-vercel-ai-security/src/module-gate.lock.test.ts
+++ b/packages/eslint-plugin-vercel-ai-security/src/module-gate.lock.test.ts
@@ -163,6 +163,21 @@ describe('Vercel AI module gate', () => {
       expect(lint(code, 'no-hardcoded-api-keys').length).toBeGreaterThan(0);
     });
 
+    it("opens on TypeScript's import-equals form", () => {
+      const code = `import ai = require('ai');\n${hardcoded}`;
+      expect(lint(code, 'no-hardcoded-api-keys').length).toBeGreaterThan(0);
+    });
+
+    it('opens on a deno.land/x URL import', () => {
+      const code = `import { generateText } from 'https://deno.land/x/ai@v1.0.0/mod.ts';\n${hardcoded}`;
+      expect(lint(code, 'no-hardcoded-api-keys').length).toBeGreaterThan(0);
+    });
+
+    it("opens on Deno's npm: specifier", () => {
+      const code = `import { openai } from 'npm:@ai-sdk/openai';\n${hardcoded}`;
+      expect(lint(code, 'no-hardcoded-api-keys').length).toBeGreaterThan(0);
+    });
+
     it('and stays silent on that same config with no SDK present', () => {
       expect(lint(hardcoded, 'no-hardcoded-api-keys')).toHaveLength(0);
     });

--- a/packages/eslint-plugin-vercel-ai-security/src/utils/vercel-ai-evidence.ts
+++ b/packages/eslint-plugin-vercel-ai-security/src/utils/vercel-ai-evidence.ts
@@ -20,7 +20,26 @@ import { AST_NODE_TYPES } from '@interlace/eslint-devkit';
 const AI_PACKAGES: ReadonlySet<string> = new Set(['ai']);
 const AI_SCOPES: ReadonlySet<string> = new Set(['@ai-sdk']);
 
+/**
+ * Strip the module-resolution prefixes Deno adds, so a Deno/Supabase Edge
+ * Function is judged on the package it actually loads.
+ *
+ * `npm:@aws-sdk/client-s3` and
+ * `https://deno.land/x/postgres@v0.17.0/mod.ts` are ordinary SDK imports
+ * written in Deno's specifier syntax. Both were silenced by every gate in the
+ * ecosystem until the false-negative audit found them in
+ * supabase/examples/**: the prefix made the specifier unrecognisable and the
+ * whole plugin abstained on real SDK code.
+ */
+function normalizeSpecifier(specifier: string): string {
+  if (specifier.startsWith('npm:')) return specifier.slice(4);
+  const deno = /^https?:\/\/deno\.land\/x\/([^@/]+)/.exec(specifier);
+  if (deno) return deno[1];
+  return specifier;
+}
+
 function isAiSpecifier(specifier: string): boolean {
+  specifier = normalizeSpecifier(specifier);
   if (specifier.startsWith('.') || specifier.startsWith('/')) return false;
   if (specifier.startsWith('@')) {
     const scope = specifier.split('/')[0];
@@ -28,6 +47,26 @@ function isAiSpecifier(specifier: string): boolean {
   }
   return AI_PACKAGES.has(specifier.split('/')[0]);
 }
+
+/**
+ * `import express = require('express')` — TypeScript's import-equals form.
+ *
+ * Not a `CallExpression`: the AST is a `TSImportEqualsDeclaration` whose
+ * `moduleReference` is a `TSExternalModuleReference` wrapping the literal, so
+ * the `require`-call arm never sees it. The false-negative audit found **82
+ * corpus files** written this way for Express alone — DefinitelyTyped uses it
+ * for nearly every CommonJS type test — with every rule in the plugin silenced.
+ */
+function isImportEqualsLoad(node: TSESTree.Node): boolean {
+  return (
+    node.type === AST_NODE_TYPES.TSImportEqualsDeclaration &&
+    node.moduleReference.type === AST_NODE_TYPES.TSExternalModuleReference &&
+    node.moduleReference.expression.type === AST_NODE_TYPES.Literal &&
+    typeof node.moduleReference.expression.value === 'string' &&
+    isAiSpecifier(node.moduleReference.expression.value)
+  );
+}
+
 
 /**
  * Whether a scope-introducing node binds the name `require`.
@@ -144,7 +183,7 @@ function computeUsesVercelAi(ast: TSESTree.Program): boolean {
       found = true;
       return;
     }
-    if (isAiDynamicLoad(node, requireIsShadowed)) {
+    if (isImportEqualsLoad(node) || isAiDynamicLoad(node, requireIsShadowed)) {
       found = true;
       return;
     }


### PR DESCRIPTION
## Summary

A **full false-negative audit** of every gated plugin, run because a documented-and-accepted FN is not acceptable. Method: sweep the 107-repository corpus twice — once with all five gates forced open, once as shipped — and compare.

- **6,686 findings silenced across 5,235 files** (that's the gates working — 16k FPs removed to date)
- **134 files flagged suspect**: the SDK *is* imported, yet the gate closed
- Verifying those one by one produced **two real defect classes** and **ruled out four false alarms**

### Defect 1 — TypeScript import-equals was invisible to 4 of 5 gates

`import express = require('express')` is a `TSImportEqualsDeclaration` whose module reference is a `TSExternalModuleReference` — not a `require` `CallExpression` — so the dynamic-load arm never saw it. **82 corpus files written that way for Express alone had every rule in the plugin silenced.** Only `mongodb-security` handled it, and only because an earlier audit forced the issue.

### Defect 2 — Deno's specifiers were unrecognisable to all 5

`npm:@aws-sdk/client-bedrock-runtime` and `https://deno.land/x/postgres@v0.17.0/mod.ts` are ordinary SDK imports in Deno and Supabase Edge Functions. The prefix made the specifier unmatchable, so the whole plugin abstained on real serverless code. Both forms are now normalised before the package test.

### Also: `postgresql-security` had no dynamic `import()` arm at all

Alone among the five — a file that lazily loads its driver was silenced entirely. Every other gate has carried that arm since #481.

## Test plan

- [x] **Re-swept the same 119,271 files with the fixes: 198 findings recovered across 88 files (196 express, 1 postgres, 1 lambda), and ZERO regressions** — nothing that reported before is silenced now.
- [x] All four suites pass, all at **100% statements / branches / functions / lines**: express 1,284 tests · lambda 527 · vercel-ai 554 · postgres 532.
- [x] `npm run oxlint` — 0 errors. Benchmarks locks 72/72.
- [x] Every new arm ships a positive control in the plugin's `module-gate.lock.test.ts` — import-equals, `npm:`, and `deno.land/x` for all four, plus dynamic `import()` for postgres.

### The two non-Express recoveries are the clearest illustration

| file | rule recovered |
|---|---|
| `supabase/examples/ai/aws_bedrock_image_gen/.../image_gen/index.ts` | `lambda-security/no-missing-authorization-check` |
| `supabase/examples/edge-functions/.../DenoPostgresDriver.ts` | `postgresql-security/no-missing-client-release` |

Both are real serverless code the ecosystem was completely blind to.

## What I deliberately did NOT widen

Four suspect groups were **ruled out** rather than swallowed by loosening the gates:

- `@serverless/*` (19 files) — the Serverless Framework's own engine source, not Lambda handler code
- `@aws-lambda-powertools/*` (3) — the library's own source; the specifier my probe saw was inside a JSDoc `@example` block
- `@payloadcms/db-mongodb` (6) and `@medusajs/deps/pg` (2) — type-only imports of adapter packages, in files that never touch the driver

## On the 196 Express recoveries

They concentrate in DefinitelyTyped, and 170 are `require-helmet` / `require-rate-limiting`. These are the rules behaving **per their contract**: `absolute-url-tests.ts` genuinely does `const app = express(); app.use(...)` with no helmet. Those files were exempt only because they used import-equals — an identical file with a normal `import` has always reported. So this removes an accidental exemption rather than creating an FP class.

Worth a separate decision, and not one I'd make unilaterally on a security rule: whether `require-helmet` should fire in any file constructing an app, or only in an app-bootstrap file. Related, `allowInTests` matches `.test.`/`.spec.` but not the `-tests.ts` convention DefinitelyTyped uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)