### PR TITLE
ci(quality): gate OSV + Scorecard floors as a parallel quality job

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -19,8 +19,11 @@ run-name: >-
 #   - Workflow + script locks   ~30s
 #   - Plugin Taxonomy           ~5s
 #   - Lockfile Sync             ~10s
+#   - Supply-chain floor        ~90s  (OSV + Scorecard offline checks)
 #
-# Total wall ~30s. Compared to the pre-split ~3m, ~80% GHA-minute reduction.
+# All of the above run in PARALLEL, so wall-clock is the slowest single job,
+# not the sum. Supply-chain floor is the slowest at ~90s (image pull + scan);
+# everything else still finishes in ~30s.
 #
 # Caching: `./.github/actions/setup` hydrates node_modules and (where used)
 # the `.turbo` task cache. See AGENTS.md "Promotion gate" for the full model.
@@ -144,13 +147,61 @@ jobs:
           fi
           echo "✅ Lockfile is in sync."
 
+  # ───────────────────────────────────────────────────────────────────────────
+  # Supply-chain floor. Runs as a sibling of the other fast gates, so it costs
+  # wall-clock only if it is the slowest one.
+  #
+  # Two assertions, both regressions this repo has actually suffered:
+  #   1. OSV over every committed lockfile. Two stale workspace-member
+  #      lockfiles carried 29 findings for ~8 months while `npm audit` showed
+  #      one low, because npm never reads those files and OSV-Scanner reads all
+  #      of them. Nothing in CI disagreed.
+  #   2. Scorecard per-check floors, for the offline-evaluable checks. The work
+  #      that moved the aggregate 6.8 -> 8.5 is otherwise unguarded.
+  # ───────────────────────────────────────────────────────────────────────────
+  supply-chain:
+    name: Supply-chain floor
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # Scans the checked-out tree only — no `npm ci`, so this sees committed
+      # lockfiles and nothing from node_modules. Exits non-zero on any finding.
+      - name: OSV — no known vulnerabilities in any committed lockfile
+        uses: google/osv-scanner-action/osv-scanner-action@8deb546fdb875b9996d27d4950be7312dac076a1 # v2.5.0
+        with:
+          scan-args: |-
+            --recursive
+            ./
+
+      # Pinned by digest, not tag: this job enforces Pinned-Dependencies, so it
+      # has no business pulling a mutable image itself.
+      - name: Scorecard — offline checks
+        env:
+          SCORECARD_IMAGE: gcr.io/openssf/scorecard@sha256:b9a535801cb5fc8e7b2bea4cf45dd2db9a342cab8cc32bb5be2ac1355a95356f
+        run: |
+          set -euo pipefail
+          docker run --rm -v "$GITHUB_WORKSPACE":/repo "$SCORECARD_IMAGE" \
+            --local=/repo --format=json \
+            --checks=Dangerous-Workflow,Token-Permissions,Binary-Artifacts,Security-Policy,Pinned-Dependencies \
+            > scorecard.json
+
+      - name: Scorecard — enforce per-check floors
+        run: |
+          set -euo pipefail
+          node scripts/check-scorecard-floor.mjs scorecard.json | tee -a "$GITHUB_STEP_SUMMARY"
+
   # Aggregate gate so branch protection has a single required check to gate on.
   # Heavy gates (test/build/typecheck/portability) live in quality-full.yml.
   quality-gate:
     name: Quality Gate
     runs-on: ubuntu-latest
     timeout-minutes: 2
-    needs: [oxlint, markdown, changelog, workflows, taxonomy, publish-metadata, lockfile]
+    needs: [oxlint, markdown, changelog, workflows, taxonomy, publish-metadata, lockfile, supply-chain]
     if: always()
     steps:
       - name: Render gate report
@@ -162,6 +213,7 @@ jobs:
           R_TAXONOMY: ${{ needs.taxonomy.result }}
           R_PUBLISH: ${{ needs.publish-metadata.result }}
           R_LOCKFILE: ${{ needs.lockfile.result }}
+          R_SUPPLY: ${{ needs.supply-chain.result }}
         run: |
           set -euo pipefail
           icon() {
@@ -175,7 +227,7 @@ jobs:
           }
 
           all_pass=true
-          for r in "$R_OXLINT" "$R_MARKDOWN" "$R_CHANGELOG" "$R_WORKFLOWS" "$R_TAXONOMY" "$R_PUBLISH" "$R_LOCKFILE"; do
+          for r in "$R_OXLINT" "$R_MARKDOWN" "$R_CHANGELOG" "$R_WORKFLOWS" "$R_TAXONOMY" "$R_PUBLISH" "$R_LOCKFILE" "$R_SUPPLY"; do
             [ "$r" = "success" ] || all_pass=false
           done
           if $all_pass; then
@@ -196,6 +248,7 @@ jobs:
             echo "| Plugin taxonomy     | $(icon "$R_TAXONOMY") $R_TAXONOMY       | code-agnostic plugins carry no SDK gates |"
             echo "| Publish metadata    | $(icon "$R_PUBLISH") $R_PUBLISH         | no package publishes with an npm warning |"
             echo "| Lockfile sync       | $(icon "$R_LOCKFILE") $R_LOCKFILE      | \`package-lock.json\` matches \`package.json\` |"
+            echo "| Supply-chain floor  | $(icon "$R_SUPPLY") $R_SUPPLY          | OSV clean + Scorecard checks above floor |"
             echo ""
             echo "_Heavy gates (build/tests/typecheck/portability) run via \`quality-full.yml\` when this PR is promoted (ready-for-review or \`run-full-ci\` label)._"
             if ! $all_pass; then

--- a/scripts/check-scorecard-floor.mjs
+++ b/scripts/check-scorecard-floor.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+
+/**
+ * check-scorecard-floor.mjs
+ *
+ * Fails closed when an OpenSSF Scorecard check regresses below its recorded
+ * floor. Reads the JSON emitted by `scorecard --local --format=json`.
+ *
+ * Why this exists: on 2026-08-12 this repo scored 0/10 on Vulnerabilities for
+ * months. Two stale `package-lock.json` files inside workspace members held 29
+ * OSV findings; npm never reads such files, so `npm audit` reported one low the
+ * entire time and nothing in CI disagreed. The fixes that took the aggregate
+ * 6.8 -> 8.5 were all invisible to the existing gates, which means they can all
+ * regress just as invisibly. This turns the score into something CI asserts.
+ *
+ * Only the checks Scorecard can evaluate **offline** are floored here — the
+ * rest (Code-Review, Maintained, SAST, Contributors…) need GitHub API data and
+ * would be flaky or unauthenticated in a PR context.
+ *
+ * Floors are the measured value at the time of writing, not aspirations.
+ * Pinned-Dependencies sits at 8 deliberately: 22 of 29 npm commands must be
+ * pinned to reach 9, only 21 are legitimately reachable, and pinning the three
+ * global CLI installs would drag 58 OSV findings back in — costing far more on
+ * Vulnerabilities than it gains here. Raise a floor when the real score rises;
+ * never lower one to make a red build green.
+ *
+ * Usage: node scripts/check-scorecard-floor.mjs <scorecard.json>
+ */
+
+import { readFileSync } from 'node:fs';
+import process from 'node:process';
+
+/** Measured 2026-08-12 against c5cf46b1. */
+const FLOORS = {
+  'Dangerous-Workflow': 10,
+  'Token-Permissions': 10,
+  'Binary-Artifacts': 10,
+  'Security-Policy': 10,
+  'Pinned-Dependencies': 8,
+};
+
+const file = process.argv[2];
+if (!file) {
+  console.error('usage: check-scorecard-floor.mjs <scorecard.json>');
+  process.exit(2);
+}
+
+let report;
+try {
+  report = JSON.parse(readFileSync(file, 'utf8'));
+} catch (err) {
+  console.error(`✖ Could not read Scorecard JSON at ${file}: ${err.message}`);
+  process.exit(2);
+}
+
+const checks = Array.isArray(report.checks) ? report.checks : [];
+const byName = new Map(checks.map((c) => [c.name, c]));
+
+const rows = [];
+const failures = [];
+
+for (const [name, floor] of Object.entries(FLOORS)) {
+  const check = byName.get(name);
+
+  // An absent check must fail. A scan that errored or was filtered produces an
+  // empty report, and "no checks below floor" would otherwise read exactly like
+  // "every check passed" — the failure mode this gate exists to prevent.
+  if (!check || typeof check.score !== 'number') {
+    failures.push(`${name}: MISSING from the report (scan did not evaluate it)`);
+    rows.push(`| ${name} | — | ${floor} | ❌ missing |`);
+    continue;
+  }
+
+  // Scorecard uses -1 for "inconclusive", which is not a pass.
+  if (check.score < 0) {
+    failures.push(`${name}: inconclusive (score ${check.score})`);
+    rows.push(`| ${name} | ${check.score} | ${floor} | ❌ inconclusive |`);
+    continue;
+  }
+
+  const ok = check.score >= floor;
+  if (!ok) failures.push(`${name}: ${check.score} < ${floor} — ${check.reason ?? 'no reason given'}`);
+  rows.push(`| ${name} | ${check.score} | ${floor} | ${ok ? '✅' : '❌'} |`);
+}
+
+console.log('| Check | Score | Floor | |');
+console.log('|---|---|---|---|');
+for (const row of rows) console.log(row);
+
+if (failures.length > 0) {
+  console.error('\n✖ Scorecard regression — a check dropped below its floor:\n');
+  for (const f of failures) console.error(`  ${f}`);
+  console.error(
+    [
+      '',
+      'Reproduce locally:',
+      '',
+      '  git archive HEAD | tar -x -C /tmp/sc && (cd /tmp/sc && git init -q .)',
+      '  docker run --rm -v /tmp/sc:/repo gcr.io/openssf/scorecard:v5.5.0 \\',
+      '    --local=/repo --format=json > /tmp/sc.json',
+      '  node scripts/check-scorecard-floor.mjs /tmp/sc.json',
+      '',
+      'If the drop is intentional and justified, update FLOORS in this file in',
+      'the same PR and say why.',
+      '',
+    ].join('\n'),
+  );
+  process.exit(1);
+}
+
+console.log(`\n✓ All ${rows.length} floored Scorecard checks hold.`);


### PR DESCRIPTION
## Summary

Everything that moved this repo from Scorecard **6.8 → 8.5** is currently unguarded. The same fixes can regress exactly as invisibly as they originally broke.

The motivating case: two stale `package-lock.json` files inside workspace members carried **29 OSV findings for ~8 months**. npm never reads such files, so `npm audit` reported a single low the entire time and no CI gate disagreed. OSV-Scanner reads every lockfile it finds — which is why Scorecard saw 29 and we saw 1.

Adds a `supply-chain` job to `quality.yml` as a **sibling of the seven existing fast gates** (`needs: []`), feeding the aggregate Quality Gate.

### What it asserts

1. **OSV over the checked-out tree** — no `npm ci`, so it sees committed lockfiles and nothing from `node_modules`. Precisely the blind spot above.
2. **Scorecard per-check floors** via `scripts/check-scorecard-floor.mjs`, for the five checks Scorecard evaluates **offline** — no token, no API, no flakiness.

| check | floor | why |
|---|---|---|
| Dangerous-Workflow | 10 | currently 10 |
| Token-Permissions | 10 | currently 10 |
| Binary-Artifacts | 10 | currently 10 |
| Security-Policy | 10 | currently 10 |
| Pinned-Dependencies | **8** | demonstrated ceiling, not a compromise |

Floors are *measured* values. Pinned-Dependencies sits at 8 deliberately: reaching 9 needs 22/29 npm commands pinned, only 21 are legitimately reachable, and pinning the three global CLI installs drags **58 OSV findings** back in — a net loss on a HIGH-weight check to gain a MEDIUM one.

The API-dependent checks (Code-Review, Maintained, SAST, Contributors, Vulnerabilities) are deliberately **not** floored here — they need GitHub API data and would be flaky or unauthenticated in a PR context. OSV covers the Vulnerabilities substance directly.

### It fails closed on absence, not just on low scores

The checker rejects a missing or inconclusive (`-1`) check, not only one below floor. An empty report otherwise reads **identically** to an all-green one — that's the exact failure mode this gate exists to catch, and I hit it myself while polling CI on #543.

### Cost

The job runs concurrently, so it only costs wall-clock if it's the slowest gate — ~90s, image-pull dominated; the other seven still finish in ~30s. The Scorecard image is pinned **by digest**, since a job that enforces Pinned-Dependencies has no business pulling a mutable tag.

## Test plan

| command | outcome |
|---|---|
| floor script vs. the real report | **pass** — all 5 checks at/above floor, exit 0 |
| regression: Pinned-Dependencies 8→6 | **fails as designed** — exit 1 |
| regression: empty `{"checks":[]}` report | **fails as designed** — exit 1, all 5 reported missing |
| regression: Security-Policy score `-1` | **fails as designed** — exit 1 |
| scorecard command, no token | **pass** — exit 0, 5 checks scored offline |
| badge/YAML parse | **pass** — 8 parallel jobs, gate `needs` all 8, `R_SUPPLY` wired into the report |
| `npm run lint:workflows` | **pass** — 35 files |
| `npm run lint:md` | **pass** — 0 issues |
| `npm run test:scripts` | 1153 pass / 2 fail — **pre-existing**, `lazy-rules-artifact` needs `dist/`; confirmed identical on clean `origin/main` |

## After merge

`Supply-chain floor` appears as a new check on every PR and rolls into `Quality Gate`, which is already the required context — so no branch-protection change is needed.

When a floor legitimately rises (e.g. SAST reaching 10, or a release finally scoring Signed-Releases), raise it in `FLOORS` in the same PR. The script's failure output prints the exact local reproduction command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)