### PR TITLE
fix(reliability): see through chained assignment and require()

### DIFF
--- a/.changeset/null-checks-sees-module-values.md
+++ b/.changeset/null-checks-sees-module-values.md
@@ -1,0 +1,28 @@
+---
+'eslint-plugin-reliability': patch
+---
+
+`no-missing-null-checks` now sees through two initialiser shapes it already
+handles when written differently.
+
+```js
+var pets = exports.pets = [];   // the init is the ASSIGNMENT, not the array
+const u = require('u');         // the CommonJS twin of `import u from 'u'`
+```
+
+The first meant the array literal two tokens away was never inspected, so every
+later use of `pets` drew a CWE-476 report. The second is the twin of the
+`ImportBinding` case the rule already exempts — and a failed `require` *throws*,
+it does not evaluate to null, so a module object is at least as non-null as an
+ESM import binding.
+
+`require` is resolved as a binding, not matched by spelling: a locally-declared
+`require` is a different function with no such contract, and still reports. Only
+plain `=` chains are unwrapped, because `||=` and `??=` can evaluate to the left
+operand.
+
+**Scope, honestly:** measured over the 20-repository corpus, this removed 2,977
+of 29,814 findings across 4,000 files — **10%**. This rule is 56% of everything
+`recommended` reports across all 30 plugins, and these two bugs are not why. The
+remaining volume is the rule reporting any member access it cannot prove
+non-null, which in untyped JavaScript is most member accesses.

--- a/packages/eslint-plugin-reliability/src/rules/reliability/no-missing-null-checks.ts
+++ b/packages/eslint-plugin-reliability/src/rules/reliability/no-missing-null-checks.ts
@@ -73,6 +73,41 @@ const NEVER_NULL_GLOBALS = new Set<string>([
  *
  * For these, the rule should not demand a null check.
  */
+/** Is `name` declared anywhere in this scope chain? Used to tell the global
+ * `require` from a local one that happens to share the spelling. */
+function scopeHasBinding(scope: TSESLint.Scope.Scope | null, name: string): boolean {
+  for (let s = scope; s; s = s.upper) {
+    if (s.variables.some((v) => v.name === name)) return true;
+  }
+  return false;
+}
+
+/**
+ * The value a declarator actually receives, through any chain of `=`.
+ *
+ * `var pets = exports.pets = []` is the ordinary CommonJS re-export idiom, and
+ * the declarator's `init` for it is the ASSIGNMENT, not the array. None of the
+ * non-null initialiser checks below match an AssignmentExpression, so every
+ * later use of `pets` fell through to a CWE-476 report — on a value that is
+ * demonstrably an array literal two tokens away.
+ *
+ * Measured over the 20-repository corpus, this rule produced 157,699 findings,
+ * 56% of everything `recommended` reports across all 30 plugins. `express`'s
+ * own `examples/mvc/db.js` opens with two of these declarations and draws a
+ * finding on every subsequent line that touches either name.
+ *
+ * Only plain `=` is unwrapped. `a = b ||= c` and `a = b ??= c` can yield the
+ * left operand, so their result is not the right-hand value and they keep the
+ * conservative reading.
+ */
+function assignedValue(init: TSESTree.Expression | null): TSESTree.Expression | null {
+  let current = init;
+  while (current?.type === 'AssignmentExpression' && current.operator === '=') {
+    current = current.right;
+  }
+  return current;
+}
+
 function isProvablyNonNullableIdentifier(
   ident: TSESTree.Identifier,
   scope: TSESLint.Scope.Scope,
@@ -96,7 +131,7 @@ function isProvablyNonNullableIdentifier(
         // sacrificing real CWE-476 detection (genuine null-deref risks come
         // from optional/maybe lookups, not from `const x = []`).
         if (def.type === 'Variable' && def.node?.type === 'VariableDeclarator') {
-          const init = (def.node as TSESTree.VariableDeclarator).init;
+          const init = assignedValue((def.node as TSESTree.VariableDeclarator).init);
           if (!init) continue;
           if (init.type === 'NewExpression') return true;
           if (init.type === 'ArrayExpression') return true;
@@ -115,6 +150,27 @@ function isProvablyNonNullableIdentifier(
             init.argument.type === 'CallExpression' &&
             init.argument.callee.type === 'Identifier' &&
             init.argument.callee.name === 'fetch'
+          ) return true;
+          // `const u = require('u')` — the CommonJS twin of the ImportBinding
+          // case above, which already returns true.
+          //
+          // A module's export object is at LEAST as non-null as an ESM import
+          // binding: a failed `require` throws, it does not evaluate to null.
+          // Handling only `import` meant every CommonJS consumer reported on
+          // every use of every dependency. Measured over 600 files of the
+          // 20-repository corpus, `<local>.prop` on a single dot was 84% of
+          // this rule's findings — and this rule alone was 56% of everything
+          // `recommended` produces across all 30 plugins.
+          //
+          // `require` must be the global. A local binding of that name is a
+          // different function with no such contract, so this resolves the
+          // reference rather than matching the spelling.
+          if (
+            init.type === 'CallExpression' &&
+            init.callee.type === 'Identifier' &&
+            init.callee.name === 'require' &&
+            init.arguments.length > 0 &&
+            !scopeHasBinding(s, 'require')
           ) return true;
           // `JSON.parse(...)` returns a value; typically non-null. Same for
           // common Object/Array static methods.

--- a/packages/eslint-plugin-reliability/src/tests/reliability/null-checks-module-values.test.ts
+++ b/packages/eslint-plugin-reliability/src/tests/reliability/null-checks-module-values.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Two initialiser shapes this rule could not see through.
+ *
+ * Measured 2026-08-20 with `scripts/preset-sweep.mts` over the 20-repository
+ * corpus: this rule produced 157,699 findings — **56% of everything
+ * `recommended` reports across all 30 plugins**, and more than the other 150
+ * firing rules combined. Two shapes accounted for a tenth of it, both of them
+ * values the rule already treats as non-null when written differently:
+ *
+ *   `var pets = exports.pets = []`   the declarator's init is the ASSIGNMENT,
+ *                                    so the array literal two tokens away was
+ *                                    never inspected
+ *   `const u = require('u')`         the CommonJS twin of ImportBinding, which
+ *                                    already returns true. A failed `require`
+ *                                    THROWS; it does not evaluate to null, so a
+ *                                    module object is at least as non-null as
+ *                                    an ESM import binding
+ *
+ * Honest about scope: fixing both removed 2,977 of 29,814 findings over 4,000
+ * corpus files — 10%. The remaining volume is not these bugs. It is the rule
+ * reporting any member access it cannot prove non-null, which in untyped JS is
+ * most member accesses, and that is a question about whether the rule belongs
+ * in `recommended` rather than one more shape to special-case.
+ */
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import parser from '@typescript-eslint/parser';
+import { noMissingNullChecks } from '../../rules/reliability/no-missing-null-checks';
+
+const ruleTester = new RuleTester({
+  languageOptions: { parser, parserOptions: { ecmaVersion: 2022, sourceType: 'module' } },
+});
+
+ruleTester.run('no-missing-null-checks — module values', noMissingNullChecks, {
+  valid: [
+    {
+      name: 'a chained assignment to exports still resolves to the array',
+      code: `var pets = exports.pets = [];\npets.push({ id: 0 });`,
+    },
+    {
+      name: 'a chained assignment to a local resolves too',
+      code: `var a;\nvar pets = a = [];\npets.push({ id: 0 });`,
+    },
+    {
+      name: 'a required module is not null',
+      code: `const u = require('u');\nu.go();`,
+    },
+    {
+      name: 'a required module reached through two dots is not null',
+      code: `const u = require('u');\nconst x = u.a.b;`,
+    },
+    {
+      // CONTROL for the ESM half that already worked, so the two stay aligned.
+      name: 'an imported binding is not null',
+      code: `import u from 'u';\nu.go();`,
+    },
+  ],
+  invalid: [
+    {
+      // FN GUARD: `require` must be THE global. A local function of that name
+      // carries none of the contract, so the spelling alone proves nothing —
+      // this is why the fix resolves the binding instead of matching the name.
+      name: 'a locally-defined require is just a function',
+      code: `function require(x) { return null; }\nconst u = require('u');\nu.go();`,
+      errors: 1,
+    },
+    {
+      // FN GUARD: `||=` can evaluate to the LEFT operand, so the right-hand
+      // value is not necessarily what lands in the binding. Only plain `=`
+      // is unwrapped.
+      name: 'a logical-assignment chain is not unwrapped',
+      code: `let a = null;\nvar pets = a ||= null;\npets.push(1);`,
+      errors: 1,
+    },
+  ],
+});


### PR DESCRIPTION
## Why this rule

`scripts/preset-sweep.mts` over the 20-repository corpus (21,394 files, 3.10M lines):

```
157699  reliability/no-missing-null-checks     <- 56% of ALL findings
 41584  import-next/no-unresolved
 22942  conventions/no-magic-numbers
```

This one rule produces more than the other 150 firing rules combined, and all 98 firing **security** rules together account for 1,326 findings — 0.5%. Anyone installing `recommended` drowns the security signal in this.

## The two shapes

Both are values the rule *already* treats as non-null when written differently:

```js
var pets = exports.pets = [];   // init is the ASSIGNMENT, not the array literal
const u = require('u');         // the CommonJS twin of `import u from 'u'`
```

The first meant the array two tokens away was never inspected. Express's own `examples/mvc/db.js` opens with two of these and drew a finding on every later line touching either name — **11 → 0**.

The second is the twin of the `ImportBinding` case already exempted. A failed `require` **throws**; it does not evaluate to null, so a module object is at least as non-null as an ESM binding.

`require` is resolved through the scope chain, **not matched on the name** — a locally-declared `require` has none of that contract and still reports. Only plain `=` chains are unwrapped, since `||=`/`??=` can evaluate to the left operand. Both pinned as FN guards.

## Scope — this is not the headline fix

| | |
|---|---|
| findings over 4,000 corpus files | **29,814 → 26,837** |
| reduction | **10%** |

I expected much more. The shape clustering says 84% of findings are `<local>.prop`, but most of those locals are not requires. **The remaining volume is not a bug** — it is the rule reporting any member access it cannot prove non-null, which in untyped JavaScript is most member accesses.

That makes the real question whether this rule belongs in `recommended` at `warn`, not which shape to special-case next. Worth deciding separately; this PR does not touch its preset membership.

## Verification

344 passing, **100%** statements and branches, `tsc` clean. The lock test fails on the unfixed rule — 4 valid cases red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)