### PR TITLE
chore(conventions): changeset for the philosophy meta.docs.url fix

### DIFF
--- a/.changeset/conventions-philosophy-urls.md
+++ b/.changeset/conventions-philosophy-urls.md
@@ -1,0 +1,18 @@
+---
+'eslint-plugin-conventions': patch
+---
+
+Point `meta.docs.url` at the philosophies' new home
+
+`utm-taxonomy`, `no-raw-cross-property-href`, and `analytics-event-naming`
+shipped `meta.docs.url` values pointing at `UTM_PHILOSOPHY.md` and
+`ANALYTICS_PHILOSOPHY.md` at the root of this repo. Those documents moved to
+[ofri-peretz/interlace `docs/philosophies/`](https://github.com/ofri-peretz/interlace/tree/main/docs/philosophies),
+so the published URLs now 404 — the "read more" link on every one of these
+diagnostics is dead in `4.2.8`.
+
+Nothing in CI caught it: `check-links.ts` only scans external URLs in MDX, so
+a `meta.docs.url` string in a rule's `.ts` is invisible to it. Worth a
+follow-up lock that resolves every rule's `meta.docs.url`.
+
+No rule behaviour changes — five string literals.


### PR DESCRIPTION
Follow-up to #493, which repointed three rules' `meta.docs.url` to the philosophies' new home in [ofri-peretz/interlace](https://github.com/ofri-peretz/interlace/tree/main/docs/philosophies) — but shipped **no changeset**, so the fix is sitting on `main` unreleased while the files it used to point at are already deleted.

## This is live, not theoretical

```
npm pack eslint-plugin-conventions@4.2.8 && grep -r 'blob/main/.*_PHILOSOPHY' package/
  → ofri-peretz/eslint/blob/main/ANALYTICS_PHILOSOPHY.md
  → ofri-peretz/eslint/blob/main/UTM_PHILOSOPHY.md
```

Both paths 404 as of #493. So the "read more" link on every `utm-taxonomy`, `no-raw-cross-property-href`, and `analytics-event-naming` diagnostic is currently dead for anyone on the published version.

A patch changeset closes it.

## Why CI didn't catch this

`check-links.ts` only scans external URLs in **MDX**. A `meta.docs.url` string inside a rule's `.ts` is invisible to it, and the changeset gate passed on #493 because other packages in that PR had coverage. Worth a follow-up lock that resolves every rule's `meta.docs.url` — that would have caught both the original breakage and the missing release.

No rule behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links for three `eslint-plugin-conventions` rules to point to their relocated philosophy documents.
  * No rule behavior changes are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->