### PR TITLE
test(workspace): property-fuzz the rule fleet with fast-check

### DIFF
--- a/SCORECARD-HARDENING-PLAN.md
+++ b/SCORECARD-HARDENING-PLAN.md
@@ -94,15 +94,44 @@ Worth noting for our own rules: this is a **silent** scoring failure. Nothing
 errored, no file was missing, and the reported filename was correct — only the
 parsed bytes came from somewhere else.
 
-### 3. Fuzzing: 0 → 10 · **+0.56** · one day
+### 3. Fuzzing: 0 → 10 · **+0.56** · ~~one day~~ **done, in an afternoon**
 
-Scorecard detects OSS-Fuzz membership or a `.clusterfuzzlite/` directory.
+The one-day estimate assumed ClusterFuzzLite. It was wrong about what Scorecard
+detects: alongside OSS-Fuzz and `.clusterfuzzlite/`, the check recognises
+**property-based testing**, and for TypeScript that means a direct import of
+`fast-check`. Confirmed in `checks/raw/fuzzing.go` and then verified end-to-end
+against the official container:
 
-An ESLint rule is close to an ideal fuzz target: feed it arbitrary parseable
-JavaScript and assert it neither throws nor hangs. We already have
-`scripts/ilb-fuzz.ts` — the work is wiring a ClusterFuzzLite harness around it
-so the detection fires, and it buys real robustness, not just a number. Rules that
-crash on exotic-but-valid syntax are a live risk with 465 of them.
+```text
+score: 10 | project is fuzzed
+  Info: TypeScriptPropertyBasedTesting integration found
+```
+
+`scripts/ilb-fuzz.ts` was the wrong base to build on: it is an LLM-driven
+FP/FN candidate generator that needs `ANTHROPIC_API_KEY` and costs ~$10 a
+fleet run. Useful, but it is not a fuzzer and cannot run in CI.
+
+`scripts/__tests__/rule-fuzz.test.ts` is. It asserts one deliberately weak
+property — **for any parseable program, linting terminates without throwing** —
+across all 30 plugins with every rule enabled. Generation is biased toward
+security-relevant shapes (sinks, optional chaining, spreads, computed members,
+template literals) because uniform noise mostly produces syntax errors that
+never reach rule code; the inputs that break rules are *valid* programs with an
+unusual AST.
+
+This earns its place independently of the score. A rule that throws takes the
+whole ESLint run down — the user stops linting altogether, which is issue #514's
+failure mode, and we ship 409 rules.
+
+Two guards keep the harness from going quietly vacuous, both asserted in the
+file itself: a deliberately throwing rule must propagate out of `linter.verify`
+(so the harness can fail at all), and the generator must produce findings
+against a real plugin (so it cannot drift into emitting inert code). Runs in
+~3s, inside `npm run test:scripts`, which `quality.yml` already executes.
+
+**Not a substitute for ClusterFuzzLite**, which would fuzz continuously with
+coverage guidance and corpus retention rather than 25 fresh draws per plugin per
+run. Revisit if crashes start appearing that this depth misses.
 
 ### 4. Branch-Protection: -1 → 10 · **+0.25** · 30 minutes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,6 +89,7 @@
         "eslint-plugin-oxlint": "^1.77.0",
         "eslint-plugin-unicorn": "^73.0.0",
         "express": "^5.2.1",
+        "fast-check": "^4.9.0",
         "get-tsconfig": "^4.14.1",
         "helmet": "^8.3.0",
         "jest": "^30.3.0",
@@ -17049,6 +17050,46 @@
       "dev": true,
       "engines": [
         "node >=0.6.0"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/fast-check": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
+    "node_modules/fast-check/node_modules/pure-rand": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
+      "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
       ],
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -287,6 +287,7 @@
     "eslint-plugin-oxlint": "^1.77.0",
     "eslint-plugin-unicorn": "^73.0.0",
     "express": "^5.2.1",
+    "fast-check": "^4.9.0",
     "get-tsconfig": "^4.14.1",
     "helmet": "^8.3.0",
     "jest": "^30.3.0",

--- a/scripts/__tests__/rule-fuzz.test.ts
+++ b/scripts/__tests__/rule-fuzz.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Property-based fuzzing of the whole rule fleet.
+ *
+ * Every rule we ship runs against code we have never seen, written by people
+ * who are not us, in repositories we do not control. Our fixtures only cover
+ * shapes we thought of — and the shapes that crash a rule are, by definition,
+ * the ones nobody thought of. A rule that throws takes the entire ESLint run
+ * down with it, so a crash is not a missed finding: it stops the user linting
+ * at all. Issue #514 ("published package crashes ESLint") is that failure mode.
+ *
+ * The property asserted here is deliberately weak and therefore hard to argue
+ * with: **for any parseable program, linting must terminate without throwing.**
+ * Nothing about what the rules should report — only that they survive contact
+ * with input they did not expect.
+ *
+ * Generation is biased toward security-relevant shapes (sinks, member chains,
+ * template literals, spreads, optional chaining) rather than uniformly random
+ * text. Uniform noise mostly produces syntax errors, which never reach rule
+ * code; the interesting inputs are *valid* programs whose AST is unusual —
+ * `a?.[b]?.(c)`, `({...x}).y`, a template literal nested in a spread argument.
+ *
+ * This is also what OpenSSF Scorecard's Fuzzing check detects for TypeScript:
+ * a direct import of `fast-check`. That was the prompt, but the test earns its
+ * place independently — see the crash class above.
+ *
+ * Run from the repo root:
+ *   npx vitest run --config scripts/__tests__/vitest.config.mts scripts/__tests__/rule-fuzz.test.ts
+ */
+
+import { Linter } from 'eslint';
+import fc from 'fast-check';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const PACKAGES_DIR = path.resolve(__dirname, '..', '..', 'packages');
+
+/**
+ * How many generated programs each plugin is linted against.
+ *
+ * Sized for the pre-commit path, not for exhaustiveness: the fleet is ~30
+ * plugins, so this is ~30 x RUNS parses plus every rule of that plugin on each.
+ * Fuzzing finds crashes by accumulating runs over time (each CI run draws a
+ * different seed), not by exhausting the space in one commit.
+ */
+const RUNS = 25;
+
+type RuleModule = { create: unknown; meta?: unknown };
+type Plugin = { rules?: Record<string, RuleModule> };
+
+const pluginDirs = fs
+  .readdirSync(PACKAGES_DIR)
+  .filter((name) => name.startsWith('eslint-plugin-'))
+  .filter((name) => fs.statSync(path.join(PACKAGES_DIR, name)).isDirectory())
+  .sort();
+
+/** Identifiers that actually reach sink-matching logic in the security rules. */
+const SINK_NAMES = [
+  'eval',
+  'exec',
+  'execSync',
+  'spawn',
+  'require',
+  'innerHTML',
+  'outerHTML',
+  'insertAdjacentHTML',
+  'setTimeout',
+  'Function',
+  'createHash',
+  'randomBytes',
+  'query',
+  'find',
+  'redirect',
+  'sign',
+  'verify',
+  'process',
+  'env',
+  'req',
+  'res',
+  'body',
+  'params',
+  'headers',
+  'user',
+  'password',
+  'token',
+  'secret',
+];
+
+const identifier = fc.constantFrom(...SINK_NAMES, 'a', 'b', 'x', '_', '$');
+
+/**
+ * A recursive expression generator.
+ *
+ * `fc.letrec` ties the knot; the `depthSize` bias keeps most draws shallow so
+ * the suite stays fast, while still producing the occasional deep chain that
+ * is exactly where an unguarded `node.parent.parent` walk falls over.
+ */
+const { expression } = fc.letrec<{ expression: string }>((tie) => ({
+  expression: fc.oneof(
+    { depthSize: 'small', withCrossShrink: true },
+    // Leaves.
+    identifier,
+    fc.constantFrom(
+      '"str"',
+      '`tpl`',
+      '0',
+      'null',
+      'undefined',
+      'true',
+      '/re/g',
+      '{}',
+      '[]',
+    ),
+    // Member access, computed and optional — the shapes that break naive
+    // `node.property.name` reads.
+    tie('expression').map((e) => `${e}.prop`),
+    tie('expression').map((e) => `${e}?.prop`),
+    tie('expression').map((e) => `${e}[0]`),
+    fc
+      .tuple(tie('expression'), tie('expression'))
+      .map(([o, k]) => `${o}?.[${k}]`),
+    // Calls, including optional calls, spreads and zero-argument calls.
+    tie('expression').map((e) => `${e}()`),
+    fc.tuple(tie('expression'), tie('expression')).map(([c, a]) => `${c}(${a})`),
+    fc
+      .tuple(tie('expression'), tie('expression'))
+      .map(([c, a]) => `${c}?.(...${a})`),
+    tie('expression').map((e) => `new ${e}()`),
+    // Template literals with embedded expressions — a common taint carrier.
+    tie('expression').map((e) => `\`pre \${${e}} post\``),
+    // Object/array literals with spread and computed keys.
+    tie('expression').map((e) => `({ ...${e} })`),
+    fc.tuple(tie('expression'), tie('expression')).map(([k, v]) => `({[${k}]: ${v}})`),
+    tie('expression').map((e) => `[...${e}]`),
+    // Operators and control flow inside expressions.
+    fc.tuple(tie('expression'), tie('expression')).map(([l, r]) => `${l} + ${r}`),
+    fc.tuple(tie('expression'), tie('expression')).map(([l, r]) => `${l} || ${r}`),
+    fc.tuple(tie('expression'), tie('expression')).map(([l, r]) => `${l} ?? ${r}`),
+    fc
+      .tuple(tie('expression'), tie('expression'), tie('expression'))
+      .map(([t, c, a]) => `(${t} ? ${c} : ${a})`),
+    // Functions, so rules that walk scopes get a scope to walk.
+    tie('expression').map((e) => `(() => ${e})`),
+    tie('expression').map((e) => `(async () => await ${e})`),
+    tie('expression').map((e) => `(function* () { yield ${e}; })`),
+  ),
+}));
+
+/** Wrap an expression in a statement context so more visitors are exercised. */
+const program = fc.oneof(
+  expression.map((e) => `${e};`),
+  expression.map((e) => `const v = ${e};`),
+  expression.map((e) => `module.exports = ${e};`),
+  expression.map((e) => `if (${e}) { ${e}; }`),
+  expression.map((e) => `try { ${e}; } catch (err) { ${e}; }`),
+  expression.map((e) => `export default ${e};`),
+  fc.tuple(expression, expression).map(([a, b]) => `function f(p) { ${a}; return ${b}; }`),
+  fc.tuple(expression, expression).map(([a, b]) => `class C { m() { ${a}; } n = ${b}; }`),
+);
+
+/**
+ * Enable every rule the plugin exposes.
+ *
+ * Rules run on their documented defaults; a rule whose schema demands options
+ * it does not default is itself a defect worth surfacing here.
+ */
+const allRulesOf = (pluginName: string, plugin: Plugin): Linter.RulesRecord =>
+  Object.fromEntries(
+    Object.keys(plugin.rules ?? {}).map((rule) => [
+      `${pluginName}/${rule}`,
+      'error' as const,
+    ]),
+  );
+
+/**
+ * The harness validates itself before it validates anything else.
+ *
+ * A fuzz test that cannot fail is worse than no fuzz test: it reports green
+ * forever and is read as coverage. Both ways this harness could be silently
+ * vacuous are asserted here — the linter swallowing rule crashes, and the
+ * generator emitting code so trivial it never reaches rule logic.
+ */
+describe('harness validity', () => {
+  it('propagates a throwing rule out of linter.verify', () => {
+    const linter = new Linter();
+    const boom = {
+      create: () => ({
+        Identifier() {
+          throw new Error('BOOM');
+        },
+      }),
+    };
+
+    expect(() =>
+      linter.verify(
+        'const v = a;',
+        [
+          {
+            plugins: { t: { rules: { boom } } as never },
+            rules: { 't/boom': 'error' },
+          },
+        ],
+        'fuzz.js',
+      ),
+    ).toThrow(/BOOM/);
+  });
+
+  it('generates programs that actually reach rule logic', async () => {
+    // node-security is the probe: its sinks (child_process, fs, eval) are the
+    // ones the generator biases toward, so zero findings here means the
+    // generator has drifted into emitting inert code.
+    const mod = (await import('eslint-plugin-node-security')) as {
+      default?: Plugin;
+    } & Plugin;
+    const plugin: Plugin = mod.default ?? mod;
+    const linter = new Linter();
+    const config: Linter.Config[] = [
+      {
+        plugins: { 'eslint-plugin-node-security': plugin as never },
+        languageOptions: { ecmaVersion: 'latest', sourceType: 'module' },
+        rules: allRulesOf('eslint-plugin-node-security', plugin),
+      },
+    ];
+
+    let findings = 0;
+    fc.assert(
+      fc.property(program, (code) => {
+        findings += linter.verify(code, config, 'fuzz.js').length;
+      }),
+      { numRuns: 200 },
+    );
+
+    expect(findings).toBeGreaterThan(0);
+  });
+});
+
+describe('rule fleet survives arbitrary parseable input', () => {
+  it('enumerates the plugin fleet (sanity floor)', () => {
+    expect(pluginDirs.length).toBeGreaterThanOrEqual(19);
+  });
+
+  describe.each(pluginDirs)('%s', (pkgName) => {
+    it('never throws while linting generated programs', async () => {
+      const mod = (await import(pkgName)) as { default?: Plugin } & Plugin;
+      const plugin: Plugin = mod.default ?? mod;
+
+      const rules = allRulesOf(pkgName, plugin);
+      // A plugin that exposes no rules would make this test vacuously green.
+      expect(Object.keys(rules).length).toBeGreaterThan(0);
+
+      const linter = new Linter();
+      const config: Linter.Config[] = [
+        {
+          plugins: { [pkgName]: plugin as never },
+          languageOptions: {
+            ecmaVersion: 'latest',
+            sourceType: 'module',
+          },
+          rules,
+        },
+      ];
+
+      fc.assert(
+        fc.property(program, (code) => {
+          // `verify` never rejects valid input by contract: a rule that throws
+          // propagates out of here, and fast-check shrinks the program that
+          // caused it down to a minimal reproducer in the failure message.
+          linter.verify(code, config, 'fuzz.js');
+        }),
+        { numRuns: RUNS },
+      );
+    });
+  });
+});


### PR DESCRIPTION
Closes OpenSSF Scorecard's **Fuzzing check (0 → 10)** — but the test earns its place independently of the score.

## The property

One deliberately weak assertion, across all 30 plugins with every rule enabled:

> **For any parseable program, linting terminates without throwing.**

Nothing about *what* rules should report. Only that they survive input they did not expect.

This is the crash class behind #514. A rule that throws does not merely miss a finding — it takes the whole ESLint run down, and the user stops linting at all. Our fixtures only cover shapes we thought of; the shapes that crash a rule are, by definition, the ones nobody thought of. We ship 409 of them.

## Why biased generation, not random noise

Uniform noise mostly produces syntax errors, which never reach rule code. The inputs that break rules are **valid** programs with an unusual AST — `a?.[b]?.(c)`, `({...x}).y`, a template literal nested inside a spread argument. Generation is therefore biased toward security-relevant shapes: sinks, optional chaining, spreads, computed members, template literals, generators.

## The harness validates itself

A fuzz test that cannot fail is worse than none — it reports green forever and gets read as coverage. Both ways this could go vacuous are asserted **in the file**:

- a deliberately throwing rule **must** propagate out of `linter.verify` (proving the harness can fail at all);
- the generator **must** produce real findings against `node-security` (proving it hasn't drifted into emitting inert code).

Both were verified by construction before being folded in.

## On the Scorecard side

The plan estimated **one day** for ClusterFuzzLite. That was wrong about what the check detects: alongside OSS-Fuzz, it recognises **property-based testing**, and for TypeScript that means a direct `fast-check` import. Verified end-to-end against `gcr.io/openssf/scorecard:stable`:

```text
score: 10 | project is fuzzed
  Info: TypeScriptPropertyBasedTesting integration found
```

`scripts/ilb-fuzz.ts` was the wrong base to build on — it is an LLM-driven FP/FN candidate generator needing `ANTHROPIC_API_KEY` at ~$10 a fleet run, so it cannot run in CI and is not a fuzzer.

**`fast-check` adds 2 packages and audits clean.** That matters here: the lighthouse pinning was deliberately left open in #537 precisely because its dependency tree would have surfaced 9 advisories on the higher-weighted Vulnerabilities check.

## Cost and limits

Runs in **~3s** inside `npm run test:scripts`, which `quality.yml` already executes.

**Not a substitute for ClusterFuzzLite**, which would fuzz continuously with coverage guidance and corpus retention rather than 25 fresh draws per plugin per run. Each CI run draws a different seed, so coverage accumulates over time rather than in any single commit.

## Verification

`lefthook run pre-commit --all-files` green; pre-push typecheck + lockfile + build-and-test green. No package changes, so no changeset.