### PR TITLE
fix(workspace): stop an agent doc from shadowing SECURITY.md for Scorecard

### DIFF
--- a/.agent/agents/security-expert.md
+++ b/.agent/agents/security-expert.md
@@ -8,6 +8,15 @@ skills:
 
 # Security Expert Agent
 
+> **Do not rename this file to `security.md`.** OpenSSF Scorecard finds the
+> repository's security policy by filename, and its path matcher falls back to
+> comparing the **basename** — so any `security.md` anywhere in the tree is a
+> candidate. It then parses the first match it encounters and stops. While this
+> file was called `.agent/agents/security.md`, Scorecard scored the root
+> `SECURITY.md` against *this* file's contents: no URL and no email, hence
+> "no linked content found" and Security-Policy stuck at 4/10.
+> `scripts/__tests__/security-policy-filename-lock.test.ts` enforces this.
+
 You are a security researcher specializing in application security, vulnerability detection, and secure coding practices.
 
 ## Core Expertise

--- a/SCORECARD-HARDENING-PLAN.md
+++ b/SCORECARD-HARDENING-PLAN.md
@@ -63,12 +63,36 @@ with anything else makes the blast radius unreadable.
 
 ### 2. Security-Policy: 4 → 10 · **+0.33** · 15 minutes
 
-Scorecard already sees the file, the disclosure language, and the timelines. It
-reports `no linked content found` even though `SECURITY.md` contains both a URL and
-an email — the one unusual thing about them is that **every link is an angle-bracket
-autolink** (`<https://…>`, `<ofriperetzdev@gmail.com>`). Rewrite them as plain
-Markdown links and bare text, then re-scan. Cheap to try, and if the warning
-survives the next scan we file it upstream with a reproducer.
+**Root cause found — it was never about the link syntax.** The autolink theory was
+wrong: the links had already been rewritten as bare URLs on `main`, and the warning
+survived. Reproduced against live `main` with the official container
+(`gcr.io/openssf/scorecard:stable`), so it was not a stale alert either.
+
+Scorecard resolves the policy file in two independent steps, and they disagreed:
+
+1. `isSecurityPolicyFilename` matches the **full path** against a fixed list
+   (`security.md`, `.github/security.md`, `docs/security.md`, …). Only the root
+   `SECURITY.md` qualified — which is why the report *named* the right file.
+2. The **content** is then fetched via `OnMatchingFileContentDo` using that path as
+   a glob. `isMatchingPath` tries the full path and, failing that, retries against
+   `path.Base(fullpath)` — so the pattern `security.md` matches *any* `security.md`
+   at *any* depth. `checkSecurityPolicyFileContent` parses the first non-empty match
+   and returns `false` ("stop looking").
+
+The repo contained `.agent/agents/security.md`, an agent persona doc. It sorted
+ahead of the root file, so Scorecard scored `SECURITY.md` against *that* file's
+text: **0 URLs, 0 emails, 8 occurrences of "vuln"/"disclos"** — precisely the
+finding set reported (text and disclosure hits, no linked content).
+
+Fixed by renaming it to `.agent/agents/security-expert.md`. Locked by
+`scripts/__tests__/security-policy-filename-lock.test.ts`, which asserts that
+exactly one tracked file carries a Scorecard policy basename and that the root
+`SECURITY.md` still satisfies Scorecard's own URL and email regexes. Verified to
+fail on the pre-fix tree, naming the offending path.
+
+Worth noting for our own rules: this is a **silent** scoring failure. Nothing
+errored, no file was missing, and the reported filename was correct — only the
+parsed bytes came from somewhere else.
 
 ### 3. Fuzzing: 0 → 10 · **+0.56** · one day
 

--- a/scripts/__tests__/security-policy-filename-lock.test.ts
+++ b/scripts/__tests__/security-policy-filename-lock.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Regression lock — only ONE file in the tree may be named like a security policy.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * THE BUG (2026-08-12)
+ * OpenSSF Scorecard's Security-Policy check sat at 4/10 reporting
+ * `no linked content found`, while the root `SECURITY.md` plainly carried the
+ * advisory URL, the disclosure email, and a timeline table. Reproduced against
+ * live `main` with the official container, so it was not a stale alert.
+ *
+ * Scorecard resolves the policy file in two independent steps, and they can
+ * disagree:
+ *
+ *   1. `isSecurityPolicyFilename` matches the FULL path against a fixed list
+ *      (`security.md`, `.github/security.md`, `docs/security.md`, …). Only the
+ *      root `SECURITY.md` qualified, so the *reported* file was correct.
+ *
+ *   2. The CONTENT is then fetched with `OnMatchingFileContentDo` using that
+ *      path as a glob. `isMatchingPath` tries the full path and, on failure,
+ *      retries against `path.Base(fullpath)` — so the pattern `security.md`
+ *      matches *any* `security.md` at *any* depth. `checkSecurityPolicyFileContent`
+ *      parses the first non-empty match and returns false ("stop looking").
+ *
+ * We had `.agent/agents/security.md`, an agent persona doc. It sorted ahead of
+ * the root file, so Scorecard scored `SECURITY.md` against that file's text:
+ * 0 URLs, 0 emails, but 8 occurrences of "vuln"/"disclos". That is exactly the
+ * finding set Scorecard reported — text and disclosure hits, no linked content.
+ *
+ * Renaming it to `security-expert.md` is the fix. This lock keeps it fixed: the
+ * failure mode is silent (the score drops, nothing errors) and the next
+ * `security.md` anywhere in the tree reintroduces it.
+ *
+ * @see https://github.com/ossf/scorecard/blob/main/checks/raw/security_policy.go
+ * @see https://github.com/ossf/scorecard/blob/main/checks/fileparser/listing.go
+ */
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { basename, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(__dirname, '../..');
+
+/**
+ * The basenames Scorecard treats as a security policy, from
+ * `isSecurityPolicyFilename`. Matching is case-insensitive.
+ *
+ * Only basenames are listed because the basename is what the content matcher
+ * actually falls back to — the directory prefixes in Scorecard's list
+ * (`.github/`, `docs/`) constrain step 1 but not step 2.
+ */
+const POLICY_BASENAMES = [
+  'security.md',
+  'security.markdown',
+  'security.adoc',
+  'security.rst',
+];
+
+/** Scorecard's own patterns, copied verbatim from `collectPolicyHits`. */
+const RE_URL = /(http|https):\/\/[a-zA-Z0-9./?=_%:-]*/;
+const RE_EMAIL = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,6}\b/;
+
+const trackedFiles = (): string[] =>
+  execFileSync('git', ['ls-files', '-z'], { cwd: REPO_ROOT, encoding: 'utf8' })
+    .split('\0')
+    .filter(Boolean);
+
+describe('OpenSSF Scorecard security-policy resolution', () => {
+  it('has exactly one file whose basename Scorecard reads as a security policy', () => {
+    const candidates = trackedFiles().filter((file) =>
+      POLICY_BASENAMES.includes(basename(file).toLowerCase()),
+    );
+
+    // Asserting on the full list rather than a count: when this fails, the
+    // message names the offending path instead of just a number.
+    expect(candidates).toEqual(['SECURITY.md']);
+  });
+
+  it('scores the linked-content criterion, which is worth 6 of the 10 points', () => {
+    const policy = readFileSync(resolve(REPO_ROOT, 'SECURITY.md'), 'utf8');
+
+    // Scorecard scans line by line, so a URL split across lines does not count.
+    const lines = policy.split('\n');
+    expect(lines.some((line) => RE_URL.test(line))).toBe(true);
+    expect(lines.some((line) => RE_EMAIL.test(line))).toBe(true);
+  });
+});


### PR DESCRIPTION
Takes OpenSSF Scorecard's **Security-Policy from 4/10 to 10/10** by renaming one file.

## The symptom

Security-Policy reported `no linked content found` while the root `SECURITY.md` plainly carries the advisory URL, the disclosure email, and a timeline table. Reproduced against live `main` with `gcr.io/openssf/scorecard:stable` — not a stale alert.

It also wasn't the angle-bracket-autolink theory recorded in `SCORECARD-HARDENING-PLAN.md`. Those had already been rewritten as bare URLs on `main`, and the warning survived.

## The cause

Scorecard resolves the policy file in **two independent steps**, and they disagreed:

1. `isSecurityPolicyFilename` matches the **full path** against a fixed list, so only the root `SECURITY.md` qualified — which is why the report *named* the right file.
2. The **content** is then fetched via `OnMatchingFileContentDo` using that path as a glob. [`isMatchingPath`](https://github.com/ossf/scorecard/blob/main/checks/fileparser/listing.go) tries the full path and, failing that, retries against `path.Base(fullpath)` — so the pattern `security.md` matches *any* `security.md` at *any* depth. `checkSecurityPolicyFileContent` parses the first non-empty match and returns `false`, stopping the search.

`.agent/agents/security.md` — an agent persona doc — sorted ahead of the root file. Scorecard scored `SECURITY.md` against **that file's** text: **0 URLs, 0 emails, 8 occurrences of `vuln`/`disclos`**. Exactly the finding set it reported.

## Proof

Minimal two-directory repro under the official container. Identical `SECURITY.md`; the only difference is a nested `security.md`:

| tree | score | finding |
|---|---|---|
| with `.agent/agents/security.md` | **4** | `no linked content found` |
| with `.agent/agents/security-expert.md` | **10** | `Found linked content` |

## The lock

`scripts/__tests__/security-policy-filename-lock.test.ts` asserts exactly one tracked file carries a Scorecard policy basename, and that `SECURITY.md` still satisfies Scorecard's own URL and email regexes (copied verbatim, and applied per-line as Scorecard applies them).

**Verified to fail on the pre-fix tree**, naming the offending path rather than a count:

```
AssertionError: expected [ '.agent/agents/security.md', …(1) ] to deeply equal [ 'SECURITY.md' ]
```

This gets a lock because the failure is **silent** — nothing errored, no file was missing, and the reported filename was correct. Only the parsed bytes came from somewhere else.

## Notes

No references to the old path exist anywhere in the repo (`.agent/README.md` lists the directory, not its files), and there is no loader globbing `.agent/agents`. No package changes, so no changeset.

Verification: `lefthook run pre-commit --all-files` green; pre-push typecheck + build-and-test green.