### PR TITLE
chore(docs): refresh plugin-stats for the published versions, superseding #569

### DIFF
--- a/apps/docs/src/data/plugin-stats.json
+++ b/apps/docs/src/data/plugin-stats.json
@@ -5,7 +5,7 @@
       "rules": 46,
       "description": "ESLint plugin for browser security — detects DOM XSS, postMessage abuse, tokens in localStorage, insecure cookies, clickjacking, mixed content, and CSP gaps",
       "category": "security",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "published": true
     },
     {
@@ -13,7 +13,7 @@
       "rules": 42,
       "description": "ESLint plugin for Node.js security — detects command injection, path traversal, SSRF, zip slip, and weak crypto (MD5/SHA-1, ECB, static IV) in fs, child_process, vm, and crypto",
       "category": "security",
-      "version": "4.13.0",
+      "version": "4.13.1",
       "published": true
     },
     {
@@ -21,7 +21,7 @@
       "rules": 33,
       "description": "ESLint plugin for secure coding — detects LDAP, XPath, XXE, GraphQL and template injection, unsafe deserialization, ReDoS, missing authentication, and PII in logs",
       "category": "security",
-      "version": "4.2.0",
+      "version": "4.3.0",
       "published": true
     },
     {
@@ -45,7 +45,7 @@
       "rules": 13,
       "description": "ESLint plugin for JWT security — detects algorithm confusion (CVE-2022-23540), alg:none, weak or hardcoded secrets, and decode-without-verify",
       "category": "security",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "published": true
     },
     {
@@ -149,7 +149,7 @@
       "rules": 28,
       "description": "ESLint plugin for Express.js security — detects permissive CORS, missing CSRF protection, missing helmet headers, insecure cookies, and GraphQL introspection in production",
       "category": "framework",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "published": true
     },
     {
@@ -229,7 +229,7 @@
       "rules": 61,
       "description": "ESLint plugin for React — hooks, prop-types, JSX correctness, render performance, and class-to-hooks migration rules for modern React codebases",
       "category": "react",
-      "version": "1.2.12",
+      "version": "1.3.0",
       "published": true
     },
     {
@@ -237,12 +237,12 @@
       "rules": 37,
       "description": "ESLint plugin for React accessibility — WCAG 2.1 rules for ARIA, alt text, keyboard interaction, and focus management, with auto-fixes",
       "category": "react",
-      "version": "2.1.15",
+      "version": "2.2.0",
       "published": true
     }
   ],
   "totalRules": 477,
   "totalPlugins": 30,
   "allPluginsCount": 30,
-  "generatedAt": "2026-08-14"
+  "generatedAt": "2026-08-16"
 }


### PR DESCRIPTION
## Summary

The docs homepage reads `plugin-stats.json` for each plugin's published version, and it still showed pre-release numbers. Regenerated against what npm now serves:

| Package | Version |
|---|---|
| `eslint-plugin-browser-security` | 1.4.1 |
| `eslint-plugin-node-security` | 4.13.1 |
| `eslint-plugin-secure-coding` | 4.3.0 |
| `eslint-plugin-jwt-security` | 3.0.1 |
| `eslint-plugin-express-security` | 3.1.1 |
| `eslint-plugin-react-features` | 1.3.0 |
| `eslint-plugin-react-a11y` | 2.2.0 |

## Why not just merge #569

#569 contains the same change and **cannot** merge. It was opened by `github-actions` using `GITHUB_TOKEN`, which by design does not trigger workflow runs — so its required checks never report and it sits `BLOCKED` with **zero** checks. Same reason #561 was closed earlier today.

## The pattern is now three-for-three today

1. **#561** — closed, unmergeable, work redone by hand
2. **#564** (release) — needed manual approval of its runs **twice**, because each force-push re-armed `action_required`
3. **#569** — this one

Fixing the token on the workflows that open these PRs (a PAT or GitHub App token instead of `GITHUB_TOKEN`) ends all three. #568 only stopped the review job going red on bot PRs; it does not make their checks run.

## Test plan

- [x] `turbo run test --filter=docs` — 20/20
- [x] Diff is exactly the eight version strings; rule counts unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin metadata to reflect the latest versions across security, React, accessibility, JWT, and Express plugins.
  * Refreshed the generated timestamp.
  * Plugin totals and counts remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->