### PR TITLE
chore(release): add the six changesets #546 was missing

### DIFF
--- a/.changeset/devkit-module-gate-sees-every-spelling.md
+++ b/.changeset/devkit-module-gate-sees-every-spelling.md
@@ -1,0 +1,31 @@
+---
+'@interlace/eslint-devkit': minor
+---
+
+The shared SDK gate now recognises every way a module can be brought into a
+file, not just `import` and a bare `require()`.
+
+```js
+import OpenAI = require('openai');        // gate stayed shut
+const { OpenAI } = await import('openai'); // gate stayed shut
+```
+
+`createModuleListEvidence` routes the flat `modules` lists that the SDK rule
+factories already take through `createModuleEvidence`, which understands
+import-equals, dynamic import, re-exports, Deno specifiers and `require`
+shadowing. Before this, four plugins — `anthropic-security`,
+`gemini-security`, `mcp-sdk-security` and `openai-security` — ran **no rule at
+all** on a file that loaded its SDK either of those two ways. The gate was
+never wrong about the library; it was wrong about the spelling.
+
+The same pass narrowed three shared factories to report evidence rather than
+resemblance: `sdk-api-key-rule` now names the property that actually held the
+credential instead of guessing the first configured one,
+`browser-escape-hatch-rule` and `system-prompt-injection-rule` check the
+receiver, and `sql-injection-rule` requires the driver import.
+
+`matchesModule` is **deprecated but still exported**. It only answers "which
+package is this string in?" and cannot see how the module was loaded — prefer
+`createModuleListEvidence`. It is kept so this stays a minor release: dropping
+it would strand every plugin on its `^1` range, which is the opposite of
+shipping these fixes.

--- a/.changeset/express-security-evidence-not-resemblance.md
+++ b/.changeset/express-security-evidence-not-resemblance.md
@@ -1,0 +1,22 @@
+---
+'eslint-plugin-express-security': major
+---
+
+All eight rules now require an Express app in the file, and one messageId is gone.
+
+**Breaking:** `require-express-body-parser-limits` no longer emits `addLimit`.
+It was a second, LOW-severity report on the *same* site that the HIGH-severity
+`missingLimit` already covered — one missing option, told twice. Suppressions
+naming `addLimit` are now unused; delete them.
+
+Two new internal probes carry the change. `app-composition` answers *"is this
+receiver an Express app, and where is its middleware stack assembled?"*, so
+`no-insecure-cookie-options`, `no-static-root-exposure`, `require-csrf-protection`,
+`require-helmet` and `require-rate-limiting` stop firing on any object that
+happens to own a matching method name. `auth-evidence` does the same for
+`require-route-authentication`, which was reporting routes that are
+authenticated by a router-level or app-level guard it could not see.
+
+`no-permissive-cors` gained a detection rather than losing one: it now reads an
+exported `CorsOptions` declaration, which is how a real application configures
+CORS, and was a false **negative** before.

--- a/.changeset/gemini-security-gate-sees-commonjs.md
+++ b/.changeset/gemini-security-gate-sees-commonjs.md
@@ -1,0 +1,16 @@
+---
+'eslint-plugin-gemini-security': patch
+---
+
+`no-disabled-safety-settings` now runs on files that load the Gemini SDK by
+`require`, `import =` or `await import`.
+
+```js
+const { GoogleGenerativeAI } = require('@google/generative-ai'); // rule did not run
+```
+
+The gate read `ImportDeclaration` and a bare `require()` callee and nothing
+else, so a `BLOCK_NONE` safety setting in a CommonJS file was never reported.
+It now goes through the shared devkit module probe, and a
+`module-gate.lock.test.ts` pins that the verdict does not depend on the
+spelling.

--- a/.changeset/jwt-security-one-rule-per-site.md
+++ b/.changeset/jwt-security-one-rule-per-site.md
@@ -1,0 +1,31 @@
+---
+'eslint-plugin-jwt-security': major
+---
+
+`no-algorithm-none` no longer reports decoding, and the whole plugin now works
+in CommonJS.
+
+**Breaking:** `no-algorithm-none` no longer emits `decodeWithoutVerify`. That
+site belongs to `no-decode-without-verify`, which reports it with its own
+severity, its own docs and its own fix — the two rules were reporting the same
+line for the same reason. Enable `no-decode-without-verify` (it is in
+`recommended`) and drop any suppression that named `decodeWithoutVerify` on
+`no-algorithm-none`.
+
+**The plugin was silent on CommonJS.** Its module gate read `ImportDeclaration`
+only, so `const jwt = require('jsonwebtoken')` — and `import jwt =
+require(...)`, `require('jsonwebtoken').decode`, a destructured require, a
+side-effect require — left every rule switched off. It now resolves the
+specifier for each of those spellings.
+
+Two false-positive classes went with it:
+
+```js
+new TextDecoder().decode(bytes);                              // not JWT decoding
+await new SignJWT(claims).setExpirationTime('2h').sign(key);  // does set an expiry
+```
+
+The gate now checks the receiver against a list of non-JWT constructors, and
+`require-expiration` follows jose's fluent builder through the chain instead of
+looking only at the object literal. `FlattenedSign`, `CompactSign` and
+`GeneralSign` are exempt outright — JWS has no `exp` claim to set.

--- a/.changeset/mcp-sdk-security-gate-sees-commonjs.md
+++ b/.changeset/mcp-sdk-security-gate-sees-commonjs.md
@@ -1,0 +1,20 @@
+---
+'eslint-plugin-mcp-sdk-security': minor
+---
+
+Every rule now runs on files that load the MCP SDK by `require`, `import =` or
+`await import`.
+
+```js
+const { Server } = require('@modelcontextprotocol/sdk/server/index.js'); // no rule ran
+```
+
+The four rules — `no-command-injection-in-tool`,
+`no-tool-description-injection`, `no-unvalidated-tool-args` and
+`require-tool-input-schema` — each opened their gate from `ImportDeclaration`
+plus a bare `require()` callee, which covers ESM and plain CommonJS and nothing
+else. They now share one `mcp-evidence` probe built on the devkit module gate,
+so every spelling is recognised in one place rather than four.
+
+A `module-gate.lock.test.ts` pins it: the same tool definition must report
+identically however the SDK was brought in.

--- a/.changeset/mongodb-lean-is-a-mongoose-modifier.md
+++ b/.changeset/mongodb-lean-is-a-mongoose-modifier.md
@@ -1,0 +1,22 @@
+---
+'eslint-plugin-mongodb-security': patch
+---
+
+`require-lean-queries` no longer asks the native driver for `.lean()`.
+
+```js
+const user = await db.collection('users').findOne({ _id: id }); // was reported
+```
+
+`.lean()` is a **Mongoose** query modifier. The native driver returns a plain
+object already and has no `.lean()` at all, so this was a false positive whose
+suggestion produces code that throws at runtime. The receiver analysis could
+not make the call on its own — it matches `db` and `collection` precisely
+because they *are* Mongo handles; it just could not tell which driver's.
+
+The new `mongo-evidence` probe also widens what counts as a Mongo file. A
+module that imports `mongoose-paginate`, `mongoose-delete` or
+`passport-local-mongoose` without importing `mongoose` itself is still
+unambiguously a Mongoose file: of the twelve corpus files containing
+`new Schema(` that the four-package list placed outside Mongo, eleven were
+exactly these plugin consumers.

--- a/packages/eslint-devkit/src/rule-creation/module-evidence.test.ts
+++ b/packages/eslint-devkit/src/rule-creation/module-evidence.test.ts
@@ -16,7 +16,7 @@ import { describe, it, expect } from 'vitest';
 import { parse } from '@typescript-eslint/parser';
 import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 import type { TSESTree } from '@typescript-eslint/utils';
-import { createModuleEvidence } from './module-evidence';
+import { createModuleEvidence, matchesModule } from './module-evidence';
 
 const ast = (code: string): TSESTree.Program =>
   parse(code, { sourceType: 'module', range: true });
@@ -292,5 +292,14 @@ describe('createModuleEvidence', () => {
   it('a probe configured with nothing matches nothing', () => {
     const none = createModuleEvidence({});
     expect(none(ast("import x from 'pg';"))).toBe(false);
+  });
+
+  describe('matchesModule (deprecated, kept for the public surface)', () => {
+    it('matches the package itself and its subpaths, and nothing that merely shares a prefix', () => {
+      expect(matchesModule('openai', ['openai'])).toBe(true);
+      expect(matchesModule('openai/resources', ['openai'])).toBe(true);
+      expect(matchesModule('openai-mock', ['openai'])).toBe(false);
+      expect(matchesModule('pg', ['openai'])).toBe(false);
+    });
   });
 });

--- a/packages/eslint-devkit/src/rule-creation/module-evidence.ts
+++ b/packages/eslint-devkit/src/rule-creation/module-evidence.ts
@@ -293,3 +293,20 @@ export function createModuleListEvidence(
     scopes: modules.filter(isBareScope),
   });
 }
+
+/**
+ * Does a module specifier name a package, or something inside one?
+ *
+ * @deprecated Prefer {@link createModuleListEvidence}. This answers only
+ * *"which package is this string in?"* and knows nothing about how the module
+ * was brought into the file, which is where the four AI plugins went silent on
+ * CommonJS.
+ *
+ * Kept because it was public API: it used to be exported from
+ * `sdk-api-key-rule` and re-exported from the package root, so removing it
+ * would make devkit a major and strand every plugin on a `^1` range — the
+ * opposite of shipping these fixes.
+ */
+export function matchesModule(source: string, modules: readonly string[]): boolean {
+  return modules.some((m) => source === m || source.startsWith(`${m}/`));
+}


### PR DESCRIPTION
## Why

[#546](https://github.com/ofri-peretz/eslint/pull/546) changed rules in **eleven** packages and shipped changesets for **three**. The other eight would have merged, gone green, and published nothing — `release.yml` only compares local `package.json` against npm, so an unbumped package is an `already published` no-op that still reports SUCCESS. The open Version PR [#538](https://github.com/ofri-peretz/eslint/pull/538) currently bumps `browser-security`, `node-security` and `secure-coding` only.

Two of the eight — `anthropic-security` and `openai-security` — changed no source outside tests; their fix arrives through devkit's module gate. The remaining six get a changeset here.

## The bumps

| package | bump | why |
|---|---|---|
| `@interlace/eslint-devkit` | minor | the shared module gate four AI plugins run on |
| `eslint-plugin-express-security` | **major** | `addLimit` messageId removed |
| `eslint-plugin-jwt-security` | **major** | `decodeWithoutVerify` removed from `no-algorithm-none` |
| `eslint-plugin-mcp-sdk-security` | minor | gate now sees `require` / `import =` / `await import` |
| `eslint-plugin-gemini-security` | patch | same gate fix, one rule |
| `eslint-plugin-mongodb-security` | patch | `.lean()` is a Mongoose modifier, not a native-driver one |

Both majors remove a messageId that duplicated another rule's report on the same line. Nothing else in the ecosystem drops a rule, a config or an option.

## Why devkit is a minor, not a major

`matchesModule` is restored as a **deprecated re-export**. It was public API — defined in `sdk-api-key-rule`, re-exported through the `rule-creation` barrel and the package root — so removing it is a breaking change on paper.

Taking that major would be actively harmful: every plugin depends on `@interlace/eslint-devkit: ^1.x`, so devkit `2.0.0` reaches **nobody** without republishing all thirty. The CommonJS gate fixes are the whole point of the release, and stranding them behind thirty patch bumps trades real distribution for a tidy version number. Keeping the two-line helper makes devkit a minor, and every plugin picks the fixes up on its next install with no republish at all.

It carries a `@deprecated` tag pointing at `createModuleListEvidence`, and a test pinning its exact old semantics (`source === m || source.startsWith(m + '/')`).

## Verification

`@interlace/eslint-devkit`: 1500 tests pass, coverage still **100%** on statements, branches, functions and lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Security rules now recognize CommonJS, TypeScript, and dynamic import patterns across supported SDKs.
  * Authentication, application composition, and module evidence checks improve detection accuracy.
  * MongoDB analysis recognizes Mongoose plugin usage, even without a direct Mongoose import.

* **Bug Fixes**
  * Reduced false positives for unrelated objects, native MongoDB queries, non-JWT `decode` calls, and fluent builders.
  * Improved JWT and Express security rule behavior, including clearer handling of body-parser limits and expiration claims.

* **Deprecations**
  * `matchesModule` remains available for compatibility but is deprecated in favor of evidence-based module detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->