### PR TITLE
fix(node-security): stop calling a shell-free spawn "command injection"

### DIFF
--- a/.agent/codeql-open-findings.md
+++ b/.agent/codeql-open-findings.md
@@ -17,37 +17,44 @@ CodeQL calls it a polynomial ReDoS. So does `recheck` — **2nd degree
 polynomial**, which matters because `recheck` is the oracle our own
 `no-redos-vulnerable-regex` consults.
 
-**Our own rule does not report it.** That is not a tuning gap, it is structural:
-the oracle may only ever REMOVE a finding, so the rule's recall is bounded by
-`scslre`, and anything scslre misses the oracle never gets asked about. We have
-a second opinion wired to veto and not to contribute.
+**Our own rule does not report it**, and the reason I first gave was wrong.
 
-That is the finding worth keeping from this batch, and it is a design question
-for the rule rather than a defect in these three files:
-
-- Letting the oracle ADD findings would catch this class, at whatever precision
-  cost `recheck`'s own false positives carry — unmeasured.
-- Keeping it veto-only holds precision and accepts the recall bound.
-
-Either way it should be a decision with a number attached, not an accident.
-
-### Why the three files are not being rewritten today
-
-The obvious linear rewrite is not one. Measured:
+I wrote that the oracle "may only ever REMOVE a finding, so recall is bounded by
+`scslre`". Measured 2026-08-20 against the RULE rather than the analyser it is
+built on, over all 2,136 regex literals in `packages/*/src` (730 re-embeddable
+in a probe file; the rest do not survive extraction, a limit of the harness, not
+the rule):
 
 ```
-  before   vulnerable   2nd degree polynomial
-  after    vulnerable   2nd degree polynomial     (classic /\*[^*]*\*+(?:[^/*][^*]*\*+)*\/ form)
-  6/6 identical output on the shapes these rules parse
+  the rule reports                    9
+  recheck says vulnerable            41
+  vulnerable, rule silent            32   = 31 polynomial deg 2 + 1 deg 3
+                                          + ZERO exponential
 ```
 
-Both forms carry the same verdict, so the rewrite buys nothing but churn. And
-the threat model is narrow: the "attacker input" is source code being linted,
-so the worst case is a developer slowing their own build with their own file.
-Timed at 16,000 repetitions of the trigger, the current pattern costs 0.1 ms.
+Zero exponential missed. The rule's own correction layers —
+`relaxBoundedRangesUnderUnboundedQuantifier` and `isProvablyCatastrophic` —
+already recover the cases scslre clears, including `/^([a-zA-Z0-9]{2,4})+$/`,
+which my first measurement listed as missed because that measurement ran raw
+scslre + recheck and never ran the rule. Measuring a reduction of the thing and
+reporting on the thing is the error this repo has a memory about; it recurred
+here.
 
-Real, low-actionability, and recorded — which is exactly the effective-FP
-category the seal record already lists as unmet for the ReDoS rule.
+So the recall gap is not structural and not exponential. It is 31 second-degree
+polynomials of the shape `/\s*,\s*/` and `/\s+\|/g`, plus one third-degree
+identifier matcher. Reporting those would be the `effectiveFp` failure the seal
+record already records as unmet.
+
+**And the veto-only wiring is not a defect to fix — it is load-bearing.**
+`recheck` is an OPTIONAL peer (`peerDependenciesMeta.recheck.optional`). If the
+oracle could add findings, installing an unrelated optional package would change
+whether a build passes. `confirmsRedos` fails open precisely so the oracle can
+only ever subtract. Making it contribute requires promoting `recheck` to a hard
+dependency first; that is a supply-chain decision, not a rule change.
+
+Disposition: **no change**. SQL_COMMENTS is deg-2, so it stays unreported, which
+agrees with the separate measurement that its textbook "linear" rewrite carries
+the identical deg-2 verdict on identical output.
 
 ## The rest
 

--- a/.changeset/child-process-says-which-defect.md
+++ b/.changeset/child-process-says-which-defect.md
@@ -1,0 +1,27 @@
+---
+'eslint-plugin-node-security': minor
+---
+
+`detect-child-process` no longer calls a shell-free spawn "command injection".
+
+`spawn`, `execFile` and `fork` default to `{ shell: false }`. When the executable
+name is attacker-steerable the defect is real, but it is process control, not
+shell-metacharacter injection — and the rule reported it as CWE-78 at CVSS 9.8
+with the advice *"use execFile/spawn with `{shell: false}`"*, which is what the
+reported line already did. Remediation that is a no-op on the line it is attached
+to is a finding nobody can act on.
+
+Measured against eslint-plugin-security's own `valid` corpus, this fired on 11 of
+their 19 valid cases for this class — the single largest source of our findings
+on code a competitor labelled clean.
+
+Those findings now report **`untrustedProgram`** — CWE-114, HIGH — whose fix is
+to resolve the name against an allowlist of permitted executables. Nothing
+becomes silent and nothing new is reported: the same calls report, saying what is
+actually true about them. `exec`/`execSync`, an explicit `shell: true`, a literal
+shell binary (`spawn('bash', ['-c', …])`) and eval flags (`-c`, `-e`, `/c`) all
+still report CWE-78, because a shell really is in the picture.
+
+If you match on `messageId`, add `untrustedProgram` alongside
+`childProcessCommandInjection`. The rule's own docs already described this split
+correctly — the code was the half that disagreed.

--- a/apps/docs/content/docs/security/plugin-node-security/rules/detect-child-process.mdx
+++ b/apps/docs/content/docs/security/plugin-node-security/rules/detect-child-process.mdx
@@ -79,9 +79,20 @@ flowchart TD
 
 ### Two different findings
 
-The rule reports **two distinct defects**, and it is worth knowing which one you are looking at because the fixes differ.
+The rule reports **three distinct defects**, and it is worth knowing which one you are looking at because the fixes differ.
 
 **CWE-78 — command injection (`childProcessCommandInjection`).** A shell sits between your command and the OS, so an attacker-steered value can start a *second* process with `;`, `|`, backticks or `$()`. This needs `exec`/`execSync`, an explicit `shell: true`, a shell binary (`sh`, `bash`, `cmd`, …), or an eval flag (`-c`, `-e`, `/c`). The fix is to remove the shell.
+
+**CWE-114 — untrusted program (`untrustedProgram`).** No shell runs, so metacharacters are inert, but the *executable name itself* is attacker-steerable — they choose which program starts:
+
+```typescript
+spawn(req.body.cmd, ['--version']);
+// cmd = "curl"  → whatever they name, with your process's privileges
+```
+
+Removing the shell does not help; there is no shell. Resolve the name against a fixed allowlist of permitted executables instead.
+
+Before 2026-08-20 these were reported as CWE-78 at CVSS 9.8, carrying the advice *"use execFile/spawn with `{shell: false}`"* — which the reported line already did. Remediation that is a no-op on the line it is attached to is a finding nobody can act on; it fired on 11 of the 19 `valid` cases in eslint-plugin-security's own corpus for this class.
 
 **CWE-88 — argument injection (`argumentInjection`).** No shell is involved and no second process can start, but the callee still parses its *own* options. An attacker-steered argv entry that begins with `-` becomes a flag:
 

--- a/packages/eslint-plugin-node-security/docs/rules/detect-child-process.md
+++ b/packages/eslint-plugin-node-security/docs/rules/detect-child-process.md
@@ -77,9 +77,20 @@ flowchart TD
 
 ### Two different findings
 
-The rule reports **two distinct defects**, and it is worth knowing which one you are looking at because the fixes differ.
+The rule reports **three distinct defects**, and it is worth knowing which one you are looking at because the fixes differ.
 
 **CWE-78 — command injection (`childProcessCommandInjection`).** A shell sits between your command and the OS, so an attacker-steered value can start a *second* process with `;`, `|`, backticks or `$()`. This needs `exec`/`execSync`, an explicit `shell: true`, a shell binary (`sh`, `bash`, `cmd`, …), or an eval flag (`-c`, `-e`, `/c`). The fix is to remove the shell.
+
+**CWE-114 — untrusted program (`untrustedProgram`).** No shell runs, so metacharacters are inert, but the *executable name itself* is attacker-steerable — they choose which program starts:
+
+```typescript
+spawn(req.body.cmd, ['--version']);
+// cmd = "curl"  → whatever they name, with your process's privileges
+```
+
+Removing the shell does not help; there is no shell. Resolve the name against a fixed allowlist of permitted executables instead.
+
+Before 2026-08-20 these were reported as CWE-78 at CVSS 9.8, carrying the advice *"use execFile/spawn with `{shell: false}`"* — which the reported line already did. Remediation that is a no-op on the line it is attached to is a finding nobody can act on; it fired on 11 of the 19 `valid` cases in eslint-plugin-security's own corpus for this class.
 
 **CWE-88 — argument injection (`argumentInjection`).** No shell is involved and no second process can start, but the callee still parses its *own* options. An attacker-steered argv entry that begins with `-` becomes a flag:
 

--- a/packages/eslint-plugin-node-security/src/rules/detect-child-process/detect-child-process.test.ts
+++ b/packages/eslint-plugin-node-security/src/rules/detect-child-process/detect-child-process.test.ts
@@ -131,7 +131,7 @@ describe('detect-child-process', () => {
         {
           code: 'child_process.spawn(userCommand, args);',
           options: UNRESOLVED,
-          errors: [{ messageId: 'childProcessCommandInjection' }],
+          errors: [{ messageId: 'untrustedProgram' }],
         },
         {
           code: 'child_process.spawnSync("sh", ["-c", userInput]);',
@@ -207,19 +207,19 @@ describe('detect-child-process', () => {
         {
           code: 'child_process.execFileSync(userCommand, args);',
           options: UNRESOLVED,
-          errors: [{ messageId: 'childProcessCommandInjection' }],
+          errors: [{ messageId: 'untrustedProgram' }],
         },
         // Test with fork to trigger default case
         {
           code: 'child_process.fork(userScript);',
           options: UNRESOLVED,
-          errors: [{ messageId: 'childProcessCommandInjection' }],
+          errors: [{ messageId: 'untrustedProgram' }],
         },
         // Test with forkSync to trigger forkSync case in generateRefactoringSteps (lines 429-438)
         {
           code: 'child_process.forkSync(userScript);',
           options: UNRESOLVED,
-          errors: [{ messageId: 'childProcessCommandInjection' }],
+          errors: [{ messageId: 'untrustedProgram' }],
         },
       ],
     });
@@ -303,7 +303,7 @@ describe('detect-child-process', () => {
             execFile(userCommand, ['--version'], callback);
           `,
           options: UNRESOLVED,
-          errors: [{ messageId: 'childProcessCommandInjection' }],
+          errors: [{ messageId: 'untrustedProgram' }],
         },
         {
           code: `
@@ -424,7 +424,7 @@ describe('detect-child-process — coverage completion', () => {
         {
           code: `const { doExec } = require('child_process'); doExec(userInput);`,
           options: [{ additionalMethods: ['doExec'], reportUnresolvedCommands: true }],
-          errors: [{ messageId: 'childProcessCommandInjection' }],
+          errors: [{ messageId: 'untrustedProgram' }],
         },
       ],
     });
@@ -746,7 +746,11 @@ describe('detect-child-process — coverage completion', () => {
         {
           code: `const { spawn } = require('child_process');
                  app.post('/run', (req) => spawn(req.body.cmd, ['--version']));`,
-          errors: [{ messageId: 'childProcessCommandInjection' }],
+          // CWE-114, not CWE-78: `spawn` runs no shell, so there are no
+          // metacharacters to interpret — the request simply names the program.
+          // The old CWE-78 message advised "use spawn with {shell: false}",
+          // which this line already does.
+          errors: [{ messageId: 'untrustedProgram' }],
         },
       ],
     });

--- a/packages/eslint-plugin-node-security/src/rules/detect-child-process/index.ts
+++ b/packages/eslint-plugin-node-security/src/rules/detect-child-process/index.ts
@@ -22,7 +22,7 @@ import { makeReadsTaintSource } from '../../utils/provenance';
  * here, alongside a `strategy: 'validate' | 'sanitize' | 'restrict' | 'auto'`
  * option meant to select between them. Neither half was ever finished:
  * `create()` never read `strategy`, and every `context.report` in this file
- * names one of the two messages below.
+ * names one of the three messages below.
  *
  * Not wired up, and deliberately so. The sibling `detect-eval-with-expression`
  * does implement the same shape, which is presumably where this was copied
@@ -30,11 +30,12 @@ import { makeReadsTaintSource } from '../../utils/provenance';
  * REPLACE a CRITICAL CWE-78 "Command injection" or a HIGH CWE-88 "Argument
  * injection" with a severity-LOW "Validate Strategy" carrying no CWE and no
  * description of what was found. Emitting them would downgrade every finding
- * this rule makes. The advice they held is already the `fix:` line of the two
+ * this rule makes. The advice they held is already the `fix:` line of the three
  * that fire.
  */
 type MessageIds =
   | 'childProcessCommandInjection'
+  | 'untrustedProgram'
   | 'argumentInjection';
 
 export interface Options {
@@ -342,6 +343,31 @@ export const detectChildProcess = createRule<RuleOptions, MessageIds>({
         severity: 'CRITICAL',
         fix: 'Use execFile/spawn with {shell: false} and array args',
         documentationLink: 'https://owasp.org/www-community/attacks/Command_Injection',
+      }),
+      /**
+       * No shell was invoked, so this is not CWE-78.
+       *
+       * `spawn`/`execFile` default to `{ shell: false }`. When the BINARY is
+       * attacker-steerable the defect is real — the caller chooses which program
+       * runs — but that is process control, not shell-metacharacter injection,
+       * and the two need different advice.
+       *
+       * Measured 2026-08-20 against eslint-plugin-security's own `valid` corpus:
+       * `spawn(str)` drew `childProcessCommandInjection` at CVSS 9.8, telling
+       * the reader to "use execFile/spawn with {shell: false}" — which is what
+       * the reported line already does. Remediation that is a no-op on the line
+       * it is attached to is a finding no developer can act on, and it fired on
+       * 11 of their 19 valid cases for this class.
+       */
+      untrustedProgram: formatLLMMessage({
+        icon: MessageIcons.SECURITY,
+        issueName: 'Untrusted program',
+        cwe: 'CWE-114',
+        description:
+          'The executable name is attacker-steerable. No shell runs here, so metacharacters are inert — but the caller still chooses which program executes.',
+        severity: 'HIGH',
+        fix: 'Resolve the name against a fixed allowlist of permitted executables before spawning it.',
+        documentationLink: 'https://cwe.mitre.org/data/definitions/114.html',
       }),
       argumentInjection: formatLLMMessage({
         icon: MessageIcons.SECURITY,
@@ -1226,9 +1252,11 @@ export const detectChildProcess = createRule<RuleOptions, MessageIds>({
       const steps = pattern ? generateRefactoringSteps(pattern) : 'Review and secure command execution';
       const alternatives = pattern?.safeAlternatives.join(', ') || 'execFile, spawn with validation'; 
 
+      // CWE-78 is a claim about a SHELL parsing metacharacters. Make it only
+      // when a shell is actually in the picture; otherwise say what is true.
       context.report({
         node,
-        messageId: 'childProcessCommandInjection',
+        messageId: usesShell(node, method) ? 'childProcessCommandInjection' : 'untrustedProgram',
         data: {
           method,
           args,


### PR DESCRIPTION
## What

`spawn`/`execFile`/`fork` default to `{ shell: false }`. When the executable name is attacker-steerable that is a real defect — the caller picks which program runs — but it is **process control (CWE-114)**, not shell-metacharacter injection (CWE-78).

The rule reported it as CWE-78 at CVSS 9.8 with this advice:

> Fix: Use execFile/spawn with `{shell: false}` and array args

…on a line that already does exactly that. **Remediation that is a no-op on its own line is a finding nobody can act on** — the `effectiveFp` axis that `SEAL.json` records as unmet on all 94 rules.

## Evidence

Measured against `eslint-plugin-security`'s own `valid` corpus (their definition of a true negative, so we can't be accused of a flattering corpus): this fired on **11 of their 19 valid cases** for this class — the largest single source of our findings on code a competitor labelled clean.

## What changed

New messageId `untrustedProgram` (CWE-114, HIGH), whose fix is *"resolve the name against a fixed allowlist of permitted executables"*.

Routed on the **existing** `usesShell` predicate, so these all keep reporting CWE-78:

- `exec` / `execSync`
- explicit `{ shell: true }`
- a literal shell binary — `spawn('bash', ['-c', req.body.script])`
- eval flags — `execFile('node', ['-e', src])`

**Nothing goes silent, and nothing new fires.** The same calls report; they now say what is true about them.

The rule's own docs already described this split correctly. The code was the half that disagreed.

## Verification

- The 7 moved expectations are a **lock, not agreement**: reverting the routing turns all 7 red.
- `usesShell` does not infer from the method name, so `doExec` (unknown method) correctly receives the weaker claim rather than CWE-78.
- Package suite **2688 passing**, **100%** statements and branches, `tsc` clean.

## Not claimed

This does **not** reduce how often the rule fires — parity `fires-on-valid` stays at 11/19, because that harness scores *whether* a rule fired, not what it said. Whether an unresolvable free-variable command should report at all under default options is the separate `effectiveFp` question, still open.

## Incidental finding

`scripts/sync-rule-docs.ts` writes to an IA that does not match the committed `apps/docs` tree — running it produced 10 untracked directories and left the live page stale. The `.mdx` here was updated from the `.md` SSOT by hand. The generator's target path is its own defect, filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)