### PR TITLE
fix(import-next): a type and a value may share a name

### DIFF
--- a/.agent/corpus-findings-budget.json
+++ b/.agent/corpus-findings-budget.json
@@ -8,6 +8,13 @@
     "browser-security/no-unencrypted-transmission": 1,
     "browser-security/no-unsafe-inline-csp": 1,
     "browser-security/require-blob-url-revocation": 1,
+    "import-next/export": 3,
+    "import-next/first": 577,
+    "import-next/newline-after-import": 693,
+    "import-next/no-cycle": 1337,
+    "import-next/no-duplicates": 37,
+    "import-next/no-empty-named-blocks": 1,
+    "import-next/order": 1825,
     "node-security/detect-eval-with-expression": 1,
     "node-security/detect-non-literal-fs-filename": 2,
     "node-security/no-math-random-crypto": 1,
@@ -47,6 +54,13 @@
     "node-security/no-shell-injection": "1. Shopify/cli packages/plugin-cloudflare/src/install-cloudflared.ts:135 — `execSync(`t...`)` with an interpolated template. Correct shape for the rule; the interpolated value is an install path the CLI itself computes.",
     "node-security/no-unsafe-dynamic-require": "1. okta-signin-widget src/v3/src/mocks/browser.ts:34 — a require with a computed specifier in a MOCK harness. Correct shape, test-support file.",
     "secure-coding/no-graphql-injection": "1. Shopify/cli .../graphql/organization_beta_flags.ts:4 — TRUE POSITIVE and the strongest finding in this group. `flags.map(f => `flag_${f}: hasFeatureFlag(handle: \"${f}\")`)` interpolates straight into the query body AND inside a quoted GraphQL string, so a `\"` in a flag name breaks out. Budgeted only because the flag list is internal; it should be fixed upstream.",
-    "secure-coding/no-unlimited-resource-allocation": "1. Shopify/cli packages/app/src/cli/services/function/binaries.ts:315 — a gunzip stream with no size cap. Correct: a decompression bomb is bounded by nothing here. The archive is fetched from Shopify's own CDN, which is why it is budgeted."
+    "secure-coding/no-unlimited-resource-allocation": "1. Shopify/cli packages/app/src/cli/services/function/binaries.ts:315 — a gunzip stream with no size cap. Correct: a decompression bomb is bounded by nothing here. The archive is fetched from Shopify's own CDN, which is why it is budgeted.",
+    "import-next/export": "778 -> 3. Batch 2, and a clear-cut RULE BUG. TypeScript has two declaration spaces and a name may occupy both:\n\n  export type Twilio = ITwilio\n  export const Twilio = ITwilio     // legal, and the point of the pattern\n\nThe rule kept ONE map keyed by name, so every such pair was 'Multiple exports of name X'. twilio-node's src/index.ts alone produced 758 of them. Fixed by splitting value space from type space, with `interface X` twice treated as declaration MERGING (legal) while `type X` twice, `type X` beside `interface X`, and an enum against either are still reported — an enum occupies both spaces. Six valid cases verified to FAIL against the old rule.",
+    "import-next/order": "1825. Correct in contract — import groups genuinely out of order. LOW severity style, dominated by large generated SDK trees (okta-auth-js, twilio-node). Nobody reorders generated imports, so these are effective FPs under the Tricorder standard, but the rule is not wrong; the question is whether a style rule belongs in `recommended`, which is a preset decision rather than a rule defect.",
+    "import-next/newline-after-import": "693. Correct in contract. Same class as `order` — LOW-severity formatting over generated files, where imports are interleaved with `const x = require(...)` so the 'last import' is genuinely ambiguous.",
+    "import-next/first": "577. Correct in contract, and the finding is real: twilio-node's generated clients emit `import`, then `const deserialize = require(...)`, then more `import`s. An import after non-import statements is exactly what the rule is for. Generated code, so nobody acts.",
+    "import-next/no-cycle": "1337. Correct — real circular imports, concentrated in generated SDK class hierarchies (twilio Page/Version/AccountsBase, okta idx remediators). CVSS 5.3 / CRITICAL is severity inflation for a circular import and is worth revisiting separately; the DETECTION is right.",
+    "import-next/no-duplicates": "37. Correct — two import statements from the same module in one file.",
+    "import-next/no-empty-named-blocks": "1. Correct — an `import {} from 'x'` with an empty named block."
   }
 }

--- a/.changeset/export-declaration-spaces.md
+++ b/.changeset/export-declaration-spaces.md
@@ -1,0 +1,25 @@
+---
+'eslint-plugin-import-next': patch
+---
+
+`export` no longer reports a type and a value that share a name.
+
+TypeScript has two declaration spaces, and one name may occupy both:
+
+```ts
+export type Twilio = ITwilio
+export const Twilio = ITwilio    // legal, and the point of the pattern
+```
+
+The rule kept a single map keyed by name, so every such pair was reported as
+`Multiple exports of name "Twilio"`. On the pinned corpus, twilio-node's
+`src/index.ts` alone produced **758** of them — **778 → 3** across all eight
+repositories.
+
+Still reported, because these really are conflicts:
+
+- `type X` twice
+- `type X` beside `interface X`, in either order
+- an `enum X` against either a value or a type — an enum occupies both spaces
+
+`interface X` twice is declaration **merging** and is now correctly silent.

--- a/benchmarks/results/ilb-cwe-corpus/2026-08-21.json
+++ b/benchmarks/results/ilb-cwe-corpus/2026-08-21.json
@@ -1,7 +1,7 @@
 {
   "bench": "ILB-CWE-Corpus",
   "benchVersion": "1.0",
-  "timestamp": "2026-08-21T04:12:12.237Z",
+  "timestamp": "2026-08-21T04:42:33.428Z",
   "methodologyHash": "sha256:ef8ea3b0b761f29a4b92403985a71a1e7cf7e55682aecc72f8c100c310c554b0",
   "methodologyPaths": [
     "benchmarks/suites/ilb-cwe-corpus/run.ts",

--- a/packages/eslint-plugin-import-next/src/rules/export.ts
+++ b/packages/eslint-plugin-import-next/src/rules/export.ts
@@ -59,19 +59,55 @@ export const exportRule = createRule<RuleOptions, MessageIds>({
   defaultOptions: [],
 
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>) {
-    const exportedNames = new Map<string, TSESTree.Node>();
+    /**
+     * TypeScript has TWO declaration spaces, and a name may occupy both.
+     *
+     *   export type Twilio = ITwilio
+     *   export const Twilio = ITwilio    // legal, and extremely common
+     *
+     * A single name-keyed map called that a duplicate export. On the pinned
+     * corpus it produced 758 findings in twilio-node alone — every one of them
+     * this shape, in a generated SDK where the pattern is deliberate.
+     *
+     * Interfaces are tracked apart from other type declarations because
+     * `interface X {}` twice in one file is declaration MERGING, which is also
+     * legal. `type X` twice is not, and neither is `interface X` beside
+     * `type X`.
+     */
+    const valueNames = new Map<string, TSESTree.Node>();
+    const typeNames = new Map<string, TSESTree.Node>();
+    const mergeableInterfaces = new Set<string>();
     let hasDefaultExport: TSESTree.Node | null = null;
 
-    function checkAndAddExport(name: string, node: TSESTree.Node) {
-      if (exportedNames.has(name)) {
+    type Space = 'value' | 'type' | 'interface';
+
+    function checkAndAddExport(name: string, node: TSESTree.Node, space: Space = 'value') {
+      // `interface X` merges with an earlier `interface X`, so a repeat is only
+      // a conflict when the earlier declaration was NOT an interface.
+      if (space === 'interface') {
+        const clash = typeNames.get(name);
+        if (clash && !mergeableInterfaces.has(name)) {
+          context.report({ node, messageId: 'duplicateExport', data: { name } });
+          return;
+        }
+        mergeableInterfaces.add(name);
+        typeNames.set(name, node);
+        return;
+      }
+
+      const bucket = space === 'type' ? typeNames : valueNames;
+      if (bucket.has(name)) {
         context.report({
           node,
           messageId: 'duplicateExport',
           data: { name },
         });
-      } else {
-        exportedNames.set(name, node);
+        return;
       }
+      // No separate `interface` check is needed here: the interface branch
+      // above writes into `typeNames`, which IS `bucket` for type space, so
+      // `type X` after `interface X` is already caught by the test above.
+      bucket.set(name, node);
     }
 
     function checkDefaultExport(node: TSESTree.Node) {
@@ -106,13 +142,18 @@ export const exportRule = createRule<RuleOptions, MessageIds>({
             if (node.declaration.id) {
               checkAndAddExport(node.declaration.id.name, node);
             }
-          } else if (
-            node.declaration.type === AST_NODE_TYPES.TSEnumDeclaration ||
-            node.declaration.type === AST_NODE_TYPES.TSInterfaceDeclaration ||
-            node.declaration.type === AST_NODE_TYPES.TSTypeAliasDeclaration
-          ) {
+          } else if (node.declaration.type === AST_NODE_TYPES.TSInterfaceDeclaration) {
+            // `id` is required on an interface and on a type alias — neither
+            // parses without a name — so no presence check here. Guarding
+            // anyway would add a branch no input can take.
+            checkAndAddExport(node.declaration.id.name, node, 'interface');
+          } else if (node.declaration.type === AST_NODE_TYPES.TSTypeAliasDeclaration) {
+            checkAndAddExport(node.declaration.id.name, node, 'type');
+          } else if (node.declaration.type === AST_NODE_TYPES.TSEnumDeclaration) {
+            // An enum creates a type AND a value, so it collides with either.
             if (node.declaration.id) {
-              checkAndAddExport(node.declaration.id.name, node);
+              checkAndAddExport(node.declaration.id.name, node, 'value');
+              checkAndAddExport(node.declaration.id.name, node, 'type');
             }
           }
         }
@@ -127,7 +168,11 @@ export const exportRule = createRule<RuleOptions, MessageIds>({
           if (exportedName === 'default') {
             checkDefaultExport(spec);
           } else {
-            checkAndAddExport(exportedName, spec);
+            // `export type { X }` and `export { type X }` are type-space.
+            const isTypeOnly =
+              node.exportKind === 'type' ||
+              (spec as TSESTree.ExportSpecifier & { exportKind?: string }).exportKind === 'type';
+            checkAndAddExport(exportedName, spec, isTypeOnly ? 'type' : 'value');
           }
         });
       },

--- a/packages/eslint-plugin-import-next/src/rules/export.ts
+++ b/packages/eslint-plugin-import-next/src/rules/export.ts
@@ -150,10 +150,18 @@ export const exportRule = createRule<RuleOptions, MessageIds>({
           } else if (node.declaration.type === AST_NODE_TYPES.TSTypeAliasDeclaration) {
             checkAndAddExport(node.declaration.id.name, node, 'type');
           } else if (node.declaration.type === AST_NODE_TYPES.TSEnumDeclaration) {
-            // An enum creates a type AND a value, so it collides with either.
-            if (node.declaration.id) {
-              checkAndAddExport(node.declaration.id.name, node, 'value');
-              checkAndAddExport(node.declaration.id.name, node, 'type');
+            // An enum creates a type AND a value, so it collides with either —
+            // but it is ONE declaration and must produce ONE report. Routing it
+            // through two `checkAndAddExport` calls made `export enum Foo {}`
+            // twice report the same node twice, because both buckets were
+            // already populated by the first enum. `id` is required here for
+            // the same reason it is on interfaces and type aliases.
+            const enumName = node.declaration.id.name;
+            if (valueNames.has(enumName) || typeNames.has(enumName)) {
+              context.report({ node, messageId: 'duplicateExport', data: { name: enumName } });
+            } else {
+              valueNames.set(enumName, node);
+              typeNames.set(enumName, node);
             }
           }
         }

--- a/packages/eslint-plugin-import-next/src/tests/coverage-batch-a.test.ts
+++ b/packages/eslint-plugin-import-next/src/tests/coverage-batch-a.test.ts
@@ -660,15 +660,14 @@ describe('export — Layer 2 (synthetic declarations)', () => {
     expect(reports).toEqual([]);
   });
 
-  it('skips TS enum declarations without an id', () => {
-    const { listeners, reports } = createWithMockContext(exportRule);
-    (listeners.ExportNamedDeclaration as (n: unknown) => void)({
-      type: 'ExportNamedDeclaration',
-      declaration: { type: 'TSEnumDeclaration', id: null },
-      specifiers: [],
-    });
-    expect(reports).toEqual([]);
-  });
+  // REMOVED: 'skips TS enum declarations without an id'.
+  //
+  // It fed a synthetic `{ type: 'TSEnumDeclaration', id: null }`, which no
+  // parser can produce — an unnamed enum is a parse error, and TSESTree types
+  // `id` as required. The guard it covered was the same dead branch this PR
+  // removed from TSInterfaceDeclaration and TSTypeAliasDeclaration, and
+  // keeping one of the three would have been the inconsistency rather than the
+  // safety. Raised by CodeRabbit on #593.
 
   it('ignores declaration types outside the tracked set', () => {
     const { listeners, reports } = createWithMockContext(exportRule);

--- a/packages/eslint-plugin-import-next/src/tests/export.test.ts
+++ b/packages/eslint-plugin-import-next/src/tests/export.test.ts
@@ -163,6 +163,27 @@ ruleTester.run('export', exportRule, {
       `,
       errors: [{ messageId: 'duplicateExport' }],
     },
+
+    // An enum occupies both spaces, so enum-vs-enum conflicts in both — but it
+    // is ONE declaration and must produce exactly ONE report. Raised by
+    // CodeRabbit on #593; routing the enum through two checkAndAddExport calls
+    // reported the same node twice, and the enum-vs-value and enum-vs-type
+    // cases above could not catch it because only one space conflicts there.
+    {
+      code: `
+        export enum Foo { A }
+        export enum Foo { B }
+      `,
+      errors: [{ messageId: 'duplicateExport' }],
+    },
+    {
+      // Same one-report rule when the earlier declaration is an interface.
+      code: `
+        export interface Foo { a: string }
+        export enum Foo { A }
+      `,
+      errors: [{ messageId: 'duplicateExport' }],
+    },
   ],
 });
 

--- a/packages/eslint-plugin-import-next/src/tests/export.test.ts
+++ b/packages/eslint-plugin-import-next/src/tests/export.test.ts
@@ -118,5 +118,108 @@ ruleTester.run('export', exportRule, {
       `,
       errors: [{ messageId: 'duplicateExport' }],
     },
+
+    // FN GUARD: two type aliases DO collide — only the type/value split is
+    // legal, not everything that touches type space.
+    {
+      code: `
+        export type Foo = A;
+        export type Foo = B;
+      `,
+      errors: [{ messageId: 'duplicateExport' }],
+    },
+
+    // FN GUARD: `type X` beside `interface X` is an error, even though two
+    // interfaces would have merged. Both orders.
+    {
+      code: `
+        export interface Foo { a: string }
+        export type Foo = B;
+      `,
+      errors: [{ messageId: 'duplicateExport' }],
+    },
+    {
+      code: `
+        export type Foo = B;
+        export interface Foo { a: string }
+      `,
+      errors: [{ messageId: 'duplicateExport' }],
+    },
+
+    // FN GUARD: an enum occupies BOTH spaces, so it collides with a value…
+    {
+      code: `
+        export const Foo = 1;
+        export enum Foo { A }
+      `,
+      errors: [{ messageId: 'duplicateExport' }],
+    },
+
+    // …and with a type.
+    {
+      code: `
+        export type Foo = A;
+        export enum Foo { A }
+      `,
+      errors: [{ messageId: 'duplicateExport' }],
+    },
   ],
+});
+
+/**
+ * TypeScript's two declaration spaces.
+ *
+ * A name may occupy the type space and the value space at once, and the rule
+ * keyed a single map by name alone. On the pinned corpus that produced 758
+ * findings in twilio-node — every one this shape, in a generated SDK where the
+ * pattern is the point.
+ */
+ruleTester.run('export — declaration spaces', exportRule, {
+  valid: [
+    {
+      // The exact shape from twilio-node src/index.ts:30-31.
+      code: `
+        export type Twilio = ITwilio;
+        export const Twilio = ITwilio;
+      `,
+    },
+    {
+      // Order must not matter.
+      code: `
+        export const AccessToken = IAccessToken;
+        export type AccessToken = IAccessToken;
+      `,
+    },
+    {
+      // Interface + value is the same split.
+      code: `
+        export interface Options { a: string }
+        export const Options = {};
+      `,
+    },
+    {
+      // `interface X` twice is declaration MERGING, and legal.
+      code: `
+        export interface Foo { a: string }
+        export interface Foo { b: number }
+      `,
+    },
+    {
+      // `export type { X }` is type-space, so it does not collide with a value.
+      code: `
+        const Foo = 1;
+        export { Foo };
+        export type { Foo } from './types';
+      `,
+    },
+    {
+      // Inline `type` specifier, same reasoning.
+      code: `
+        const Foo = 1;
+        export { Foo };
+        export { type Foo } from './types';
+      `,
+    },
+  ],
+  invalid: [],
 });

--- a/scripts/corpus-scan.ts
+++ b/scripts/corpus-scan.ts
@@ -53,6 +53,7 @@ const PLUGINS = [
   'eslint-plugin-jwt-security',
   'eslint-plugin-express-security',
   'eslint-plugin-reliability',
+  'eslint-plugin-import-next',
 ] as const;
 
 /**
@@ -120,6 +121,33 @@ const RECHECK_RANGE: string = (() => {
   }
   return range;
 })();
+
+/**
+ * Rules this instrument CANNOT measure, and why.
+ *
+ * The targets are shallow git clones. They are never `npm install`ed and never
+ * built, so any rule whose verdict depends on the dependency tree or on
+ * generated output is answering a question about the clone rather than about
+ * the rule. Measured 2026-08-21 on `import-next`:
+ *
+ *   no-unresolved                3,671 — 1,108 bare specifiers with no
+ *                                        node_modules to resolve against, and
+ *                                        2,402 relative imports of files that
+ *                                        graphql-codegen writes at build time
+ *                                        (Shopify/cli `./types.js`)
+ *   no-extraneous-dependencies   1,067 — cannot compare against packages that
+ *                                        were never installed
+ *
+ * A budget would be worse than an exclusion here: the number would look like a
+ * quality signal, and it would drift whenever a pinned SHA moves for reasons
+ * that have nothing to do with the rule. Excluding it says the true thing —
+ * this gate has nothing to say about these rules. They need a rig that
+ * installs and builds each target, which is a separate piece of work.
+ */
+const UNMEASURABLE_RULES: ReadonlySet<string> = new Set([
+  'import-next/no-unresolved',
+  'import-next/no-extraneous-dependencies',
+]);
 
 const BUDGET_FILE = path.join(ROOT, '.agent', 'corpus-findings-budget.json');
 
@@ -301,6 +329,17 @@ function main(): number {
       // decides findings, so an unpinned one lets a `recheck` release restate
       // published corpus numbers without a commit here.
       `recheck@${RECHECK_RANGE}`,
+      // The import RESOLVER. `oxc-resolver` is an OPTIONAL peer of
+      // @interlace/eslint-devkit, and `no-unresolved` / `named` / `default` /
+      // `namespace` cannot answer anything without it.
+      //
+      // Unlike the ReDoS oracle this one fails CLOSED — `loadResolverFactory`
+      // throws MissingResolverPeerError rather than quietly returning "not
+      // resolved" — so its absence surfaces as every target erroring instead
+      // of as a silently perfect score. Installed for the same reason all the
+      // same: an optional dependency that changes the answer is not optional
+      // to the measurement.
+      'oxc-resolver',
       ...PLUGINS.map((p) => `${p}@file:${path.join(ROOT, 'packages', p)}`),
     ],
     RIG,
@@ -393,7 +432,11 @@ function main(): number {
     const next: Budget = {
       $comment: budget.$comment,
       generated: new Date().toISOString().slice(0, 10),
-      budgets: Object.fromEntries([...totals.entries()].sort(([a], [b]) => a.localeCompare(b))),
+      budgets: Object.fromEntries(
+        [...totals.entries()]
+          .filter(([rule]) => !UNMEASURABLE_RULES.has(rule))
+          .sort(([a], [b]) => a.localeCompare(b)),
+      ),
       ...(budget.triage ? { triage: budget.triage } : {}),
     };
     writeFileSync(BUDGET_FILE, `${JSON.stringify(next, null, 2)}\n`);
@@ -405,6 +448,8 @@ function main(): number {
   const under: Array<{ rule: string; found: number; allowed: number }> = [];
 
   for (const [rule, found] of totals) {
+    // Skipped, not budgeted at zero — see UNMEASURABLE_RULES.
+    if (UNMEASURABLE_RULES.has(rule)) continue;
     // A rule with no budget entry is new to the corpus. Treat 0 as its budget
     // so a newly-noisy rule cannot arrive unnoticed.
     const allowed = budget.budgets[rule] ?? 0;


### PR DESCRIPTION
Batch 2 of the rule re-review (`.agent/RULE-REVIEW-BATCHES.md`). `import-next` is **22%** of what a user sees.

## The rule bug

TypeScript has **two declaration spaces**, and one name may occupy both:

```ts
export type Twilio = ITwilio
export const Twilio = ITwilio    // legal, and the point of the pattern
```

`export` kept a single map keyed by name, so every such pair became `Multiple exports of name "Twilio"`. twilio-node's `src/index.ts` alone produced **758**.

| | findings |
|---|---|
| `import-next/export` before | **778** |
| after | **3** |

Still reported, because these really are conflicts:

- `type X` twice
- `type X` beside `interface X`, **in either order**
- an `enum X` against either a value or a type — an enum occupies both spaces

`interface X` twice is declaration **merging** and is now correctly silent. Six valid cases verified to fail against the old rule.

Two dead branches removed while locking it: a `type X` check that `bucket` already caught, and `if (node.declaration.id)` on interface/type-alias nodes where `id` is required and the false arm is unreachable.

## What this gate cannot measure

The corpus targets are shallow clones — never installed, never built. A rule whose verdict depends on the dependency tree is answering a question about the *clone*, not about the rule:

| rule | findings | why |
|---|---|---|
| `no-unresolved` | 3,671 | 1,108 bare specifiers with no `node_modules`; 2,402 relative imports of files graphql-codegen writes at build time (`./types.js`) |
| `no-extraneous-dependencies` | 1,067 | cannot compare against packages that were never installed |

Both are now in `UNMEASURABLE_RULES` — **excluded, not budgeted**. A budget would look like a quality signal and would drift whenever a pinned SHA moved for reasons unrelated to the rule. Measuring these needs a rig that installs and builds each target, which is separate work.

## The rest

Correct in contract, budgeted with reasoning: `order` (1825), `no-cycle` (1337), `newline-after-import` (693), `first` (577), `no-duplicates` (37), `export` (3), `no-empty-named-blocks` (1).

`first` is worth naming — twilio's generated clients emit `import`, then `const x = require(...)`, then more `import`s. That is exactly what the rule is for. These are effective FPs under the Tricorder standard because nobody reorders generated code, but the rules are not wrong; whether style rules belong in `recommended` is a preset decision, not a rule defect.

## Verification

- `import-next`: **1316 passing, 100%** statements / branches / functions / lines
- corpus gate green
- CWE recall **69/69, FP=0**
- script locks **1295 passing**

🤖 Generated with [Claude Code](https://claude.com/claude-code)