### PR TITLE
fix(release): split the mixed changeset and gate on versionability

### DIFF
--- a/.changeset/rate-limiting-error-and-dark-destructive.md
+++ b/.changeset/rate-limiting-error-and-dark-destructive.md
@@ -1,19 +1,17 @@
 ---
 'eslint-plugin-express-security': minor
-'@interlace/ui': patch
 ---
 
-`require-rate-limiting` moves from `warn` to `error` in `recommended`, and the
-dark-mode `--destructive` token becomes legible.
+`require-rate-limiting` moves from `warn` to `error` in `recommended`.
 
-**`require-rate-limiting`: warn → error.** Its findings concentrate in
-single-purpose demo apps — `express/examples/*` — where rate limiting genuinely
-is not wanted. Those are correct detections, not false positives, and the
-reporting posture is now written down: we report, and the consumer scopes.
-Someone who does not want this in a demo directory disables it there,
-explicitly, where the decision is visible in their config. A path exclusion we
-shipped instead would be a decision made silently on behalf of every consumer,
-including the ones whose `examples/` directory is production code.
+Its findings concentrate in single-purpose demo apps — `express/examples/*` —
+where rate limiting genuinely is not wanted. Those are correct detections, not
+false positives, and the reporting posture is now written down: we report, and
+the consumer scopes. Someone who does not want this in a demo directory disables
+it there, explicitly, where the decision is visible in their config. A path
+exclusion shipped in the preset would be a decision made silently on behalf of
+every consumer, including the ones whose `examples/` directory is production
+code.
 
 This resolves an inconsistency `.agent/wild-ground-truth.json` had already
 flagged as "the actionable part": `require-helmet`, the same shape with the same
@@ -24,13 +22,3 @@ If you were relying on this being a warning, set it back in your config:
 ```js
 rules: { 'express-security/require-rate-limiting': 'warn' }
 ```
-
-**`--destructive` in dark mode.** The token had a single literal value defined
-in `:root` — a red chosen to pass on white — and no `.dark` counterpart, so dark
-mode painted it on a near-black surface at **2.36:1** against the 4.5:1 WCAG AA
-requires. It is now `hsl(0, 91%, 71%)` in `.dark`, measured at **6.40:1** on the
-same surface.
-
-`--destructive-foreground` is deliberately unchanged: the solid variants already
-carry `dark:bg-destructive/60`, which composites the new red to `rgb(159,78,78)`
-— 5.7:1 under white text.

--- a/.github/workflows/changesets-pr.yml
+++ b/.github/workflows/changesets-pr.yml
@@ -179,6 +179,23 @@ jobs:
             echo "::warning::PR changes packages/ source but has no changeset."
           fi
 
+      # Presence is not validity. The check above greps for a `.changeset/*.md`
+      # file and stops there, so a changeset that `changeset version` refuses
+      # passed this job green and failed on `main` after merge — where it
+      # blocks the release PR and every publish behind it.
+      #
+      # That happened on #549: a changeset listing `eslint-plugin-express-security`
+      # (published) alongside `@interlace/ui` (`private: true`, so changesets
+      # treats it as ignored). Mixing ignored and non-ignored packages in one
+      # changeset is rejected, and nothing said so until it was already merged.
+      #
+      # `changeset status` builds the same release plan `version` does and exits
+      # 1 on exactly this class. Verified both directions before wiring it up:
+      # exit 1 on the mixed changeset, exit 0 once split.
+      - name: Changeset is versionable
+        if: steps.check.outputs.status == 'present'
+        run: npx changeset status
+
       - name: Summarize
         if: always()
         env:


### PR DESCRIPTION
`main` is red and the release is blocked. Both halves of that are fixed here.

## The break

#549 merged a changeset that `changeset version` refuses:

```
Found mixed changeset rate-limiting-error-and-dark-destructive
  Found ignored packages: @interlace/ui
  Found not ignored packages: eslint-plugin-express-security
  Mixed changesets that contain both ignored and not ignored packages are not allowed
```

`@interlace/ui` is `private: true`, which changesets treats as **ignored** — it cannot share a changeset with a published package. The `ignore` array in `.changeset/config.json` is empty, so this is implicit and easy to miss.

The dark-mode `--destructive` fix needed no changeset at all: it is a private package and nothing publishes from it. Only the `express-security` severity change is user-visible, so the changeset now names that alone.

Consequence while broken: `Changesets · open / refresh Version PR` fails on every push to `main`, so the release PR cannot refresh and **nothing can publish** — including the `express-security` minor from #549.

## Why it got through

The `Changeset present` gate greps for a `.changeset/*.md` file and stops there. Presence, not validity. An unversionable changeset passed it green and the failure surfaced only after merge, at the worst possible point.

`changeset status` builds the same release plan `version` does, so it catches exactly this class. Wired into the same job, gated on a changeset actually being present.

Verified both directions rather than assumed:

| changeset | `changeset status` exit |
| --- | ---: |
| mixed (as merged) | **1** |
| split (this PR) | **0** |

`changeset status` now reports the intended outcome:

```
info Packages to be bumped at minor:
- eslint-plugin-express-security
```

34 workflow files still pass `lint:workflows`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)