### PR TITLE
chore(workspace): add the missing changeset for the two React rule fixes

### DIFF
--- a/.changeset/react-rules-evidence-2026-08-15.md
+++ b/.changeset/react-rules-evidence-2026-08-15.md
@@ -1,0 +1,31 @@
+---
+'eslint-plugin-react-features': minor
+'eslint-plugin-react-a11y': minor
+---
+
+Two React rules now judge evidence rather than names.
+
+**`display-name`** reported every component. `hasDisplayNameInScope()` returned a
+hardcoded `false` under a comment reading "For now, always require explicit
+displayName", so `function Profile() {}` and `const Profile = () => {}` were both
+findings — in a codebase where every component is named, that is every component.
+React reads the display name off `Function.name` / `Class.name`, so those are
+already named and there was nothing to fix.
+
+It now reports the three shapes React genuinely cannot name: an anonymous
+`export default`, an anonymous class component, and `memo`/`forwardRef` with no
+binding to take a name from. Wrapper calls are walked through, so
+`const Row = memo(forwardRef(fn))` stays quiet. Measured at 4 of 67 files on the
+benchmark's safe corpus before the fix, all four this defect.
+
+If you were suppressing this rule because of the noise, it is worth re-enabling.
+
+**`alt-text`** now resolves `next/image` from its **import** rather than requiring
+`{ img: ['Image'] }` — a default nobody sets, on the framework most likely to need
+it. A renamed default import (`import Pic from 'next/image'`) is caught;
+`next/legacy/image` and `next/future/image` too. A same-named `<Image>` from an
+unrelated package is not, and neither is `getImageProps` aliased to `Image`, which
+returns props rather than rendering.
+
+This is new detection: expect findings on Next.js images that were previously
+invisible.


### PR DESCRIPTION
## Summary

- `eslint-plugin-react-features` and `eslint-plugin-react-a11y` both changed rule behaviour in #563 and neither had a changeset. Release PR #564 therefore bumps six packages and not these two.

Without this the fixes sit on `main` and never reach npm. The failure mode is silent: the release pipeline succeeds and simply publishes less than you expect.

| Rule | Change | Bump |
|---|---|---|
| `react-features/display-name` | Reported **every** component — `hasDisplayNameInScope()` returned a hardcoded `false`. Now reports only what React genuinely cannot name. | minor |
| `react-a11y/alt-text` | Resolves `next/image` from its import instead of requiring `{ img: ['Image'] }`. New detection. | minor |

## Test plan

- [x] `npx changeset status` — both packages now listed under "Packages to be bumped at minor"
- [x] Verified both rule changes are on `main` (`16274468`, `42bf9ade`, squashed into `20b22aab`)

## After merge

#564 refreshes to include both packages. Watch that `eslint-plugin-react-features` and `eslint-plugin-react-a11y` appear in its version bumps before merging the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `display-name` reporting to flag only genuinely unnameable component forms.
  * Improved `alt-text` handling for supported Next.js image imports, including renamed default imports.
  * Prevented unrelated components and `getImageProps` aliases from being incorrectly reported.

* **Documentation**
  * Added release notes for the updated React ESLint rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->