### PR TITLE
fix(release): stop the Version PR job failing when nothing is releasable

### DIFF
--- a/.github/workflows/changesets-pr.yml
+++ b/.github/workflows/changesets-pr.yml
@@ -53,8 +53,49 @@ jobs:
         with:
           turbo-cache: "false"
 
+      # `changesets/action` opens the Version PR unconditionally. With nothing
+      # pending, `changeset version` produces no diff, the action pushes an
+      # identical `changeset-release/main`, and GitHub rejects the PR:
+      #
+      #   Validation Failed: No commits between main and changeset-release/main
+      #
+      # The job then fails on EVERY push to main for as long as the changeset
+      # queue is empty — which is the normal state right after a release. Two
+      # of today's four failures were this, including one on the previous
+      # release merge (#538) before any related change, so it is the steady
+      # state and not a regression.
+      #
+      # Nothing is wrong when this happens: there is simply nothing to release.
+      # A job that goes red for the expected case trains you to ignore it, and
+      # this one shares a name with the gate that actually matters.
+      # Counting `.changeset/*.md` is NOT the test, which is the subtlety that
+      # makes this worth a step of its own. A changeset naming only private
+      # packages is ignored by changesets and bumps nothing — `.changeset/` is
+      # non-empty, the release plan is empty, and the action still tries to
+      # open the PR. That is the live state right now:
+      # `fix-plugin-stats-rule-count.md` names `docs`, which is `private: true`,
+      # so `changeset status` reports 0 releases from 1 changeset.
+      #
+      # The release plan is the only thing that predicts whether `version`
+      # produces a diff, so gate on that. `--output` writes the plan as JSON;
+      # `releases` is what would actually be bumped.
+      - name: Will the Version PR have anything in it?
+        id: pending
+        run: |
+          set -euo pipefail
+          npx changeset status --output=/tmp/release-plan.json > /dev/null
+          releases=$(node -p "require('/tmp/release-plan.json').releases.length")
+          changesets=$(node -p "require('/tmp/release-plan.json').changesets.length")
+          echo "releases=${releases}" >> "$GITHUB_OUTPUT"
+          if [ "$releases" -eq 0 ]; then
+            echo "::notice::${changesets} changeset(s) present but 0 package(s) to release — nothing to open a Version PR for."
+          else
+            echo "${releases} package(s) to release from ${changesets} changeset(s)."
+          fi
+
       - name: Open / refresh Version PR
         id: changesets
+        if: steps.pending.outputs.releases != '0'
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1
         with:
           # `version` runs `npm run changeset:version`, which bumps versions
@@ -107,6 +148,7 @@ jobs:
           HAS_CHANGESETS: ${{ steps.changesets.outputs.hasChangesets }}
           PR_NUMBER: ${{ steps.changesets.outputs.pullRequestNumber }}
           PUBLISHED: ${{ steps.changesets.outputs.published }}
+          RELEASES: ${{ steps.pending.outputs.releases }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -121,6 +163,16 @@ jobs:
               else
                 echo "📦 Changesets detected but Version PR not opened (likely first run after CI was set up). Re-running may help; otherwise check the action logs."
               fi
+            elif [ "${RELEASES:-0}" = "0" ]; then
+              # Distinguish "queue is empty" from "queue holds only changesets
+              # that bump nothing" — the second looks identical here but means
+              # a changeset named only private packages, which will never
+              # release and will sit in `.changeset/` indefinitely.
+              echo "✅ Nothing to release — no changeset names a publishable package."
+              echo ""
+              echo "If \`.changeset/\` is not empty, those changesets name only private"
+              echo "packages (\`private: true\`), which changesets ignores. They bump"
+              echo "nothing and can be removed."
             else
               echo "✅ No pending changesets — nothing queued for release."
               echo ""

--- a/.github/workflows/changesets-pr.yml
+++ b/.github/workflows/changesets-pr.yml
@@ -87,8 +87,16 @@ jobs:
           releases=$(node -p "require('/tmp/release-plan.json').releases.length")
           changesets=$(node -p "require('/tmp/release-plan.json').changesets.length")
           echo "releases=${releases}" >> "$GITHUB_OUTPUT"
-          if [ "$releases" -eq 0 ]; then
-            echo "::notice::${changesets} changeset(s) present but 0 package(s) to release — nothing to open a Version PR for."
+          # Both counts are exported: `releases` decides whether the action
+          # runs, `changesets` is what separates "queue is empty" from "queue
+          # holds only changesets that bump nothing". Exporting just the first
+          # collapses the two and makes the summary below claim a distinction
+          # it cannot see.
+          echo "changesets=${changesets}" >> "$GITHUB_OUTPUT"
+          if [ "$releases" -eq 0 ] && [ "$changesets" -gt 0 ]; then
+            echo "::notice::${changesets} changeset(s) present but 0 package(s) to release — they name only private packages, so nothing can be versioned."
+          elif [ "$releases" -eq 0 ]; then
+            echo "No changesets pending — nothing to open a Version PR for."
           else
             echo "${releases} package(s) to release from ${changesets} changeset(s)."
           fi
@@ -149,6 +157,7 @@ jobs:
           PR_NUMBER: ${{ steps.changesets.outputs.pullRequestNumber }}
           PUBLISHED: ${{ steps.changesets.outputs.published }}
           RELEASES: ${{ steps.pending.outputs.releases }}
+          CHANGESETS: ${{ steps.pending.outputs.changesets }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -163,16 +172,16 @@ jobs:
               else
                 echo "📦 Changesets detected but Version PR not opened (likely first run after CI was set up). Re-running may help; otherwise check the action logs."
               fi
-            elif [ "${RELEASES:-0}" = "0" ]; then
-              # Distinguish "queue is empty" from "queue holds only changesets
-              # that bump nothing" — the second looks identical here but means
-              # a changeset named only private packages, which will never
-              # release and will sit in `.changeset/` indefinitely.
-              echo "✅ Nothing to release — no changeset names a publishable package."
+            elif [ "${RELEASES:-0}" = "0" ] && [ "${CHANGESETS:-0}" != "0" ]; then
+              # Both counts are needed to tell these apart. `releases == 0`
+              # alone is also true for an empty queue — the normal state right
+              # after a release — so branching on it would print this message
+              # almost every run and bury the case it is meant to flag.
+              echo "✅ Nothing to release — the ${CHANGESETS} pending changeset(s) name only private packages."
               echo ""
-              echo "If \`.changeset/\` is not empty, those changesets name only private"
-              echo "packages (\`private: true\`), which changesets ignores. They bump"
-              echo "nothing and can be removed."
+              echo "Changesets ignores \`private: true\` packages, so these bump nothing"
+              echo "and will sit in \`.changeset/\` indefinitely. Remove them, or point"
+              echo "them at a published package."
             else
               echo "✅ No pending changesets — nothing queued for release."
               echo ""


### PR DESCRIPTION
`Changesets · open / refresh Version PR` fails on **every push to main** right now:

```
Validation Failed: No commits between main and changeset-release/main
```

`changesets/action` opens the Version PR unconditionally. When the release plan is empty, `changeset version` produces no diff, the action pushes an identical `changeset-release/main`, and GitHub rejects the PR.

**Pre-existing, not a regression.** The same failure hit at 05:31 today on the previous release merge (#538), before any of today's issue work.

## Counting changeset files is not the right gate

A changeset naming only **private** packages is ignored by changesets and bumps nothing — `.changeset/` is non-empty while the release plan is empty. That is the live state on main:

```
$ changeset status
info NO packages to be bumped at patch
info NO packages to be bumped at minor
info NO packages to be bumped at major
$ echo $?
0
```

`fix-plugin-stats-rule-count.md` names `docs`, which is `private: true`. So: **1 changeset, 0 releases, exit 0**. A file-count gate would have passed it straight into the same failure.

This is the third time today this repo has been bitten by "private packages are invisible to changesets" — the mixed-changeset break in #552 was the same family.

## The gate

The release plan is the only thing that predicts whether `version` produces a diff. `changeset status --output` writes it as JSON:

| state | `changesets` | `releases` | action runs? |
| --- | ---: | ---: | --- |
| main today | 1 | 0 | no |
| after a real changeset | ≥1 | ≥1 | yes |

Downstream steps already guard on `hasChangesets`, so skipping is safe. `Summarize` runs with `always()` and now distinguishes "queue is empty" from "queue holds only changesets that bump nothing" — the second is indistinguishable otherwise and means a changeset that will sit in `.changeset/` forever.

34 workflow files still pass `lint:workflows`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release pull requests are now skipped when no releasable package changes are pending.
  * Release status summaries now clearly distinguish between no pending changes and changes affecting only private packages.
* **Chores**
  * Improved release workflow checks and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->