### PR TITLE
docs(express-security): correct the 3.0.0 changelog

### DIFF
--- a/.changeset/express-changelog-accuracy.md
+++ b/.changeset/express-changelog-accuracy.md
@@ -1,0 +1,10 @@
+---
+---
+
+Docs-only: corrects the `eslint-plugin-express-security@3.0.0` changelog entry,
+which described the wrong reason for a removal.
+
+Deliberately empty — no version bump. The shipped 3.0.0 package is correct; only
+its description was wrong, and cutting 3.0.1 to reword a paragraph is not worth
+the release noise. The corrected text rides along with the package's next real
+publish, and is right on GitHub immediately.

--- a/apps/docs/src/data/plugin-stats.json
+++ b/apps/docs/src/data/plugin-stats.json
@@ -5,7 +5,7 @@
       "rules": 46,
       "description": "ESLint plugin for browser security — detects DOM XSS, postMessage abuse, tokens in localStorage, insecure cookies, clickjacking, mixed content, and CSP gaps",
       "category": "security",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "published": true
     },
     {
@@ -13,7 +13,7 @@
       "rules": 42,
       "description": "ESLint plugin for Node.js security — detects command injection, path traversal, SSRF, zip slip, and weak crypto (MD5/SHA-1, ECB, static IV) in fs, child_process, vm, and crypto",
       "category": "security",
-      "version": "4.10.0",
+      "version": "4.11.0",
       "published": true
     },
     {
@@ -21,7 +21,7 @@
       "rules": 32,
       "description": "ESLint plugin for secure coding — detects LDAP, XPath, XXE, GraphQL and template injection, unsafe deserialization, ReDoS, missing authentication, and PII in logs",
       "category": "security",
-      "version": "3.7.1",
+      "version": "4.0.0",
       "published": true
     },
     {
@@ -37,7 +37,7 @@
       "rules": 16,
       "description": "ESLint plugin for MongoDB and Mongoose security — detects NoSQL operator injection, unsafe queries and regex, hardcoded connection strings, and missing TLS",
       "category": "security",
-      "version": "9.0.0",
+      "version": "9.0.1",
       "published": true
     },
     {
@@ -45,7 +45,7 @@
       "rules": 13,
       "description": "ESLint plugin for JWT security — detects algorithm confusion (CVE-2022-23540), alg:none, weak or hardcoded secrets, and decode-without-verify",
       "category": "security",
-      "version": "2.4.0",
+      "version": "3.0.0",
       "published": true
     },
     {
@@ -77,7 +77,7 @@
       "rules": 4,
       "description": "ESLint plugin for Model Context Protocol (MCP) SDK security — catches tools registered without an input schema, handlers reading arguments the schema never declared, model-visible descriptions built from dynamic text, and tool arguments reaching a shell",
       "category": "security",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "published": true
     },
     {
@@ -117,7 +117,7 @@
       "rules": 3,
       "description": "ESLint plugin for Google Gemini SDK security — catches safety thresholds set to BLOCK_NONE, hardcoded API keys, and system instructions assembled from untrusted input",
       "category": "security",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "published": true
     },
     {
@@ -149,7 +149,7 @@
       "rules": 28,
       "description": "ESLint plugin for Express.js security — detects permissive CORS, missing CSRF protection, missing helmet headers, insecure cookies, and GraphQL introspection in production",
       "category": "framework",
-      "version": "2.0.1",
+      "version": "3.0.0",
       "published": true
     },
     {

--- a/packages/eslint-plugin-express-security/CHANGELOG.md
+++ b/packages/eslint-plugin-express-security/CHANGELOG.md
@@ -2,12 +2,31 @@
 
 ### Major Changes
 
-- [#548](https://github.com/ofri-peretz/eslint/pull/548) [`d86a8d8`](https://github.com/ofri-peretz/eslint/commit/d86a8d8de3e6fa4c404192365a7aa66c9646233d) Thanks [@ofri-peretz](https://github.com/ofri-peretz)! - All eight rules now require an Express app in the file, and one messageId is gone.
+- [#548](https://github.com/ofri-peretz/eslint/pull/548) [`d86a8d8`](https://github.com/ofri-peretz/eslint/commit/d86a8d8de3e6fa4c404192365a7aa66c9646233d) Thanks [@ofri-peretz](https://github.com/ofri-peretz)! - All eight rules now require an Express app in the file, and one rule stops reporting a non-issue.
 
-  **Breaking:** `require-express-body-parser-limits` no longer emits `addLimit`.
-  It was a second, LOW-severity report on the _same_ site that the HIGH-severity
-  `missingLimit` already covered — one missing option, told twice. Suppressions
-  naming `addLimit` are now unused; delete them.
+  > **Correction (2026-08-13).** The entry published with 3.0.0 said only
+  > `addLimit` was removed, and that `missingLimit` still covered the site. That
+  > was wrong — **both** messageIds are gone, and the reason is the one below.
+  > The package itself is correct; only this description was. No republish: the
+  > text is fixed here and ships with the next release.
+
+  **Breaking:** `require-express-body-parser-limits` no longer emits
+  `missingLimit` or `addLimit`. It no longer reports a *missing* limit at all.
+
+  `express.json()` with no options is **not** unbounded. All four parsers —
+  `json`, `urlencoded`, `raw`, `text` — ship `limit: '100kb'` by default, in
+  Express 4 and 5 alike. The old message ("Missing Body Parser Limit … attackers
+  can exhaust server memory") was a claim about a default that does not exist:
+  100kb is far below every threshold this rule enforces, so it reported a
+  configuration it would have accepted had it been written out. All seven
+  findings on the 8-repo corpus were that shape, including
+  `app.use(express.urlencoded({ extended: true }))`.
+
+  What remains is `excessiveLimit` — an *explicit* limit above `maxLimit`, which
+  is also the only form an attacker can steer. It now also catches the numeric
+  spelling (`limit: 52428800`) that the string-only comparison missed entirely.
+
+  Suppressions naming `missingLimit` or `addLimit` are now unused; delete them.
 
   Two new internal probes carry the change. `app-composition` answers _"is this
   receiver an Express app, and where is its middleware stack assembled?"_, so


### PR DESCRIPTION
## What was wrong

The 3.0.0 entry I wrote in [#548](https://github.com/ofri-peretz/eslint/pull/548) said `require-express-body-parser-limits` dropped only `addLimit`, and that the HIGH-severity `missingLimit` still covered the site.

Both messageIds are gone, and the reason is not deduplication. Verified against the published tarball:

```
$ npm i eslint-plugin-express-security@3.0.0
$ node -e 'console.log(Object.keys(require("eslint-plugin-express-security").rules["require-express-body-parser-limits"].meta.messages))'
[ 'excessiveLimit' ]
```

The rule stopped reporting a **missing** limit because the premise was false. All four Express parsers — `json`, `urlencoded`, `raw`, `text` — ship `limit: '100kb'` by default in Express 4 and 5, far below every threshold the rule enforces. It was reporting a configuration it would have accepted had it been written out; all seven findings on the 8-repo corpus were that shape, including `app.use(express.urlencoded({ extended: true }))`.

A reader of the published text would conclude that missing-limit detection survives. It does not, and that changes what they do.

## Why no republish

The shipped package is correct — only its description was wrong. Cutting 3.0.1 to reword a paragraph is not worth the release noise, so the changeset here is deliberately empty. The corrected text is live on GitHub now and rides along with the package's next real publish.

The entry carries an inline `> **Correction (2026-08-13)**` note rather than a silent rewrite, since the original wording is already in the 3.0.0 tarball on npm and readers may be holding it.

## How I got it wrong

I checked for the removal with `git grep -c missingLimit | wc -l`, which counts *files containing the string* — docs and tests included — not messageIds in the rule's `meta.messages`. It reported "2 files before, 2 after" and I read that as "still present". The rule's own header comment stated the real rationale in full; I did not read it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)