### PR TITLE
fix(conventions): prose is not commented-out code

### DIFF
--- a/.agent/corpus-findings-budget.json
+++ b/.agent/corpus-findings-budget.json
@@ -8,6 +8,9 @@
     "browser-security/no-unencrypted-transmission": 1,
     "browser-security/no-unsafe-inline-csp": 1,
     "browser-security/require-blob-url-revocation": 1,
+    "conventions/analytics-event-naming": 1,
+    "conventions/no-commented-code": 143,
+    "conventions/no-magic-numbers": 1635,
     "import-next/export": 3,
     "import-next/first": 577,
     "import-next/newline-after-import": 693,
@@ -61,6 +64,9 @@
     "import-next/first": "577. Correct in contract, and the finding is real: twilio-node's generated clients emit `import`, then `const deserialize = require(...)`, then more `import`s. An import after non-import statements is exactly what the rule is for. Generated code, so nobody acts.",
     "import-next/no-cycle": "1337. Correct — real circular imports, concentrated in generated SDK class hierarchies (twilio Page/Version/AccountsBase, okta idx remediators). CVSS 5.3 / CRITICAL is severity inflation for a circular import and is worth revisiting separately; the DETECTION is right.",
     "import-next/no-duplicates": "37. Correct — two import statements from the same module in one file.",
-    "import-next/no-empty-named-blocks": "1. Correct — an `import {} from 'x'` with an empty named block."
+    "import-next/no-empty-named-blocks": "1. Correct — an `import {} from 'x'` with an empty named block.",
+    "conventions/no-commented-code": "2,441 -> 143. Batch 3, and the FPs were English rather than code. Three mechanics inside `looksLikeCode`, all measured on the pinned corpus:\n\n  `Copyright (c) 2018 …`   the call pattern allowed whitespace before `(`, so every legal banner in okta-auth-js reported\n  `https://example.com/x`  matched the `ident:` assignment pattern — `https:` reads as a label — so every documentation link reported\n  `for backward compat…`   a sentence that merely OPENS with a JavaScript keyword: 'for widget / idx-js backward compatibility', 'if no key is passed', 'let existing promise finish', 'return all cookies when…'\n\nThe discriminator that survived is punctuation. Commented-out code is COPIED out of a file and keeps its semicolons and braces; a sentence ends in a word. Known trade, recorded rather than hidden: a terminator-less fragment such as `// x = 1` is no longer reported.\n\nA fourth fix was written and then DELETED — a special case for the terser `/*!` preserve banner. It was unreachable: tightening the paren pattern already covered every banner, and the guard only looked load-bearing.\n\nThe 143 remaining are real: `const target = actionDefinition.href;`, `err = wwwAuthErr ?? err;`, `const inputs = this.getInputs();` — commented-out bodies in okta-auth-js's generateIdxAction.ts and GenericRemediator.ts.",
+    "conventions/no-magic-numbers": "1635. Correct in contract, and a taste rule by nature. Sampled okta-auth-js: HTTP status codes (`err.xhr.status === 429`), millisecond timeouts (`15 * 1000`, `options?.timeout || 15000`), backoff arithmetic (`Math.pow(2, retryCount) * 1000`) and ESLint config tuples in `.eslintrc.js` (`complexity: [2, 7]`). The config-file case is the one worth revisiting — a config is declarative data rather than logic — but that is a scope decision for the rule, not a defect, so it is budgeted rather than changed here.",
+    "conventions/analytics-event-naming": "1. Correct in contract — a single analytics event name off the configured taxonomy."
   }
 }

--- a/.changeset/commented-code-prose.md
+++ b/.changeset/commented-code-prose.md
@@ -1,0 +1,24 @@
+---
+'eslint-plugin-conventions': patch
+---
+
+`no-commented-code` no longer reports English prose.
+
+On the pinned 8-repository corpus this rule produced **2,441 findings**, and
+the overwhelming majority were sentences. Three mechanics did it:
+
+```js
+// Copyright (c) 2018-Present, Okta, Inc.      <- the call pattern allowed a
+//                                                gap before the paren
+// https://developer.mozilla.org/…/fetch       <- `https:` matched `ident:`
+// for widget / idx-js backward compatibility  <- opens with a keyword
+```
+
+The discriminator is punctuation: commented-out code is **copied** out of a
+file and keeps its semicolons and braces, while a sentence ends in a word.
+
+**2,441 → 143**, and what remains is real — `const target =
+actionDefinition.href;`, `err = wwwAuthErr ?? err;`.
+
+Known trade: a terminator-less fragment such as `// x = 1` is no longer
+reported.

--- a/benchmarks/results/ilb-cwe-corpus/2026-08-21.json
+++ b/benchmarks/results/ilb-cwe-corpus/2026-08-21.json
@@ -1,7 +1,7 @@
 {
   "bench": "ILB-CWE-Corpus",
   "benchVersion": "1.0",
-  "timestamp": "2026-08-21T04:42:33.428Z",
+  "timestamp": "2026-08-21T05:10:46.074Z",
   "methodologyHash": "sha256:ef8ea3b0b761f29a4b92403985a71a1e7cf7e55682aecc72f8c100c310c554b0",
   "methodologyPaths": [
     "benchmarks/suites/ilb-cwe-corpus/run.ts",

--- a/packages/eslint-plugin-conventions/src/rules/conventions/no-commented-code.ts
+++ b/packages/eslint-plugin-conventions/src/rules/conventions/no-commented-code.ts
@@ -33,6 +33,13 @@ type RuleOptions = [Options?];
  * Check if a comment block contains code-like patterns
  */
 function looksLikeCode(comment: string, isBlockComment: boolean): boolean {
+  // NOTE: no special case for the terser `/*!` "preserve" banner. One was
+  // written here first, on the reasoning that a legal notice is never code —
+  // true, but redundant: what made every banner report was `Copyright (c)`
+  // matching the call pattern, and tightening that pattern to reject a gap
+  // before the paren already covers it. The guard was unreachable, so it is
+  // gone rather than sitting here looking load-bearing.
+
   // Remove comment markers for pattern matching
   let text = comment;
   if (isBlockComment) {
@@ -64,9 +71,23 @@ function looksLikeCode(comment: string, isBlockComment: boolean): boolean {
   const codePatterns = [
     /^(const|let|var|function|class|if|for|while|return|import|export)\s+/,
     /^[a-zA-Z_$][a-zA-Z0-9_$]*\s*[=:]\s*/,
-    /^[a-zA-Z_$][a-zA-Z0-9_$]*\s*\(/,
+    // No whitespace before the paren. `foo(x)` is a call; `Copyright (c)` and
+    // `Authn (classic) api` are prose with a parenthetical, and allowing the
+    // gap made every legal banner on the corpus a finding.
+    /^[a-zA-Z_$][a-zA-Z0-9_$]*\(/,
     /^[{}[\]]/,
   ];
+
+  /**
+   * A bare URL is not code, whatever the scheme looks like.
+   *
+   * `https://example.com/x#y` matched the `ident:` assignment pattern — `https:`
+   * reads as a label — so every documentation link in a comment reported.
+   */
+  const URL_LINE = /^[a-z][a-z0-9+.-]*:\/\//i;
+
+  /** A statement ends in punctuation; a sentence ends in a word. */
+  const ENDS_LIKE_CODE = /[;{},()[\]]$|=>$/;
 
   // Count how many lines look like code
   let codeLikeLines = 0;
@@ -75,6 +96,33 @@ function looksLikeCode(comment: string, isBlockComment: boolean): boolean {
   for (const line of lines) {
     // Skip TODO/FIXME comments
     if (/^(TODO|FIXME|HACK|XXX)/i.test(line)) {
+      continue;
+    }
+
+    // A link is a reference, not commented-out code.
+    if (URL_LINE.test(line)) {
+      continue;
+    }
+
+    // Commented-out code is COPIED from source, so it keeps its punctuation.
+    // English prose does not. Without this, every comment that happens to open
+    // with a JavaScript keyword reported:
+    //
+    //   // for widget / idx-js backward compatibility
+    //   // if no key is passed, all cookies are returned
+    //   // let existing promise finish to prevent running into loops
+    //   // return all cookies when no args is provided
+    //   // fetch() can throw exceptions
+    //
+    // Each matches a pattern below on its first word alone. None ends the way
+    // a statement does.
+    //
+    // Known trade: a terminator-less fragment such as `// x = 1` is no longer
+    // reported. Real commented-out code is lifted from a file that had
+    // semicolons; prose that ends in punctuation is rare. Measured on the
+    // pinned corpus this removed ~1,400 findings and cost no true positive
+    // that could be found by inspection.
+    if (!ENDS_LIKE_CODE.test(line)) {
       continue;
     }
 

--- a/packages/eslint-plugin-conventions/src/tests/conventions/no-commented-code.test.ts
+++ b/packages/eslint-plugin-conventions/src/tests/conventions/no-commented-code.test.ts
@@ -194,3 +194,69 @@ const b = 2;
     });
   });
 });
+
+/**
+ * Prose is not code, however it opens.
+ *
+ * Measured on the pinned 8-repository corpus: this rule reported 2,441
+ * findings, and the overwhelming majority were English. Three mechanics did
+ * it, all inside `looksLikeCode`:
+ *
+ *   `Copyright (c) 2018 …`  — the call pattern allowed whitespace before `(`
+ *   `https://example.com/x` — `https:` matched the `ident:` assign pattern
+ *   `for backward compat…`  — a sentence that opens with a keyword
+ *
+ * The discriminator that survived is punctuation. Commented-out code is COPIED
+ * out of a file and keeps its semicolons and braces; a sentence ends in a word.
+ * 2,441 -> 143.
+ */
+describe('no-commented-code — prose is not code', () => {
+  ruleTester.run('valid - English that opens like code', noCommentedCode, {
+    valid: [
+      // Sentences that begin with a JavaScript keyword.
+      { code: 'const a = 1;\n// for widget / idx-js backward compatibility' },
+      { code: 'const a = 1;\n// if no key is passed, all cookies are returned' },
+      { code: 'const a = 1;\n// let existing promise finish to prevent running into loops' },
+      { code: 'const a = 1;\n// return all cookies when no args is provided' },
+      { code: 'const a = 1;\n// class names are kebab-case here' },
+      // Prose with a parenthetical reads as a call only if the gap is allowed.
+      { code: 'const a = 1;\n// Authn (classic) api' },
+      { code: 'const a = 1;\n// fetch() can throw exceptions' },
+      // A documentation link.
+      { code: 'const a = 1;\n// https://developer.mozilla.org/en-US/docs/Web/API/fetch#exceptions' },
+      { code: 'const a = 1;\n// See http://example.com/a/b#c for details' },
+      // The terser "preserve" banner: a legal notice, never code.
+      {
+        code: '/*!\n * Copyright (c) 2018-Present, Okta, Inc. and/or its affiliates.\n * Licensed under the Apache License, Version 2.0\n */\nconst a = 1;',
+      },
+    ],
+    invalid: [
+      {
+        // FN GUARD: real commented-out code keeps its punctuation.
+        // okta-auth-js lib/idx/idxState/v1/generateIdxAction.ts:80.
+        code: 'const a = 1;\n//   const target = actionDefinition.href;',
+        errors: [{ messageId: 'commentedCode', suggestions: [{ messageId: 'removeCode', output: 'const a = 1;\n' }] }],
+      },
+      {
+        // okta-auth-js lib/http/request.ts:110.
+        code: 'const a = 1;\n//   err = wwwAuthErr ?? err;',
+        errors: [{ messageId: 'commentedCode', suggestions: [{ messageId: 'removeCode', output: 'const a = 1;\n' }] }],
+      },
+      {
+        // A call with no gap before the paren is still a call.
+        code: 'const a = 1;\n// const inputs = this.getInputs();',
+        errors: [{ messageId: 'commentedCode', suggestions: [{ messageId: 'removeCode', output: 'const a = 1;\n' }] }],
+      },
+      {
+        // A keyword line that DOES end like a statement.
+        code: 'const a = 1;\n// if (ready) {',
+        errors: [{ messageId: 'commentedCode', suggestions: [{ messageId: 'removeCode', output: 'const a = 1;\n' }] }],
+      },
+      {
+        // A plain block comment is not a `/*!` banner and is still checked.
+        code: '/*\n * const target = actionDefinition.href;\n */\nconst a = 1;',
+        errors: [{ messageId: 'commentedCode', suggestions: [{ messageId: 'removeCode', output: '\nconst a = 1;' }] }],
+      },
+    ],
+  });
+});

--- a/scripts/corpus-scan.ts
+++ b/scripts/corpus-scan.ts
@@ -54,6 +54,7 @@ const PLUGINS = [
   'eslint-plugin-express-security',
   'eslint-plugin-reliability',
   'eslint-plugin-import-next',
+  'eslint-plugin-conventions',
 ] as const;
 
 /**


### PR DESCRIPTION
Batch 3 of the rule re-review (`.agent/RULE-REVIEW-BATCHES.md`). `conventions` is **12%** of what a user sees, and `no-commented-code` was 2,441 of its findings.

## Almost all of them were English

Three mechanics inside `looksLikeCode`:

```js
// Copyright (c) 2018-Present, Okta, Inc.      // the call pattern allowed a gap before `(`
// https://developer.mozilla.org/…/fetch       // `https:` matched the `ident:` assign pattern
// for widget / idx-js backward compatibility  // a sentence that opens with a keyword
```

That last class is the big one — comments routinely start with `for`, `if`, `let`, `return`, `class`:

> `// if no key is passed, all cookies are returned`
> `// let existing promise finish to prevent running into loops`
> `// return all cookies when no args is provided`

**The discriminator is punctuation.** Commented-out code is *copied* out of a file and keeps its semicolons and braces; a sentence ends in a word.

| | findings |
|---|---|
| `no-commented-code` before | **2,441** |
| after | **143** |

Survivors are real: `const target = actionDefinition.href;`, `err = wwwAuthErr ?? err;`, `const inputs = this.getInputs();` — commented-out bodies in okta-auth-js.

**Known trade, recorded not hidden:** a terminator-less fragment such as `// x = 1` is no longer reported.

## A fix I wrote and then deleted

I added a special case for the terser `/*!` preserve banner — a legal notice is never code. True, but **unreachable**: tightening the paren pattern already covered every banner. Coverage caught it at 99.86%, and it was removed rather than left looking load-bearing.

## The rest

`no-magic-numbers` (1635) and `analytics-event-naming` (1) are correct in contract and budgeted with reasoning. Worth revisiting separately: magic numbers inside `.eslintrc.js`, since a config is declarative data rather than logic — a scope decision for the rule, not a defect.

## Verification

- `conventions`: **445 passing, 100%** statements / branches / functions / lines
- **9 of the new cases verified to fail** against the unfixed rule
- corpus gate green
- CWE recall **69/69, FP=0**
- script locks **1295 passing**

🤖 Generated with [Claude Code](https://claude.com/claude-code)