### PR TITLE
fix(secure-coding): no-improper-sanitization ignores .length in markup

### DIFF
--- a/.changeset/improper-sanitization-length-is-a-number.md
+++ b/.changeset/improper-sanitization-length-is-a-number.md
@@ -1,0 +1,20 @@
+---
+'eslint-plugin-secure-coding': patch
+---
+
+`no-improper-sanitization` no longer reports `.length` interpolated into markup.
+
+```js
+res.send('<p>' + arr.length + '</p>');   // was reported, twice
+```
+
+`.length` is a number in every JavaScript engine, so there is nothing to
+escape. Found while measuring `express/examples/online/index.js:53` for #398.
+
+Non-computed access only. `data[length]` reads a *variable* named `length`,
+which carries whatever that variable holds, so it still reports — the exemption
+must not become a way to smuggle an attacker-controlled key past the check.
+
+Note this does **not** change the Express finding count: that line is
+`'<p>Users online: ' + ids.length + '</p>' + list(ids)`, and `list(ids)` is an
+unsanitized call reaching an HTML sink, which is a legitimate finding.

--- a/packages/eslint-plugin-secure-coding/src/rules/no-improper-sanitization/index.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/no-improper-sanitization/index.ts
@@ -599,6 +599,22 @@ export const noImproperSanitization = createRule<RuleOptions, MessageIds>({
                   property.type === 'Property' && isSafeText(property.value),
               );
             }
+            // `.length` is a number in every JavaScript engine, and a number
+            // cannot carry markup. `res.send('<p>Users online: ' + ids.length +
+            // '</p>')` (express `examples/online/index.js:53`) was reported as
+            // an unescaped interpolation; there is nothing to escape.
+            //
+            // Non-computed only: `obj['length']` is the same property, but
+            // `obj[length]` reads a variable, and this guard must not be a way
+            // to smuggle an attacker-controlled key past the check.
+            if (
+              expr.type === 'MemberExpression' &&
+              !expr.computed &&
+              expr.property.type === 'Identifier' &&
+              expr.property.name === 'length'
+            ) {
+              return true;
+            }
             if (expr.type === 'CallExpression') {
               const callee = expr.callee;
               // ['<h1>', '<li>…'].join('\n') — express/examples/resource

--- a/packages/eslint-plugin-secure-coding/src/rules/no-improper-sanitization/no-improper-sanitization.test.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/no-improper-sanitization/no-improper-sanitization.test.ts
@@ -60,8 +60,25 @@ describe('no-improper-sanitization', () => {
 
   describe('#398 regression: static output stays silent, real sinks do not', () => {
     ruleTester.run('static vs tainted response output', noImproperSanitization, {
-      valid: [],
+      valid: [
+        // express/examples/online/index.js:53. `.length` is a number in every
+        // JavaScript engine, so there is nothing to escape — but the
+        // concatenation was reported as an unescaped interpolation, twice.
+        `res.send('<p>Users online: ' + ids.length + '</p>');`,
+        `res.send('<ul>' + items.length + '</ul>');`,
+      ],
       invalid: [
+        // `obj[length]` reads a VARIABLE named length, not the array property,
+        // so it carries whatever that variable holds. The `.length` exemption
+        // is non-computed only and must never become a way to smuggle an
+        // attacker-controlled key past the check.
+        {
+          code: `res.send('<p>' + data[length] + '</p>');`,
+          errors: [
+            { messageId: 'unsafeReplaceSanitization' },
+            { messageId: 'unsafeReplaceSanitization' },
+          ],
+        },
         // Hardcoded but genuinely dangerous: the literal IS the vector, so
         // author-controlled is not a defence. Must still report.
         {


### PR DESCRIPTION
## Summary

`.length` is a number in every JavaScript engine, so it cannot carry markup —
but interpolating it into an HTML string was reported as an unescaped
interpolation, twice per line.

```js
res.send('<p>' + arr.length + '</p>');   // was: 2 findings
```

Found while re-measuring Express for #398.

## Deliberately narrow

Non-computed access only. `data[length]` reads a **variable** named `length`
and carries whatever that variable holds, so it still reports — the exemption
must not become a way to smuggle an attacker-controlled key past the check.
There is an invalid fixture pinning exactly that.

## What this does *not* do

It does not change Express's finding count, and the changeset says so. Express's
actual line is:

```js
res.send('<p>Users online: ' + ids.length + '</p>' + list(ids));
```

`list(ids)` is an unsanitized call reaching an HTML sink — a legitimate finding
that should keep reporting. Worth stating plainly rather than implying the fix
moved a number it didn't.

## Test plan

- [x] Mutation-verified — reverting the rule turns 2 fixtures red
- [x] `no-improper-sanitization` 56 tests, 100% statement/branch/function/line coverage
- [x] Verified against the real file: the pure `.length` shape goes silent, Express's line correctly still reports

## Context

See the [#398 re-measurement](https://github.com/ofri-peretz/eslint/issues/398#issuecomment-5263901138):
Express went 188 → 57 findings, its library code is at 4, and both defects that
issue named as blocking are fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sanitization analysis for markup interpolations involving numeric `.length` values.
  * Avoids reporting safe `.length` expressions while continuing to flag computed property access and unsanitized HTML sinks.

* **Tests**
  * Added regression coverage for valid numeric length interpolations and unsafe computed accesses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->