### PR TITLE
ci(workspace): make the docs-data sync PR actually mergeable, and self-merging

### DIFF
--- a/.github/workflows/docs-data.yml
+++ b/.github/workflows/docs-data.yml
@@ -46,6 +46,16 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
+          # The push below has to use the same token the PR is opened with.
+          # `actions/checkout` persists whatever it is given into the local git
+          # config, defaulting to `github.token` — so setting GH_TOKEN for the
+          # `gh` CLI alone is not enough: `git push` would still authenticate as
+          # GITHUB_TOKEN, the resulting `synchronize` event would fire no
+          # workflows, and the PR's checks would go stale on every run after the
+          # first. `--auto` then has nothing to merge on. Needs `contents: write`
+          # on whichever PAT resolves; without one this falls back to
+          # `github.token` and behaves exactly as it does today.
+          token: ${{ secrets.RELEASE_BOT_PAT || secrets.AGENTS_REPO_PAT || github.token }}
       - uses: ./.github/actions/setup
         with:
           turbo-cache: "false"
@@ -86,12 +96,14 @@ jobs:
       # Reuses one branch, so repeated runs update a single open PR rather than
       # opening one per push to main.
       #
-      # Opened with a PAT and set to auto-merge, because `github.token` made the
-      # PR unmergeable BY DESIGN: GitHub does not fire `on: pull_request`
-      # workflows for a PR created with GITHUB_TOKEN, so the required contexts
-      # never reported and the PR sat `BLOCKED` with ZERO checks forever. That
-      # is the same failure the note above describes, one step later — the sync
-      # succeeded, and its output was discarded anyway.
+      # Opened with a PAT where one is configured, and set to auto-merge,
+      # because `github.token` made the PR unmergeable BY DESIGN: GitHub does
+      # not fire `on: pull_request` workflows for a PR created with
+      # GITHUB_TOKEN, so the required contexts never reported and the PR sat
+      # `BLOCKED` with ZERO checks forever. That is the same failure the note
+      # above describes, one step later — the sync succeeded, and its output was
+      # discarded anyway. With no PAT set, every line here still works and the
+      # old behaviour returns; nothing depends on the fallback being a PAT.
       #
       # This is NOT the bypass token the note rejects. Nothing about branch
       # protection changes: the PR still runs every required check and still has
@@ -141,14 +153,31 @@ jobs:
           git commit -m "chore(docs): sync data [automated]"
           git push --force-with-lease="$BRANCH:$LEASE" origin "$BRANCH"
 
-          PR=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[].number')
+          # `--base main --limit 1` and `.[0].number // empty`: a bare
+          # `--head "$BRANCH"` lookup does not filter by base and can return
+          # several numbers, which would put a multi-line value into $PR and make
+          # every later `gh pr` call nonsense.
+          find_pr() {
+            gh pr list --head "$BRANCH" --base main --state open --limit 1 \
+              --json number --jq '.[0].number // empty'
+          }
+
+          PR=$(find_pr)
           if [ -n "$PR" ]; then
             echo "Existing PR #$PR updated with the new sync commit."
           else
             gh pr create --base main --head "$BRANCH" \
               --title "chore(docs): sync generated data" \
               --body "Regenerated apps/docs/src/data/ (trigger: $TRIGGER). Opened by the Docs Data Sync workflow; contents come entirely from the apps/docs/scripts/sync-* scripts, so review the diff rather than hand-editing."
-            PR=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[].number')
+            PR=$(find_pr)
+          fi
+
+          # Fail loudly rather than carrying an empty $PR into `gh pr merge`,
+          # where it would be swallowed by the `|| echo` below and reported as a
+          # successful sync that quietly enabled nothing.
+          if [ -z "$PR" ]; then
+            echo "::error::Pushed $BRANCH but could not resolve its PR number."
+            exit 1
           fi
 
           # Idempotent: re-asserting auto-merge on every run is harmless, and it

--- a/.github/workflows/docs-data.yml
+++ b/.github/workflows/docs-data.yml
@@ -85,9 +85,22 @@ jobs:
       #
       # Reuses one branch, so repeated runs update a single open PR rather than
       # opening one per push to main.
+      #
+      # Opened with a PAT and set to auto-merge, because `github.token` made the
+      # PR unmergeable BY DESIGN: GitHub does not fire `on: pull_request`
+      # workflows for a PR created with GITHUB_TOKEN, so the required contexts
+      # never reported and the PR sat `BLOCKED` with ZERO checks forever. That
+      # is the same failure the note above describes, one step later — the sync
+      # succeeded, and its output was discarded anyway.
+      #
+      # This is NOT the bypass token the note rejects. Nothing about branch
+      # protection changes: the PR still runs every required check and still has
+      # to go green. The PAT only makes those checks RUN, and `--auto` merges the
+      # PR once they pass so nobody has to babysit a diff of generated JSON.
+      # `changesets-pr.yml` already uses exactly this pattern.
       - name: Open sync PR
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_BOT_PAT || secrets.AGENTS_REPO_PAT || github.token }}
           BRANCH: automated/docs-data-sync
           # Passed through env rather than interpolated into the script body —
           # `${{ }}` inside `run:` is substituted before the shell sees it, so
@@ -128,10 +141,19 @@ jobs:
           git commit -m "chore(docs): sync data [automated]"
           git push --force-with-lease="$BRANCH:$LEASE" origin "$BRANCH"
 
-          if [ -n "$(gh pr list --head "$BRANCH" --state open --json number --jq '.[].number')" ]; then
-            echo "Existing PR updated with the new sync commit."
+          PR=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[].number')
+          if [ -n "$PR" ]; then
+            echo "Existing PR #$PR updated with the new sync commit."
           else
             gh pr create --base main --head "$BRANCH" \
               --title "chore(docs): sync generated data" \
               --body "Regenerated apps/docs/src/data/ (trigger: $TRIGGER). Opened by the Docs Data Sync workflow; contents come entirely from the apps/docs/scripts/sync-* scripts, so review the diff rather than hand-editing."
+            PR=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[].number')
           fi
+
+          # Idempotent: re-asserting auto-merge on every run is harmless, and it
+          # re-arms the PR after a force-push resets its checks. Failure here is
+          # not fatal -- the PR still exists and can be merged by hand.
+          gh pr merge "$PR" --auto --squash || \
+            echo "::warning::Could not enable auto-merge on #$PR; merge it manually."
+


### PR DESCRIPTION
## The actual problem

The sync PR **could never merge**. It is opened with `github.token`, and GitHub does not fire `on: pull_request` workflows for a PR created with `GITHUB_TOKEN` — so its required contexts never report and it sits `BLOCKED` with **zero** checks indefinitely.

#561 and #569 both died this way today. Both had to be regenerated by hand on a human branch and closed.

That is the same failure the existing comment in this file describes (`git push` to main → `GH006` → data thrown away), just one step later: the sync succeeds and its output is discarded anyway.

## This is not the bypass token that comment rejects

> *"A bot token that bypasses protection would clear the red X by punching a hole in the rule instead."*

Agreed, and nothing about branch protection changes here. The PR still runs every required check and still has to go green. The PAT only makes those checks **run**. `--auto` merges it once they pass.

`changesets-pr.yml` already uses this exact pattern.

## Also

- Auto-merge is re-asserted on **every** run, not just at creation — a force-push resets the PR's checks and disarms it.
- Failure to set auto-merge is a `::warning::`, not an error; the PR still exists and merges by hand.

## On the trigger

Worth saying explicitly: it is **not** a daily schedule. It is `push to main on packages/**`, so it fires when a plugin actually changes. It felt daily because today was a release day.

## Test plan

- [x] `npm run lint:workflows` — 34 files pass
- [x] YAML parses
- [x] Token falls through `RELEASE_BOT_PAT → AGENTS_REPO_PAT → github.token`, so it degrades to today's behaviour if no PAT resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated documentation synchronization checks for generated pull requests.
  * Re-enabled automatic squash merging after successful synchronization.
  * Added graceful handling when automatic merging cannot be enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->