### PR TITLE
feat(docs): carry per-rule detection quality into the manifest

### DIFF
--- a/apps/docs/scripts/build-rules-manifest.mts
+++ b/apps/docs/scripts/build-rules-manifest.mts
@@ -82,6 +82,37 @@ type Entry = {
   corpusFindings: number | null;
   budgetReason: string | null;
   seal: { axesMet: number; axesTotal: number; status: string; knownGaps: number } | null;
+  detection: Detection | null;
+};
+
+/**
+ * What the rule's own fixture corpus measured.
+ *
+ * `tp` is what it CAUGHT, `fn` what it MISSED, `fp` what it wrongly reported,
+ * and `tn` the safe fixtures it correctly stayed quiet on. All four are needed:
+ * precision alone hides misses, recall alone hides noise, and a rule with no
+ * safe fixtures at all can score a perfect 1.0 on both while being useless.
+ * `fixtures` and `vulnerable` are carried so a score can be read against the
+ * size of the sample that produced it — 1.0 over 19 fixtures is a different
+ * claim from 1.0 over 3.
+ *
+ * `competitors` is the duel: the same fixtures scored against every other
+ * plugin that ships a comparable rule. It is the only number here that is not
+ * our opinion of our own output.
+ */
+type Detection = {
+  tp: number;
+  fp: number;
+  fn: number;
+  tn: number;
+  precision: number | null;
+  recall: number | null;
+  f1: number | null;
+  fixtures: number | null;
+  vulnerable: number | null;
+  missed: string[];
+  falsePositives: string[];
+  competitors: { name: string; tp: number; fp: number; fn: number; f1: number | null }[];
 };
 
 /**
@@ -125,6 +156,58 @@ if (existsSync(sealDir)) {
       axesTotal: axes.length,
       status: record.status ?? 'open',
       knownGaps: (record.knownGaps ?? []).length,
+    });
+  }
+}
+
+/** Detection scores, keyed by rule id, from each rule corpus RESULTS.json. */
+const detections = new Map<string, Detection>();
+if (existsSync(sealDir)) {
+  for (const dir of readdirSync(sealDir)) {
+    const results = readJson<{
+      rule?: string;
+      fixtures?: number;
+      vulnerable?: number;
+      results?: {
+        name?: string;
+        tp?: number;
+        fp?: number;
+        fn?: number;
+        tn?: number;
+        precision?: number;
+        recall?: number;
+        f1?: number;
+        missed?: unknown[];
+        falsePositives?: unknown[];
+      }[];
+    }>(path.join(sealDir, dir, 'RESULTS.json'));
+    if (!results?.rule || !Array.isArray(results.results) || results.results.length === 0) continue;
+
+    // Ours is the entry naming this ecosystem; everything else in the array is
+    // a competitor scored on the SAME fixtures. Matching on the `Interlace`
+    // prefix rather than on position, because position is not a contract.
+    const mine = results.results.find((r) => r.name?.startsWith('Interlace')) ?? results.results[0];
+    const others = results.results.filter((r) => r !== mine);
+    const asName = (x: unknown) => (typeof x === 'string' ? x : JSON.stringify(x));
+    detections.set(results.rule, {
+      tp: mine.tp ?? 0,
+      fp: mine.fp ?? 0,
+      fn: mine.fn ?? 0,
+      tn: mine.tn ?? 0,
+      precision: typeof mine.precision === 'number' ? mine.precision : null,
+      recall: typeof mine.recall === 'number' ? mine.recall : null,
+      f1: typeof mine.f1 === 'number' ? mine.f1 : null,
+      fixtures: results.fixtures ?? null,
+      vulnerable: results.vulnerable ?? null,
+      missed: (mine.missed ?? []).map(asName),
+      falsePositives: (mine.falsePositives ?? []).map(asName),
+      competitors: others.map((c) => ({
+        name: c.name ?? 'unknown',
+        tp: c.tp ?? 0,
+        fp: c.fp ?? 0,
+        fn: c.fn ?? 0,
+        f1: typeof c.f1 === 'number' ? c.f1 : null,
+      })),
     });
   }
 }
@@ -186,6 +269,7 @@ for (const dirName of readdirSync(path.join(ROOT, 'packages'))) {
       corpusFindings: budget.budgets[id] ?? null,
       budgetReason: budget.triage?.[id] ?? null,
       seal: seals.get(id) ?? null,
+      detection: detections.get(id) ?? null,
     });
   }
 }
@@ -203,6 +287,11 @@ const manifest = {
     withSealRecord: entries.filter((e) => e.seal).length,
     sealed: entries.filter((e) => e.seal?.status === 'sealed').length,
     firingOnCorpus: entries.filter((e) => (e.corpusFindings ?? 0) > 0).length,
+    withDetection: entries.filter((e) => e.detection).length,
+    perfectDetection: entries.filter(
+      (e) => e.detection && e.detection.fp === 0 && e.detection.fn === 0 && e.detection.tp > 0,
+    ).length,
+    duelled: entries.filter((e) => (e.detection?.competitors.length ?? 0) > 0).length,
   },
   rules: entries,
 };

--- a/apps/docs/src/data/rules-manifest.json
+++ b/apps/docs/src/data/rules-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-22T03:24:39.639Z",
+  "generatedAt": "2026-08-22T03:44:58.189Z",
   "totals": {
     "plugins": 30,
     "rules": 478,
@@ -8,7 +8,10 @@
     "withCwe": 325,
     "withSealRecord": 99,
     "sealed": 0,
-    "firingOnCorpus": 54
+    "firingOnCorpus": 54,
+    "withDetection": 94,
+    "perfectDetection": 75,
+    "duelled": 7
   },
   "rules": [
     {
@@ -28,7 +31,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-browser-api-key-exposure.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-anthropic-security",
@@ -47,7 +51,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-hardcoded-api-key.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-anthropic-security",
@@ -66,7 +71,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-untrusted-content-in-prompt.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-browser-security",
@@ -90,6 +96,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 15,
+        "fp": 0,
+        "fn": 0,
+        "tn": 17,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 32,
+        "vulnerable": 15,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -109,7 +129,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-browser-security/rules/no-allow-arbitrary-loads",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-browser-security",
@@ -133,6 +154,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 11,
+        "fp": 0,
+        "fn": 0,
+        "tn": 12,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 23,
+        "vulnerable": 11,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -157,6 +192,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 12,
+        "fp": 0,
+        "fn": 0,
+        "tn": 10,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 22,
+        "vulnerable": 12,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -181,6 +230,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 12,
+        "fp": 0,
+        "fn": 0,
+        "tn": 10,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 22,
+        "vulnerable": 12,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -200,7 +263,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-browser-security/rules/no-credentials-in-query-params",
       "corpusFindings": 1,
       "budgetReason": "1. okta-signin-widget src/v1/util/RouterUtil.js:34 — a handlebars template `{{baseUrl}}/login/sessionCookieRedirect?...&token={{{token}}}`. CORRECT: a session token in a query string is CWE-598, and query strings reach logs, proxies and Referer headers. Budgeted rather than must-fix because the URL shape is Okta's own published API contract — the maintainer cannot change it from this file.",
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-browser-security",
@@ -219,7 +283,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-browser-security/rules/no-disabled-certificate-validation",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-browser-security",
@@ -243,6 +308,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 12,
+        "fp": 0,
+        "fn": 0,
+        "tn": 11,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 23,
+        "vulnerable": 12,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -267,6 +346,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 14,
+        "fp": 0,
+        "fn": 0,
+        "tn": 11,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 25,
+        "vulnerable": 14,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -286,7 +379,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-browser-security/rules/no-filereader-innerhtml",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-browser-security",
@@ -310,6 +404,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 10,
+        "fp": 0,
+        "fn": 0,
+        "tn": 14,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 24,
+        "vulnerable": 10,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -334,6 +442,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 6,
+        "fp": 0,
+        "fn": 0,
+        "tn": 7,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 13,
+        "vulnerable": 6,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -358,6 +480,42 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 24,
+        "fp": 0,
+        "fn": 0,
+        "tn": 20,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 44,
+        "vulnerable": 24,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": [
+          {
+            "name": "no-unsanitized (Mozilla) [property, method]",
+            "tp": 20,
+            "fp": 9,
+            "fn": 4,
+            "f1": 0.7547169811320755
+          },
+          {
+            "name": "@microsoft/sdl [no-inner-html, no-html-method, no-document-write]",
+            "tp": 19,
+            "fp": 11,
+            "fn": 5,
+            "f1": 0.7037037037037038
+          },
+          {
+            "name": "sonarjs [dompurify-unsafe-config]",
+            "tp": 0,
+            "fp": 0,
+            "fn": 24,
+            "f1": 0
+          }
+        ]
       }
     },
     {
@@ -382,6 +540,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 2
+      },
+      "detection": {
+        "tp": 17,
+        "fp": 0,
+        "fn": 0,
+        "tn": 14,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 31,
+        "vulnerable": 17,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -406,6 +578,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 8,
+        "fp": 0,
+        "fn": 0,
+        "tn": 9,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 17,
+        "vulnerable": 8,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -430,6 +616,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 18,
+        "fp": 0,
+        "fn": 0,
+        "tn": 14,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 32,
+        "vulnerable": 18,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -449,7 +649,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-browser-security/rules/no-missing-cors-check",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-browser-security",
@@ -473,6 +674,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 8,
+        "fp": 0,
+        "fn": 0,
+        "tn": 9,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 17,
+        "vulnerable": 8,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -497,6 +712,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 11,
+        "fp": 0,
+        "fn": 0,
+        "tn": 13,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 24,
+        "vulnerable": 11,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -521,6 +750,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 12,
+        "fp": 0,
+        "fn": 0,
+        "tn": 10,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 22,
+        "vulnerable": 12,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -545,6 +788,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 11,
+        "fp": 0,
+        "fn": 0,
+        "tn": 10,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 21,
+        "vulnerable": 11,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -564,7 +821,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-browser-security/rules/no-postmessage-innerhtml",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-browser-security",
@@ -583,7 +841,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-browser-security/rules/no-postmessage-wildcard-origin",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-browser-security",
@@ -607,6 +866,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 11,
+        "fp": 0,
+        "fn": 0,
+        "tn": 10,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 21,
+        "vulnerable": 11,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -631,6 +904,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 12,
+        "fp": 0,
+        "fn": 0,
+        "tn": 10,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 22,
+        "vulnerable": 12,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -655,6 +942,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 13,
+        "fp": 0,
+        "fn": 0,
+        "tn": 10,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 23,
+        "vulnerable": 13,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -679,6 +980,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 13,
+        "fp": 0,
+        "fn": 0,
+        "tn": 10,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 23,
+        "vulnerable": 13,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -703,6 +1018,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 14,
+        "fp": 0,
+        "fn": 0,
+        "tn": 11,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 25,
+        "vulnerable": 14,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -727,6 +1056,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 12,
+        "fp": 0,
+        "fn": 0,
+        "tn": 10,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 22,
+        "vulnerable": 12,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -751,6 +1094,22 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 11,
+        "fp": 0,
+        "fn": 1,
+        "tn": 11,
+        "precision": 1,
+        "recall": 0.9166666666666666,
+        "f1": 0.9565217391304348,
+        "fixtures": 23,
+        "vulnerable": 12,
+        "missed": [
+          "vulnerable/11-consent-shaped-but-unrelated.js"
+        ],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -775,6 +1134,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 9,
+        "fp": 0,
+        "fn": 0,
+        "tn": 12,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 21,
+        "vulnerable": 9,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -799,6 +1172,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 21,
+        "fp": 0,
+        "fn": 0,
+        "tn": 24,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 45,
+        "vulnerable": 21,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -823,6 +1210,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 14,
+        "fp": 0,
+        "fn": 0,
+        "tn": 11,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 25,
+        "vulnerable": 14,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -842,7 +1243,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-browser-security/rules/no-unsafe-inline-csp",
       "corpusFindings": 1,
       "budgetReason": "1. okta-signin-widget Gruntfile.js:267 — a `script-src` string containing an inline allowance. CORRECT reading of the directive; it is BUILD tooling rather than shipped policy, which is why it is budgeted.",
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-browser-security",
@@ -866,6 +1268,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 13,
+        "fp": 0,
+        "fn": 0,
+        "tn": 9,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 22,
+        "vulnerable": 13,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -890,6 +1306,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 11,
+        "fp": 0,
+        "fn": 0,
+        "tn": 10,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 21,
+        "vulnerable": 11,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -909,7 +1339,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-browser-security/rules/no-websocket-innerhtml",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-browser-security",
@@ -928,7 +1359,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-browser-security/rules/no-worker-message-innerhtml",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-browser-security",
@@ -952,6 +1384,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 10,
+        "fp": 0,
+        "fn": 0,
+        "tn": 10,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 20,
+        "vulnerable": 10,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -976,6 +1422,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 12,
+        "fp": 0,
+        "fn": 0,
+        "tn": 11,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 23,
+        "vulnerable": 12,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -1000,6 +1460,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 11,
+        "fp": 0,
+        "fn": 0,
+        "tn": 12,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 23,
+        "vulnerable": 11,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -1024,6 +1498,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 13,
+        "fp": 0,
+        "fn": 0,
+        "tn": 18,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 31,
+        "vulnerable": 13,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -1048,6 +1536,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 10,
+        "fp": 0,
+        "fn": 0,
+        "tn": 11,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 21,
+        "vulnerable": 10,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -1067,7 +1569,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-browser-security/rules/require-postmessage-origin-check",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-browser-security",
@@ -1091,6 +1594,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 13,
+        "fp": 0,
+        "fn": 0,
+        "tn": 11,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 24,
+        "vulnerable": 13,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -1115,6 +1632,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 8,
+        "fp": 0,
+        "fn": 0,
+        "tn": 11,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 19,
+        "vulnerable": 8,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -1134,7 +1665,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/analytics-event-naming.md",
       "corpusFindings": 1,
       "budgetReason": "1. Correct in contract — a single analytics event name off the configured taxonomy.",
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-conventions",
@@ -1153,7 +1685,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/consistent-existence-index-check.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-conventions",
@@ -1172,7 +1705,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/expiring-todo-comments.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-conventions",
@@ -1191,7 +1725,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/filename-case.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-conventions",
@@ -1215,7 +1750,8 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 4
-      }
+      },
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-conventions",
@@ -1234,7 +1770,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-console-spaces.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-conventions",
@@ -1253,7 +1790,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-deprecated-api.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-conventions",
@@ -1272,7 +1810,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-json-schema-tags.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-conventions",
@@ -1296,7 +1835,8 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 4
-      }
+      },
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-conventions",
@@ -1315,7 +1855,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-raw-cross-property-href.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-conventions",
@@ -1334,7 +1875,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/prefer-code-point.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-conventions",
@@ -1353,7 +1895,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/prefer-dependency-version-strategy.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-conventions",
@@ -1372,7 +1915,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/prefer-dom-node-text-content.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-conventions",
@@ -1391,7 +1935,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-data-testid.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-conventions",
@@ -1410,7 +1955,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/utm-taxonomy.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-drizzle-security",
@@ -1429,7 +1975,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-drizzle-security/docs/rules/no-mass-assignment.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-drizzle-security",
@@ -1448,7 +1995,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-drizzle-security/docs/rules/no-raw-identifier-interpolation.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-drizzle-security",
@@ -1467,7 +2015,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-drizzle-security/docs/rules/no-unsafe-query.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-drizzle-security",
@@ -1486,7 +2035,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-drizzle-security/docs/rules/no-unscoped-mutation.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-express-security",
@@ -1505,7 +2055,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-client-controlled-authorization.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-express-security",
@@ -1524,7 +2075,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-cors-credentials-wildcard.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-express-security",
@@ -1543,7 +2095,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-disabled-helmet-protections.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-express-security",
@@ -1562,7 +2115,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-error-details-in-response.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-express-security",
@@ -1581,7 +2135,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-exposed-debug-endpoints.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-express-security",
@@ -1600,7 +2155,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-express-unsafe-regex-route.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-express-security",
@@ -1619,7 +2175,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-graphql-introspection-production.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-express-security",
@@ -1638,7 +2195,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-host-header-in-links.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-express-security",
@@ -1657,7 +2215,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-idor-resource-access.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-express-security",
@@ -1676,7 +2235,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-insecure-cookie-options.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-express-security",
@@ -1695,7 +2255,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-missing-cors-check.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-express-security",
@@ -1714,7 +2275,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-missing-csrf-protection.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-express-security",
@@ -1733,7 +2295,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-missing-security-headers.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-express-security",
@@ -1752,7 +2315,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-permissive-cors.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-express-security",
@@ -1771,7 +2335,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-permissive-trust-proxy.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-express-security",
@@ -1790,7 +2355,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-sensitive-data-in-query.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-express-security",
@@ -1809,7 +2375,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-static-root-exposure.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-express-security",
@@ -1828,7 +2395,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-unsafe-csp-directives.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-express-security",
@@ -1847,7 +2415,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-user-controlled-redirect.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-express-security",
@@ -1866,7 +2435,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-user-controlled-render-locals.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-express-security",
@@ -1885,7 +2455,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-case-insensitive-path-guard.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-express-security",
@@ -1904,7 +2475,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-csrf-protection.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-express-security",
@@ -1923,7 +2495,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-express-body-parser-limits.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-express-security",
@@ -1942,7 +2515,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-helmet.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-express-security",
@@ -1961,7 +2535,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-query-type-guard.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-express-security",
@@ -1980,7 +2555,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-rate-limiting.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-express-security",
@@ -1999,7 +2575,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-route-authentication.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-express-security",
@@ -2018,7 +2595,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-strict-transport-security.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-gemini-security",
@@ -2037,7 +2615,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-disabled-safety-settings.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-gemini-security",
@@ -2056,7 +2635,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-hardcoded-api-key.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-gemini-security",
@@ -2075,7 +2655,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-untrusted-content-in-prompt.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2094,7 +2675,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/consistent-type-specifier-style.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2113,7 +2695,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/default.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2132,7 +2715,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/dynamic-import-chunkname.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2151,7 +2735,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/enforce-dependency-direction.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2170,7 +2755,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/enforce-import-order.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2189,7 +2775,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/enforce-team-boundaries.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2213,7 +2800,8 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 2
-      }
+      },
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2232,7 +2820,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/exports-last.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2251,7 +2840,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/extensions.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2270,7 +2860,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/first.md",
       "corpusFindings": 577,
       "budgetReason": "577. Correct in contract, and the finding is real: twilio-node's generated clients emit `import`, then `const deserialize = require(...)`, then more `import`s. An import after non-import statements is exactly what the rule is for. Generated code, so nobody acts.",
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2289,7 +2880,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/group-exports.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2308,7 +2900,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/max-dependencies.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2327,7 +2920,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/named.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2346,7 +2940,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/namespace.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2365,7 +2960,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/newline-after-import.md",
       "corpusFindings": 693,
       "budgetReason": "693. Correct in contract. Same class as `order` — LOW-severity formatting over generated files, where imports are interleaved with `const x = require(...)` so the 'last import' is genuinely ambiguous.",
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2384,7 +2980,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-absolute-path.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2403,7 +3000,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-amd.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2422,7 +3020,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-anonymous-default-export.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2441,7 +3040,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-barrel-file.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2460,7 +3060,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-barrel-import.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2479,7 +3080,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-commonjs.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2498,7 +3100,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-cross-domain-imports.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2517,7 +3120,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-cycle.md",
       "corpusFindings": 1337,
       "budgetReason": "1337. Correct — real circular imports, concentrated in generated SDK class hierarchies (twilio Page/Version/AccountsBase, okta idx remediators). CVSS 5.3 / CRITICAL is severity inflation for a circular import and is worth revisiting separately; the DETECTION is right.",
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2536,7 +3140,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-default-export.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2555,7 +3160,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-deprecated.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2574,7 +3180,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-duplicates.md",
       "corpusFindings": 37,
       "budgetReason": "37. Correct — two import statements from the same module in one file.",
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2593,7 +3200,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-dynamic-require.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2612,7 +3220,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-empty-named-blocks.md",
       "corpusFindings": 1,
       "budgetReason": "1. Correct — an `import {} from 'x'` with an empty named block.",
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2631,7 +3240,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-extraneous-dependencies.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2650,7 +3260,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-full-package-import.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2669,7 +3280,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-import-module-exports.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2688,7 +3300,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-internal-modules.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2707,7 +3320,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-legacy-imports.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2726,7 +3340,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-mutable-exports.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2745,7 +3360,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-named-as-default.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2764,7 +3380,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-named-as-default-member.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2783,7 +3400,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-named-default.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2802,7 +3420,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-named-export.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2821,7 +3440,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-namespace.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2840,7 +3460,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-nodejs-modules.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2859,7 +3480,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-relative-packages.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2878,7 +3500,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-relative-parent-imports.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2897,7 +3520,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-restricted-paths.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2916,7 +3540,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-self-import.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2935,7 +3560,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-unassigned-import.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2954,7 +3580,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-unresolved.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2973,7 +3600,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-unused-modules.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -2992,7 +3620,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-useless-path-segments.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -3011,7 +3640,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/enforce-import-order.md",
       "corpusFindings": 1825,
       "budgetReason": "1825. Correct in contract — import groups genuinely out of order. LOW severity style, dominated by large generated SDK trees (okta-auth-js, twilio-node). Nobody reorders generated imports, so these are effective FPs under the Tricorder standard, but the rule is not wrong; the question is whether a style rule belongs in `recommended`, which is a preset decision rather than a rule defect.",
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -3030,7 +3660,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/prefer-default-export.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -3049,7 +3680,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/prefer-direct-import.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -3068,7 +3700,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/prefer-modern-api.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -3087,7 +3720,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/prefer-node-protocol.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -3106,7 +3740,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/prefer-tree-shakeable-imports.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -3125,7 +3760,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-import-approval.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-import-next",
@@ -3144,7 +3780,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/unambiguous.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-jwt-security",
@@ -3163,7 +3800,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-algorithm-confusion.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-jwt-security",
@@ -3182,7 +3820,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-algorithm-none.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-jwt-security",
@@ -3201,7 +3840,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-decode-without-verify.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-jwt-security",
@@ -3220,7 +3860,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-hardcoded-secret.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-jwt-security",
@@ -3239,7 +3880,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-sensitive-payload.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-jwt-security",
@@ -3258,7 +3900,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-timestamp-manipulation.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-jwt-security",
@@ -3277,7 +3920,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-weak-secret.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-jwt-security",
@@ -3296,7 +3940,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-algorithm-whitelist.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-jwt-security",
@@ -3315,7 +3960,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-audience-validation.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-jwt-security",
@@ -3334,7 +3980,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-expiration.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-jwt-security",
@@ -3353,7 +4000,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-issued-at.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-jwt-security",
@@ -3372,7 +4020,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-issuer-validation.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-jwt-security",
@@ -3391,7 +4040,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-max-age.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-knex-security",
@@ -3410,7 +4060,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-knex-security/docs/rules/no-hardcoded-credentials.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-knex-security",
@@ -3429,7 +4080,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-knex-security/docs/rules/no-mass-assignment.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-knex-security",
@@ -3448,7 +4100,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-knex-security/docs/rules/no-unsafe-query.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-knex-security",
@@ -3467,7 +4120,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-knex-security/docs/rules/no-unscoped-mutation.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-knex-security",
@@ -3486,7 +4140,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-knex-security/docs/rules/require-tls.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-lambda-security",
@@ -3505,7 +4160,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-env-logging.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-lambda-security",
@@ -3524,7 +4180,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-error-swallowing.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-lambda-security",
@@ -3543,7 +4200,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-exposed-debug-endpoints.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-lambda-security",
@@ -3562,7 +4220,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-exposed-error-details.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-lambda-security",
@@ -3581,7 +4240,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-hardcoded-credentials-sdk.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-lambda-security",
@@ -3600,7 +4260,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-missing-authorization-check.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-lambda-security",
@@ -3619,7 +4280,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-overly-permissive-iam-policy.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-lambda-security",
@@ -3638,7 +4300,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-permissive-cors-middy.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-lambda-security",
@@ -3657,7 +4320,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-permissive-cors-response.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-lambda-security",
@@ -3676,7 +4340,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-secrets-in-env.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-lambda-security",
@@ -3695,7 +4360,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-unbounded-batch-processing.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-lambda-security",
@@ -3714,7 +4380,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-unvalidated-event-body.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-lambda-security",
@@ -3733,7 +4400,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-user-controlled-requests.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-lambda-security",
@@ -3752,7 +4420,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-timeout-handling.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-maintainability",
@@ -3771,7 +4440,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/cognitive-complexity.md",
       "corpusFindings": 671,
       "budgetReason": "671. Correct in contract — functions over the configured cognitive-complexity budget, concentrated in generated SDK dispatch and in okta's idx remediator tree. A measurement of the target's code, not a defect in ours.",
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-maintainability",
@@ -3790,7 +4460,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/consistent-function-scoping.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-maintainability",
@@ -3809,7 +4480,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/error-message.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-maintainability",
@@ -3833,7 +4505,8 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 3
-      }
+      },
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-maintainability",
@@ -3852,7 +4525,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/max-parameters.md",
       "corpusFindings": 185,
       "budgetReason": "185. Correct in contract — functions over the configured parameter count. Same character as cognitive-complexity: a true statement about the target.",
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-maintainability",
@@ -3871,7 +4545,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/nested-complexity-hotspots.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-maintainability",
@@ -3890,7 +4565,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-lonely-if.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-maintainability",
@@ -3909,7 +4585,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-missing-error-context.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-maintainability",
@@ -3928,7 +4605,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-nested-ternary.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-maintainability",
@@ -3947,7 +4625,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-silent-errors.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-maintainability",
@@ -3966,7 +4645,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-unhandled-promise.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-maintainability",
@@ -3985,7 +4665,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-unreadable-iife.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-mcp-sdk-security",
@@ -4004,7 +4685,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-command-injection-in-tool.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-mcp-sdk-security",
@@ -4023,7 +4705,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-tool-description-injection.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-mcp-sdk-security",
@@ -4042,7 +4725,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-unvalidated-tool-args.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-mcp-sdk-security",
@@ -4061,7 +4745,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-tool-input-schema.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-modernization",
@@ -4080,7 +4765,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-instanceof-array.md",
       "corpusFindings": 1,
       "budgetReason": "1. Correct — `instanceof Array` fails across realms; `Array.isArray` does not.",
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-modernization",
@@ -4099,7 +4785,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/prefer-at.md",
       "corpusFindings": 15,
       "budgetReason": "15. Correct — `arr[arr.length - 1]` where `.at(-1)` reads better.",
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-modernization",
@@ -4118,7 +4805,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/prefer-event-target.md",
       "corpusFindings": 17,
       "budgetReason": "17. Correct — Node EventEmitter where the cross-platform EventTarget would do.",
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-modernization",
@@ -4137,7 +4825,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/prefer-template-literal.md",
       "corpusFindings": 185,
       "budgetReason": "185. Correct — `'okta-auth-js/' + SDK_VERSION`, `sdk.getIssuerOrigin() + '/api/v1/authn'`. String concatenation that reads better as a template. LOW-value style, no defect.",
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-modularity",
@@ -4156,7 +4845,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/ddd-anemic-domain-model.md",
       "corpusFindings": 526,
       "budgetReason": "526. Batch 5, and the largest entry in it. Correct in contract: the rule flags classes that hold data without behaviour. Sampled okta-auth-js — AuthnTransactionImpl, OktaAuthBase, BaseOptionsConstructor — and every one is a transport or options object in an SDK, which is exactly what an anemic model looks like and exactly what an SDK is supposed to ship.\n\nA philosophical mismatch rather than a defect: DDD is an opinion about DOMAIN code, and it is being applied to a client library. Budgeted. Whether this rule belongs in `recommended` is a preset question of the same kind raised by the style rules in Batch 2.",
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-modularity",
@@ -4175,7 +4865,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/ddd-value-object-immutability.md",
       "corpusFindings": 11,
       "budgetReason": "11. Correct — value-object fields reassigned after construction.",
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-modularity",
@@ -4194,7 +4885,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/enforce-naming.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-modularity",
@@ -4213,7 +4905,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/enforce-rest-conventions.md",
       "corpusFindings": 6,
       "budgetReason": "6. Correct — route shapes off the configured REST convention.",
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-modularity",
@@ -4232,7 +4925,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-external-api-calls-in-utils.md",
       "corpusFindings": 1,
       "budgetReason": "1. Correct — a network call from a util module.",
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-modularity",
@@ -4251,7 +4945,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-mutable-exports.md",
       "corpusFindings": 1,
       "budgetReason": "1. Correct — an exported binding that is reassigned.",
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-mongodb-security",
@@ -4270,7 +4965,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-bypass-middleware.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-mongodb-security",
@@ -4289,7 +4985,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-debug-mode-production.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-mongodb-security",
@@ -4308,7 +5005,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-hardcoded-connection-string.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-mongodb-security",
@@ -4327,7 +5025,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-hardcoded-credentials.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-mongodb-security",
@@ -4346,7 +5045,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-operator-injection.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-mongodb-security",
@@ -4365,7 +5065,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-select-sensitive-fields.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-mongodb-security",
@@ -4384,7 +5085,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-unbounded-find.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-mongodb-security",
@@ -4403,7 +5105,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-unsafe-populate.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-mongodb-security",
@@ -4422,7 +5125,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-unsafe-query.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-mongodb-security",
@@ -4441,7 +5145,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-unsafe-regex-query.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-mongodb-security",
@@ -4460,7 +5165,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-unsafe-where.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-mongodb-security",
@@ -4479,7 +5185,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-auth-mechanism.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-mongodb-security",
@@ -4498,7 +5205,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-lean-queries.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-mongodb-security",
@@ -4517,7 +5225,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-projection.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-mongodb-security",
@@ -4536,7 +5245,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-schema-validation.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-mongodb-security",
@@ -4555,7 +5265,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-tls-connection.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-mysql-security",
@@ -4574,7 +5285,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-mysql-security/docs/rules/no-hardcoded-credentials.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-mysql-security",
@@ -4593,7 +5305,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-mysql-security/docs/rules/no-unsafe-query.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-mysql-security",
@@ -4612,7 +5325,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-mysql-security/docs/rules/require-tls.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-nestjs-security",
@@ -4631,7 +5345,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-exposed-private-fields.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-nestjs-security",
@@ -4650,7 +5365,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-hybrid-app-config-loss.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-nestjs-security",
@@ -4669,7 +5385,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-missing-validation-pipe.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-nestjs-security",
@@ -4688,7 +5405,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-permissive-cors.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-nestjs-security",
@@ -4707,7 +5425,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-res-bypass-serialization.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-nestjs-security",
@@ -4726,7 +5445,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-unguarded-swagger.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-nestjs-security",
@@ -4745,7 +5465,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-unsafe-multer-filename.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-nestjs-security",
@@ -4764,7 +5485,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-guards.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-nestjs-security",
@@ -4783,7 +5505,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-throttler.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-nestjs-security",
@@ -4802,7 +5525,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-validation-pipe-whitelist.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-node-security",
@@ -4821,7 +5545,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-node-security/rules/detect-child-process",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-node-security",
@@ -4845,6 +5570,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 14,
+        "fp": 0,
+        "fn": 0,
+        "tn": 11,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 25,
+        "vulnerable": 14,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -4869,6 +5608,28 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 2
+      },
+      "detection": {
+        "tp": 10,
+        "fp": 0,
+        "fn": 0,
+        "tn": 10,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 20,
+        "vulnerable": 10,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": [
+          {
+            "name": "eslint-plugin-security [detect-non-literal-fs-filename]",
+            "tp": 10,
+            "fp": 8,
+            "fn": 0,
+            "f1": 0.7142857142857143
+          }
+        ]
       }
     },
     {
@@ -4893,6 +5654,22 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 15,
+        "fp": 1,
+        "fn": 0,
+        "tn": 9,
+        "precision": 0.9375,
+        "recall": 1,
+        "f1": 0.967741935483871,
+        "fixtures": 25,
+        "vulnerable": 15,
+        "missed": [],
+        "falsePositives": [
+          "safe/10-reactn-real-package.js"
+        ],
+        "competitors": []
       }
     },
     {
@@ -4917,6 +5694,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 0,
+        "fp": 0,
+        "fn": 0,
+        "tn": 4,
+        "precision": 0,
+        "recall": 0,
+        "f1": 0,
+        "fixtures": 4,
+        "vulnerable": 0,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -4936,7 +5727,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-node-security/rules/no-arbitrary-file-access",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-node-security",
@@ -4960,6 +5752,22 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 11,
+        "fp": 0,
+        "fn": 1,
+        "tn": 14,
+        "precision": 1,
+        "recall": 0.9166666666666666,
+        "f1": 0.9565217391304348,
+        "fixtures": 26,
+        "vulnerable": 12,
+        "missed": [
+          "vulnerable/12-helper-parameter-from-wire.js"
+        ],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -4984,6 +5792,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 15,
+        "fp": 0,
+        "fn": 0,
+        "tn": 16,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 31,
+        "vulnerable": 15,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -5008,6 +5830,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 13,
+        "fp": 0,
+        "fn": 0,
+        "tn": 15,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 28,
+        "vulnerable": 13,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -5032,6 +5868,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 15,
+        "fp": 0,
+        "fn": 0,
+        "tn": 13,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 28,
+        "vulnerable": 15,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -5056,6 +5906,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 9,
+        "fp": 0,
+        "fn": 0,
+        "tn": 12,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 21,
+        "vulnerable": 9,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -5075,7 +5939,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-node-security/rules/no-deprecated-cipher-method",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-node-security",
@@ -5094,7 +5959,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-node-security/rules/no-dynamic-algorithm-selection",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-node-security",
@@ -5118,6 +5984,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 16,
+        "fp": 0,
+        "fn": 0,
+        "tn": 16,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 32,
+        "vulnerable": 16,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -5142,6 +6022,22 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 11,
+        "fp": 1,
+        "fn": 0,
+        "tn": 9,
+        "precision": 0.9166666666666666,
+        "recall": 1,
+        "f1": 0.9565217391304348,
+        "fixtures": 21,
+        "vulnerable": 11,
+        "missed": [],
+        "falsePositives": [
+          "safe/08-allowlist-lookup.js"
+        ],
+        "competitors": []
       }
     },
     {
@@ -5161,7 +6057,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-node-security/rules/no-dynamic-require",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-node-security",
@@ -5180,7 +6077,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-node-security/rules/no-ecb-mode",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-node-security",
@@ -5199,7 +6097,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-node-security/rules/no-env-injection",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-node-security",
@@ -5218,7 +6117,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-node-security/rules/no-insecure-http-parser",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-node-security",
@@ -5242,6 +6142,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 15,
+        "fp": 0,
+        "fn": 0,
+        "tn": 18,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 33,
+        "vulnerable": 15,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -5261,7 +6175,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-node-security/rules/no-insecure-rsa-padding",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-node-security",
@@ -5285,6 +6200,23 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 20,
+        "fp": 0,
+        "fn": 2,
+        "tn": 18,
+        "precision": 1,
+        "recall": 0.9090909090909091,
+        "f1": 0.9523809523809523,
+        "fixtures": 40,
+        "vulnerable": 22,
+        "missed": [
+          "vulnerable/06-temp-upload-filename.js",
+          "vulnerable/33-unrevealing-name.js"
+        ],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -5304,7 +6236,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-node-security/rules/no-self-signed-certs",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-node-security",
@@ -5323,7 +6256,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-node-security/rules/no-sha1-hash",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-node-security",
@@ -5342,7 +6276,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-node-security/rules/no-shell-injection",
       "corpusFindings": 1,
       "budgetReason": "1. Shopify/cli packages/plugin-cloudflare/src/install-cloudflared.ts:135 — `execSync(`t...`)` with an interpolated template. Correct shape for the rule; the interpolated value is an install path the CLI itself computes.",
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-node-security",
@@ -5361,7 +6296,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-node-security/rules/no-ssrf",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-node-security",
@@ -5385,6 +6321,22 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 14,
+        "fp": 0,
+        "fn": 1,
+        "tn": 15,
+        "precision": 1,
+        "recall": 0.9333333333333333,
+        "f1": 0.9655172413793104,
+        "fixtures": 30,
+        "vulnerable": 15,
+        "missed": [
+          "vulnerable/10-derived-from-key.js"
+        ],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -5409,6 +6361,22 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 2
+      },
+      "detection": {
+        "tp": 24,
+        "fp": 0,
+        "fn": 1,
+        "tn": 18,
+        "precision": 1,
+        "recall": 0.96,
+        "f1": 0.9795918367346939,
+        "fixtures": 43,
+        "vulnerable": 25,
+        "missed": [
+          "vulnerable/32-unrevealing-both-sides.js"
+        ],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -5433,6 +6401,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 16,
+        "fp": 0,
+        "fn": 0,
+        "tn": 15,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 31,
+        "vulnerable": 16,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -5452,7 +6434,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-node-security/rules/no-unbounded-decompression",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-node-security",
@@ -5476,6 +6459,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 13,
+        "fp": 0,
+        "fn": 0,
+        "tn": 12,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 25,
+        "vulnerable": 13,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -5500,6 +6497,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 12,
+        "fp": 0,
+        "fn": 0,
+        "tn": 12,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 24,
+        "vulnerable": 12,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -5519,7 +6530,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-node-security/rules/no-weak-cipher-algorithm",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-node-security",
@@ -5538,7 +6550,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-node-security/rules/no-weak-hash-algorithm",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-node-security",
@@ -5557,7 +6570,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-node-security/rules/no-zip-slip",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-node-security",
@@ -5581,6 +6595,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 15,
+        "fp": 0,
+        "fn": 0,
+        "tn": 18,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 33,
+        "vulnerable": 15,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -5600,7 +6628,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-node-security/rules/require-aead-tag-verification",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-node-security",
@@ -5624,6 +6653,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 10,
+        "fp": 0,
+        "fn": 0,
+        "tn": 9,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 19,
+        "vulnerable": 10,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -5648,6 +6691,29 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 9,
+        "fp": 3,
+        "fn": 4,
+        "tn": 9,
+        "precision": 0.75,
+        "recall": 0.6923076923076923,
+        "f1": 0.7199999999999999,
+        "fixtures": 25,
+        "vulnerable": 13,
+        "missed": [
+          "vulnerable/07-session-storage-cast.ts",
+          "vulnerable/08-store-alias.js",
+          "vulnerable/09-credentials-object-json.js",
+          "vulnerable/13-asyncstorage-multiset.js"
+        ],
+        "falsePositives": [
+          "safe/06-password-policy-config.js",
+          "safe/08-env-doc-url.js",
+          "safe/12-env-flag-defaults.js"
+        ],
+        "competitors": []
       }
     },
     {
@@ -5672,6 +6738,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 9,
+        "fp": 0,
+        "fn": 0,
+        "tn": 9,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 18,
+        "vulnerable": 9,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -5696,6 +6776,31 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 4,
+        "fp": 2,
+        "fn": 7,
+        "tn": 7,
+        "precision": 0.6666666666666666,
+        "recall": 0.36363636363636365,
+        "f1": 0.4705882352941177,
+        "fixtures": 20,
+        "vulnerable": 11,
+        "missed": [
+          "vulnerable/02-destructured-write-apikey.js",
+          "vulnerable/04-json-stringify-credentials.js",
+          "vulnerable/05-ts-cast-client-secret.ts",
+          "vulnerable/08-kubeconfig-service-account.js",
+          "vulnerable/09-fake-local-encrypt.js",
+          "vulnerable/10-computed-member-write.js",
+          "vulnerable/11-fs-extra-outputfile-secret.js"
+        ],
+        "falsePositives": [
+          "safe/07-password-policy-doc.js",
+          "safe/08-tokenizer-cache.js"
+        ],
+        "competitors": []
       }
     },
     {
@@ -5715,7 +6820,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-node-security/rules/require-stream-error-handler",
       "corpusFindings": 4,
       "budgetReason": "4, and all 4 are TRUE POSITIVES. Re-examined 2026-08-21 because 'there is an error handler three lines up' made them look like obvious FPs. They are not, and the question is always WHICH STREAM the handler is attached to:\n\nShopify archiver.ts:55 and :163 blame `output`, the write stream. `archive.on('error')` covers the archiver; `output` has only an 'close' listener, so a disk-full or EACCES on the destination is an uncaught exception. .pipe() does not forward errors in either direction.\n\nokta ImageDiff.js:12 blames `fs.createReadStream(image)`. The chained `.on('error', reject)` attaches to the PNG DESTINATION, not the source, so ENOENT on a missing image is unhandled — the classic pipe gotcha the rule exists for.\n\nokta ImageDiff.js:63 has no handler on either end at all.\n\nDo not 'fix' this rule by treating a nearby .on('error') as coverage. Any such change must keep these four reporting.",
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-openai-security",
@@ -5734,7 +6840,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-browser-api-key-exposure.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-openai-security",
@@ -5753,7 +6860,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-hardcoded-api-key.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-openai-security",
@@ -5772,7 +6880,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-untrusted-content-in-prompt.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-operability",
@@ -5791,7 +6900,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-console-log.md",
       "corpusFindings": 107,
       "budgetReason": "107. Correct, and deliberately overlapping with operability/no-debug-code-in-production (120) — the two report the same `console.log` lines under different framings, one as 'do not log from a library', the other as 'this is debug code'. Sampled okta-auth-js env/index.js:22 and scripts/verify-package.js:3/:12: build scripts and env loaders, not shipped code.\n\nSame gap as its twin: a repo's `scripts/`, `bin/` and `env/` trees are not production, and neither rule scopes by path. Worth one shared path-scoping option rather than two; that is a scope decision, not a defect. The overlap is also worth a partition note — two rules reporting one line is the shape the browser-security URL family was already partitioned to avoid.",
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-operability",
@@ -5810,7 +6920,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-debug-code-in-production.md",
       "corpusFindings": 120,
       "budgetReason": "120. Correct detection, wrong audience. Sampled okta-auth-js: env/index.js:22 and scripts/verify-package.js:3 — `console.log` in BUILD scripts and env loaders, not shipped code. The rule is right that it is debug output; the gap is that a repo's `scripts/`, `bin/` and `env/` trees are not production. Worth a path-scoping option, which is a scope decision rather than a bug.",
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-operability",
@@ -5829,7 +6940,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-process-exit.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-operability",
@@ -5848,7 +6960,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-verbose-error-messages.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-operability",
@@ -5867,7 +6980,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-code-minification.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-operability",
@@ -5886,7 +7000,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-data-minimization.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-postgresql-security",
@@ -5910,6 +7025,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 16,
+        "fp": 0,
+        "fn": 0,
+        "tn": 16,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 32,
+        "vulnerable": 16,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -5934,6 +7063,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 14,
+        "fp": 0,
+        "fn": 0,
+        "tn": 13,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 27,
+        "vulnerable": 14,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -5958,6 +7101,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 14,
+        "fp": 0,
+        "fn": 0,
+        "tn": 14,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 28,
+        "vulnerable": 14,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -5982,6 +7139,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 11,
+        "fp": 0,
+        "fn": 0,
+        "tn": 12,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 23,
+        "vulnerable": 11,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -6006,6 +7177,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 11,
+        "fp": 0,
+        "fn": 0,
+        "tn": 10,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 21,
+        "vulnerable": 11,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -6030,6 +7215,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 10,
+        "fp": 0,
+        "fn": 0,
+        "tn": 10,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 20,
+        "vulnerable": 10,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -6054,6 +7253,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 12,
+        "fp": 0,
+        "fn": 0,
+        "tn": 13,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 25,
+        "vulnerable": 12,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -6078,6 +7291,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 10,
+        "fp": 0,
+        "fn": 0,
+        "tn": 10,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 20,
+        "vulnerable": 10,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -6102,6 +7329,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 14,
+        "fp": 0,
+        "fn": 0,
+        "tn": 12,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 26,
+        "vulnerable": 14,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -6126,6 +7367,35 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 9,
+        "fp": 0,
+        "fn": 0,
+        "tn": 7,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 16,
+        "vulnerable": 9,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": [
+          {
+            "name": "sonarjs [sql-queries]",
+            "tp": 4,
+            "fp": 1,
+            "fn": 5,
+            "f1": 0.5714285714285714
+          },
+          {
+            "name": "eslint-plugin-security [detect-object-injection]",
+            "tp": 0,
+            "fp": 0,
+            "fn": 9,
+            "f1": 0
+          }
+        ]
       }
     },
     {
@@ -6150,6 +7420,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 15,
+        "fp": 0,
+        "fn": 0,
+        "tn": 14,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 29,
+        "vulnerable": 15,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -6174,6 +7458,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 11,
+        "fp": 0,
+        "fn": 0,
+        "tn": 15,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 26,
+        "vulnerable": 11,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -6198,6 +7496,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 9,
+        "fp": 0,
+        "fn": 0,
+        "tn": 10,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 19,
+        "vulnerable": 9,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -6217,7 +7529,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-prisma-security/docs/rules/no-mass-assignment.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-prisma-security",
@@ -6236,7 +7549,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-prisma-security/docs/rules/no-raw-identifier-interpolation.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-prisma-security",
@@ -6255,7 +7569,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-prisma-security/docs/rules/no-unsafe-query.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-prisma-security",
@@ -6274,7 +7589,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-prisma-security/docs/rules/no-unscoped-mutation.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-a11y",
@@ -6293,7 +7609,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/alt-text.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-a11y",
@@ -6312,7 +7629,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/anchor-ambiguous-text.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-a11y",
@@ -6331,7 +7649,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/anchor-has-content.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-a11y",
@@ -6350,7 +7669,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/anchor-is-valid.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-a11y",
@@ -6369,7 +7689,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/aria-activedescendant-has-tabindex.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-a11y",
@@ -6388,7 +7709,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/aria-props.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-a11y",
@@ -6407,7 +7729,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/aria-role.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-a11y",
@@ -6426,7 +7749,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/aria-unsupported-elements.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-a11y",
@@ -6445,7 +7769,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/autocomplete-valid.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-a11y",
@@ -6464,7 +7789,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/click-events-have-key-events.md",
       "corpusFindings": 7,
       "budgetReason": "7. Correct — onClick with no keyboard equivalent, so the control is mouse-only.",
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-a11y",
@@ -6483,7 +7809,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/control-has-associated-label.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-a11y",
@@ -6502,7 +7829,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/heading-has-content.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-a11y",
@@ -6521,7 +7849,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/html-has-lang.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-a11y",
@@ -6540,7 +7869,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/iframe-has-title.md",
       "corpusFindings": 1,
       "budgetReason": "1. Correct — an iframe with no accessible name.",
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-a11y",
@@ -6559,7 +7889,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/img-redundant-alt.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-a11y",
@@ -6578,7 +7909,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/interactive-supports-focus.md",
       "corpusFindings": 7,
       "budgetReason": "7. Correct — an interactive element that cannot be reached by keyboard.",
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-a11y",
@@ -6597,7 +7929,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/label-has-associated-control.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-a11y",
@@ -6616,7 +7949,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/lang.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-a11y",
@@ -6635,7 +7969,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/media-has-caption.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-a11y",
@@ -6654,7 +7989,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/mouse-events-have-key-events.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-a11y",
@@ -6673,7 +8009,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-access-key.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-a11y",
@@ -6692,7 +8029,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-aria-hidden-on-focusable.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-a11y",
@@ -6711,7 +8049,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-autofocus.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-a11y",
@@ -6730,7 +8069,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-distracting-elements.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-a11y",
@@ -6749,7 +8089,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-interactive-element-to-noninteractive-role.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-a11y",
@@ -6768,7 +8109,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-keyboard-inaccessible-elements.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-a11y",
@@ -6787,7 +8129,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-missing-aria-labels.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-a11y",
@@ -6806,7 +8149,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-noninteractive-element-interactions.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-a11y",
@@ -6825,7 +8169,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-noninteractive-element-to-interactive-role.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-a11y",
@@ -6844,7 +8189,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-noninteractive-tabindex.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-a11y",
@@ -6863,7 +8209,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-redundant-roles.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-a11y",
@@ -6882,7 +8229,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-static-element-interactions.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-a11y",
@@ -6901,7 +8249,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/prefer-tag-over-role.md",
       "corpusFindings": 31,
       "budgetReason": "31. Correct — `<div role=\"button\">` where `<button>` carries the semantics, focus and keyboard behaviour for free.",
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-a11y",
@@ -6920,7 +8269,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/role-has-required-aria-props.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-a11y",
@@ -6939,7 +8289,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/role-supports-aria-props.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-a11y",
@@ -6958,7 +8309,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/scope.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-a11y",
@@ -6977,7 +8329,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/tabindex-no-positive.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -6996,7 +8349,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/checked-requires-onchange-or-readonly.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7015,7 +8369,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/default-props-match-prop-types.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7034,7 +8389,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/display-name.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7053,7 +8409,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/hooks-exhaustive-deps.md",
       "corpusFindings": 84,
       "budgetReason": "91. Correct in contract — a hook dependency array missing a value the effect reads. The canonical React correctness rule; a missing dep is a stale-closure bug, not a style opinion.\n\nMeasurement note — RESOLVED. Budgeted at 84, and the number is now stable.\n\nThe swing was never in the rule. The scan rig had no lockfile and installed `eslint@9`, `@typescript-eslint/parser` and `oxc-resolver` UNPINNED, so every install was free to resolve differently — and did: CI read this corpus at 14,996, 15,003 and 15,361 findings on the same commit, and this rule at both 84 and 91 on clean builds. Pinning every rig dependency to the workspace lockfile gives 14,876 on three consecutive fresh-rig runs, with this rule at 84 every time.\n\nPinning fixed a second thing nobody had noticed: the gate was measuring the plugins under ESLint 9 while the repository builds and tests them under 10. It now measures what the repo actually ships against.\n\nRecorded because the reasoning was the failure, not the number: I called 84 the truth, 'corrected' it to 91 arguing CI is the clean-environment authority, then corrected back when CI read 84. Three independent methods agreed on 84 throughout and I twice talked myself out of them. When measurements of the same thing disagree, the instrument is the finding.",
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7072,7 +8429,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/jsx-handler-names.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7091,7 +8449,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/jsx-key.md",
       "corpusFindings": 13,
       "budgetReason": "13. Correct — a list element rendered without a key. A real reconciliation bug.",
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7110,7 +8469,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/jsx-max-depth.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7129,7 +8489,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/jsx-no-bind.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7148,7 +8509,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/jsx-no-duplicate-props.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7167,7 +8529,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/jsx-no-literals.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7186,7 +8549,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/jsx-no-script-url.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7205,7 +8569,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/jsx-no-target-blank.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7224,7 +8589,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-access-state-in-setstate.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7243,7 +8609,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-adjacent-inline-elements.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7262,7 +8629,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-arbitrary-token-class.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7281,7 +8649,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-arrow-function-lifecycle.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7300,7 +8669,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-children-prop.md",
       "corpusFindings": 2,
       "budgetReason": "2. Correct — `children` passed as a prop rather than nested.",
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7319,7 +8689,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-danger.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7338,7 +8709,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-danger-with-children.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7357,7 +8729,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-default-test-id.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7376,7 +8749,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-deprecated.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7395,7 +8769,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-did-mount-set-state.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7414,7 +8789,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-did-update-set-state.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7433,7 +8809,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-direct-mutation-state.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7452,7 +8829,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-find-dom-node.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7471,7 +8849,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-inline-style.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7490,7 +8869,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-invalid-html-attribute.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7509,7 +8889,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-is-mounted.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7528,7 +8909,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-is-prefix-prop.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7547,7 +8929,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-kind-prop-discriminator.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7566,7 +8949,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-multi-comp.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7585,7 +8969,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-namespace.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7604,7 +8989,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-object-type-as-default-prop.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7623,7 +9009,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-raw-color-literal.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7642,7 +9029,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-redundant-should-component-update.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7661,7 +9049,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-render-return-value.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7680,7 +9069,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-set-state.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7699,7 +9089,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-string-refs.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7718,7 +9109,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-this-in-sfc.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7737,7 +9129,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-typos.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7756,7 +9149,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-unescaped-entities.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7775,7 +9169,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-unknown-property.md",
       "corpusFindings": 65,
       "budgetReason": "65. Correct — DOM props spelled the HTML way rather than the React way (`class`, `for`, `tabindex`). Concentrated in okta-signin-widget's older JSX.",
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7794,7 +9189,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-unnecessary-rerenders.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7813,7 +9209,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-unsafe.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7832,7 +9229,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-wrapper-sub-component.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7851,7 +9249,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/prefer-es6-class.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7870,7 +9269,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/prefer-stateless-function.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7889,7 +9289,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/prop-types.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7908,7 +9309,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/react-class-to-hooks.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7927,7 +9329,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/react-in-jsx-scope.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7946,7 +9349,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/react-no-inline-functions.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7965,7 +9369,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/react-render-optimization.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -7984,7 +9389,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-data-slot.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -8003,7 +9409,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-default-props.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -8022,7 +9429,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-optimization.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -8041,7 +9449,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-render-return.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -8060,7 +9469,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/required-attributes.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -8079,7 +9489,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/sort-comp.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -8098,7 +9509,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/state-in-constructor.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -8117,7 +9529,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/static-property-placement.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-react-features",
@@ -8136,7 +9549,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/void-dom-elements-no-children.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-reliability",
@@ -8155,7 +9569,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/error-message.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-reliability",
@@ -8174,7 +9589,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-await-in-loop.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-reliability",
@@ -8193,7 +9609,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-jsdoc-terminator-in-example.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-reliability",
@@ -8212,7 +9629,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-missing-error-context.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-reliability",
@@ -8236,7 +9654,8 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 11
-      }
+      },
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-reliability",
@@ -8255,7 +9674,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-silent-errors.md",
       "corpusFindings": 36,
       "budgetReason": "36. Kept. Literal `catch (error) {}` and bare `catch {}` with an empty body — a swallowed failure with nothing logged and nothing rethrown. Sampled Shopify/cli: create-test-app.js:92, create-test-theme.js:88, update-observe.js:395/417, public_metadata.ts:20, loader.ts:325. In contract and defensible; budgeted because an empty catch in a metrics hook is a deliberate choice a maintainer would not act on.",
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-reliability",
@@ -8274,7 +9694,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-unhandled-promise.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-reliability",
@@ -8293,7 +9714,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-unsafe-type-narrowing.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-reliability",
@@ -8312,7 +9734,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-network-timeout.md",
       "corpusFindings": 40,
       "budgetReason": "40. Kept. `await fetch(url)` with no AbortSignal or timeout. Node's fetch has NO default timeout, so a hung connection hangs the caller forever — this is the rule's contract and the findings are in it. Sampled Shopify/cli: create-homebrew-pr.js:138/152, get-graphql-schemas.js:124, bundle.ts:70, graphiql-token-provider.ts:26. Weaker case in one-shot bin/ scripts than in the shipped CLI, which is why it is budgeted rather than must-fix.",
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-secure-coding",
@@ -8336,6 +9759,28 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 2
+      },
+      "detection": {
+        "tp": 16,
+        "fp": 0,
+        "fn": 0,
+        "tn": 16,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 32,
+        "vulnerable": 16,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": [
+          {
+            "name": "eslint-plugin-security [detect-non-literal-regexp]",
+            "tp": 13,
+            "fp": 8,
+            "fn": 3,
+            "f1": 0.7027027027027026
+          }
+        ]
       }
     },
     {
@@ -8360,6 +9805,35 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 1
+      },
+      "detection": {
+        "tp": 14,
+        "fp": 0,
+        "fn": 0,
+        "tn": 14,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 28,
+        "vulnerable": 14,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": [
+          {
+            "name": "eslint-plugin-security [detect-object-injection]",
+            "tp": 9,
+            "fp": 7,
+            "fn": 5,
+            "f1": 0.6000000000000001
+          },
+          {
+            "name": "sonarjs",
+            "tp": 0,
+            "fp": 0,
+            "fn": 0,
+            "f1": null
+          }
+        ]
       }
     },
     {
@@ -8384,6 +9858,22 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 9,
+        "fp": 0,
+        "fn": 1,
+        "tn": 8,
+        "precision": 1,
+        "recall": 0.9,
+        "f1": 0.9473684210526316,
+        "fixtures": 18,
+        "vulnerable": 10,
+        "missed": [
+          "vulnerable/07-zod-schema-minimum.ts"
+        ],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -8403,7 +9893,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-secure-coding/rules/no-bidi-characters",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-secure-coding",
@@ -8427,6 +9918,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 11,
+        "fp": 0,
+        "fn": 0,
+        "tn": 12,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 23,
+        "vulnerable": 11,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -8451,6 +9956,22 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 10,
+        "fp": 0,
+        "fn": 1,
+        "tn": 9,
+        "precision": 1,
+        "recall": 0.9090909090909091,
+        "f1": 0.9523809523809523,
+        "fixtures": 20,
+        "vulnerable": 11,
+        "missed": [
+          "vulnerable/09-shell-open-external.js"
+        ],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -8470,7 +9991,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-secure-coding/rules/no-fail-open-auth",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-secure-coding",
@@ -8494,6 +10016,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 10,
+        "fp": 0,
+        "fn": 0,
+        "tn": 10,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 20,
+        "vulnerable": 10,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -8513,7 +10049,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-secure-coding/rules/no-graphql-injection",
       "corpusFindings": 1,
       "budgetReason": "1. Shopify/cli .../graphql/organization_beta_flags.ts:4 — TRUE POSITIVE and the strongest finding in this group. `flags.map(f => `flag_${f}: hasFeatureFlag(handle: \"${f}\")`)` interpolates straight into the query body AND inside a quoted GraphQL string, so a `\"` in a flag name breaks out. Budgeted only because the flag list is internal; it should be fixed upstream.",
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-secure-coding",
@@ -8532,7 +10069,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-secure-coding/rules/no-hardcoded-credentials",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-secure-coding",
@@ -8551,7 +10089,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-secure-coding/rules/no-hardcoded-session-tokens",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-secure-coding",
@@ -8570,7 +10109,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-secure-coding/rules/no-homoglyph-identifiers",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-secure-coding",
@@ -8589,7 +10129,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-secure-coding/rules/no-improper-sanitization",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-secure-coding",
@@ -8613,6 +10154,27 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 6,
+        "fp": 0,
+        "fn": 6,
+        "tn": 10,
+        "precision": 1,
+        "recall": 0.5,
+        "f1": 0.6666666666666666,
+        "fixtures": 22,
+        "vulnerable": 12,
+        "missed": [
+          "vulnerable/01-nosql-operator-object.js",
+          "vulnerable/02-array-coercion.js",
+          "vulnerable/04-ts-cast-is-not-a-check.ts",
+          "vulnerable/07-param-root-untyped.js",
+          "vulnerable/08-fake-mitigation-truthiness.js",
+          "vulnerable/11-local-fake-validator.js"
+        ],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -8637,6 +10199,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 13,
+        "fp": 0,
+        "fn": 0,
+        "tn": 11,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 24,
+        "vulnerable": 13,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -8661,6 +10237,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 14,
+        "fp": 0,
+        "fn": 0,
+        "tn": 9,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 23,
+        "vulnerable": 14,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -8680,7 +10270,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-secure-coding/rules/no-log-injection",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-secure-coding",
@@ -8704,6 +10295,23 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 10,
+        "fp": 0,
+        "fn": 2,
+        "tn": 11,
+        "precision": 1,
+        "recall": 0.8333333333333334,
+        "f1": 0.9090909090909091,
+        "fixtures": 23,
+        "vulnerable": 12,
+        "missed": [
+          "vulnerable/10-dynamic-method.js",
+          "vulnerable/12-noop-auth-middleware.js"
+        ],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -8728,6 +10336,22 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 8,
+        "fp": 1,
+        "fn": 0,
+        "tn": 6,
+        "precision": 0.8888888888888888,
+        "recall": 1,
+        "f1": 0.9411764705882353,
+        "fixtures": 15,
+        "vulnerable": 8,
+        "missed": [],
+        "falsePositives": [
+          "safe/07-tokenizer-metrics.js"
+        ],
+        "competitors": []
       }
     },
     {
@@ -8752,6 +10376,26 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 8,
+        "fp": 1,
+        "fn": 3,
+        "tn": 10,
+        "precision": 0.8888888888888888,
+        "recall": 0.7272727272727273,
+        "f1": 0.7999999999999999,
+        "fixtures": 22,
+        "vulnerable": 11,
+        "missed": [
+          "vulnerable/08-membership-tier.js",
+          "vulnerable/09-fail-open-guard.js",
+          "vulnerable/11-mass-assignment.js"
+        ],
+        "falsePositives": [
+          "safe/09-lookup-table.js"
+        ],
+        "competitors": []
       }
     },
     {
@@ -8776,6 +10420,35 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 3
+      },
+      "detection": {
+        "tp": 14,
+        "fp": 0,
+        "fn": 0,
+        "tn": 14,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 28,
+        "vulnerable": 14,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": [
+          {
+            "name": "eslint-plugin-security [detect-unsafe-regex]",
+            "tp": 9,
+            "fp": 7,
+            "fn": 5,
+            "f1": 0.6000000000000001
+          },
+          {
+            "name": "eslint-plugin-regexp [no-super-linear-backtracking]",
+            "tp": 11,
+            "fp": 0,
+            "fn": 3,
+            "f1": 0.88
+          }
+        ]
       }
     },
     {
@@ -8800,6 +10473,22 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 13,
+        "fp": 0,
+        "fn": 1,
+        "tn": 13,
+        "precision": 1,
+        "recall": 0.9285714285714286,
+        "f1": 0.962962962962963,
+        "fixtures": 27,
+        "vulnerable": 14,
+        "missed": [
+          "vulnerable/13-innocuous-column-names.js"
+        ],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -8824,6 +10513,35 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 23,
+        "fp": 0,
+        "fn": 0,
+        "tn": 20,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 43,
+        "vulnerable": 23,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": [
+          {
+            "name": "sonarjs [sql-queries]",
+            "tp": 0,
+            "fp": 0,
+            "fn": 23,
+            "f1": 0
+          },
+          {
+            "name": "eslint-plugin-security [detect-object-injection]",
+            "tp": 1,
+            "fp": 0,
+            "fn": 22,
+            "f1": 0.08333333333333333
+          }
+        ]
       }
     },
     {
@@ -8843,7 +10561,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-secure-coding/rules/no-template-injection",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-secure-coding",
@@ -8867,6 +10586,24 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 9,
+        "fp": 0,
+        "fn": 3,
+        "tn": 13,
+        "precision": 1,
+        "recall": 0.75,
+        "f1": 0.8571428571428571,
+        "fixtures": 25,
+        "vulnerable": 12,
+        "missed": [
+          "vulnerable/08-unbounded-recursion.js",
+          "vulnerable/10-param-root.js",
+          "vulnerable/11-renamed-identifiers.js"
+        ],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -8891,6 +10628,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 4
+      },
+      "detection": {
+        "tp": 10,
+        "fp": 0,
+        "fn": 0,
+        "tn": 16,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 26,
+        "vulnerable": 10,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -8915,6 +10666,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 12,
+        "fp": 0,
+        "fn": 0,
+        "tn": 12,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 24,
+        "vulnerable": 12,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -8939,6 +10704,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 12,
+        "fp": 0,
+        "fn": 0,
+        "tn": 12,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 24,
+        "vulnerable": 12,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -8958,7 +10737,8 @@
       "docsUrl": "https://eslint.interlace.tools/docs/security/plugin-secure-coding/rules/no-weak-password-recovery",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-secure-coding",
@@ -8982,6 +10762,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 12,
+        "fp": 0,
+        "fn": 0,
+        "tn": 12,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 24,
+        "vulnerable": 12,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -9006,6 +10800,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 12,
+        "fp": 0,
+        "fn": 0,
+        "tn": 11,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 23,
+        "vulnerable": 12,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -9030,6 +10838,22 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 8,
+        "fp": 0,
+        "fn": 1,
+        "tn": 8,
+        "precision": 1,
+        "recall": 0.8888888888888888,
+        "f1": 0.9411764705882353,
+        "fixtures": 17,
+        "vulnerable": 9,
+        "missed": [
+          "vulnerable/08-renamed-property.jsx"
+        ],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -9054,6 +10878,20 @@
         "axesTotal": 12,
         "status": "open",
         "knownGaps": 0
+      },
+      "detection": {
+        "tp": 7,
+        "fp": 0,
+        "fn": 0,
+        "tn": 8,
+        "precision": 1,
+        "recall": 1,
+        "f1": 1,
+        "fixtures": 15,
+        "vulnerable": 7,
+        "missed": [],
+        "falsePositives": [],
+        "competitors": []
       }
     },
     {
@@ -9073,7 +10911,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-sequelize-security/docs/rules/no-hardcoded-credentials.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-sequelize-security",
@@ -9092,7 +10931,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-sequelize-security/docs/rules/no-mass-assignment.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-sequelize-security",
@@ -9111,7 +10951,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-sequelize-security/docs/rules/no-unsafe-query.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-sequelize-security",
@@ -9130,7 +10971,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-sequelize-security/docs/rules/require-tls.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-sqlite-security",
@@ -9149,7 +10991,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-sqlite-security/docs/rules/no-unsafe-query.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-typeorm-security",
@@ -9168,7 +11011,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-typeorm-security/docs/rules/no-hardcoded-credentials.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-typeorm-security",
@@ -9187,7 +11031,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-typeorm-security/docs/rules/no-mass-assignment.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-typeorm-security",
@@ -9206,7 +11051,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-typeorm-security/docs/rules/no-unsafe-query.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-typeorm-security",
@@ -9225,7 +11071,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-typeorm-security/docs/rules/require-tls.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-vercel-ai-security",
@@ -9244,7 +11091,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-dynamic-system-prompt.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-vercel-ai-security",
@@ -9263,7 +11111,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-hardcoded-api-keys.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-vercel-ai-security",
@@ -9282,7 +11131,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-sensitive-in-prompt.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-vercel-ai-security",
@@ -9301,7 +11151,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-system-prompt-leak.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-vercel-ai-security",
@@ -9320,7 +11171,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-training-data-exposure.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-vercel-ai-security",
@@ -9339,7 +11191,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/no-unsafe-output-handling.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-vercel-ai-security",
@@ -9358,7 +11211,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-abort-signal.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-vercel-ai-security",
@@ -9377,7 +11231,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-audit-logging.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-vercel-ai-security",
@@ -9396,7 +11251,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-embedding-validation.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-vercel-ai-security",
@@ -9415,7 +11271,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-error-handling.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-vercel-ai-security",
@@ -9434,7 +11291,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-max-steps.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-vercel-ai-security",
@@ -9453,7 +11311,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-max-tokens.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-vercel-ai-security",
@@ -9472,7 +11331,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-output-filtering.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-vercel-ai-security",
@@ -9491,7 +11351,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-output-validation.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-vercel-ai-security",
@@ -9510,7 +11371,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-rag-content-validation.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-vercel-ai-security",
@@ -9529,7 +11391,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-request-timeout.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-vercel-ai-security",
@@ -9548,7 +11411,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-tool-confirmation.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-vercel-ai-security",
@@ -9567,7 +11431,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-tool-schema.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     },
     {
       "plugin": "eslint-plugin-vercel-ai-security",
@@ -9586,7 +11451,8 @@
       "docsUrl": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin/docs/rules/require-validated-prompt.md",
       "corpusFindings": null,
       "budgetReason": null,
-      "seal": null
+      "seal": null,
+      "detection": null
     }
   ]
 }


### PR DESCRIPTION
The manifest said what each rule **is**. It could not say whether the rule **works**.

`benchmarks/rule-corpus/*/RESULTS.json` already held that for 94 rules, and nothing read it.

## What each rule now carries

| | |
|---|---|
| `tp` | what it **caught** |
| `fp` | what it **wrongly reported** |
| `fn` | what it **missed** |
| `tn` | safe fixtures it correctly stayed quiet on |

All four, deliberately. Precision alone hides misses, recall alone hides noise, and a rule with no safe fixtures can score 1.0 on both while being useless — which is why `fixtures` and `vulnerable` ride along. **1.0 over 19 fixtures is a different claim from 1.0 over 3.**

`missed` and `falsePositives` carry the fixture **names**, so a score can be opened up rather than taken on faith.

## The duel

`competitors` scores the same fixtures against every other plugin shipping a comparable rule — the only number here that isn't our opinion of our own output:

| plugin | tp | fp | fn | F1 |
|---|---|---|---|---|
| **`browser-security/no-innerhtml`** | **24** | **0** | **0** | **100%** |
| `no-unsanitized` (Mozilla) | 20 | 9 | 4 | 75% |
| `@microsoft/sdl` | 19 | 11 | 5 | 70% |
| `sonarjs` | 0 | 0 | 24 | 0% |

Ours is matched by the `Interlace` name prefix rather than by array position, because position is not a contract.

## New totals

`withDetection` **94** · `perfectDetection` **75** · `duelled` **7**

So **94 of 478** rules have been measured at all — and that gap is now visible rather than implied.

## Test plan

- [x] `npx tsx apps/docs/scripts/build-rules-manifest.mts` — 478 rules, 30 plugins
- [x] duel data verified against `no-innerhtml` RESULTS.json
- [x] `generated-data-write-lock.test.ts` passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)