### PR TITLE
docs(workspace): record why overrides cannot close the lhci pin alert

### DIFF
--- a/SCORECARD-HARDENING-PLAN.md
+++ b/SCORECARD-HARDENING-PLAN.md
@@ -207,14 +207,41 @@ higher-weighted check. The exposure is identical either way — the global insta
 runs the same code — so pinning moves vulnerabilities into view without removing
 any.
 
-The one route that would close it without that cost is replacing the global
-install with a SHA-pinned `treosh/lighthouse-ci-action`: Scorecard counts a
-hash-pinned action as pinned, and the action's transitive tree never enters our
-lockfiles. Not done here because it is an unverifiable-in-review rewrite of a
-working job — the report step reads `apps/docs/.lighthouseci` and the
-issue-filing step depends on `lhci`'s outcome, and neither can be exercised
-without a built docs site and Chrome. Worth doing deliberately, with a run to
-prove it, rather than as a drive-by.
+Two routes were evaluated and measured on 2026-08-13. Both are recorded here so
+the question does not get re-litigated from scratch.
+
+**`overrides` — helps, cannot close it.** The obvious idea is to pin the
+lockfile *and* force the vulnerable transitives to patched versions, satisfying
+Pinned-Dependencies and Vulnerabilities at once. It gets most of the way:
+
+| tree | advisories |
+| --- | ---: |
+| `@lhci/cli@0.15.1` | 10 |
+| `+ overrides: { tmp: 0.2.7, uuid: 11.1.1 }` | **6** |
+
+Only three of the ten are real roots — `tmp`, `uuid`, `extract-zip` — and the
+rest are ancestors npm flags for depending on them. `tmp` and `uuid` have fixed
+releases. **`extract-zip` does not: the advisory is `<=2.0.1` and 2.0.1 IS the
+latest published version.** An override can only redirect to a version that
+exists, so the remaining 6 (extract-zip plus five ancestors) are unreachable by
+any override. Six high findings is still a worse trade than one medium alert.
+
+Note `npm audit`'s own suggestion here is `@lhci/cli@0.1.0 [MAJOR]` — a
+downgrade to a 2019 release. That is npm failing to resolve in-range, not
+evidence that no fix exists, and it is why "no version avoids them" needed
+checking properly rather than being taken at face value.
+
+**SHA-pinned `treosh/lighthouse-ci-action` — closes the alert, changes nothing
+real.** Scorecard counts a hash-pinned action as pinned and the action's tree
+never enters our lockfiles, so the alert would go green. But the action ships
+`@lhci/cli: ^0.15.1` — the same version, carrying the same unfixable
+`extract-zip` advisory, just somewhere the scanner does not look. That is
+moving a finding out of view rather than fixing it, which is the practice
+`CLAIMS.md` exists to prevent. Rejected on those grounds, not on effort.
+
+**Conclusion: genuinely blocked upstream.** Revisit when `extract-zip` ships a
+release above 2.0.1, or when lighthouse-ci drops it. At that point `overrides`
+plus a hash-pinned local install closes this cleanly and honestly.
 
 ### 7. SAST: 9 → 10 · **+0.06** · a judgement call
 

--- a/SCORECARD-HARDENING-PLAN.md
+++ b/SCORECARD-HARDENING-PLAN.md
@@ -214,10 +214,30 @@ the question does not get re-litigated from scratch.
 lockfile *and* force the vulnerable transitives to patched versions, satisfying
 Pinned-Dependencies and Vulnerabilities at once. It gets most of the way:
 
-| tree | advisories |
-| --- | ---: |
-| `@lhci/cli@0.15.1` | 10 |
-| `+ overrides: { tmp: 0.2.7, uuid: 11.1.1 }` | **6** |
+| tree | total | high | moderate | low |
+| --- | ---: | ---: | ---: | ---: |
+| `@lhci/cli@0.15.1` | 10 | 7 | 1 | 2 |
+| `+ overrides: { tmp: 0.2.7, uuid: 11.1.1 }` | **6** | **6** | 0 | 0 |
+
+Reproduce it in a throwaway directory — **these overrides are deliberately not
+in this repo's `package.json`**, because `@lhci/cli` is a global CI install and
+is not in our dependency graph at all. The probe exists only to answer whether
+pinning *could* be made clean:
+
+```bash
+mkdir /tmp/lhci-probe && cd /tmp/lhci-probe
+cat > package.json <<'JSON'
+{ "name": "lhci-override-probe", "version": "0.0.0", "private": true,
+  "dependencies": { "@lhci/cli": "0.15.1" },
+  "overrides": { "tmp": "0.2.7", "uuid": "11.1.1" } }
+JSON
+npm install --package-lock-only --no-audit --no-fund
+npm audit --json | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>console.log(JSON.stringify(JSON.parse(s).metadata.vulnerabilities)))"
+# => {"info":0,"low":0,"moderate":0,"high":6,"critical":0,"total":6}
+```
+
+Measured 2026-08-13 on Node v24.12.0 / npm 11.16.0. Drop the `overrides` key to
+reproduce the 10-advisory baseline.
 
 Only three of the ten are real roots — `tmp`, `uuid`, `extract-zip` — and the
 rest are ancestors npm flags for depending on them. `tmp` and `uuid` have fixed
@@ -239,9 +259,16 @@ never enters our lockfiles, so the alert would go green. But the action ships
 moving a finding out of view rather than fixing it, which is the practice
 `CLAIMS.md` exists to prevent. Rejected on those grounds, not on effort.
 
-**Conclusion: genuinely blocked upstream.** Revisit when `extract-zip` ships a
-release above 2.0.1, or when lighthouse-ci drops it. At that point `overrides`
-plus a hash-pinned local install closes this cleanly and honestly.
+**Conclusion: genuinely blocked upstream.** Recheck with
+`npm view extract-zip version` — while that returns `2.0.1`, nothing here has
+changed. When it goes above 2.0.1 (or lighthouse-ci drops the dependency), the
+close is: add `.github/deps/lhci/{package.json,package-lock.json}` carrying
+`@lhci/cli` plus the `overrides` above, install it with
+`npm ci --prefix .github/deps/lhci`, and call
+`.github/deps/lhci/node_modules/.bin/lhci` — the same shape
+`.github/deps/cyclonedx/` already uses. Verify with
+`gh workflow run lighthouse.yml --ref <branch>` before merging; the job is
+`workflow_dispatch`-triggered, so it can be exercised on a branch.
 
 ### 7. SAST: 9 → 10 · **+0.06** · a judgement call
 


### PR DESCRIPTION
Answers "why not just use `overrides`?" for Scorecard alert #1304, with measurements rather than assertion, so it does not get re-litigated.

## `overrides` — helps, cannot close it

| tree | advisories |
| --- | ---: |
| `@lhci/cli@0.15.1` | 10 |
| `+ overrides: { tmp: 0.2.7, uuid: 11.1.1 }` | **6** |

Only **three** of the ten are real roots — `tmp`, `uuid`, `extract-zip`. The other seven are ancestors npm flags for depending on them.

`tmp` (0.2.7) and `uuid` (11.1.1+) have fixed releases. **`extract-zip` does not** — the advisory is `<=2.0.1` and **2.0.1 is the latest published version**. An override can only redirect to a version that exists, so those 6 are unreachable.

Six high findings is still a worse trade than the one medium alert it would close.

Worth recording on its own: `npm audit` reports the fix as `@lhci/cli@0.1.0 [MAJOR]` — a downgrade to a 2019 release. That is npm failing to resolve in-range, not evidence no fix exists, and it is why the original "no version avoids them" needed checking properly instead of being taken at face value.

## SHA-pinned `treosh/lighthouse-ci-action` — rejected on principle

It would turn the alert green: Scorecard counts a hash-pinned action as pinned, and the action's tree never enters our lockfiles.

But the action ships `@lhci/cli: ^0.15.1` — the same version, carrying the same unfixable `extract-zip` advisory, relocated somewhere the scanner does not look. Identical exposure, better score. That is precisely the practice `CLAIMS.md` exists to prevent, so it is rejected on those grounds rather than on effort.

(My earlier note said this was "not done because it is unverifiable in review". That was wrong on the facts — `lighthouse.yml` has `workflow_dispatch`, so it *is* verifiable on a branch. The real objection is the one above.)

## Conclusion

Genuinely blocked upstream. Revisit when `extract-zip` ships above 2.0.1, or lighthouse-ci drops it — at which point `overrides` plus a hash-pinned local install closes this cleanly.

Docs only; no workflow or package changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security documentation with the status of the remaining Lighthouse CI dependency alerts.
  * Documented evaluated mitigation options and their limitations.
  * Classified the issue as blocked pending an upstream fix or removal of the affected dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->