### PR TITLE
feat(eslint-devkit): share one SDK-evidence probe, close the gate debt

### DIFF
--- a/.changeset/close-the-gate-debt.md
+++ b/.changeset/close-the-gate-debt.md
@@ -1,0 +1,23 @@
+---
+'@interlace/eslint-devkit': minor
+'eslint-plugin-nestjs-security': major
+---
+
+Share one SDK-evidence probe, and gate the last plugin that had none
+
+`createModuleEvidence` moves the probe into the devkit. Five plugins each
+carried their own copy, so the two false-negative classes the audit found —
+TypeScript's `import =` form and Deno's `npm:` / `deno.land` specifiers — had to
+be fixed five times. One implementation now carries package-root matching,
+rejection of relative specifiers, both dynamic forms, lexically-scoped `require`
+shadowing, an optional non-import evidence arm, and a per-`Program` cache.
+
+`nestjs-security` is gated on it. Measured over 107,382 files across 107
+repositories, **22% of everything it reported (219 of 999 findings) was in a
+file importing no NestJS package** — its rules key on decorator and method names
+that Angular, TypeORM and plain TypeScript classes share. This is a **major**:
+any rule may now stay silent where it previously reported.
+
+Every other SDK plugin already abstained, but eight of them proved it only
+inside a devkit factory. They now ship a registry-wide lock as well, so the
+guarantee survives a hand-written rule added tomorrow.

--- a/apps/docs/src/data/plugin-stats.json
+++ b/apps/docs/src/data/plugin-stats.json
@@ -21,7 +21,7 @@
       "rules": 28,
       "description": "ESLint plugin for secure coding — detects LDAP, XPath, XXE, GraphQL and template injection, unsafe deserialization, ReDoS, missing authentication, and PII in logs",
       "category": "security",
-      "version": "3.5.0",
+      "version": "3.6.0",
       "published": true
     },
     {
@@ -29,7 +29,7 @@
       "rules": 19,
       "description": "ESLint plugin for Vercel AI SDK security — detects prompt injection, system-prompt leaks, hardcoded API keys, and unvalidated model output in generateText and streamText",
       "category": "security",
-      "version": "1.5.4",
+      "version": "2.0.0",
       "published": true
     },
     {
@@ -37,7 +37,7 @@
       "rules": 16,
       "description": "ESLint plugin for MongoDB and Mongoose security — detects NoSQL operator injection, unsafe queries and regex, hardcoded connection strings, and missing TLS",
       "category": "security",
-      "version": "8.4.0",
+      "version": "9.0.0",
       "published": true
     },
     {
@@ -45,7 +45,7 @@
       "rules": 13,
       "description": "ESLint plugin for JWT security — detects algorithm confusion (CVE-2022-23540), alg:none, weak or hardcoded secrets, and decode-without-verify",
       "category": "security",
-      "version": "2.3.3",
+      "version": "2.3.4",
       "published": true
     },
     {
@@ -53,7 +53,7 @@
       "rules": 13,
       "description": "ESLint plugin for the pg PostgreSQL driver — detects SQL injection, unreleased clients, floating queries, unsafe search_path, and insecure SSL",
       "category": "security",
-      "version": "1.5.3",
+      "version": "2.0.0",
       "published": true
     },
     {
@@ -61,7 +61,7 @@
       "rules": 5,
       "description": "ESLint plugin for knex — detects SQL injection in raw queries built with string concatenation or template literals, connection configuration that disables TLS or certificate validation, and hardcoded database credentials",
       "category": "security",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "published": true
     },
     {
@@ -69,7 +69,7 @@
       "rules": 4,
       "description": "ESLint plugin for drizzle-orm — detects SQL injection in raw queries built with string concatenation or template literals",
       "category": "security",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "published": true
     },
     {
@@ -85,7 +85,7 @@
       "rules": 4,
       "description": "ESLint plugin for @prisma/client — detects SQL injection in raw queries built with string concatenation or template literals",
       "category": "security",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "published": true
     },
     {
@@ -93,7 +93,7 @@
       "rules": 4,
       "description": "ESLint plugin for the Sequelize ORM — detects SQL injection in raw sequelize.query() and Sequelize.literal() calls built with string concatenation or template literals, connection configuration that disables TLS or certificate validation, and hardcoded database credentials",
       "category": "security",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "published": true
     },
     {
@@ -101,7 +101,7 @@
       "rules": 4,
       "description": "ESLint plugin for typeorm — detects SQL injection in raw queries built with string concatenation or template literals, connection configuration that disables TLS or certificate validation, and hardcoded database credentials",
       "category": "security",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "published": true
     },
     {
@@ -125,7 +125,7 @@
       "rules": 3,
       "description": "ESLint plugin for mysql2 / mysql — detects SQL injection in raw queries built with string concatenation or template literals, connection configuration that disables TLS or certificate validation, and hardcoded database credentials",
       "category": "security",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "published": true
     },
     {
@@ -141,7 +141,7 @@
       "rules": 1,
       "description": "ESLint plugin for better-sqlite3 / sqlite3 — detects SQL injection in raw queries built with string concatenation or template literals",
       "category": "security",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "published": true
     },
     {
@@ -149,7 +149,7 @@
       "rules": 28,
       "description": "ESLint plugin for Express.js security — detects permissive CORS, missing CSRF protection, missing helmet headers, insecure cookies, and GraphQL introspection in production",
       "category": "framework",
-      "version": "1.5.6",
+      "version": "2.0.0",
       "published": true
     },
     {
@@ -157,7 +157,7 @@
       "rules": 14,
       "description": "ESLint plugin for AWS Lambda security — detects overly permissive IAM policies and CORS, unvalidated event bodies, secrets in env vars, and leaked error details",
       "category": "framework",
-      "version": "1.3.4",
+      "version": "2.0.0",
       "published": true
     },
     {
@@ -181,7 +181,7 @@
       "rules": 15,
       "description": "ESLint plugin for team code conventions — enforces filename case, magic-number bans, commented-out code, expiring TODOs, and deprecated-API usage",
       "category": "quality",
-      "version": "4.2.8",
+      "version": "4.2.9",
       "published": true
     },
     {
@@ -244,5 +244,5 @@
   "totalRules": 466,
   "totalPlugins": 30,
   "allPluginsCount": 30,
-  "generatedAt": "2026-08-10"
+  "generatedAt": "2026-08-11"
 }

--- a/benchmarks/__tests__/sdk-gate-coverage.lock.test.ts
+++ b/benchmarks/__tests__/sdk-gate-coverage.lock.test.ts
@@ -69,33 +69,24 @@ const REPO_ROOT = path.resolve(HERE, '../..');
  *
  * @see NEXT-LEVEL-PLAN.md items 4 and 6
  */
-const UNGATED: Readonly<Record<string, number>> = {
-  // No gate at all — ordered by measured blast radius.
-  // vercel-ai-security (was 1,738) is gated as of #489 and now ships
-  // src/module-gate.lock.test.ts; re-measured on the same corpus it reports 0
-  // off-SDK findings.
-  // mongodb-security (was 1,663) is gated as of the mongo-evidence PR and now
-  // ships src/module-gate.lock.test.ts.
-  'nestjs-security': 219,
-  // Effectively gated already: `isJwtLibraryCall` requires the file to import a
-  // JWT library, which took it from 702 off-SDK findings to 27. What it still
-  // owes is the registry-wide lock, so the property cannot be lost by a rule
-  // that skips the helper.
-  'jwt-security': 27,
-  'openai-security': 0,
-  'anthropic-security': 0,
-  'gemini-security': 0,
-  'mcp-sdk-security': 0,
-  // Gated by the devkit SQL factory; measured 0 off-SDK. Owed a registry lock so
-  // the property survives the next hand-written rule.
-  'typeorm-security': 0,
-  'mysql-security': 0,
-  'knex-security': 0,
-  'drizzle-security': 0,
-  'sqlite-security': 0,
-  'prisma-security': 0,
-  'sequelize-security': 0,
-};
+/**
+ * SDK plugins that do not yet ship `src/module-gate.lock.test.ts`.
+ *
+ * **Empty, as of 2026-08-11.** Every SDK-specific plugin now ships a
+ * registry-wide lock proving that none of its rules reports in a file that does
+ * not use its SDK. Getting here took five plugins gated outright
+ * (postgresql, lambda, express, vercel-ai, mongodb) and eight more that were
+ * already gated inside a devkit factory — the seven SQL plugins via
+ * `createSqlInjectionRule`, the AI-key plugins via `createSdkApiKeyRule` —
+ * finally proving it at the registry level, where a hand-written rule added
+ * tomorrow cannot slip past.
+ *
+ * Keep this mechanism even while empty: a **new** SDK plugin lands on neither
+ * list and turns this suite red until it is gated too. Adding an entry here to
+ * silence a failure is the one thing it must never be used for — an entry is a
+ * debt with a number attached, and the fix is the gate.
+ */
+const UNGATED: Readonly<Record<string, number>> = {};
 
 /**
  * Files that use no SDK from any of these plugins. Each is a real

--- a/packages/eslint-devkit/src/rule-creation/index.ts
+++ b/packages/eslint-devkit/src/rule-creation/index.ts
@@ -37,3 +37,4 @@ export * from './message-source';
 // Shared CWE-89 detector for the *other* half of SQL injection: identifiers
 // spliced into a query the tagged template only parameterizes values in.
 export * from './raw-identifier-rule';
+export * from './module-evidence';

--- a/packages/eslint-devkit/src/rule-creation/module-evidence.test.ts
+++ b/packages/eslint-devkit/src/rule-creation/module-evidence.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Tests for the shared SDK-evidence probe.
+ *
+ * Every rule in every SDK-specific plugin is gated on one of these, so a bug
+ * here is a bug in ~150 rules at once — silently, in whichever direction the
+ * bug leans. The cases below are the accumulated findings of the corpus sweep
+ * and the false-negative audit, not invented edge cases.
+ */
+import { describe, it, expect } from 'vitest';
+import { parse } from '@typescript-eslint/parser';
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+import type { TSESTree } from '@typescript-eslint/utils';
+import { createModuleEvidence } from './module-evidence';
+
+const ast = (code: string): TSESTree.Program =>
+  parse(code, { sourceType: 'module', range: true });
+
+const pg = createModuleEvidence({ packages: ['pg', 'postgres'] });
+const ai = createModuleEvidence({ packages: ['ai'], scopes: ['@ai-sdk'] });
+const lambda = createModuleEvidence({
+  packages: ['aws-lambda'],
+  scopes: ['@aws-sdk'],
+  prefixes: ['serverless-'],
+});
+
+describe('createModuleEvidence', () => {
+  describe('imports', () => {
+    it.each([
+      ["import { Pool } from 'pg';", 'bare package'],
+      ["import c from 'pg/lib/client';", 'deep path counts — matched on the root'],
+      ["import 'pg';", 'side-effect import with no bindings'],
+      ["export { Pool } from 'pg';", 're-export'],
+      ["export * from 'pg';", 'star re-export'],
+      ["import type { Client } from 'pg';", 'type-only import'],
+    ])('%s → true (%s)', (code) => {
+      expect(pg(ast(code))).toBe(true);
+    });
+
+    it.each([
+      ["import x from 'mysql2';", 'a different driver'],
+      ["import x from 'pgx';", 'a package merely sharing the prefix'],
+      ["import x from './pg';", 'relative — a local file named after the package'],
+      ["import x from '../db/pg';", 'relative parent'],
+      ["import x from '/pg';", 'absolute'],
+      ['export const x = 1;', 'a local export with no source'],
+      ["export * from './helpers';", 'a re-export of something else'],
+      ['', 'an empty file'],
+    ])('%s → false (%s)', (code) => {
+      expect(pg(ast(code))).toBe(false);
+    });
+  });
+
+  describe('scopes and prefixes', () => {
+    it('a whole scope matches every package under it', () => {
+      expect(ai(ast("import { openai } from '@ai-sdk/openai';"))).toBe(true);
+      // The point of matching the scope rather than enumerating providers: a
+      // provider we have never heard of still opens the gate.
+      expect(ai(ast("import x from '@ai-sdk/some-future-provider';"))).toBe(true);
+      expect(ai(ast("import x from '@ai-sdk/openai/edge';"))).toBe(true);
+    });
+
+    it('a different scope does not', () => {
+      expect(ai(ast("import x from '@other/openai';"))).toBe(false);
+    });
+
+    it('a bare scope with no package name matches the scope', () => {
+      // `@ai-sdk` alone is not installable, so this cannot occur in real code.
+      // It resolves to the scope rather than being special-cased: erring open
+      // on a specifier that cannot exist costs nothing, and the alternative is
+      // a branch no corpus file would ever reach.
+      expect(ai(ast("import x from '@ai-sdk';"))).toBe(true);
+    });
+
+    it('prefixes match on the package root', () => {
+      expect(lambda(ast("import s from 'serverless-http';"))).toBe(true);
+      expect(lambda(ast("import s from 'serverless-http/lib';"))).toBe(true);
+      expect(lambda(ast("import s from 'server-less';"))).toBe(false);
+    });
+  });
+
+  describe("Deno's specifiers — a false-negative class from the audit", () => {
+    it.each([
+      "import { S3 } from 'npm:@aws-sdk/client-s3';",
+      "import x from 'npm:aws-lambda';",
+    ])('%s → true (npm: prefix stripped)', (code) => {
+      expect(lambda(ast(code))).toBe(true);
+    });
+
+    it('deno.land/x URLs are matched on the package segment', () => {
+      expect(
+        pg(ast("import { Client } from 'https://deno.land/x/postgres@v0.17.0/mod.ts';")),
+      ).toBe(true);
+      expect(
+        pg(ast("import x from 'http://deno.land/x/postgres/mod.ts';")),
+      ).toBe(true);
+    });
+
+    it('an unrelated URL is not evidence', () => {
+      expect(pg(ast("import x from 'https://esm.sh/lodash';"))).toBe(false);
+      expect(pg(ast("import x from 'https://deno.land/x/oak/mod.ts';"))).toBe(false);
+    });
+  });
+
+  describe("TypeScript's import-equals — the other audit class", () => {
+    it('import pg = require("pg") counts', () => {
+      // 82 corpus files were written this way for Express alone, with every
+      // rule in the plugin silenced.
+      expect(pg(ast('import client = require("pg");'))).toBe(true);
+    });
+
+    it('import-equals of something else does not', () => {
+      expect(pg(ast('import x = require("mysql2");'))).toBe(false);
+    });
+
+    it('an import-equals alias of a namespace is not a module load', () => {
+      expect(pg(ast('namespace N { export const x = 1; }\nimport A = N;'))).toBe(false);
+    });
+  });
+
+  describe('require and dynamic import', () => {
+    it.each([
+      "const { Pool } = require('pg');",
+      "function f() { return require('pg'); }",
+      "if (x) { require('pg'); }",
+      "const m = await import('pg');",
+    ])('%s → true', (code) => {
+      expect(pg(ast(code))).toBe(true);
+    });
+
+    it.each([
+      ["require('mysql2');", 'a different package'],
+      ["require('./pg');", 'a relative path'],
+      ['require(name);', 'a non-literal specifier'],
+      ['require();', 'no arguments'],
+      ['require(123);', 'a non-string literal'],
+      ['notRequire("pg");', 'a differently named function'],
+      ['obj.require("pg");', 'a member call, not the global require'],
+      ["await import('./pg');", 'a relative dynamic import'],
+      ['await import(name);', 'a non-literal dynamic import'],
+    ])('%s → false (%s)', (code) => {
+      expect(pg(ast(code))).toBe(false);
+    });
+  });
+
+  describe('a locally bound `require` is not module loading', () => {
+    it.each([
+      "function f(require) { require('pg'); }",
+      "const load = (require) => require('pg');",
+      "const require = (m) => m; require('pg');",
+      "{ const require = (m) => m; require('pg'); }",
+    ])('%s → false', (code) => {
+      expect(pg(ast(code))).toBe(false);
+    });
+
+    // Shadowing is lexical, not file-wide. A file-wide flag silenced every rule
+    // in the plugin whenever any inner binding existed — an FP fix that created
+    // an FN, which is the worse direction.
+    it('an unshadowed require survives a shadowing binding elsewhere', () => {
+      expect(pg(ast("const c = require('pg');\nfunction w(require) {}"))).toBe(true);
+      expect(pg(ast("function w(require) {}\nconst c = require('pg');"))).toBe(true);
+      expect(
+        pg(ast("function outer() { const c = require('pg'); }\nfunction w(require) {}")),
+      ).toBe(true);
+    });
+
+    it('the other arms still apply when `require` is shadowed', () => {
+      expect(pg(ast("import { Pool } from 'pg';\nfunction f(require) { require('pg'); }"))).toBe(true);
+      expect(pg(ast("import c = require('pg');\nfunction f(require) { require('pg'); }"))).toBe(true);
+    });
+  });
+
+  describe('extraEvidence — the non-import shapes', () => {
+    // Lambda and Express need one because 45% and 60% of their real files
+    // respectively import nothing; every other SDK is import-only.
+    const withHandler = createModuleEvidence({
+      packages: ['aws-lambda'],
+      extraEvidence: (node) =>
+        node.type === AST_NODE_TYPES.ExportNamedDeclaration &&
+        node.declaration?.type === AST_NODE_TYPES.VariableDeclaration &&
+        node.declaration.declarations.some(
+          (d) =>
+            d.id.type === AST_NODE_TYPES.Identifier && d.id.name === 'handler',
+        ),
+    });
+
+    it('opens the gate with no import at all', () => {
+      expect(withHandler(ast('export const handler = async (e) => {};'))).toBe(true);
+    });
+
+    it('does not fire for a near-miss', () => {
+      expect(withHandler(ast('export const handleRequest = async (e) => {};'))).toBe(false);
+    });
+
+    it('is additive — the import arm still works without it', () => {
+      expect(withHandler(ast("import type { Handler } from 'aws-lambda';"))).toBe(true);
+    });
+
+    it('a probe with no extraEvidence is unaffected', () => {
+      expect(pg(ast('export const handler = async (e) => {};'))).toBe(false);
+    });
+  });
+
+  describe('caching', () => {
+    it('returns the same answer for the same Program without recomputing', () => {
+      const program = ast("import { Pool } from 'pg';");
+      expect(pg(program)).toBe(true);
+      expect(pg(program)).toBe(true);
+    });
+
+    it('caches a negative too', () => {
+      const program = ast('const x = 1;');
+      expect(pg(program)).toBe(false);
+      expect(pg(program)).toBe(false);
+    });
+
+    it('two probes over the same Program do not share a cache entry', () => {
+      const program = ast("import { Pool } from 'pg';");
+      expect(pg(program)).toBe(true);
+      expect(ai(program)).toBe(false);
+    });
+  });
+
+
+  describe('the shapes only a real rule produces', () => {
+    const nest = createModuleEvidence({
+      packages: ['@nestjs/common', '@nestjs/core'],
+      prefixes: ['@nestjs/platform-'],
+    });
+
+    it('a scoped package can be listed exactly, not only by scope', () => {
+      expect(nest(ast("import { Injectable } from '@nestjs/common';"))).toBe(true);
+      expect(nest(ast("import { NestFactory } from '@nestjs/core';"))).toBe(true);
+      // Same scope, package not listed — the scope alone is not the signal here.
+      expect(nest(ast("import x from '@nestjs/graphql';"))).toBe(false);
+    });
+
+    it('a bare scope that matches no configured scope is compared as a root', () => {
+      // Reaches the branch where the specifier has a scope but no package name
+      // and the scope itself is not configured — `@nestjs` is neither a listed
+      // package nor a listed scope for this probe.
+      expect(nest(ast("import x from '@nestjs';"))).toBe(false);
+    });
+
+    it('a prefix can match inside a scope', () => {
+      expect(nest(ast("import { Express } from '@nestjs/platform-express';"))).toBe(true);
+      expect(nest(ast("import x from '@nestjs/platform';"))).toBe(false);
+    });
+
+    it('terminates on an AST carrying parent links', () => {
+      // `parse()` sets no parents, but a rule passes `context.sourceCode.ast`,
+      // which does. Without the `parent` skip the walk would follow the link
+      // back up and recurse until the stack blew — on every file.
+      const program = ast("const x = 1;\nimport { Pool } from 'pg';");
+      const link = (node: Record<string, unknown>, parent: unknown): void => {
+        node.parent = parent;
+        for (const [key, value] of Object.entries(node)) {
+          if (key === 'parent') continue;
+          if (Array.isArray(value)) {
+            for (const child of value) {
+              if (child && typeof child.type === 'string') link(child, node);
+            }
+          } else if (value && typeof value === 'object' && typeof (value as { type?: unknown }).type === 'string') {
+            link(value as Record<string, unknown>, node);
+          }
+        }
+      };
+      link(program as unknown as Record<string, unknown>, null);
+      expect(pg(program)).toBe(true);
+    });
+
+    it('an import-equals whose reference is not a string literal is not a load', () => {
+      // TypeScript requires a string there, so this cannot be parsed — it is
+      // built by hand to pin the defensive branch rather than leave it untested.
+      const program = ast('const x = 1;');
+      (program.body as unknown as unknown[]).push({
+        type: AST_NODE_TYPES.TSImportEqualsDeclaration,
+        moduleReference: {
+          type: AST_NODE_TYPES.TSExternalModuleReference,
+          expression: { type: AST_NODE_TYPES.Identifier, name: 'pg' },
+        },
+      });
+      expect(pg(program)).toBe(false);
+    });
+  });
+
+  it('a probe configured with nothing matches nothing', () => {
+    const none = createModuleEvidence({});
+    expect(none(ast("import x from 'pg';"))).toBe(false);
+  });
+});

--- a/packages/eslint-devkit/src/rule-creation/module-evidence.ts
+++ b/packages/eslint-devkit/src/rule-creation/module-evidence.ts
@@ -1,0 +1,261 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+import type { TSESTree } from '@typescript-eslint/utils';
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+
+/**
+ * Extra evidence a plugin accepts beyond an import.
+ *
+ * Most SDKs need none: if the file does not import the package, it does not use
+ * the SDK. Two do, and both were established by measuring rather than guessing:
+ *
+ *   - **Lambda** — 184 of 413 handler files (45%) import nothing AWS, because
+ *     `aws-lambda` is a types package and a plain JS handler imports nothing.
+ *   - **Express** — 68 of 114 files with a `(req, res)`-shaped function (60%)
+ *     import no `express`, because route modules receive `app` from a caller.
+ *
+ * Anything supplied here is an *additional* way to open the gate, so a loose
+ * predicate re-introduces the false positives the gate exists to remove. It
+ * must identify the SDK's own contract — a handler export, a middleware
+ * signature — never a name that merely sounds related.
+ */
+export type ExtraEvidence = (node: TSESTree.Node) => boolean;
+
+export interface ModuleEvidenceConfig {
+  /** Exact package roots, e.g. `['pg', 'postgres']`. */
+  readonly packages?: readonly string[];
+  /** Whole scopes, e.g. `['@ai-sdk']` — every package under them counts. */
+  readonly scopes?: readonly string[];
+  /** Package-root prefixes, e.g. `['serverless-']`. */
+  readonly prefixes?: readonly string[];
+  /** Non-import shapes that also mean "this file uses the SDK". */
+  readonly extraEvidence?: ExtraEvidence;
+}
+
+/**
+ * Strip the module-resolution prefixes Deno adds, so a Deno / Supabase Edge
+ * Function is judged on the package it actually loads.
+ *
+ * `npm:@aws-sdk/client-s3` and `https://deno.land/x/postgres@v0.17.0/mod.ts`
+ * are ordinary SDK imports in Deno's specifier syntax. The prefix made them
+ * unmatchable and every gate abstained on real SDK code until the
+ * false-negative audit found them in `supabase/examples/**`.
+ */
+function normalizeSpecifier(specifier: string): string {
+  if (specifier.startsWith('npm:')) return specifier.slice(4);
+  const deno = /^https?:\/\/deno\.land\/x\/([^@/]+)/.exec(specifier);
+  return deno ? deno[1] : specifier;
+}
+
+/**
+ * `import pg = require('pg')` — TypeScript's import-equals form.
+ *
+ * A `TSImportEqualsDeclaration` wrapping a `TSExternalModuleReference`, not a
+ * `CallExpression`, so the `require` arm never sees it. The audit found **82
+ * corpus files** written this way for Express alone (DefinitelyTyped uses it
+ * for nearly every CommonJS type test) with the whole plugin silenced.
+ */
+function importEqualsSpecifier(node: TSESTree.Node): string | null {
+  if (node.type !== AST_NODE_TYPES.TSImportEqualsDeclaration) return null;
+  const ref = node.moduleReference;
+  if (ref.type !== AST_NODE_TYPES.TSExternalModuleReference) return null;
+  return ref.expression.type === AST_NODE_TYPES.Literal &&
+    typeof ref.expression.value === 'string'
+    ? ref.expression.value
+    : null;
+}
+
+/**
+ * Whether a scope-introducing node binds the name `require`.
+ *
+ * `function f(require) { require('pg'); }` is not module loading — treating it
+ * as evidence would be a security plugin taking a *name* as proof of an
+ * *interface*, the error these gates exist to correct.
+ *
+ * Shadowing is **lexical**, propagated down the walk. A file-wide flag reads
+ * `const c = require('pg'); function wrapper(require) {}` as fully shadowed and
+ * silences every rule in the plugin — trading a false positive for a false
+ * negative, which is the worse direction.
+ */
+function bindsRequire(node: TSESTree.Node): boolean {
+  if (
+    node.type === AST_NODE_TYPES.FunctionDeclaration ||
+    node.type === AST_NODE_TYPES.FunctionExpression ||
+    node.type === AST_NODE_TYPES.ArrowFunctionExpression
+  ) {
+    return node.params.some(
+      (p) => p.type === AST_NODE_TYPES.Identifier && p.name === 'require',
+    );
+  }
+  if (
+    node.type === AST_NODE_TYPES.Program ||
+    node.type === AST_NODE_TYPES.BlockStatement
+  ) {
+    return node.body.some(
+      (stmt) =>
+        stmt.type === AST_NODE_TYPES.VariableDeclaration &&
+        stmt.declarations.some(
+          (d) =>
+            d.id.type === AST_NODE_TYPES.Identifier && d.id.name === 'require',
+        ),
+    );
+  }
+  return false;
+}
+
+/**
+ * Build a per-file "does this file use my SDK?" probe.
+ *
+ * Every SDK-specific plugin gates every rule on one of these. Measured over
+ * 107,382 files across 107 repositories, **40% of all SDK-plugin findings were
+ * about an SDK the file never imports** — `lambda-security` reported on any
+ * `try/catch`, `postgresql-security` on any `.connect()`, and the seven SQL
+ * plugins on each other. A rule that matches a method name is detecting a word,
+ * not an interface.
+ *
+ * This lives in the devkit because it previously did not: five plugins each
+ * carried their own copy, so the two false-negative classes the audit found —
+ * TypeScript's `import =` and Deno's specifiers — had to be fixed five times,
+ * and the next such class would have been fixed ten. One implementation, one
+ * fix.
+ *
+ * The returned probe caches per `Program`, because `create` runs once per rule:
+ * an uncached probe walks the whole AST once for every rule in the plugin, and
+ * the files paying that cost are mostly the ones the gate exists to skip.
+ *
+ * @example
+ * ```ts
+ * export const fileUsesPostgres = createModuleEvidence({
+ *   packages: ['pg', 'postgres', 'slonik'],
+ *   scopes: ['@neondatabase'],
+ * });
+ *
+ * // in a rule:
+ * create(context) {
+ *   if (!fileUsesPostgres(context.sourceCode.ast)) return {};
+ *   …
+ * }
+ * ```
+ */
+export function createModuleEvidence(
+  config: ModuleEvidenceConfig,
+): (ast: TSESTree.Program) => boolean {
+  const packages = new Set(config.packages ?? []);
+  const scopes = new Set(config.scopes ?? []);
+  const prefixes = config.prefixes ?? [];
+  const extra = config.extraEvidence;
+
+  /**
+   * Compared on the **package root**, so `pg/lib/client` and
+   * `@ai-sdk/openai/edge` count. A relative or absolute specifier is never a
+   * package and is rejected outright — otherwise `'./pg'` would satisfy the
+   * gate in a repo that has no `pg` at all.
+   */
+  const owns = (raw: string): boolean => {
+    const specifier = normalizeSpecifier(raw);
+    if (specifier.startsWith('.') || specifier.startsWith('/')) return false;
+    if (specifier.startsWith('@')) {
+      const [scope, name] = specifier.split('/');
+      if (scopes.has(scope)) return true;
+      const root = name === undefined ? scope : `${scope}/${name}`;
+      return packages.has(root) || prefixes.some((p) => root.startsWith(p));
+    }
+    const root = specifier.split('/')[0];
+    return packages.has(root) || prefixes.some((p) => root.startsWith(p));
+  };
+
+  const dynamicLoadSpecifier = (
+    node: TSESTree.Node,
+    requireIsShadowed: boolean,
+  ): string | null => {
+    const argument =
+      node.type === AST_NODE_TYPES.ImportExpression
+        ? node.source
+        : !requireIsShadowed &&
+            node.type === AST_NODE_TYPES.CallExpression &&
+            node.callee.type === AST_NODE_TYPES.Identifier &&
+            node.callee.name === 'require'
+          ? node.arguments[0]
+          : undefined;
+    return argument?.type === AST_NODE_TYPES.Literal &&
+      typeof argument.value === 'string'
+      ? argument.value
+      : null;
+  };
+
+  const cache = new WeakMap<TSESTree.Program, boolean>();
+
+  const compute = (ast: TSESTree.Program): boolean => {
+    let found = false;
+
+    // No guard at the top of `visit`: every recursive call site below already
+    // checks `found`, which would make it unreachable.
+    const visit = (node: TSESTree.Node, requireIsShadowed: boolean): void => {
+      if (
+        (node.type === AST_NODE_TYPES.ImportDeclaration ||
+          node.type === AST_NODE_TYPES.ExportNamedDeclaration ||
+          node.type === AST_NODE_TYPES.ExportAllDeclaration) &&
+        node.source?.type === AST_NODE_TYPES.Literal &&
+        typeof node.source.value === 'string' &&
+        owns(node.source.value)
+      ) {
+        found = true;
+        return;
+      }
+
+      const importEquals = importEqualsSpecifier(node);
+      if (importEquals !== null && owns(importEquals)) {
+        found = true;
+        return;
+      }
+
+      const dynamic = dynamicLoadSpecifier(node, requireIsShadowed);
+      if (dynamic !== null && owns(dynamic)) {
+        found = true;
+        return;
+      }
+
+      if (extra?.(node)) {
+        found = true;
+        return;
+      }
+
+      // Everything below this node is inside any scope it introduces.
+      const shadowedHere = requireIsShadowed || bindsRequire(node);
+      for (const key of Object.keys(node)) {
+        if (key === 'parent') continue;
+        const value = (node as unknown as Record<string, unknown>)[key];
+        if (Array.isArray(value)) {
+          for (const child of value) {
+            if (child && typeof (child as TSESTree.Node).type === 'string') {
+              visit(child as TSESTree.Node, shadowedHere);
+              if (found) return;
+            }
+          }
+        } else if (
+          value &&
+          typeof value === 'object' &&
+          typeof (value as TSESTree.Node).type === 'string'
+        ) {
+          visit(value as TSESTree.Node, shadowedHere);
+          if (found) return;
+        }
+      }
+    };
+
+    visit(ast, false);
+    return found;
+  };
+
+  return (ast: TSESTree.Program): boolean => {
+    const cached = cache.get(ast);
+    if (cached !== undefined) return cached;
+    const result = compute(ast);
+    cache.set(ast, result);
+    return result;
+  };
+}

--- a/packages/eslint-devkit/src/rule-creation/module-evidence.ts
+++ b/packages/eslint-devkit/src/rule-creation/module-evidence.ts
@@ -5,7 +5,11 @@
  */
 
 import type { TSESTree } from '@typescript-eslint/utils';
-import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+// AST_NODE_TYPES comes from the local shim, not upstream: it is an enum, so a
+// value import of it would emit a runtime `require('@typescript-eslint/utils')`
+// into the published output — an optional peer npm does not install. The type
+// import above is erased at compile time and is fine.
+import { AST_NODE_TYPES } from '../ast-node-types';
 
 /**
  * Extra evidence a plugin accepts beyond an import.

--- a/packages/eslint-plugin-anthropic-security/src/module-gate.lock.test.ts
+++ b/packages/eslint-plugin-anthropic-security/src/module-gate.lock.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Regression lock: no rule in this plugin reports in a file that does not use
+ * the Anthropic SDK.
+ *
+ * Its rules are built by `createSdkApiKeyRule`, which gates on the configured
+ * `modules`. That guarantee lives in the devkit factory, so nothing fails if a
+ * hand-written rule is added to this plugin tomorrow. This lock is that.
+ *
+ * Written over the whole rule registry rather than per rule, so a rule added
+ * later is covered the day it lands: it will fail here until it is gated too.
+ * Revert the gate in any single rule and this test goes red.
+ */
+import { describe, it, expect } from 'vitest';
+import { Linter } from 'eslint';
+import parser from '@typescript-eslint/parser';
+import plugin from './index';
+
+const RULES = Object.keys(plugin.rules);
+
+/** The SDK import that is the whole difference between the two halves below. */
+const SDK = "import Anthropic from '@anthropic-ai/sdk';";
+
+/**
+ * A real violation of `no-hardcoded-api-key`. It appears twice on purpose: once
+ * without the import (must be silent) and once with it (must report). One
+ * fixture proving both directions is what stops this suite passing with the
+ * gate shut on everything.
+ */
+const VIOLATION = `const client = new Anthropic({ apiKey: 'sk-ant-hardcoded' });`;
+
+/** Files that use no the Anthropic SDK at all. */
+const NON_SDK_SOURCES: ReadonlyArray<readonly [string, string]> = [
+  ['the violation itself, minus the import', VIOLATION],
+  [
+    'a plain helper',
+    `export function parse(s: string) {
+       try { return JSON.parse(s); } catch { return null; }
+     }`,
+  ],
+  [
+    'a React component',
+    `export default function Panel({ items }) {
+       return items.map((i) => i.name).join(', ');
+     }`,
+  ],
+  [
+    'a config module',
+    `export const config = { token: process.env.API_TOKEN, retries: 3 };`,
+  ],
+];
+
+const lint = (code: string, rule: string): Linter.LintMessage[] => {
+  // `configType: 'flat'` because a bare `new Linter()` still defaults to
+  // eslintrc on the declared ESLint floor, which would ignore the config below
+  // and skip every rule — a suite that passes having run nothing.
+  const linter = new Linter({ configType: 'flat' });
+  return linter.verify(
+    code,
+    {
+      files: ['**/*.ts'],
+      languageOptions: {
+        parser: parser as unknown as Linter.Parser,
+        parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+      },
+      plugins: { a: plugin as unknown as Linter.Plugin },
+      rules: { [`a/${rule}`]: 'error' },
+    },
+    // Without a filename the Linter lints `<input>`, which matches no `files`
+    // entry — every rule skipped, every negative below vacuously true.
+    'sample.ts',
+  );
+};
+
+describe('the Anthropic SDK module gate', () => {
+  it('the registry is non-empty, so the sweep below is not vacuous', () => {
+    expect(RULES.length).toBeGreaterThan(0);
+  });
+
+  describe.each(NON_SDK_SOURCES)('%s', (_name, code) => {
+    it.each(RULES)('%s reports nothing', (rule) => {
+      const messages = lint(code, rule);
+      // A parse or config error also yields zero *rule* findings, so it is
+      // asserted away rather than counted as a pass.
+      expect(messages.filter((m) => !m.ruleId)).toHaveLength(0);
+      expect(messages.map((m) => m.ruleId)).toEqual([]);
+    });
+  });
+
+  describe('positive control — the gate must open for real the Anthropic SDK code', () => {
+    it('the same violation reports once the file imports the SDK', () => {
+      expect(lint(`${SDK}\n${VIOLATION}`, 'no-hardcoded-api-key').length).toBeGreaterThan(0);
+    });
+
+    it('and is silent with the import removed', () => {
+      expect(lint(VIOLATION, 'no-hardcoded-api-key')).toHaveLength(0);
+    });
+  });
+});

--- a/packages/eslint-plugin-drizzle-security/src/module-gate.lock.test.ts
+++ b/packages/eslint-plugin-drizzle-security/src/module-gate.lock.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Regression lock: no rule in this plugin reports in a file that does not use
+ * drizzle-orm.
+ *
+ * `createSqlInjectionRule` discriminated on method name alone until the corpus
+ * sweep found 1,142 lines where two or more SQL plugins reported the same CWE.
+ * It now takes a `modules` list and abstains in files importing none of them,
+ * which took this plugin to **0 off-SDK findings** across 107,382 files. That
+ * guarantee lives in the devkit factory, so nothing fails if a hand-written
+ * rule is added to this plugin tomorrow. This lock is that.
+ *
+ * Written over the whole rule registry rather than per rule, so a rule added
+ * later is covered the day it lands: it will fail here until it is gated too.
+ * Revert the gate in any single rule and this test goes red.
+ */
+import { describe, it, expect } from 'vitest';
+import { Linter } from 'eslint';
+import parser from '@typescript-eslint/parser';
+import plugin from './index';
+
+const RULES = Object.keys(plugin.rules);
+
+/** The SDK import that is the whole difference between the two halves below. */
+const SDK = "import { drizzle } from 'drizzle-orm';";
+
+/**
+ * A real violation of `no-unsafe-query`. It appears twice on purpose: once
+ * without the import (must be silent) and once with it (must report). One
+ * fixture proving both directions is what stops this suite passing with the
+ * gate shut on everything.
+ */
+const VIOLATION = `db.execute(sql.raw('SELECT * FROM users WHERE id = ' + id));`;
+
+/** Files that use no drizzle-orm at all. */
+const NON_SDK_SOURCES: ReadonlyArray<readonly [string, string]> = [
+  ['the violation itself, minus the import', VIOLATION],
+  [
+    'a plain helper',
+    `export function parse(s: string) {
+       try { return JSON.parse(s); } catch { return null; }
+     }`,
+  ],
+  [
+    'a React component',
+    `export default function Panel({ items }) {
+       return items.map((i) => i.name).join(', ');
+     }`,
+  ],
+  [
+    'a config module',
+    `export const config = { token: process.env.API_TOKEN, retries: 3 };`,
+  ],
+];
+
+const lint = (code: string, rule: string): Linter.LintMessage[] => {
+  // `configType: 'flat'` because a bare `new Linter()` still defaults to
+  // eslintrc on the declared ESLint floor, which would ignore the config below
+  // and skip every rule — a suite that passes having run nothing.
+  const linter = new Linter({ configType: 'flat' });
+  return linter.verify(
+    code,
+    {
+      files: ['**/*.ts'],
+      languageOptions: {
+        parser: parser as unknown as Linter.Parser,
+        parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+      },
+      plugins: { s: plugin as unknown as Linter.Plugin },
+      rules: { [`s/${rule}`]: 'error' },
+    },
+    // Without a filename the Linter lints `<input>`, which matches no `files`
+    // entry — every rule skipped, every negative below vacuously true.
+    'sample.ts',
+  );
+};
+
+describe('drizzle-orm module gate', () => {
+  it('the registry is non-empty, so the sweep below is not vacuous', () => {
+    expect(RULES.length).toBeGreaterThan(0);
+  });
+
+  describe.each(NON_SDK_SOURCES)('%s', (_name, code) => {
+    it.each(RULES)('%s reports nothing', (rule) => {
+      const messages = lint(code, rule);
+      // A parse or config error also yields zero *rule* findings, so it is
+      // asserted away rather than counted as a pass.
+      expect(messages.filter((m) => !m.ruleId)).toHaveLength(0);
+      expect(messages.map((m) => m.ruleId)).toEqual([]);
+    });
+  });
+
+  describe('positive control — the gate must open for real drizzle-orm code', () => {
+    it('the same violation reports once the file imports the SDK', () => {
+      expect(lint(`${SDK}\n${VIOLATION}`, 'no-unsafe-query').length).toBeGreaterThan(0);
+    });
+
+    it('and is silent with the import removed', () => {
+      expect(lint(VIOLATION, 'no-unsafe-query')).toHaveLength(0);
+    });
+  });
+});

--- a/packages/eslint-plugin-gemini-security/src/module-gate.lock.test.ts
+++ b/packages/eslint-plugin-gemini-security/src/module-gate.lock.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Regression lock: no rule in this plugin reports in a file that does not use
+ * Gemini.
+ *
+ * It reported nothing off-SDK across the 107-repository corpus, but its
+ * hand-written rule had no gate, so nothing stopped it from doing so. "Did not
+ * happen to fire" is not "cannot".
+ *
+ * Written over the whole rule registry rather than per rule, so a rule added
+ * later is covered the day it lands: it will fail here until it is gated too.
+ * Revert the gate in any single rule and this test goes red.
+ */
+import { describe, it, expect } from 'vitest';
+import { Linter } from 'eslint';
+import parser from '@typescript-eslint/parser';
+import plugin from './index';
+
+const RULES = Object.keys(plugin.rules);
+
+/** The SDK import that is the whole difference between the two halves below. */
+const SDK = "import { GoogleGenerativeAI } from '@google/generative-ai';";
+
+/**
+ * A real violation of `no-disabled-safety-settings`. It appears twice on purpose: once
+ * without the import (must be silent) and once with it (must report). One
+ * fixture proving both directions is what stops this suite passing with the
+ * gate shut on everything.
+ */
+const VIOLATION = `const cfg = { safetySettings: [{ category: 'HARM_CATEGORY_HARASSMENT', threshold: 'BLOCK_NONE' }] };`;
+
+/** Files that use no Gemini at all. */
+const NON_SDK_SOURCES: ReadonlyArray<readonly [string, string]> = [
+  ['the violation itself, minus the import', VIOLATION],
+  [
+    'a plain helper',
+    `export function parse(s: string) {
+       try { return JSON.parse(s); } catch { return null; }
+     }`,
+  ],
+  [
+    'a React component',
+    `export default function Panel({ items }) {
+       return items.map((i) => i.name).join(', ');
+     }`,
+  ],
+  [
+    'a config module',
+    `export const config = { token: process.env.API_TOKEN, retries: 3 };`,
+  ],
+];
+
+const lint = (code: string, rule: string): Linter.LintMessage[] => {
+  // `configType: 'flat'` because a bare `new Linter()` still defaults to
+  // eslintrc on the declared ESLint floor, which would ignore the config below
+  // and skip every rule — a suite that passes having run nothing.
+  const linter = new Linter({ configType: 'flat' });
+  return linter.verify(
+    code,
+    {
+      files: ['**/*.ts'],
+      languageOptions: {
+        parser: parser as unknown as Linter.Parser,
+        parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+      },
+      plugins: { g: plugin as unknown as Linter.Plugin },
+      rules: { [`g/${rule}`]: 'error' },
+    },
+    // Without a filename the Linter lints `<input>`, which matches no `files`
+    // entry — every rule skipped, every negative below vacuously true.
+    'sample.ts',
+  );
+};
+
+describe('Gemini module gate', () => {
+  it('the registry is non-empty, so the sweep below is not vacuous', () => {
+    expect(RULES.length).toBeGreaterThan(0);
+  });
+
+  describe.each(NON_SDK_SOURCES)('%s', (_name, code) => {
+    it.each(RULES)('%s reports nothing', (rule) => {
+      const messages = lint(code, rule);
+      // A parse or config error also yields zero *rule* findings, so it is
+      // asserted away rather than counted as a pass.
+      expect(messages.filter((m) => !m.ruleId)).toHaveLength(0);
+      expect(messages.map((m) => m.ruleId)).toEqual([]);
+    });
+  });
+
+  describe('positive control — the gate must open for real Gemini code', () => {
+    it('the same violation reports once the file imports the SDK', () => {
+      expect(lint(`${SDK}\n${VIOLATION}`, 'no-disabled-safety-settings').length).toBeGreaterThan(0);
+    });
+
+    it('and is silent with the import removed', () => {
+      expect(lint(VIOLATION, 'no-disabled-safety-settings')).toHaveLength(0);
+    });
+  });
+});

--- a/packages/eslint-plugin-jwt-security/src/module-gate.lock.test.ts
+++ b/packages/eslint-plugin-jwt-security/src/module-gate.lock.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Regression lock: no rule in this plugin reports in a file that does not use
+ * a JWT library.
+ *
+ * Measured over 107,382 files across 107 repositories it reports 27 findings in
+ * files importing no JWT library, down from 702 before `isJwtLibraryCall`
+ * started requiring the import. That helper is the gate; this lock is what
+ * stops a future rule from skipping it.
+ *
+ * Written over the whole rule registry rather than per rule, so a rule added
+ * later is covered the day it lands: it will fail here until it is gated too.
+ * Revert the gate in any single rule and this test goes red.
+ */
+import { describe, it, expect } from 'vitest';
+import { Linter } from 'eslint';
+import parser from '@typescript-eslint/parser';
+import plugin from './index';
+
+const RULES = Object.keys(plugin.rules);
+
+/** The SDK import that is the whole difference between the two halves below. */
+const SDK = "import jwt from 'jsonwebtoken';";
+
+/**
+ * A real violation of `no-hardcoded-secret`. It appears twice on purpose: once
+ * without the import (must be silent) and once with it (must report). One
+ * fixture proving both directions is what stops this suite passing with the
+ * gate shut on everything.
+ */
+const VIOLATION = `jwt.sign(payload, 'super-secret-value');`;
+
+/** Files that use no a JWT library at all. */
+const NON_SDK_SOURCES: ReadonlyArray<readonly [string, string]> = [
+  ['the violation itself, minus the import', VIOLATION],
+  [
+    'a plain helper',
+    `export function parse(s: string) {
+       try { return JSON.parse(s); } catch { return null; }
+     }`,
+  ],
+  [
+    'a React component',
+    `export default function Panel({ items }) {
+       return items.map((i) => i.name).join(', ');
+     }`,
+  ],
+  [
+    'a config module',
+    `export const config = { token: process.env.API_TOKEN, retries: 3 };`,
+  ],
+];
+
+const lint = (code: string, rule: string): Linter.LintMessage[] => {
+  // `configType: 'flat'` because a bare `new Linter()` still defaults to
+  // eslintrc on the declared ESLint floor, which would ignore the config below
+  // and skip every rule — a suite that passes having run nothing.
+  const linter = new Linter({ configType: 'flat' });
+  return linter.verify(
+    code,
+    {
+      files: ['**/*.ts'],
+      languageOptions: {
+        parser: parser as unknown as Linter.Parser,
+        parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+      },
+      plugins: { j: plugin as unknown as Linter.Plugin },
+      rules: { [`j/${rule}`]: 'error' },
+    },
+    // Without a filename the Linter lints `<input>`, which matches no `files`
+    // entry — every rule skipped, every negative below vacuously true.
+    'sample.ts',
+  );
+};
+
+describe('a JWT library module gate', () => {
+  it('the registry is non-empty, so the sweep below is not vacuous', () => {
+    expect(RULES.length).toBeGreaterThan(0);
+  });
+
+  describe.each(NON_SDK_SOURCES)('%s', (_name, code) => {
+    it.each(RULES)('%s reports nothing', (rule) => {
+      const messages = lint(code, rule);
+      // A parse or config error also yields zero *rule* findings, so it is
+      // asserted away rather than counted as a pass.
+      expect(messages.filter((m) => !m.ruleId)).toHaveLength(0);
+      expect(messages.map((m) => m.ruleId)).toEqual([]);
+    });
+  });
+
+  describe('positive control — the gate must open for real a JWT library code', () => {
+    it('the same violation reports once the file imports the SDK', () => {
+      expect(lint(`${SDK}\n${VIOLATION}`, 'no-hardcoded-secret').length).toBeGreaterThan(0);
+    });
+
+    it('and is silent with the import removed', () => {
+      expect(lint(VIOLATION, 'no-hardcoded-secret')).toHaveLength(0);
+    });
+  });
+});

--- a/packages/eslint-plugin-knex-security/src/module-gate.lock.test.ts
+++ b/packages/eslint-plugin-knex-security/src/module-gate.lock.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Regression lock: no rule in this plugin reports in a file that does not use
+ * knex.
+ *
+ * `createSqlInjectionRule` discriminated on method name alone until the corpus
+ * sweep found 1,142 lines where two or more SQL plugins reported the same CWE.
+ * It now takes a `modules` list and abstains in files importing none of them,
+ * which took this plugin to **0 off-SDK findings** across 107,382 files. That
+ * guarantee lives in the devkit factory, so nothing fails if a hand-written
+ * rule is added to this plugin tomorrow. This lock is that.
+ *
+ * Written over the whole rule registry rather than per rule, so a rule added
+ * later is covered the day it lands: it will fail here until it is gated too.
+ * Revert the gate in any single rule and this test goes red.
+ */
+import { describe, it, expect } from 'vitest';
+import { Linter } from 'eslint';
+import parser from '@typescript-eslint/parser';
+import plugin from './index';
+
+const RULES = Object.keys(plugin.rules);
+
+/** The SDK import that is the whole difference between the two halves below. */
+const SDK = "import knex from 'knex';";
+
+/**
+ * A real violation of `no-unsafe-query`. It appears twice on purpose: once
+ * without the import (must be silent) and once with it (must report). One
+ * fixture proving both directions is what stops this suite passing with the
+ * gate shut on everything.
+ */
+const VIOLATION = `db.raw('SELECT * FROM users WHERE id = ' + id);`;
+
+/** Files that use no knex at all. */
+const NON_SDK_SOURCES: ReadonlyArray<readonly [string, string]> = [
+  ['the violation itself, minus the import', VIOLATION],
+  [
+    'a plain helper',
+    `export function parse(s: string) {
+       try { return JSON.parse(s); } catch { return null; }
+     }`,
+  ],
+  [
+    'a React component',
+    `export default function Panel({ items }) {
+       return items.map((i) => i.name).join(', ');
+     }`,
+  ],
+  [
+    'a config module',
+    `export const config = { token: process.env.API_TOKEN, retries: 3 };`,
+  ],
+];
+
+const lint = (code: string, rule: string): Linter.LintMessage[] => {
+  // `configType: 'flat'` because a bare `new Linter()` still defaults to
+  // eslintrc on the declared ESLint floor, which would ignore the config below
+  // and skip every rule — a suite that passes having run nothing.
+  const linter = new Linter({ configType: 'flat' });
+  return linter.verify(
+    code,
+    {
+      files: ['**/*.ts'],
+      languageOptions: {
+        parser: parser as unknown as Linter.Parser,
+        parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+      },
+      plugins: { s: plugin as unknown as Linter.Plugin },
+      rules: { [`s/${rule}`]: 'error' },
+    },
+    // Without a filename the Linter lints `<input>`, which matches no `files`
+    // entry — every rule skipped, every negative below vacuously true.
+    'sample.ts',
+  );
+};
+
+describe('knex module gate', () => {
+  it('the registry is non-empty, so the sweep below is not vacuous', () => {
+    expect(RULES.length).toBeGreaterThan(0);
+  });
+
+  describe.each(NON_SDK_SOURCES)('%s', (_name, code) => {
+    it.each(RULES)('%s reports nothing', (rule) => {
+      const messages = lint(code, rule);
+      // A parse or config error also yields zero *rule* findings, so it is
+      // asserted away rather than counted as a pass.
+      expect(messages.filter((m) => !m.ruleId)).toHaveLength(0);
+      expect(messages.map((m) => m.ruleId)).toEqual([]);
+    });
+  });
+
+  describe('positive control — the gate must open for real knex code', () => {
+    it('the same violation reports once the file imports the SDK', () => {
+      expect(lint(`${SDK}\n${VIOLATION}`, 'no-unsafe-query').length).toBeGreaterThan(0);
+    });
+
+    it('and is silent with the import removed', () => {
+      expect(lint(VIOLATION, 'no-unsafe-query')).toHaveLength(0);
+    });
+  });
+});

--- a/packages/eslint-plugin-mcp-sdk-security/src/module-gate.lock.test.ts
+++ b/packages/eslint-plugin-mcp-sdk-security/src/module-gate.lock.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Regression lock: no rule in this plugin reports in a file that does not use
+ * MCP SDK.
+ *
+ * It reported nothing off-SDK across the 107-repository corpus, but it had no
+ * gate, so nothing stopped the next rule from doing so. "Did not happen to
+ * fire" is not "cannot".
+ *
+ * Written over the whole rule registry rather than per rule, so a rule added
+ * later is covered the day it lands: it will fail here until it is gated too.
+ * Revert the gate in any single rule and this test goes red.
+ */
+import { describe, it, expect } from 'vitest';
+import { Linter } from 'eslint';
+import parser from '@typescript-eslint/parser';
+import plugin from './index';
+
+const RULES = Object.keys(plugin.rules);
+
+/** The SDK import that is the whole difference between the two halves below. */
+const SDK = "import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';";
+
+/**
+ * A real violation of `no-command-injection-in-tool`. It appears twice on purpose: once
+ * without the import (must be silent) and once with it (must report). One
+ * fixture proving both directions is what stops this suite passing with the
+ * gate shut on everything.
+ */
+const VIOLATION = `server.registerTool('run', cfg, async ({ cmd }) => { execSync(cmd); });`;
+
+/** Files that use no MCP SDK at all. */
+const NON_SDK_SOURCES: ReadonlyArray<readonly [string, string]> = [
+  ['the violation itself, minus the import', VIOLATION],
+  [
+    'a plain helper',
+    `export function parse(s: string) {
+       try { return JSON.parse(s); } catch { return null; }
+     }`,
+  ],
+  [
+    'a React component',
+    `export default function Panel({ items }) {
+       return items.map((i) => i.name).join(', ');
+     }`,
+  ],
+  [
+    'a config module',
+    `export const config = { token: process.env.API_TOKEN, retries: 3 };`,
+  ],
+];
+
+const lint = (code: string, rule: string): Linter.LintMessage[] => {
+  // `configType: 'flat'` because a bare `new Linter()` still defaults to
+  // eslintrc on the declared ESLint floor, which would ignore the config below
+  // and skip every rule — a suite that passes having run nothing.
+  const linter = new Linter({ configType: 'flat' });
+  return linter.verify(
+    code,
+    {
+      files: ['**/*.ts'],
+      languageOptions: {
+        parser: parser as unknown as Linter.Parser,
+        parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+      },
+      plugins: { m: plugin as unknown as Linter.Plugin },
+      rules: { [`m/${rule}`]: 'error' },
+    },
+    // Without a filename the Linter lints `<input>`, which matches no `files`
+    // entry — every rule skipped, every negative below vacuously true.
+    'sample.ts',
+  );
+};
+
+describe('MCP SDK module gate', () => {
+  it('the registry is non-empty, so the sweep below is not vacuous', () => {
+    expect(RULES.length).toBeGreaterThan(0);
+  });
+
+  describe.each(NON_SDK_SOURCES)('%s', (_name, code) => {
+    it.each(RULES)('%s reports nothing', (rule) => {
+      const messages = lint(code, rule);
+      // A parse or config error also yields zero *rule* findings, so it is
+      // asserted away rather than counted as a pass.
+      expect(messages.filter((m) => !m.ruleId)).toHaveLength(0);
+      expect(messages.map((m) => m.ruleId)).toEqual([]);
+    });
+  });
+
+  describe('positive control — the gate must open for real MCP SDK code', () => {
+    it('the same violation reports once the file imports the SDK', () => {
+      expect(lint(`${SDK}\n${VIOLATION}`, 'no-command-injection-in-tool').length).toBeGreaterThan(0);
+    });
+
+    it('and is silent with the import removed', () => {
+      expect(lint(VIOLATION, 'no-command-injection-in-tool')).toHaveLength(0);
+    });
+  });
+});

--- a/packages/eslint-plugin-mysql-security/src/module-gate.lock.test.ts
+++ b/packages/eslint-plugin-mysql-security/src/module-gate.lock.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Regression lock: no rule in this plugin reports in a file that does not use
+ * mysql2.
+ *
+ * `createSqlInjectionRule` discriminated on method name alone until the corpus
+ * sweep found 1,142 lines where two or more SQL plugins reported the same CWE.
+ * It now takes a `modules` list and abstains in files importing none of them,
+ * which took this plugin to **0 off-SDK findings** across 107,382 files. That
+ * guarantee lives in the devkit factory, so nothing fails if a hand-written
+ * rule is added to this plugin tomorrow. This lock is that.
+ *
+ * Written over the whole rule registry rather than per rule, so a rule added
+ * later is covered the day it lands: it will fail here until it is gated too.
+ * Revert the gate in any single rule and this test goes red.
+ */
+import { describe, it, expect } from 'vitest';
+import { Linter } from 'eslint';
+import parser from '@typescript-eslint/parser';
+import plugin from './index';
+
+const RULES = Object.keys(plugin.rules);
+
+/** The SDK import that is the whole difference between the two halves below. */
+const SDK = "import mysql from 'mysql2';";
+
+/**
+ * A real violation of `no-unsafe-query`. It appears twice on purpose: once
+ * without the import (must be silent) and once with it (must report). One
+ * fixture proving both directions is what stops this suite passing with the
+ * gate shut on everything.
+ */
+const VIOLATION = `conn.query('SELECT * FROM users WHERE id = ' + id);`;
+
+/** Files that use no mysql2 at all. */
+const NON_SDK_SOURCES: ReadonlyArray<readonly [string, string]> = [
+  ['the violation itself, minus the import', VIOLATION],
+  [
+    'a plain helper',
+    `export function parse(s: string) {
+       try { return JSON.parse(s); } catch { return null; }
+     }`,
+  ],
+  [
+    'a React component',
+    `export default function Panel({ items }) {
+       return items.map((i) => i.name).join(', ');
+     }`,
+  ],
+  [
+    'a config module',
+    `export const config = { token: process.env.API_TOKEN, retries: 3 };`,
+  ],
+];
+
+const lint = (code: string, rule: string): Linter.LintMessage[] => {
+  // `configType: 'flat'` because a bare `new Linter()` still defaults to
+  // eslintrc on the declared ESLint floor, which would ignore the config below
+  // and skip every rule — a suite that passes having run nothing.
+  const linter = new Linter({ configType: 'flat' });
+  return linter.verify(
+    code,
+    {
+      files: ['**/*.ts'],
+      languageOptions: {
+        parser: parser as unknown as Linter.Parser,
+        parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+      },
+      plugins: { s: plugin as unknown as Linter.Plugin },
+      rules: { [`s/${rule}`]: 'error' },
+    },
+    // Without a filename the Linter lints `<input>`, which matches no `files`
+    // entry — every rule skipped, every negative below vacuously true.
+    'sample.ts',
+  );
+};
+
+describe('mysql2 module gate', () => {
+  it('the registry is non-empty, so the sweep below is not vacuous', () => {
+    expect(RULES.length).toBeGreaterThan(0);
+  });
+
+  describe.each(NON_SDK_SOURCES)('%s', (_name, code) => {
+    it.each(RULES)('%s reports nothing', (rule) => {
+      const messages = lint(code, rule);
+      // A parse or config error also yields zero *rule* findings, so it is
+      // asserted away rather than counted as a pass.
+      expect(messages.filter((m) => !m.ruleId)).toHaveLength(0);
+      expect(messages.map((m) => m.ruleId)).toEqual([]);
+    });
+  });
+
+  describe('positive control — the gate must open for real mysql2 code', () => {
+    it('the same violation reports once the file imports the SDK', () => {
+      expect(lint(`${SDK}\n${VIOLATION}`, 'no-unsafe-query').length).toBeGreaterThan(0);
+    });
+
+    it('and is silent with the import removed', () => {
+      expect(lint(VIOLATION, 'no-unsafe-query')).toHaveLength(0);
+    });
+  });
+});

--- a/packages/eslint-plugin-nestjs-security/src/branch-coverage.test.ts
+++ b/packages/eslint-plugin-nestjs-security/src/branch-coverage.test.ts
@@ -25,13 +25,57 @@ import { noMissingValidationPipe } from './rules/no-missing-validation-pipe';
 import { requireThrottler } from './rules/require-throttler';
 import { noExposedPrivateFields } from './rules/no-exposed-private-fields';
 
+/**
+ * Every fixture imports from NestJS, because the rules now abstain in files
+ * that use no NestJS at all. Wrapping the arrays rather than editing each
+ * fixture means one cannot be left behind — a fixture missing the import would
+ * pass vacuously on the gate instead of exercising the detection it was written
+ * for. A SIDE-EFFECT import, so it reserves no binding a fixture might declare.
+ * `output` and errors[].suggestions[].output are prefixed too, because autofix
+ * fixtures assert the whole file back.
+ */
+const asNest = (code: string): string => `import '@nestjs/common';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const nest = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asNest(c) as T;
+    const t = c as Case;
+    return {
+      ...c,
+      code: asNest(t.code),
+      ...(typeof t.output === 'string' ? { output: asNest(t.output) } : {}),
+      ...(t.errors
+        ? {
+            errors: t.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asNest(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 const ruleTester = new RuleTester();
 
 // ===========================================================================
 // require-guards
 // ===========================================================================
 ruleTester.run('require-guards (branch edges)', requireGuards, {
-  valid: [
+  valid: nest([
     // Bare @Public identifier decorator on the method (Identifier arm)
     {
       code: `
@@ -65,8 +109,8 @@ ruleTester.run('require-guards (branch edges)', requireGuards, {
         }
       `,
     },
-  ],
-  invalid: [
+  ]),
+  invalid: nest([
     // Member-expression decorator on the class: hits the '' fallback in
     // hasControllerDecorator / return-false tail of hasUseGuardsDecorator
     {
@@ -142,7 +186,7 @@ ruleTester.run('require-guards (branch edges)', requireGuards, {
       `,
       errors: [{ messageId: 'missingGuards', data: { name: '<anonymous>' } }],
     },
-  ],
+  ]),
 });
 
 // ===========================================================================
@@ -152,7 +196,7 @@ ruleTester.run(
   'no-missing-validation-pipe (branch edges)',
   noMissingValidationPipe,
   {
-    valid: [
+    valid: nest([
       {
         code: `
         @Controller('u')
@@ -213,8 +257,8 @@ ruleTester.run(
       `,
       },
       // Member-expression param decorator: '' fallback → not an input decorator
-    ],
-    invalid: [
+    ]),
+    invalid: nest([
       {
         code: `
         @Controller('u')
@@ -302,7 +346,7 @@ ruleTester.run(
         options: [{ requireExplicitPipe: true }],
         errors: [{ messageId: 'missingValidation' }],
       },
-    ],
+    ]),
   },
 );
 
@@ -310,7 +354,7 @@ ruleTester.run(
 // require-throttler
 // ===========================================================================
 ruleTester.run('require-throttler (branch edges)', requireThrottler, {
-  valid: [
+  valid: nest([
     // Bare @SkipThrottle identifier decorator (Identifier arm of hasThrottleDecorator)
     {
       code: `
@@ -332,8 +376,8 @@ ruleTester.run('require-throttler (branch edges)', requireThrottler, {
         }
       `,
     },
-  ],
-  invalid: [
+  ]),
+  invalid: nest([
     // Bare @Controller identifier decorator (Identifier arm)
     {
       code: `
@@ -386,7 +430,7 @@ ruleTester.run('require-throttler (branch edges)', requireThrottler, {
         { messageId: 'missingThrottler', data: { name: '<anonymous>' } },
       ],
     },
-  ],
+  ]),
 });
 
 // ===========================================================================
@@ -400,7 +444,7 @@ ruleTester.run(
   'no-exposed-private-fields (branch edges)',
   noExposedPrivateFields,
   {
-    valid: [
+    valid: nest([
       {
         code: `
         class UserEntity {
@@ -432,8 +476,8 @@ ruleTester.run(
         }
       `,
       },
-    ],
-    invalid: [
+    ]),
+    invalid: nest([
       {
         code: `
         @orm.Entity()
@@ -454,7 +498,7 @@ ruleTester.run(
         errors: [{ messageId: 'exposedField', data: { field: 'password' } }],
       },
       // Member-expression decorator on the field is not @Exclude ('' fallback)
-    ],
+    ]),
   },
 );
 

--- a/packages/eslint-plugin-nestjs-security/src/detection-contract.test.ts
+++ b/packages/eslint-plugin-nestjs-security/src/detection-contract.test.ts
@@ -26,6 +26,10 @@ const linter = new Linter({ configType: 'flat' });
 
 /** Run one rule over a snippet and return its message ids. */
 function run(rule: string, code: string, options?: unknown): string[] {
+  // The rules abstain in files that use no NestJS, so every fixture here is
+  // linted as the NestJS file it stands for. Prefixing once here means no
+  // fixture can be left behind and pass vacuously on the gate.
+  code = `import '@nestjs/common';\n${code}`;
   const messages = linter.verify(
     code,
     {

--- a/packages/eslint-plugin-nestjs-security/src/global-registration.test.ts
+++ b/packages/eslint-plugin-nestjs-security/src/global-registration.test.ts
@@ -56,6 +56,10 @@ beforeEach(() => {
 });
 
 function run(rule: string, code: string, options?: unknown): number {
+  // The rules abstain in files that use no NestJS, so every fixture here is
+  // linted as the NestJS file it stands for. A side-effect import adds no
+  // binding, and prefixing once here means no fixture can be left behind.
+  code = `import '@nestjs/common';\n${code}`;
   return linter
     .verify(
       code,

--- a/packages/eslint-plugin-nestjs-security/src/module-gate.lock.test.ts
+++ b/packages/eslint-plugin-nestjs-security/src/module-gate.lock.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Regression lock: no rule in this plugin reports in a file that does not use
+ * NestJS.
+ *
+ * Measured over 107,382 files across 107 repositories, **22% of everything this
+ * plugin reported (219 of 999 findings) was in a file importing no NestJS
+ * package** — the rules key on decorator and method names that Angular, TypeORM
+ * and plain TypeScript classes share.
+ *
+ * Written over the whole rule registry rather than per rule, so a rule added
+ * later is covered the day it lands: it will fail here until it is gated too.
+ * Revert the gate in any single rule and this test goes red.
+ */
+import { describe, it, expect } from 'vitest';
+import { Linter } from 'eslint';
+import parser from '@typescript-eslint/parser';
+import plugin from './index';
+
+const RULES = Object.keys(plugin.rules);
+
+/** The SDK import that is the whole difference between the two halves below. */
+const SDK = "import '@nestjs/common';";
+
+/**
+ * A real violation of `no-exposed-private-fields`. It appears twice on purpose: once
+ * without the import (must be silent) and once with it (must report). One
+ * fixture proving both directions is what stops this suite passing with the
+ * gate shut on everything.
+ */
+const VIOLATION = `@Entity()
+     class ApiKeyToken {
+       @Column()
+       apiSecret: string;
+     }`;
+
+/** Files that use no NestJS at all. */
+const NON_SDK_SOURCES: ReadonlyArray<readonly [string, string]> = [
+  ['the violation itself, minus the import', VIOLATION],
+  [
+    'a plain helper',
+    `export function parse(s: string) {
+       try { return JSON.parse(s); } catch { return null; }
+     }`,
+  ],
+  [
+    'a React component',
+    `export default function Panel({ items }) {
+       return items.map((i) => i.name).join(', ');
+     }`,
+  ],
+  [
+    'a config module',
+    `export const config = { token: process.env.API_TOKEN, retries: 3 };`,
+  ],
+];
+
+const lint = (code: string, rule: string): Linter.LintMessage[] => {
+  // `configType: 'flat'` because a bare `new Linter()` still defaults to
+  // eslintrc on the declared ESLint floor, which would ignore the config below
+  // and skip every rule — a suite that passes having run nothing.
+  const linter = new Linter({ configType: 'flat' });
+  return linter.verify(
+    code,
+    {
+      files: ['**/*.ts'],
+      languageOptions: {
+        parser: parser as unknown as Linter.Parser,
+        parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+      },
+      plugins: { n: plugin as unknown as Linter.Plugin },
+      rules: { [`n/${rule}`]: 'error' },
+    },
+    // Without a filename the Linter lints `<input>`, which matches no `files`
+    // entry — every rule skipped, every negative below vacuously true.
+    'sample.ts',
+  );
+};
+
+describe('NestJS module gate', () => {
+  it('the registry is non-empty, so the sweep below is not vacuous', () => {
+    expect(RULES.length).toBeGreaterThan(0);
+  });
+
+  describe.each(NON_SDK_SOURCES)('%s', (_name, code) => {
+    it.each(RULES)('%s reports nothing', (rule) => {
+      const messages = lint(code, rule);
+      // A parse or config error also yields zero *rule* findings, so it is
+      // asserted away rather than counted as a pass.
+      expect(messages.filter((m) => !m.ruleId)).toHaveLength(0);
+      expect(messages.map((m) => m.ruleId)).toEqual([]);
+    });
+  });
+
+  describe('positive control — the gate must open for real NestJS code', () => {
+    it('the same violation reports once the file imports the SDK', () => {
+      expect(lint(`${SDK}\n${VIOLATION}`, 'no-exposed-private-fields').length).toBeGreaterThan(0);
+    });
+
+    it('and is silent with the import removed', () => {
+      expect(lint(VIOLATION, 'no-exposed-private-fields')).toHaveLength(0);
+    });
+  });
+});

--- a/packages/eslint-plugin-nestjs-security/src/option-defaults.test.ts
+++ b/packages/eslint-plugin-nestjs-security/src/option-defaults.test.ts
@@ -32,6 +32,11 @@ import { rules } from './index';
 const linter = new Linter({ configType: 'flat' });
 
 function findings(rule: string, code: string, options?: unknown): string[] {
+  // The rules abstain in files that use no NestJS, so every fixture here is
+  // linted as the NestJS file it stands for. A side-effect import: it adds no
+  // binding, and prefixing once in this helper means no fixture can be left
+  // behind and pass vacuously on the gate.
+  code = `import '@nestjs/common';\n${code}`;
   return linter
     .verify(
       code,

--- a/packages/eslint-plugin-nestjs-security/src/real-world-lock.test.ts
+++ b/packages/eslint-plugin-nestjs-security/src/real-world-lock.test.ts
@@ -35,6 +35,11 @@ function findings(
   code: string,
   filename = 'app.controller.ts',
 ): Record<string, number> {
+  // The rules abstain in files that use no NestJS, so every fixture here is
+  // linted as the NestJS file it stands for. A side-effect import: it adds no
+  // binding, and prefixing once in this helper means no fixture can be left
+  // behind and pass vacuously on the gate.
+  code = `import '@nestjs/common';\n${code}`;
   const messages = linter.verify(
     code,
     {

--- a/packages/eslint-plugin-nestjs-security/src/rules/no-exposed-private-fields/index.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/no-exposed-private-fields/index.ts
@@ -13,6 +13,7 @@
  * @see https://docs.nestjs.com/techniques/serialization
  */
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
+import { fileUsesNestjs } from '../../utils/nestjs-evidence';
 import {
   AST_NODE_TYPES,
   createRule,
@@ -135,6 +136,10 @@ export const noExposedPrivateFields = createRule<RuleOptions, MessageIds>({
     context: TSESLint.RuleContext<MessageIds, RuleOptions>,
     [options = {}],
   ) {
+    // Registering no visitors is both the gate and the cheap path: a file
+    // that does not use this SDK does no work at all.
+    if (!fileUsesNestjs(context.sourceCode.ast)) return {};
+
     const { allowInTests = true, sensitivePatterns = [] } = options as Options;
 
     if (allowInTests && isTestFile(context.filename)) {

--- a/packages/eslint-plugin-nestjs-security/src/rules/no-exposed-private-fields/no-exposed-private-fields.test.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/no-exposed-private-fields/no-exposed-private-fields.test.ts
@@ -16,6 +16,50 @@ import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { noExposedPrivateFields } from './index';
 
+/**
+ * Every fixture imports from NestJS, because the rules now abstain in files
+ * that use no NestJS at all. Wrapping the arrays rather than editing each
+ * fixture means one cannot be left behind — a fixture missing the import would
+ * pass vacuously on the gate instead of exercising the detection it was written
+ * for. A SIDE-EFFECT import, so it reserves no binding a fixture might declare.
+ * `output` and errors[].suggestions[].output are prefixed too, because autofix
+ * fixtures assert the whole file back.
+ */
+const asNest = (code: string): string => `import '@nestjs/common';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const nest = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asNest(c) as T;
+    const t = c as Case;
+    return {
+      ...c,
+      code: asNest(t.code),
+      ...(typeof t.output === 'string' ? { output: asNest(t.output) } : {}),
+      ...(t.errors
+        ? {
+            errors: t.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asNest(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
@@ -32,7 +76,7 @@ const ruleTester = new RuleTester({
 describe('no-exposed-private-fields', () => {
   describe('Valid Code - Properly Excluded Fields', () => {
     ruleTester.run('valid - excluded fields', noExposedPrivateFields, {
-      valid: [
+      valid: nest([
         // prisma-starter/src/user/models/user.model.ts:36 — @HideField() is
         // @nestjs/graphql's @Exclude(): the property never reaches the schema.
         `
@@ -175,8 +219,8 @@ describe('no-exposed-private-fields', () => {
             }
           `,
         },
-      ],
-      invalid: [
+      ]),
+      invalid: nest([
         // Persistence still outranks the name: a stored credential is serialized
         // outward whatever the class is called.
         {
@@ -235,13 +279,13 @@ describe('no-exposed-private-fields', () => {
       `,
           errors: [{ messageId: 'exposedField' }],
         },
-      ],
+      ]),
     });
   });
 
   describe('Valid Code - Non-Sensitive Classes', () => {
     ruleTester.run('valid - non-entity classes', noExposedPrivateFields, {
-      valid: [
+      valid: nest([
         // Regular class (not entity/dto)
         {
           code: `
@@ -279,7 +323,7 @@ describe('no-exposed-private-fields', () => {
             }
           `,
         },
-      ],
+      ]),
       invalid: [],
     });
   });
@@ -287,7 +331,7 @@ describe('no-exposed-private-fields', () => {
   describe('Invalid Code - Exposed Sensitive Fields', () => {
     ruleTester.run('invalid - exposed passwords', noExposedPrivateFields, {
       valid: [],
-      invalid: [
+      invalid: nest([
         // Entity with exposed password
         {
           code: `
@@ -359,14 +403,14 @@ describe('no-exposed-private-fields', () => {
             { messageId: 'exposedField' },
           ],
         },
-      ],
+      ]),
     });
   });
 
   describe('Invalid Code - Decorated Classes', () => {
     ruleTester.run('invalid - decorated classes', noExposedPrivateFields, {
       valid: [],
-      invalid: [
+      invalid: nest([
         // @Schema (Mongoose)
         {
           code: `
@@ -387,13 +431,13 @@ describe('no-exposed-private-fields', () => {
           `,
           errors: [{ messageId: 'exposedField' }],
         },
-      ],
+      ]),
     });
   });
 
   describe('Edge Cases', () => {
     ruleTester.run('edge cases', noExposedPrivateFields, {
-      valid: [
+      valid: nest([
         // Partially excluded - only sensitive fields excluded
         {
           code: `
@@ -406,8 +450,8 @@ describe('no-exposed-private-fields', () => {
             }
           `,
         },
-      ],
-      invalid: [
+      ]),
+      invalid: nest([
         // Mixed - some excluded, some exposed
         {
           code: `
@@ -430,14 +474,14 @@ describe('no-exposed-private-fields', () => {
           `,
           errors: [{ messageId: 'exposedField' }],
         },
-      ],
+      ]),
     });
   });
 });
 
 // Regression locks for the token-aligned matcher and the skip rules.
 ruleTester.run('no-exposed-private-fields (matching)', noExposedPrivateFields, {
-  valid: [
+  valid: nest([
     // A boolean flag says *whether* something is secret; it is not the secret.
     `
       class EnvironmentVariableResponseDto {
@@ -517,8 +561,8 @@ ruleTester.run('no-exposed-private-fields (matching)', noExposedPrivateFields, {
         [dynamicKey]: string;
       }
     `,
-  ],
-  invalid: [
+  ]),
+  invalid: nest([
     // Qualifier-prefixed credentials still match.
     {
       code: `
@@ -556,5 +600,5 @@ ruleTester.run('no-exposed-private-fields (matching)', noExposedPrivateFields, {
       options: [{ sensitivePatterns: ['internalNote'] }],
       errors: [{ messageId: 'exposedField' }],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-nestjs-security/src/rules/no-hybrid-app-config-loss/index.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/no-hybrid-app-config-loss/index.ts
@@ -59,6 +59,7 @@ import {
   MessageIcons,
 } from '@interlace/eslint-devkit';
 import type { TSESTree } from '@interlace/eslint-devkit';
+import { fileUsesNestjs } from '../../utils/nestjs-evidence';
 import {
   expressionName,
   isTestFile,
@@ -113,6 +114,10 @@ export const noHybridAppConfigLoss = createRule<RuleOptions, MessageIds>({
   },
   defaultOptions: [{}],
   create(context, [options = {}]) {
+    // Registering no visitors is both the gate and the cheap path: a file
+    // that does not use this SDK does no work at all.
+    if (!fileUsesNestjs(context.sourceCode.ast)) return {};
+
     const { allowInTests = true } = options;
     if (allowInTests && isTestFile(context.filename)) return {};
 

--- a/packages/eslint-plugin-nestjs-security/src/rules/no-hybrid-app-config-loss/no-hybrid-app-config-loss.test.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/no-hybrid-app-config-loss/no-hybrid-app-config-loss.test.ts
@@ -1,10 +1,54 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { noHybridAppConfigLoss } from './index';
 
+/**
+ * Every fixture imports from NestJS, because the rules now abstain in files
+ * that use no NestJS at all. Wrapping the arrays rather than editing each
+ * fixture means one cannot be left behind — a fixture missing the import would
+ * pass vacuously on the gate instead of exercising the detection it was written
+ * for. A SIDE-EFFECT import, so it reserves no binding a fixture might declare.
+ * `output` and errors[].suggestions[].output are prefixed too, because autofix
+ * fixtures assert the whole file back.
+ */
+const asNest = (code: string): string => `import '@nestjs/common';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const nest = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asNest(c) as T;
+    const t = c as Case;
+    return {
+      ...c,
+      code: asNest(t.code),
+      ...(typeof t.output === 'string' ? { output: asNest(t.output) } : {}),
+      ...(t.errors
+        ? {
+            errors: t.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asNest(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 const ruleTester = new RuleTester();
 
 ruleTester.run('no-hybrid-app-config-loss', noHybridAppConfigLoss, {
-  valid: [
+  valid: nest([
     // The fix, in the shape the NestJS docs publish.
     {
       code: `
@@ -59,8 +103,8 @@ ruleTester.run('no-hybrid-app-config-loss', noHybridAppConfigLoss, {
       code: `app.connectMicroservice(options);`,
       filename: 'app.e2e-spec.ts',
     },
-  ],
-  invalid: [
+  ]),
+  invalid: nest([
     // amplication/packages/amplication-server/src/main.ts:41 and four siblings.
     {
       code: `app.connectMicroservice<MicroserviceOptions>(createNestjsKafkaConfig());`,
@@ -108,7 +152,7 @@ ruleTester.run('no-hybrid-app-config-loss', noHybridAppConfigLoss, {
       options: [{ allowInTests: false }],
       errors: [{ messageId: 'configNotInherited' }],
     },
-  ],
+  ]),
 });
 
 /**

--- a/packages/eslint-plugin-nestjs-security/src/rules/no-missing-validation-pipe/index.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/no-missing-validation-pipe/index.ts
@@ -34,6 +34,7 @@ import { getProjectContext } from '../../utils/project-context';
 import { hasParserServices, getParserServices } from '@interlace/eslint-devkit';
 import type ts from 'typescript';
 import { loadTypeScript } from '../../utils/typescript-peer';
+import { fileUsesNestjs } from '../../utils/nestjs-evidence';
 
 type MessageIds = 'missingValidation' | 'addValidationPipe' | 'undecoratedDto';
 
@@ -154,6 +155,10 @@ export const noMissingValidationPipe = createRule<RuleOptions, MessageIds>({
     context: TSESLint.RuleContext<MessageIds, RuleOptions>,
     [options = {}],
   ) {
+    // Registering no visitors is both the gate and the cheap path: a file
+    // that does not use this SDK does no work at all.
+    if (!fileUsesNestjs(context.sourceCode.ast)) return {};
+
     const {
       allowInTests = true,
       assumeGlobalPipes = false,

--- a/packages/eslint-plugin-nestjs-security/src/rules/no-missing-validation-pipe/no-missing-validation-pipe.test.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/no-missing-validation-pipe/no-missing-validation-pipe.test.ts
@@ -1,10 +1,54 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { noMissingValidationPipe } from './index';
 
+/**
+ * Every fixture imports from NestJS, because the rules now abstain in files
+ * that use no NestJS at all. Wrapping the arrays rather than editing each
+ * fixture means one cannot be left behind — a fixture missing the import would
+ * pass vacuously on the gate instead of exercising the detection it was written
+ * for. A SIDE-EFFECT import, so it reserves no binding a fixture might declare.
+ * `output` and errors[].suggestions[].output are prefixed too, because autofix
+ * fixtures assert the whole file back.
+ */
+const asNest = (code: string): string => `import '@nestjs/common';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const nest = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asNest(c) as T;
+    const t = c as Case;
+    return {
+      ...c,
+      code: asNest(t.code),
+      ...(typeof t.output === 'string' ? { output: asNest(t.output) } : {}),
+      ...(t.errors
+        ? {
+            errors: t.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asNest(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 const ruleTester = new RuleTester();
 
 ruleTester.run('no-missing-validation-pipe', noMissingValidationPipe, {
-  valid: [
+  valid: nest([
     // nest-framework/.../hello.controller.ts:29 — a custom pipe resolves the id
     // to an entity and throws when it cannot. Matching the literal name
     // `ValidationPipe` reported every one of NestJS's own samples.
@@ -139,8 +183,8 @@ ruleTester.run('no-missing-validation-pipe', noMissingValidationPipe, {
         }
       `,
     },
-  ],
-  invalid: [
+  ]),
+  invalid: nest([
     // A global ValidationPipe cannot validate what carries no runtime class.
     // The early return that used to skip the whole file on a global
     // registration hid exactly these.
@@ -201,7 +245,7 @@ ruleTester.run('no-missing-validation-pipe', noMissingValidationPipe, {
       options: [{ requireExplicitPipe: true, allowInTests: false }],
       errors: [{ messageId: 'missingValidation' }],
     },
-  ],
+  ]),
 });
 
 // Locks for the parameter-scoped pipe and the untyped-@Body false negative.
@@ -209,7 +253,7 @@ ruleTester.run(
   'no-missing-validation-pipe (parameter scope)',
   noMissingValidationPipe,
   {
-    valid: [
+    valid: nest([
       // A pipe applied directly to the parameter validates it.
       `
       @Controller('u')
@@ -225,8 +269,8 @@ ruleTester.run(
         create(@Body(ValidationPipe) dto: CreateDto) {}
       }
     `,
-    ],
-    invalid: [
+    ]),
+    invalid: nest([
       // FN-5: an untyped @Body is the most dangerous shape and was silent.
       {
         code: `
@@ -251,7 +295,7 @@ ruleTester.run(
         options: [{ requireExplicitPipe: true }],
         errors: [{ messageId: 'missingValidation' }],
       },
-    ],
+    ]),
   },
 );
 
@@ -262,7 +306,7 @@ ruleTester.run(
   'no-missing-validation-pipe (unvalidatable shapes)',
   noMissingValidationPipe,
   {
-    valid: [
+    valid: nest([
       // A typed DTO IS validated by a global ValidationPipe.
       `
       @Controller('u')
@@ -278,8 +322,8 @@ ruleTester.run(
         find(@Query() dto: SearchRequestDto) {}
       }
     `,
-    ],
-    invalid: [
+    ]),
+    invalid: nest([
       // No annotation: the pipe has no metatype, so nothing is checked.
       {
         code: `
@@ -327,6 +371,6 @@ ruleTester.run(
           { messageId: 'missingValidation' },
         ],
       },
-    ],
+    ]),
   },
 );

--- a/packages/eslint-plugin-nestjs-security/src/rules/no-permissive-cors/index.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/no-permissive-cors/index.ts
@@ -32,6 +32,7 @@
  * @see https://docs.nestjs.com/security/cors
  */
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
+import { fileUsesNestjs } from '../../utils/nestjs-evidence';
 import {
   AST_NODE_TYPES,
   createRule,
@@ -298,6 +299,10 @@ export const noPermissiveCors = createRule<RuleOptions, MessageIds>({
     context: TSESLint.RuleContext<MessageIds, RuleOptions>,
     [options = {}],
   ) {
+    // Registering no visitors is both the gate and the cheap path: a file
+    // that does not use this SDK does no work at all.
+    if (!fileUsesNestjs(context.sourceCode.ast)) return {};
+
     const { allowInTests = true } = options;
     if (allowInTests && isTestFile(context.filename)) return {};
 

--- a/packages/eslint-plugin-nestjs-security/src/rules/no-permissive-cors/no-permissive-cors.test.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/no-permissive-cors/no-permissive-cors.test.ts
@@ -5,12 +5,56 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { noPermissiveCors } from './index';
 
+/**
+ * Every fixture imports from NestJS, because the rules now abstain in files
+ * that use no NestJS at all. Wrapping the arrays rather than editing each
+ * fixture means one cannot be left behind — a fixture missing the import would
+ * pass vacuously on the gate instead of exercising the detection it was written
+ * for. A SIDE-EFFECT import, so it reserves no binding a fixture might declare.
+ * `output` and errors[].suggestions[].output are prefixed too, because autofix
+ * fixtures assert the whole file back.
+ */
+const asNest = (code: string): string => `import '@nestjs/common';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const nest = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asNest(c) as T;
+    const t = c as Case;
+    return {
+      ...c,
+      code: asNest(t.code),
+      ...(typeof t.output === 'string' ? { output: asNest(t.output) } : {}),
+      ...(t.errors
+        ? {
+            errors: t.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asNest(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 const ruleTester = new RuleTester({
   languageOptions: { ecmaVersion: 2022, sourceType: 'module' },
 });
 
 ruleTester.run('no-permissive-cors', noPermissiveCors, {
-  valid: [
+  valid: nest([
     // nest-framework/packages/core/nest-application.ts:130 — NestJS's own
     // implementation of the API this rule watches. An application holds the
     // app in a binding; a `this` receiver means the class *is* the app.
@@ -139,8 +183,8 @@ ruleTester.run('no-permissive-cors', noPermissiveCors, {
       code: `app.enableCors();`,
       filename: 'app.e2e-spec.ts',
     },
-  ],
-  invalid: [
+  ]),
+  invalid: nest([
     // The documented Fastify spelling puts the options object third, so
     // reading `arguments[1]` found the adapter and gave up.
     {
@@ -282,7 +326,7 @@ ruleTester.run('no-permissive-cors', noPermissiveCors, {
       options: [{ allowInTests: false }],
       errors: [{ messageId: 'defaultOrigin' }],
     },
-  ],
+  ]),
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -291,7 +335,7 @@ ruleTester.run('no-permissive-cors', noPermissiveCors, {
 // helper returning null is the safe answer, not a missed finding.
 // ─────────────────────────────────────────────────────────────────────────────
 ruleTester.run('no-permissive-cors (coverage gaps)', noPermissiveCors, {
-  valid: [
+  valid: nest([
     // Callee is a member expression whose property is computed, not `enableCors`.
     { code: `app['enableCors']();` },
     // Callee is not a member expression at all.
@@ -332,8 +376,8 @@ ruleTester.run('no-permissive-cors (coverage gaps)', noPermissiveCors, {
         app.enableCors(corsOptions);
       `,
     },
-  ],
-  invalid: [
+  ]),
+  invalid: nest([
     // Computed key: `origin` is not provably set and there is no spread to
     // explain it, so the CORS default of '*' applies either way.
     {
@@ -351,7 +395,7 @@ ruleTester.run('no-permissive-cors (coverage gaps)', noPermissiveCors, {
       `,
       errors: [{ messageId: 'wildcardOrigin' }],
     },
-  ],
+  ]),
 });
 
 /**
@@ -363,7 +407,7 @@ ruleTester.run('no-permissive-cors (coverage gaps)', noPermissiveCors, {
  * the file — the name is not evidence, the import it resolves to is.
  */
 ruleTester.run('no-permissive-cors (annotated declaration)', noPermissiveCors, {
-  valid: [
+  valid: nest([
     // The allowlist form. This is the fix ultimate-backend should apply, and it
     // is already written 7 lines below the defect in their own file.
     `
@@ -414,8 +458,8 @@ ruleTester.run('no-permissive-cors (annotated declaration)', noPermissiveCors, {
         const corsOptions: CorsOptions = { origin: true };
       }
     `,
-  ],
-  invalid: [
+  ]),
+  invalid: nest([
     // The ultimate-backend shape, reduced. Reflected origin + credentials.
     {
       code: `
@@ -479,7 +523,7 @@ ruleTester.run('no-permissive-cors (annotated declaration)', noPermissiveCors, {
       `,
       errors: [{ messageId: 'reflectedOrigin' }],
     },
-  ],
+  ]),
 });
 
 // A computed key named `origin` is a variable reference, not the property.
@@ -490,7 +534,7 @@ ruleTester.run(
   noPermissiveCors,
   {
     valid: [],
-    invalid: [
+    invalid: nest([
       {
         code: `
         const origin = 'credentials';
@@ -498,6 +542,6 @@ ruleTester.run(
       `,
         errors: [{ messageId: 'defaultOrigin' }],
       },
-    ],
+    ]),
   },
 );

--- a/packages/eslint-plugin-nestjs-security/src/rules/no-res-bypass-serialization/index.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/no-res-bypass-serialization/index.ts
@@ -31,6 +31,7 @@ import {
 } from '@interlace/eslint-devkit';
 import { AST_NODE_TYPES } from '@interlace/eslint-devkit';
 import type { TSESTree } from '@interlace/eslint-devkit';
+import { fileUsesNestjs } from '../../utils/nestjs-evidence';
 import {
   callReceiver,
   decoratorCall,
@@ -159,6 +160,10 @@ export const noResBypassSerialization = createRule<RuleOptions, MessageIds>({
   },
   defaultOptions: [{}],
   create(context, [options = {}]) {
+    // Registering no visitors is both the gate and the cheap path: a file
+    // that does not use this SDK does no work at all.
+    if (!fileUsesNestjs(context.sourceCode.ast)) return {};
+
     const { allowInTests = true, assumeGlobalSerializer = false } = options;
     if (allowInTests && isTestFile(context.filename)) return {};
 

--- a/packages/eslint-plugin-nestjs-security/src/rules/no-res-bypass-serialization/no-res-bypass-serialization.test.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/no-res-bypass-serialization/no-res-bypass-serialization.test.ts
@@ -1,10 +1,54 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { noResBypassSerialization } from './index';
 
+/**
+ * Every fixture imports from NestJS, because the rules now abstain in files
+ * that use no NestJS at all. Wrapping the arrays rather than editing each
+ * fixture means one cannot be left behind — a fixture missing the import would
+ * pass vacuously on the gate instead of exercising the detection it was written
+ * for. A SIDE-EFFECT import, so it reserves no binding a fixture might declare.
+ * `output` and errors[].suggestions[].output are prefixed too, because autofix
+ * fixtures assert the whole file back.
+ */
+const asNest = (code: string): string => `import '@nestjs/common';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const nest = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asNest(c) as T;
+    const t = c as Case;
+    return {
+      ...c,
+      code: asNest(t.code),
+      ...(typeof t.output === 'string' ? { output: asNest(t.output) } : {}),
+      ...(t.errors
+        ? {
+            errors: t.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asNest(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 const ruleTester = new RuleTester();
 
 ruleTester.run('no-res-bypass-serialization', noResBypassSerialization, {
-  valid: [
+  valid: nest([
     // ghostfolio/apps/api/src/app/endpoints/sitemap/sitemap.controller.ts:34 —
     // declares XML and sends an interpolated document. The body is a helper
     // call so it is not provably a string, but the content type settles it:
@@ -307,8 +351,8 @@ ruleTester.run('no-res-bypass-serialization', noResBypassSerialization, {
         }
       }
     `,
-  ],
-  invalid: [
+  ]),
+  invalid: nest([
     // A non-JSON content type on some *other* object says nothing about what
     // this handler writes. Scanning the whole body let it silence the rule.
     {
@@ -568,5 +612,5 @@ ruleTester.run('no-res-bypass-serialization', noResBypassSerialization, {
       `,
       errors: [{ messageId: 'bypassesSerialization' }],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-nestjs-security/src/rules/no-unguarded-swagger/index.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/no-unguarded-swagger/index.ts
@@ -35,6 +35,7 @@ import {
 } from '@interlace/eslint-devkit';
 import type { TSESTree } from '@interlace/eslint-devkit';
 import { expressionName, isTestFile } from '../../utils/nest-ast';
+import { fileUsesNestjs } from '../../utils/nestjs-evidence';
 
 type MessageIds = 'unguardedSwagger';
 
@@ -98,6 +99,10 @@ export const noUnguardedSwagger = createRule<RuleOptions, MessageIds>({
   },
   defaultOptions: [{}],
   create(context, [options = {}]) {
+    // Registering no visitors is both the gate and the cheap path: a file
+    // that does not use this SDK does no work at all.
+    if (!fileUsesNestjs(context.sourceCode.ast)) return {};
+
     const { allowInTests = true } = options;
     if (allowInTests && isTestFile(context.filename)) return {};
 

--- a/packages/eslint-plugin-nestjs-security/src/rules/no-unguarded-swagger/no-unguarded-swagger.test.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/no-unguarded-swagger/no-unguarded-swagger.test.ts
@@ -1,10 +1,54 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { noUnguardedSwagger } from './index';
 
+/**
+ * Every fixture imports from NestJS, because the rules now abstain in files
+ * that use no NestJS at all. Wrapping the arrays rather than editing each
+ * fixture means one cannot be left behind — a fixture missing the import would
+ * pass vacuously on the gate instead of exercising the detection it was written
+ * for. A SIDE-EFFECT import, so it reserves no binding a fixture might declare.
+ * `output` and errors[].suggestions[].output are prefixed too, because autofix
+ * fixtures assert the whole file back.
+ */
+const asNest = (code: string): string => `import '@nestjs/common';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const nest = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asNest(c) as T;
+    const t = c as Case;
+    return {
+      ...c,
+      code: asNest(t.code),
+      ...(typeof t.output === 'string' ? { output: asNest(t.output) } : {}),
+      ...(t.errors
+        ? {
+            errors: t.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asNest(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 const ruleTester = new RuleTester();
 
 ruleTester.run('no-unguarded-swagger', noUnguardedSwagger, {
-  valid: [
+  valid: nest([
     // prisma-starter: the minimally-different correct version, from the corpus.
     `
       async function bootstrap() {
@@ -71,8 +115,8 @@ ruleTester.run('no-unguarded-swagger', noUnguardedSwagger, {
       `,
       filename: 'main.e2e-spec.ts',
     },
-  ],
-  invalid: [
+  ]),
+  invalid: nest([
     // realworld/src/main.ts — straight-line in bootstrap, no check anywhere.
     {
       code: `
@@ -116,5 +160,5 @@ ruleTester.run('no-unguarded-swagger', noUnguardedSwagger, {
       options: [{ allowInTests: false }],
       errors: [{ messageId: 'unguardedSwagger' }],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-nestjs-security/src/rules/no-unsafe-multer-filename/index.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/no-unsafe-multer-filename/index.ts
@@ -54,6 +54,7 @@ import {
   MessageIcons,
 } from '@interlace/eslint-devkit';
 import { isTestFile } from '../../utils/nest-ast';
+import { fileUsesNestjs } from '../../utils/nestjs-evidence';
 
 type MessageIds = 'clientControlledFilename';
 
@@ -183,6 +184,10 @@ export const noUnsafeMulterFilename = createRule<RuleOptions, MessageIds>({
     context: TSESLint.RuleContext<MessageIds, RuleOptions>,
     [options = {}],
   ) {
+    // Registering no visitors is both the gate and the cheap path: a file
+    // that does not use this SDK does no work at all.
+    if (!fileUsesNestjs(context.sourceCode.ast)) return {};
+
     const { allowInTests = true } = options;
     if (allowInTests && isTestFile(context.filename)) return {};
 

--- a/packages/eslint-plugin-nestjs-security/src/rules/no-unsafe-multer-filename/no-unsafe-multer-filename.test.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/no-unsafe-multer-filename/no-unsafe-multer-filename.test.ts
@@ -10,12 +10,56 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { noUnsafeMulterFilename } from './index';
 
+/**
+ * Every fixture imports from NestJS, because the rules now abstain in files
+ * that use no NestJS at all. Wrapping the arrays rather than editing each
+ * fixture means one cannot be left behind — a fixture missing the import would
+ * pass vacuously on the gate instead of exercising the detection it was written
+ * for. A SIDE-EFFECT import, so it reserves no binding a fixture might declare.
+ * `output` and errors[].suggestions[].output are prefixed too, because autofix
+ * fixtures assert the whole file back.
+ */
+const asNest = (code: string): string => `import '@nestjs/common';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const nest = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asNest(c) as T;
+    const t = c as Case;
+    return {
+      ...c,
+      code: asNest(t.code),
+      ...(typeof t.output === 'string' ? { output: asNest(t.output) } : {}),
+      ...(t.errors
+        ? {
+            errors: t.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asNest(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 const ruleTester = new RuleTester({
   languageOptions: { ecmaVersion: 2022, sourceType: 'module' },
 });
 
 ruleTester.run('no-unsafe-multer-filename', noUnsafeMulterFilename, {
-  valid: [
+  valid: nest([
     // truthy/src/common/helper/multer-options.helper.ts — the correct fix.
     // `extname` cannot return a path separator, so the client controls at most
     // the suffix of a name we chose.
@@ -138,8 +182,8 @@ ruleTester.run('no-unsafe-multer-filename', noUnsafeMulterFilename, {
       code: `diskStorage({ filename(req, file, cb) { cb(null, file.originalname); } });`,
       filename: 'upload.spec.ts',
     },
-  ],
-  invalid: [
+  ]),
+  invalid: nest([
     // nestjs-course-code/nest-multer-upload/src/my-file-storage.ts — the exact
     // shape three separate course projects ship, and the reason this rule
     // exists: a timestamp prefix reads as a mitigation and is not one.
@@ -248,5 +292,5 @@ ruleTester.run('no-unsafe-multer-filename', noUnsafeMulterFilename, {
       options: [{ allowInTests: false }],
       errors: [{ messageId: 'clientControlledFilename' }],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-nestjs-security/src/rules/require-guards/index.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/require-guards/index.ts
@@ -40,6 +40,7 @@ import {
 } from '../../utils/nest-ast';
 import { tokenize } from '../../utils/sensitive-names';
 import { getProjectContext } from '../../utils/project-context';
+import { fileUsesNestjs } from '../../utils/nestjs-evidence';
 
 type MessageIds =
   'missingGuards' | 'emptyGuards' | 'missingRequiredGuard' | 'addGuards';
@@ -358,6 +359,10 @@ export const requireGuards = createRule<RuleOptions, MessageIds>({
     context: TSESLint.RuleContext<MessageIds, RuleOptions>,
     [options = {}],
   ) {
+    // Registering no visitors is both the gate and the cheap path: a file
+    // that does not use this SDK does no work at all.
+    if (!fileUsesNestjs(context.sourceCode.ast)) return {};
+
     const {
       allowInTests = true,
       allowPublicDecorator = true,

--- a/packages/eslint-plugin-nestjs-security/src/rules/require-guards/require-guards.test.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/require-guards/require-guards.test.ts
@@ -1,10 +1,54 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { requireGuards } from './index';
 
+/**
+ * Every fixture imports from NestJS, because the rules now abstain in files
+ * that use no NestJS at all. Wrapping the arrays rather than editing each
+ * fixture means one cannot be left behind — a fixture missing the import would
+ * pass vacuously on the gate instead of exercising the detection it was written
+ * for. A SIDE-EFFECT import, so it reserves no binding a fixture might declare.
+ * `output` and errors[].suggestions[].output are prefixed too, because autofix
+ * fixtures assert the whole file back.
+ */
+const asNest = (code: string): string => `import '@nestjs/common';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const nest = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asNest(c) as T;
+    const t = c as Case;
+    return {
+      ...c,
+      code: asNest(t.code),
+      ...(typeof t.output === 'string' ? { output: asNest(t.output) } : {}),
+      ...(t.errors
+        ? {
+            errors: t.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asNest(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 const ruleTester = new RuleTester();
 
 ruleTester.run('require-guards', requireGuards, {
-  valid: [
+  valid: nest([
     // amplication/.../auth.controller.ts — an auth entry point is qualified by
     // its provider (`auth0Login`) or its transport (`githubCallback`), and
     // exact-name matching reported every one of them.
@@ -441,8 +485,8 @@ ruleTester.run('require-guards', requireGuards, {
         }
       `,
     },
-  ],
-  invalid: [
+  ]),
+  invalid: nest([
     // The configured-secret exemption is bounded on both sides. Comparing
     // already-trusted data is authorization, not authentication — it says
     // nothing about whether the caller proved who they are.
@@ -892,7 +936,7 @@ ruleTester.run('require-guards', requireGuards, {
       `,
       errors: [{ messageId: 'missingGuards' }],
     },
-  ],
+  ]),
 });
 
 /**

--- a/packages/eslint-plugin-nestjs-security/src/rules/require-throttler/index.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/require-throttler/index.ts
@@ -35,6 +35,7 @@ import {
 } from '../../utils/nest-ast';
 import { getProjectContext } from '../../utils/project-context';
 import { tokenize } from '../../utils/sensitive-names';
+import { fileUsesNestjs } from '../../utils/nestjs-evidence';
 
 type MessageIds = 'missingThrottler' | 'addThrottler';
 
@@ -213,6 +214,10 @@ export const requireThrottler = createRule<RuleOptions, MessageIds>({
     context: TSESLint.RuleContext<MessageIds, RuleOptions>,
     [options = {}],
   ) {
+    // Registering no visitors is both the gate and the cheap path: a file
+    // that does not use this SDK does no work at all.
+    if (!fileUsesNestjs(context.sourceCode.ast)) return {};
+
     const {
       allowInTests = true,
       assumeGlobalThrottler = false,

--- a/packages/eslint-plugin-nestjs-security/src/rules/require-throttler/require-throttler.test.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/require-throttler/require-throttler.test.ts
@@ -1,10 +1,54 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { requireThrottler } from './index';
 
+/**
+ * Every fixture imports from NestJS, because the rules now abstain in files
+ * that use no NestJS at all. Wrapping the arrays rather than editing each
+ * fixture means one cannot be left behind — a fixture missing the import would
+ * pass vacuously on the gate instead of exercising the detection it was written
+ * for. A SIDE-EFFECT import, so it reserves no binding a fixture might declare.
+ * `output` and errors[].suggestions[].output are prefixed too, because autofix
+ * fixtures assert the whole file back.
+ */
+const asNest = (code: string): string => `import '@nestjs/common';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const nest = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asNest(c) as T;
+    const t = c as Case;
+    return {
+      ...c,
+      code: asNest(t.code),
+      ...(typeof t.output === 'string' ? { output: asNest(t.output) } : {}),
+      ...(t.errors
+        ? {
+            errors: t.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asNest(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 const ruleTester = new RuleTester();
 
 ruleTester.run('require-throttler', requireThrottler, {
-  valid: [
+  valid: nest([
     // Substring matching reported these: 'authors'.includes('auth') and
     // 'tokenize'.includes('token') are both true. An author listing is not a
     // credential endpoint, and saying so costs the rule its credibility.
@@ -135,8 +179,8 @@ ruleTester.run('require-throttler', requireThrottler, {
         }
       `,
     },
-  ],
-  invalid: [
+  ]),
+  invalid: nest([
     // …while a sensitive token in any position still counts. The corpus names
     // these handlers verb-first as often as noun-first, so suffix-only
     // matching would drop most of them.
@@ -192,12 +236,12 @@ ruleTester.run('require-throttler', requireThrottler, {
       options: [{ allowInTests: false, onlySensitiveRoutes: false }],
       errors: [{ messageId: 'missingThrottler' }],
     },
-  ],
+  ]),
 });
 
 // Lock for `skipRoutes`, which was declared in the schema but never read.
 ruleTester.run('require-throttler (skipRoutes)', requireThrottler, {
-  valid: [
+  valid: nest([
     // Matches the handler name (a route that would otherwise be reported).
     {
       code: `
@@ -220,8 +264,8 @@ ruleTester.run('require-throttler (skipRoutes)', requireThrottler, {
       `,
       options: [{ skipRoutes: ['status'], onlySensitiveRoutes: false }],
     },
-  ],
-  invalid: [
+  ]),
+  invalid: nest([
     // A bare (uninvoked) @Get declares no path, so only the name can match.
     {
       code: `
@@ -246,12 +290,12 @@ ruleTester.run('require-throttler (skipRoutes)', requireThrottler, {
       options: [{ skipRoutes: ['status'], onlySensitiveRoutes: false }],
       errors: [{ messageId: 'missingThrottler' }],
     },
-  ],
+  ]),
 });
 
 // The default now targets credential/abuse-prone routes only.
 ruleTester.run('require-throttler (sensitive routes)', requireThrottler, {
-  valid: [
+  valid: nest([
     // Behind authentication: not a brute-force target. This is the exact
     // complement of require-guards, which exempts public auth entry points.
     `
@@ -298,8 +342,8 @@ ruleTester.run('require-throttler (sensitive routes)', requireThrottler, {
         login() {}
       }
     `,
-  ],
-  invalid: [
+  ]),
+  invalid: nest([
     // Brute-forceable: login by handler name.
     {
       code: `
@@ -333,5 +377,5 @@ ruleTester.run('require-throttler (sensitive routes)', requireThrottler, {
       `,
       errors: [{ messageId: 'missingThrottler' }],
     },
-  ],
+  ]),
 });

--- a/packages/eslint-plugin-nestjs-security/src/rules/require-validation-pipe-whitelist/index.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/require-validation-pipe-whitelist/index.ts
@@ -46,6 +46,7 @@ import {
 } from '@interlace/eslint-devkit';
 
 import { isTestFile } from '../../utils/nest-ast';
+import { fileUsesNestjs } from '../../utils/nestjs-evidence';
 
 type MessageIds = 'missingWhitelist';
 
@@ -166,6 +167,10 @@ export const requireValidationPipeWhitelist = createRule<
     context: TSESLint.RuleContext<MessageIds, RuleOptions>,
     [options = {}],
   ) {
+    // Registering no visitors is both the gate and the cheap path: a file
+    // that does not use this SDK does no work at all.
+    if (!fileUsesNestjs(context.sourceCode.ast)) return {};
+
     const { allowInTests = true, requireForbidNonWhitelisted = false } =
       options;
     if (allowInTests && isTestFile(context.filename)) return {};

--- a/packages/eslint-plugin-nestjs-security/src/rules/require-validation-pipe-whitelist/require-validation-pipe-whitelist.test.ts
+++ b/packages/eslint-plugin-nestjs-security/src/rules/require-validation-pipe-whitelist/require-validation-pipe-whitelist.test.ts
@@ -5,6 +5,50 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { requireValidationPipeWhitelist } from './index';
 
+/**
+ * Every fixture imports from NestJS, because the rules now abstain in files
+ * that use no NestJS at all. Wrapping the arrays rather than editing each
+ * fixture means one cannot be left behind — a fixture missing the import would
+ * pass vacuously on the gate instead of exercising the detection it was written
+ * for. A SIDE-EFFECT import, so it reserves no binding a fixture might declare.
+ * `output` and errors[].suggestions[].output are prefixed too, because autofix
+ * fixtures assert the whole file back.
+ */
+const asNest = (code: string): string => `import '@nestjs/common';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const nest = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asNest(c) as T;
+    const t = c as Case;
+    return {
+      ...c,
+      code: asNest(t.code),
+      ...(typeof t.output === 'string' ? { output: asNest(t.output) } : {}),
+      ...(t.errors
+        ? {
+            errors: t.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asNest(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 const ruleTester = new RuleTester({
   languageOptions: { ecmaVersion: 2022, sourceType: 'module' },
 });
@@ -13,7 +57,7 @@ ruleTester.run(
   'require-validation-pipe-whitelist',
   requireValidationPipeWhitelist,
   {
-    valid: [
+    valid: nest([
       { code: `app.useGlobalPipes(new ValidationPipe({ whitelist: true }));` },
       {
         code: `app.useGlobalPipes(new ValidationPipe({ transform: true, whitelist: true }));`,
@@ -38,8 +82,8 @@ ruleTester.run(
       { code: `new ParseIntPipe();` },
       // Test files exempt by default.
       { code: `new ValidationPipe();`, filename: 'app.e2e-spec.ts' },
-    ],
-    invalid: [
+    ]),
+    invalid: nest([
       // The shape in notiz-dev/nestjs-prisma-starter and squareboat/nestjs-boilerplate.
       {
         code: `app.useGlobalPipes(new ValidationPipe());`,
@@ -87,7 +131,7 @@ ruleTester.run(
         options: [{ allowInTests: false }],
         errors: [{ messageId: 'missingWhitelist' }],
       },
-    ],
+    ]),
   },
 );
 
@@ -99,7 +143,7 @@ ruleTester.run(
   'require-validation-pipe-whitelist (coverage gaps)',
   requireValidationPipeWhitelist,
   {
-    valid: [
+    valid: nest([
       // Namespaced constructor — callee is a member expression, not an Identifier.
       { code: `new nest.ValidationPipe();` },
       // Identifier never declared — scope walk exhausts.
@@ -124,8 +168,8 @@ ruleTester.run(
       // Computed key — cannot be read as `whitelist`, and a spread-free object
       // with an unknown key is still unknown, so stay quiet is wrong here…
       // (see invalid below: this one DOES report, kept out of valid deliberately)
-    ],
-    invalid: [
+    ]),
+    invalid: nest([
       // Computed key: `whitelist` is not provably set, and there is no spread to
       // explain it away, so the rule reports.
       {
@@ -147,7 +191,7 @@ ruleTester.run(
       `,
         errors: [{ messageId: 'missingWhitelist' }],
       },
-    ],
+    ]),
   },
 );
 
@@ -162,7 +206,7 @@ ruleTester.run(
   requireValidationPipeWhitelist,
   {
     valid: [],
-    invalid: [
+    invalid: nest([
       {
         code: `
         const whitelist = 'transform';
@@ -178,7 +222,7 @@ ruleTester.run(
         options: [{ requireForbidNonWhitelisted: true }],
         errors: [{ messageId: 'missingWhitelist' }],
       },
-    ],
+    ]),
   },
 );
 
@@ -187,12 +231,12 @@ ruleTester.run(
   'require-validation-pipe-whitelist (strict satisfied)',
   requireValidationPipeWhitelist,
   {
-    valid: [
+    valid: nest([
       {
         code: `new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true });`,
         options: [{ requireForbidNonWhitelisted: true }],
       },
-    ],
+    ]),
     invalid: [],
   },
 );

--- a/packages/eslint-plugin-nestjs-security/src/type-aware.test.ts
+++ b/packages/eslint-plugin-nestjs-security/src/type-aware.test.ts
@@ -24,6 +24,50 @@ import parser from '@typescript-eslint/parser';
 import * as path from 'node:path';
 import { noMissingValidationPipe } from './rules/no-missing-validation-pipe';
 
+/**
+ * Every fixture imports from NestJS, because the rules now abstain in files
+ * that use no NestJS at all. Wrapping the arrays rather than editing each
+ * fixture means one cannot be left behind — a fixture missing the import would
+ * pass vacuously on the gate instead of exercising the detection it was written
+ * for. A SIDE-EFFECT import, so it reserves no binding a fixture might declare.
+ * `output` and errors[].suggestions[].output are prefixed too, because autofix
+ * fixtures assert the whole file back.
+ */
+const asNest = (code: string): string => `import '@nestjs/common';\n${code}`;
+type Suggestion = { output?: string | null };
+type Case = {
+  code: string;
+  output?: string | null;
+  errors?: ReadonlyArray<{ suggestions?: readonly Suggestion[] } | string>;
+};
+const nest = <T,>(cases: T[]): T[] =>
+  cases.map((c) => {
+    if (typeof c === 'string') return asNest(c) as T;
+    const t = c as Case;
+    return {
+      ...c,
+      code: asNest(t.code),
+      ...(typeof t.output === 'string' ? { output: asNest(t.output) } : {}),
+      ...(t.errors
+        ? {
+            errors: t.errors.map((e) =>
+              typeof e === 'string' || !e.suggestions
+                ? e
+                : {
+                    ...e,
+                    suggestions: e.suggestions.map((s) =>
+                      typeof s.output === 'string'
+                        ? { ...s, output: asNest(s.output) }
+                        : s,
+                    ),
+                  },
+            ),
+          }
+        : {}),
+    } as T;
+  });
+
+
 RuleTester.afterAll = afterAll;
 RuleTester.describe = describe;
 RuleTester.it = it;
@@ -49,7 +93,7 @@ ruleTester.run(
   'no-missing-validation-pipe (type-aware)',
   noMissingValidationPipe,
   {
-    valid: [
+    valid: nest([
       // The DTO declares a real class-validator rule, so a pipe has something to
       // enforce. This is the case the name-based predecessor could not tell apart
       // from the one below.
@@ -169,8 +213,8 @@ ruleTester.run(
         }
       `,
       },
-    ],
-    invalid: [
+    ]),
+    invalid: nest([
       // No annotation at all: nothing for this half to resolve, so it falls
       // through to the syntax-only finding rather than double-reporting.
       {
@@ -270,6 +314,6 @@ ruleTester.run(
       `,
         errors: [{ messageId: 'undecoratedDto' }],
       },
-    ],
+    ]),
   },
 );

--- a/packages/eslint-plugin-nestjs-security/src/utils/nestjs-evidence.ts
+++ b/packages/eslint-plugin-nestjs-security/src/utils/nestjs-evidence.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+import type { TSESTree } from '@interlace/eslint-devkit';
+import { createModuleEvidence } from '@interlace/eslint-devkit';
+
+/**
+ * Whether this file uses the SDK this plugin is about.
+ *
+ * Every rule in this plugin is gated on it. Measured over 107,382 files across 107 repositories, **22% of everything this
+ * plugin reported (219 of 999 findings) was in a file importing no NestJS
+ * package** — the rules key on decorator and method names that Angular, TypeORM
+ * and plain TypeScript classes share.
+ *
+ * The probe itself lives in the devkit so the whole ecosystem shares one
+ * implementation: package-root matching, rejection of relative specifiers,
+ * TypeScript's `import =` form, Deno's `npm:` and `deno.land` specifiers,
+ * dynamic `import()`, lexically-scoped `require` shadowing, and a per-`Program`
+ * cache. Five plugins previously carried their own copy, so each
+ * false-negative class had to be fixed five times.
+ */
+export const fileUsesNestjs: (ast: TSESTree.Program) => boolean =
+  createModuleEvidence({
+    // Every NestJS file imports from the framework: the decorators that define
+    // a controller, provider or module (`@Controller`, `@Injectable`, `@Module`)
+    // are values imported from `@nestjs/common` or `@nestjs/core`. There is no
+    // decorator-shaped convention that exists without the import, so unlike
+    // Lambda and Express this gate needs no extra evidence arm.
+    scopes: ['@nestjs'],
+  });

--- a/packages/eslint-plugin-openai-security/src/module-gate.lock.test.ts
+++ b/packages/eslint-plugin-openai-security/src/module-gate.lock.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Regression lock: no rule in this plugin reports in a file that does not use
+ * the OpenAI SDK.
+ *
+ * Its rules are built by `createSdkApiKeyRule`, which gates on the configured
+ * `modules`. That guarantee lives in the devkit factory, so nothing fails if a
+ * hand-written rule is added to this plugin tomorrow. This lock is that.
+ *
+ * Written over the whole rule registry rather than per rule, so a rule added
+ * later is covered the day it lands: it will fail here until it is gated too.
+ * Revert the gate in any single rule and this test goes red.
+ */
+import { describe, it, expect } from 'vitest';
+import { Linter } from 'eslint';
+import parser from '@typescript-eslint/parser';
+import plugin from './index';
+
+const RULES = Object.keys(plugin.rules);
+
+/** The SDK import that is the whole difference between the two halves below. */
+const SDK = "import OpenAI from 'openai';";
+
+/**
+ * A real violation of `no-hardcoded-api-key`. It appears twice on purpose: once
+ * without the import (must be silent) and once with it (must report). One
+ * fixture proving both directions is what stops this suite passing with the
+ * gate shut on everything.
+ */
+const VIOLATION = `const client = new OpenAI({ apiKey: 'sk-proj-hardcoded' });`;
+
+/** Files that use no the OpenAI SDK at all. */
+const NON_SDK_SOURCES: ReadonlyArray<readonly [string, string]> = [
+  ['the violation itself, minus the import', VIOLATION],
+  [
+    'a plain helper',
+    `export function parse(s: string) {
+       try { return JSON.parse(s); } catch { return null; }
+     }`,
+  ],
+  [
+    'a React component',
+    `export default function Panel({ items }) {
+       return items.map((i) => i.name).join(', ');
+     }`,
+  ],
+  [
+    'a config module',
+    `export const config = { token: process.env.API_TOKEN, retries: 3 };`,
+  ],
+];
+
+const lint = (code: string, rule: string): Linter.LintMessage[] => {
+  // `configType: 'flat'` because a bare `new Linter()` still defaults to
+  // eslintrc on the declared ESLint floor, which would ignore the config below
+  // and skip every rule — a suite that passes having run nothing.
+  const linter = new Linter({ configType: 'flat' });
+  return linter.verify(
+    code,
+    {
+      files: ['**/*.ts'],
+      languageOptions: {
+        parser: parser as unknown as Linter.Parser,
+        parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+      },
+      plugins: { o: plugin as unknown as Linter.Plugin },
+      rules: { [`o/${rule}`]: 'error' },
+    },
+    // Without a filename the Linter lints `<input>`, which matches no `files`
+    // entry — every rule skipped, every negative below vacuously true.
+    'sample.ts',
+  );
+};
+
+describe('the OpenAI SDK module gate', () => {
+  it('the registry is non-empty, so the sweep below is not vacuous', () => {
+    expect(RULES.length).toBeGreaterThan(0);
+  });
+
+  describe.each(NON_SDK_SOURCES)('%s', (_name, code) => {
+    it.each(RULES)('%s reports nothing', (rule) => {
+      const messages = lint(code, rule);
+      // A parse or config error also yields zero *rule* findings, so it is
+      // asserted away rather than counted as a pass.
+      expect(messages.filter((m) => !m.ruleId)).toHaveLength(0);
+      expect(messages.map((m) => m.ruleId)).toEqual([]);
+    });
+  });
+
+  describe('positive control — the gate must open for real the OpenAI SDK code', () => {
+    it('the same violation reports once the file imports the SDK', () => {
+      expect(lint(`${SDK}\n${VIOLATION}`, 'no-hardcoded-api-key').length).toBeGreaterThan(0);
+    });
+
+    it('and is silent with the import removed', () => {
+      expect(lint(VIOLATION, 'no-hardcoded-api-key')).toHaveLength(0);
+    });
+  });
+});

--- a/packages/eslint-plugin-prisma-security/src/module-gate.lock.test.ts
+++ b/packages/eslint-plugin-prisma-security/src/module-gate.lock.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Regression lock: no rule in this plugin reports in a file that does not use
+ * @prisma/client.
+ *
+ * `createSqlInjectionRule` discriminated on method name alone until the corpus
+ * sweep found 1,142 lines where two or more SQL plugins reported the same CWE.
+ * It now takes a `modules` list and abstains in files importing none of them,
+ * which took this plugin to **0 off-SDK findings** across 107,382 files. That
+ * guarantee lives in the devkit factory, so nothing fails if a hand-written
+ * rule is added to this plugin tomorrow. This lock is that.
+ *
+ * Written over the whole rule registry rather than per rule, so a rule added
+ * later is covered the day it lands: it will fail here until it is gated too.
+ * Revert the gate in any single rule and this test goes red.
+ */
+import { describe, it, expect } from 'vitest';
+import { Linter } from 'eslint';
+import parser from '@typescript-eslint/parser';
+import plugin from './index';
+
+const RULES = Object.keys(plugin.rules);
+
+/** The SDK import that is the whole difference between the two halves below. */
+const SDK = "import { PrismaClient } from '@prisma/client';";
+
+/**
+ * A real violation of `no-unsafe-query`. It appears twice on purpose: once
+ * without the import (must be silent) and once with it (must report). One
+ * fixture proving both directions is what stops this suite passing with the
+ * gate shut on everything.
+ */
+const VIOLATION = `prisma.$queryRawUnsafe('SELECT * FROM users WHERE id = ' + id);`;
+
+/** Files that use no @prisma/client at all. */
+const NON_SDK_SOURCES: ReadonlyArray<readonly [string, string]> = [
+  ['the violation itself, minus the import', VIOLATION],
+  [
+    'a plain helper',
+    `export function parse(s: string) {
+       try { return JSON.parse(s); } catch { return null; }
+     }`,
+  ],
+  [
+    'a React component',
+    `export default function Panel({ items }) {
+       return items.map((i) => i.name).join(', ');
+     }`,
+  ],
+  [
+    'a config module',
+    `export const config = { token: process.env.API_TOKEN, retries: 3 };`,
+  ],
+];
+
+const lint = (code: string, rule: string): Linter.LintMessage[] => {
+  // `configType: 'flat'` because a bare `new Linter()` still defaults to
+  // eslintrc on the declared ESLint floor, which would ignore the config below
+  // and skip every rule — a suite that passes having run nothing.
+  const linter = new Linter({ configType: 'flat' });
+  return linter.verify(
+    code,
+    {
+      files: ['**/*.ts'],
+      languageOptions: {
+        parser: parser as unknown as Linter.Parser,
+        parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+      },
+      plugins: { s: plugin as unknown as Linter.Plugin },
+      rules: { [`s/${rule}`]: 'error' },
+    },
+    // Without a filename the Linter lints `<input>`, which matches no `files`
+    // entry — every rule skipped, every negative below vacuously true.
+    'sample.ts',
+  );
+};
+
+describe('@prisma/client module gate', () => {
+  it('the registry is non-empty, so the sweep below is not vacuous', () => {
+    expect(RULES.length).toBeGreaterThan(0);
+  });
+
+  describe.each(NON_SDK_SOURCES)('%s', (_name, code) => {
+    it.each(RULES)('%s reports nothing', (rule) => {
+      const messages = lint(code, rule);
+      // A parse or config error also yields zero *rule* findings, so it is
+      // asserted away rather than counted as a pass.
+      expect(messages.filter((m) => !m.ruleId)).toHaveLength(0);
+      expect(messages.map((m) => m.ruleId)).toEqual([]);
+    });
+  });
+
+  describe('positive control — the gate must open for real @prisma/client code', () => {
+    it('the same violation reports once the file imports the SDK', () => {
+      expect(lint(`${SDK}\n${VIOLATION}`, 'no-unsafe-query').length).toBeGreaterThan(0);
+    });
+
+    it('and is silent with the import removed', () => {
+      expect(lint(VIOLATION, 'no-unsafe-query')).toHaveLength(0);
+    });
+  });
+});

--- a/packages/eslint-plugin-sequelize-security/src/module-gate.lock.test.ts
+++ b/packages/eslint-plugin-sequelize-security/src/module-gate.lock.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Regression lock: no rule in this plugin reports in a file that does not use
+ * sequelize.
+ *
+ * `createSqlInjectionRule` discriminated on method name alone until the corpus
+ * sweep found 1,142 lines where two or more SQL plugins reported the same CWE.
+ * It now takes a `modules` list and abstains in files importing none of them,
+ * which took this plugin to **0 off-SDK findings** across 107,382 files. That
+ * guarantee lives in the devkit factory, so nothing fails if a hand-written
+ * rule is added to this plugin tomorrow. This lock is that.
+ *
+ * Written over the whole rule registry rather than per rule, so a rule added
+ * later is covered the day it lands: it will fail here until it is gated too.
+ * Revert the gate in any single rule and this test goes red.
+ */
+import { describe, it, expect } from 'vitest';
+import { Linter } from 'eslint';
+import parser from '@typescript-eslint/parser';
+import plugin from './index';
+
+const RULES = Object.keys(plugin.rules);
+
+/** The SDK import that is the whole difference between the two halves below. */
+const SDK = "import { Sequelize } from 'sequelize';";
+
+/**
+ * A real violation of `no-unsafe-query`. It appears twice on purpose: once
+ * without the import (must be silent) and once with it (must report). One
+ * fixture proving both directions is what stops this suite passing with the
+ * gate shut on everything.
+ */
+const VIOLATION = `sequelize.query('SELECT * FROM users WHERE id = ' + id);`;
+
+/** Files that use no sequelize at all. */
+const NON_SDK_SOURCES: ReadonlyArray<readonly [string, string]> = [
+  ['the violation itself, minus the import', VIOLATION],
+  [
+    'a plain helper',
+    `export function parse(s: string) {
+       try { return JSON.parse(s); } catch { return null; }
+     }`,
+  ],
+  [
+    'a React component',
+    `export default function Panel({ items }) {
+       return items.map((i) => i.name).join(', ');
+     }`,
+  ],
+  [
+    'a config module',
+    `export const config = { token: process.env.API_TOKEN, retries: 3 };`,
+  ],
+];
+
+const lint = (code: string, rule: string): Linter.LintMessage[] => {
+  // `configType: 'flat'` because a bare `new Linter()` still defaults to
+  // eslintrc on the declared ESLint floor, which would ignore the config below
+  // and skip every rule — a suite that passes having run nothing.
+  const linter = new Linter({ configType: 'flat' });
+  return linter.verify(
+    code,
+    {
+      files: ['**/*.ts'],
+      languageOptions: {
+        parser: parser as unknown as Linter.Parser,
+        parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+      },
+      plugins: { s: plugin as unknown as Linter.Plugin },
+      rules: { [`s/${rule}`]: 'error' },
+    },
+    // Without a filename the Linter lints `<input>`, which matches no `files`
+    // entry — every rule skipped, every negative below vacuously true.
+    'sample.ts',
+  );
+};
+
+describe('sequelize module gate', () => {
+  it('the registry is non-empty, so the sweep below is not vacuous', () => {
+    expect(RULES.length).toBeGreaterThan(0);
+  });
+
+  describe.each(NON_SDK_SOURCES)('%s', (_name, code) => {
+    it.each(RULES)('%s reports nothing', (rule) => {
+      const messages = lint(code, rule);
+      // A parse or config error also yields zero *rule* findings, so it is
+      // asserted away rather than counted as a pass.
+      expect(messages.filter((m) => !m.ruleId)).toHaveLength(0);
+      expect(messages.map((m) => m.ruleId)).toEqual([]);
+    });
+  });
+
+  describe('positive control — the gate must open for real sequelize code', () => {
+    it('the same violation reports once the file imports the SDK', () => {
+      expect(lint(`${SDK}\n${VIOLATION}`, 'no-unsafe-query').length).toBeGreaterThan(0);
+    });
+
+    it('and is silent with the import removed', () => {
+      expect(lint(VIOLATION, 'no-unsafe-query')).toHaveLength(0);
+    });
+  });
+});

--- a/packages/eslint-plugin-sqlite-security/src/module-gate.lock.test.ts
+++ b/packages/eslint-plugin-sqlite-security/src/module-gate.lock.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Regression lock: no rule in this plugin reports in a file that does not use
+ * better-sqlite3.
+ *
+ * `createSqlInjectionRule` discriminated on method name alone until the corpus
+ * sweep found 1,142 lines where two or more SQL plugins reported the same CWE.
+ * It now takes a `modules` list and abstains in files importing none of them,
+ * which took this plugin to **0 off-SDK findings** across 107,382 files. That
+ * guarantee lives in the devkit factory, so nothing fails if a hand-written
+ * rule is added to this plugin tomorrow. This lock is that.
+ *
+ * Written over the whole rule registry rather than per rule, so a rule added
+ * later is covered the day it lands: it will fail here until it is gated too.
+ * Revert the gate in any single rule and this test goes red.
+ */
+import { describe, it, expect } from 'vitest';
+import { Linter } from 'eslint';
+import parser from '@typescript-eslint/parser';
+import plugin from './index';
+
+const RULES = Object.keys(plugin.rules);
+
+/** The SDK import that is the whole difference between the two halves below. */
+const SDK = "import Database from 'better-sqlite3';";
+
+/**
+ * A real violation of `no-unsafe-query`. It appears twice on purpose: once
+ * without the import (must be silent) and once with it (must report). One
+ * fixture proving both directions is what stops this suite passing with the
+ * gate shut on everything.
+ */
+const VIOLATION = `db.exec('SELECT * FROM users WHERE id = ' + id);`;
+
+/** Files that use no better-sqlite3 at all. */
+const NON_SDK_SOURCES: ReadonlyArray<readonly [string, string]> = [
+  ['the violation itself, minus the import', VIOLATION],
+  [
+    'a plain helper',
+    `export function parse(s: string) {
+       try { return JSON.parse(s); } catch { return null; }
+     }`,
+  ],
+  [
+    'a React component',
+    `export default function Panel({ items }) {
+       return items.map((i) => i.name).join(', ');
+     }`,
+  ],
+  [
+    'a config module',
+    `export const config = { token: process.env.API_TOKEN, retries: 3 };`,
+  ],
+];
+
+const lint = (code: string, rule: string): Linter.LintMessage[] => {
+  // `configType: 'flat'` because a bare `new Linter()` still defaults to
+  // eslintrc on the declared ESLint floor, which would ignore the config below
+  // and skip every rule — a suite that passes having run nothing.
+  const linter = new Linter({ configType: 'flat' });
+  return linter.verify(
+    code,
+    {
+      files: ['**/*.ts'],
+      languageOptions: {
+        parser: parser as unknown as Linter.Parser,
+        parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+      },
+      plugins: { s: plugin as unknown as Linter.Plugin },
+      rules: { [`s/${rule}`]: 'error' },
+    },
+    // Without a filename the Linter lints `<input>`, which matches no `files`
+    // entry — every rule skipped, every negative below vacuously true.
+    'sample.ts',
+  );
+};
+
+describe('better-sqlite3 module gate', () => {
+  it('the registry is non-empty, so the sweep below is not vacuous', () => {
+    expect(RULES.length).toBeGreaterThan(0);
+  });
+
+  describe.each(NON_SDK_SOURCES)('%s', (_name, code) => {
+    it.each(RULES)('%s reports nothing', (rule) => {
+      const messages = lint(code, rule);
+      // A parse or config error also yields zero *rule* findings, so it is
+      // asserted away rather than counted as a pass.
+      expect(messages.filter((m) => !m.ruleId)).toHaveLength(0);
+      expect(messages.map((m) => m.ruleId)).toEqual([]);
+    });
+  });
+
+  describe('positive control — the gate must open for real better-sqlite3 code', () => {
+    it('the same violation reports once the file imports the SDK', () => {
+      expect(lint(`${SDK}\n${VIOLATION}`, 'no-unsafe-query').length).toBeGreaterThan(0);
+    });
+
+    it('and is silent with the import removed', () => {
+      expect(lint(VIOLATION, 'no-unsafe-query')).toHaveLength(0);
+    });
+  });
+});

--- a/packages/eslint-plugin-typeorm-security/src/module-gate.lock.test.ts
+++ b/packages/eslint-plugin-typeorm-security/src/module-gate.lock.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Regression lock: no rule in this plugin reports in a file that does not use
+ * typeorm.
+ *
+ * `createSqlInjectionRule` discriminated on method name alone until the corpus
+ * sweep found 1,142 lines where two or more SQL plugins reported the same CWE.
+ * It now takes a `modules` list and abstains in files importing none of them,
+ * which took this plugin to **0 off-SDK findings** across 107,382 files. That
+ * guarantee lives in the devkit factory, so nothing fails if a hand-written
+ * rule is added to this plugin tomorrow. This lock is that.
+ *
+ * Written over the whole rule registry rather than per rule, so a rule added
+ * later is covered the day it lands: it will fail here until it is gated too.
+ * Revert the gate in any single rule and this test goes red.
+ */
+import { describe, it, expect } from 'vitest';
+import { Linter } from 'eslint';
+import parser from '@typescript-eslint/parser';
+import plugin from './index';
+
+const RULES = Object.keys(plugin.rules);
+
+/** The SDK import that is the whole difference between the two halves below. */
+const SDK = "import { DataSource } from 'typeorm';";
+
+/**
+ * A real violation of `no-unsafe-query`. It appears twice on purpose: once
+ * without the import (must be silent) and once with it (must report). One
+ * fixture proving both directions is what stops this suite passing with the
+ * gate shut on everything.
+ */
+const VIOLATION = `ds.query('SELECT * FROM users WHERE id = ' + id);`;
+
+/** Files that use no typeorm at all. */
+const NON_SDK_SOURCES: ReadonlyArray<readonly [string, string]> = [
+  ['the violation itself, minus the import', VIOLATION],
+  [
+    'a plain helper',
+    `export function parse(s: string) {
+       try { return JSON.parse(s); } catch { return null; }
+     }`,
+  ],
+  [
+    'a React component',
+    `export default function Panel({ items }) {
+       return items.map((i) => i.name).join(', ');
+     }`,
+  ],
+  [
+    'a config module',
+    `export const config = { token: process.env.API_TOKEN, retries: 3 };`,
+  ],
+];
+
+const lint = (code: string, rule: string): Linter.LintMessage[] => {
+  // `configType: 'flat'` because a bare `new Linter()` still defaults to
+  // eslintrc on the declared ESLint floor, which would ignore the config below
+  // and skip every rule — a suite that passes having run nothing.
+  const linter = new Linter({ configType: 'flat' });
+  return linter.verify(
+    code,
+    {
+      files: ['**/*.ts'],
+      languageOptions: {
+        parser: parser as unknown as Linter.Parser,
+        parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+      },
+      plugins: { s: plugin as unknown as Linter.Plugin },
+      rules: { [`s/${rule}`]: 'error' },
+    },
+    // Without a filename the Linter lints `<input>`, which matches no `files`
+    // entry — every rule skipped, every negative below vacuously true.
+    'sample.ts',
+  );
+};
+
+describe('typeorm module gate', () => {
+  it('the registry is non-empty, so the sweep below is not vacuous', () => {
+    expect(RULES.length).toBeGreaterThan(0);
+  });
+
+  describe.each(NON_SDK_SOURCES)('%s', (_name, code) => {
+    it.each(RULES)('%s reports nothing', (rule) => {
+      const messages = lint(code, rule);
+      // A parse or config error also yields zero *rule* findings, so it is
+      // asserted away rather than counted as a pass.
+      expect(messages.filter((m) => !m.ruleId)).toHaveLength(0);
+      expect(messages.map((m) => m.ruleId)).toEqual([]);
+    });
+  });
+
+  describe('positive control — the gate must open for real typeorm code', () => {
+    it('the same violation reports once the file imports the SDK', () => {
+      expect(lint(`${SDK}\n${VIOLATION}`, 'no-unsafe-query').length).toBeGreaterThan(0);
+    });
+
+    it('and is silent with the import removed', () => {
+      expect(lint(VIOLATION, 'no-unsafe-query')).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes the last of the off-SDK gate debt that [#486](https://github.com/ofri-peretz/eslint/pull/486)'s ratchet was tracking. **The `UNGATED` list is now empty.**

Three things, in order of consequence:

### 1. One probe, in the devkit

Five plugins each carried their own copy. The two false-negative classes the audit found — TypeScript's `import =` form and Deno's `npm:` / `deno.land` specifiers — had to be fixed **five times**, and adding the remaining plugins would have made it ten.

`createModuleEvidence` is that implementation once, carrying everything the copies had learned:

- package-root matching (`pg/lib/client`, `@ai-sdk/openai/edge`), scopes, prefixes
- relative and absolute specifiers rejected — `'./pg'` must not satisfy a `pg` gate
- `import =`, dynamic `import()`, `require`
- Deno's `npm:@aws-sdk/client-s3` and `https://deno.land/x/postgres@v0.17.0/mod.ts`
- **lexically-scoped** `require` shadowing — a file-wide flag silenced whole plugins
- an optional `extraEvidence` arm for the two SDKs that measurably need one (Lambda: 45% of handlers import nothing; Express: 60% of `(req,res)` files)
- a per-`Program` cache, because `create` runs once per rule

### 2. `nestjs-security` — the last plugin with no gate at all

Over 107,382 files it reported 999 findings, **219 (22%) in files importing no NestJS package**, because its rules key on decorator and method names that Angular, TypeORM and plain TypeScript classes share.

Gated on the `@nestjs` scope, with **no extra evidence arm** — and that is a deliberate difference from Lambda and Express. NestJS decorators are *values imported from* `@nestjs/common`, so there is no decorator-shaped convention that exists without the import. Adding a name-based arm would re-import the problem.

### 3. Ten plugins that abstained but could not prove it

The seven SQL plugins gate inside `createSqlInjectionRule` (`modules`), the AI-key plugins inside `createSdkApiKeyRule`. **A factory guarantee does not survive a hand-written rule**, so all ten now ship a registry-wide `module-gate.lock.test.ts`.

Each lock uses **one real violation twice** — once without the SDK import (must be silent), once with it (must report). A negatives-only suite passes just as well with the gate shut on everything, which is the trap these locks exist to avoid.

## Two things this surfaced rather than assumed

- **vercel-ai and mongodb were already gated by concurrent work** ([#489](https://github.com/ofri-peretz/eslint/pull/489), [#491](https://github.com/ofri-peretz/eslint/pull/491), [#492](https://github.com/ofri-peretz/eslint/pull/492)). My worktree was a stale `main` and I had begun duplicating both — I even overwrote `mongo-evidence.ts` before catching it. Discarded and reverted. The ratchet from #486 is what made the overlap visible in minutes instead of at merge.
- **mcp-sdk and gemini already carried per-rule SDK checks**, so adding a plugin-wide gate made that reviewed code unreachable and the coverage threshold went red. Deleting working code to satisfy a threshold is the wrong trade — they get the lock only.

## Test plan

- [x] `createModuleEvidence` — 57 cases at the devkit's 100% threshold: every import form, scopes vs exact packages vs prefixes, both Deno syntaxes, `import =` (including a hand-built non-literal reference), every invalid `require`/`import()` shape, shadowing in both directions, `extraEvidence` additive and absent, cache identity across two probes, and **termination on an AST carrying `parent` links** — the shape only a real rule produces, which without the skip would recurse until the stack blew.
- [x] Every gated plugin's own suite green at 100% coverage: nestjs **752 → 752** with the gate in place (795 with the lock), mcp-sdk 174, gemini 63, and the ten lock-only plugins unchanged.
- [x] `sdk-gate-coverage.lock.test.ts` — **94 tests**, every one of the 18 SDK plugins now in the gated half.
- [x] `npx turbo build` — 33/33.

nestjs fixtures are wrapped by a `nest()` helper; the four suites that lint through a central `findings()` / `run()` helper are prefixed once **inside that helper**, so no fixture can be left behind and pass vacuously.

## After merge

`nestjs-security` is a **major** — any rule may now stay silent where it previously reported.

Follow-up worth doing separately: migrate the five existing bespoke probes (postgres, lambda, express, vercel-ai, mongodb) onto `createModuleEvidence` and delete their copies. Their locks make that a safe mechanical change; it is kept out of this PR to avoid colliding with concurrent work in those files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)