### PR TITLE
ci(scripts): make the corpus scan automatic, and pin its corpus

### DIFF
--- a/.github/workflows/weekly-corpus-scan.yml
+++ b/.github/workflows/weekly-corpus-scan.yml
@@ -24,9 +24,20 @@ on:
   schedule:
     - cron: "0 6 * * 1" # 06:00 UTC Monday
   workflow_dispatch:
-  # Run on demand for a PR that changes rule logic, via the label.
+  # Automatic for any PR that changes rule LOGIC, and on demand via the label
+  # for anything else.
+  #
+  # It was label-only until 2026-08-20. On that day six PRs changed rule logic
+  # and none carried the label, so none were scanned — including two that fixed
+  # false positives this scan is built to catch (a shell-free `spawn` reported
+  # as CWE-78 command injection at CVSS 9.8, and `gh … -c NAME` read as a shell
+  # eval flag). A gate that depends on remembering to ask for it is not a gate.
   pull_request:
-    types: [labeled]
+    types: [opened, synchronize, reopened, labeled]
+    paths:
+      - 'packages/eslint-plugin-*/src/rules/**'
+      - 'packages/eslint-devkit/src/**'
+      - '.agent/corpus-findings-budget.json'
 
 concurrency:
   group: weekly-corpus-scan-${{ github.ref }}
@@ -38,9 +49,10 @@ permissions:
 jobs:
   scan:
     name: Scan pinned corpus
-    # The label gate keeps this off every unrelated PR while still letting a
-    # rule change ask for the measurement before it merges.
-    if: github.event_name != 'pull_request' || github.event.label.name == 'run-corpus-scan'
+    # `paths:` already limits pull_request runs to rule-logic changes, so the
+    # only thing left to filter is a `labeled` event that named some OTHER
+    # label — those would otherwise re-run the scan on every label edit.
+    if: github.event.action != 'labeled' || github.event.label.name == 'run-corpus-scan'
     runs-on: ubuntu-latest
     # Eight shallow clones plus a fresh rig install. Observed ~6 min locally
     # with a warm clone cache and no cache in CI; 25 leaves room for a slow

--- a/scripts/corpus-scan.ts
+++ b/scripts/corpus-scan.ts
@@ -34,7 +34,7 @@
  *   tsx scripts/corpus-scan.ts --json      # machine-readable report on stdout
  */
 import { execFileSync } from 'node:child_process';
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { SCAN_IGNORES } from './lib/corpus-scan-ignores.ts';
 import { ensurePrivateDir, resolveCacheHome } from './lib/private-cache-dir.ts';
@@ -57,15 +57,24 @@ const PLUGINS = [
  * Pinned to a commit, not a branch: a moving target turns "this rule
  * regressed" and "they refactored" into the same signal.
  */
+// Resolved 2026-08-20 from each repository's default branch. The comment above
+// has said "pinned to a commit, not a branch" since this file was written, and
+// the list said `master` / `main` — so the corpus moved under the ratchet, and
+// every upstream refactor arrived looking exactly like a rule regression. That
+// is the failure the comment predicts, and it is why eight rules sat over
+// budget with no rule change to explain them.
+//
+// Advancing a pin is now a deliberate commit that shows up in review, which is
+// the same standard `--update` already applies to the budget itself.
 const TARGETS: ReadonlyArray<{ repo: string; ref: string }> = [
-  { repo: 'okta/okta-auth-js', ref: 'master' },
-  { repo: 'auth0/express-openid-connect', ref: 'master' },
-  { repo: 'stripe/stripe-js', ref: 'master' },
-  { repo: 'twilio/twilio-node', ref: 'main' },
-  { repo: 'redis/ioredis', ref: 'main' },
-  { repo: 'paypal/paypal-checkout-components', ref: 'main' },
-  { repo: 'okta/okta-signin-widget', ref: 'master' },
-  { repo: 'Shopify/cli', ref: 'main' },
+  { repo: 'okta/okta-auth-js', ref: '17efe6a87db904c7bf8de9abb8e5961580f6a30c' },
+  { repo: 'auth0/express-openid-connect', ref: '94a08dd6c214a5a427a70110898e0e2099e5daab' },
+  { repo: 'stripe/stripe-js', ref: '16f79edb92e1e74c8da01c975cf85520b8f14c5b' },
+  { repo: 'twilio/twilio-node', ref: 'c8a4c27de84ec3838726da878cb9ca04a438ec59' },
+  { repo: 'redis/ioredis', ref: 'c0cd66cad8bc3d6fb02e2021f32ae2a88506ee97' },
+  { repo: 'paypal/paypal-checkout-components', ref: '861ab38f819840054eaed903bfc1ce32eb9b535f' },
+  { repo: 'okta/okta-signin-widget', ref: '0fec2f240ae83e5303c2e5e822989e7f82a3eaec' },
+  { repo: 'Shopify/cli', ref: 'cdcb458232c1482f13ae502b72112afb827f9135' },
 ];
 
 const ROOT = path.resolve(import.meta.dirname, '..');
@@ -264,18 +273,35 @@ function main(): number {
   for (const { repo, ref } of TARGETS) {
     const dir = path.join(WORK, repo.replace('/', '__'));
     try {
-      if (!existsSync(dir)) {
-        log(`Cloning ${repo}@${ref}…`);
-        sh('git', [
-          'clone',
-          '--depth',
-          '1',
-          '--branch',
-          ref,
-          '--quiet',
-          `https://github.com/${repo}.git`,
-          dir,
-        ]);
+      // `git clone --branch` takes a branch or tag, never a SHA, so a pinned
+      // commit needs init + fetch. Kept shallow: one commit, no history.
+      //
+      // The cached clone is also VERIFIED against the pin rather than trusted.
+      // Reusing whatever `dir` happens to hold is how a scan silently measures
+      // the wrong code — the cache survives a pin change, and the run would
+      // report numbers for the old commit under the new pin's name.
+      const headMatches = (): boolean => {
+        if (!existsSync(path.join(dir, '.git'))) return false;
+        try {
+          return sh('git', ['-C', dir, 'rev-parse', 'HEAD']).trim() === ref;
+        } catch {
+          return false;
+        }
+      };
+      if (!headMatches()) {
+        if (existsSync(dir)) {
+          log(`Cached ${repo} is not at ${ref.slice(0, 8)} — refetching…`);
+          rmSync(dir, { recursive: true, force: true });
+        }
+        log(`Fetching ${repo}@${ref.slice(0, 8)}…`);
+        // Through the hardening, not a bare mkdirSync — `private-cache-dir`
+        // rejects a relative path or one inside the shared tmpdir, and the
+        // scratch-space lock test asserts every directory here goes via it.
+        ensurePrivateDir(dir, CACHE_HOME);
+        sh('git', ['-C', dir, 'init', '--quiet']);
+        sh('git', ['-C', dir, 'remote', 'add', 'origin', `https://github.com/${repo}.git`]);
+        sh('git', ['-C', dir, 'fetch', '--depth', '1', '--quiet', 'origin', ref]);
+        sh('git', ['-C', dir, 'checkout', '--quiet', 'FETCH_HEAD']);
       }
       for (const [rule, n] of scanTarget(dir, configPath)) {
         totals.set(rule, (totals.get(rule) ?? 0) + n);


### PR DESCRIPTION
Two gaps in the gate that is supposed to catch false positives on real code. Neither is in a rule; both are in the harness.

## 1. It never ran

`weekly-corpus-scan` was `pull_request: types: [labeled]`, gated on someone remembering to apply `run-corpus-scan`. **Today six PRs changed rule logic and not one carried the label.**

Two of them fixed exactly what this scan exists to catch:

- a shell-free `spawn(str)` reported as **CWE-78 command injection at CVSS 9.8**, advising *"use spawn with `{shell: false}`"* on a line that already did ([#581](https://github.com/ofri-peretz/eslint/pull/581))
- `execFileSync('gh', [..., '-c', name])` read as a shell eval flag, when `-c` there is gh's own `--codespace` ([#584](https://github.com/ofri-peretz/eslint/pull/584))

Both live in `node-security`, which **is** in the scan's `PLUGINS`. Neither rule has a budget entry, and an unbudgeted rule is allowed **zero** findings. The gate would have failed on both. It was never invoked.

Now automatic for `packages/eslint-plugin-*/src/rules/**`, `eslint-devkit/src/**` and the budget file. `paths:` keeps it off unrelated PRs, so cost there is unchanged.

## 2. Its corpus was moving

`corpus-scan.ts` has carried this comment since it was written:

> Pinned to a commit, not a branch: a moving target turns "this rule regressed" and "they refactored" into the same signal.

`TARGETS` listed `master` and `main`.

Measured, not assumed: after writing the SHAs in, **5 of the 8 cached clones were no longer at their pinned commit**. Every upstream refactor since the budget was last written (2026-08-13) has been arriving as an apparent rule regression.

`git clone --branch` never accepts a SHA, so this needed `init` + `fetch --depth 1` + `checkout FETCH_HEAD`. Still shallow. The scratch dir goes through `ensurePrivateDir` — the scratch-space lock test caught a bare `mkdirSync` on my first attempt.

The cached clone is now **verified against the pin** rather than trusted. A cache outlives a pin change, so reusing whatever `dir` holds would report the old commit's numbers under the new pin's name — a stale artifact somewhere nobody would look.

## State of the gate right now

```
42 findings across 8/8 targets — 8 rule(s) over budget
```

A second run is byte-identical with no refetches, so the pinning is idempotent.

Those **8 rules are left over budget on purpose**. Each is either a rule to fix or a budget to raise deliberately, and blanket `--update` would bury whichever ones are real. They need triage, and this PR does none of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)