### PR TITLE
fix(scripts): corpus-scan --local now measures the local devkit

### DIFF
--- a/.changeset/corpus-scan-local-devkit.md
+++ b/.changeset/corpus-scan-local-devkit.md
@@ -1,0 +1,33 @@
+---
+'@interlace/eslint-devkit': patch
+---
+
+`corpus-scan --local` now actually measures the local working tree.
+
+Three layers of staleness, each hiding the next:
+
+1. **The devkit came from npm.** Every plugin declares
+   `@interlace/eslint-devkit` as a semver *range*, so npm resolved it from the
+   registry and the rig ran local plugins against the **published** devkit.
+   Everything living there — `isTestFilePath`, `createRule`'s skip flags, every
+   shared detector — was measured at whatever was last released, while the
+   report said "LOCAL WORKING TREE".
+
+2. **The fingerprint did not cover it.** `distHash` ran over the plugins only,
+   so a devkit-only change left the rig stamped unchanged.
+
+3. **npm's cache served the old tarball.** `--install-links` packs each `file:`
+   dependency under `name@version`, and a rebuild does not bump the version.
+   The rig now uses a private cache directory, dropped whenever the fingerprint
+   changes.
+
+This surfaced loudly — `isGeneratedFile is not a function`, on 8 of 8 targets —
+only because the change added a *new* export. A change to an existing one is
+silent: the scan runs, produces a number, and the number describes code that is
+not in the tree.
+
+It explains a measurement that had been recorded as unexplained.
+`react-features/hooks-exhaustive-deps` read 84 on some runs and 91 on others,
+and plugin staleness, npm cache and filesystem case-sensitivity had each been
+ruled out. Against a correctly local rig it reads **84**. The 91 was the
+published devkit.

--- a/scripts/__tests__/corpus-scan-modes.test.ts
+++ b/scripts/__tests__/corpus-scan-modes.test.ts
@@ -61,4 +61,40 @@ describe('corpus-scan modes', () => {
     expect(SOURCE).toMatch(/local \? `\$\{plugin\}:local:\$\{distHash\(plugin\)\}`/);
     expect(SOURCE).toContain('`${plugin}@${publishedVersion(plugin)}`');
   });
+
+  it('installs the devkit FROM THE WORKING TREE in local mode', () => {
+    // Without this, `--local` did not measure the local tree. Every plugin
+    // declares `@interlace/eslint-devkit` as a semver RANGE, so npm resolved it
+    // from the registry and the rig ran local plugins against the PUBLISHED
+    // devkit. Everything living there — isTestFilePath, createRule's skip
+    // flags, every shared detector — was measured at the last release while the
+    // report said "local working tree".
+    //
+    // Measured after the fix: react-features/hooks-exhaustive-deps reads 84,
+    // not 91. That number had disagreed with itself across runs for a day and
+    // the mechanism was recorded as unknown. It was this.
+    expect(SOURCE).toContain('@interlace/eslint-devkit@file:');
+    // The devkit's dist, NOT its package root. A plugin's `files` lists both
+    // `src/` and `dist/`; the devkit's lists only `src/` while its `main` is
+    // `./dist/src/index.js`, so packing its root yields a tarball whose entry
+    // point is not in it. It is published FROM `dist/`.
+    expect(SOURCE).toMatch(/'eslint-devkit', 'dist'/);
+  });
+
+  it('includes the devkit in the local fingerprint', () => {
+    // Hashing only the plugins left a devkit-only change stamped as unchanged,
+    // so the rig kept its stale copy. Adding an export made it loud; changing
+    // an existing one is silent.
+    expect(SOURCE).toContain("`eslint-devkit:local:${distHash('eslint-devkit')}`");
+  });
+
+  it('gives the rig a private npm cache and drops it on rebuild', () => {
+    // `--install-links` packs each file: dependency into a tarball npm caches
+    // under name@version, and a rebuild does not bump the version — so the
+    // shared cache serves the previous build. Scoped to the rig so wiping it
+    // cannot touch the developer's own.
+    expect(SOURCE).toContain('const NPM_CACHE');
+    expect(SOURCE).toContain('rmSync(NPM_CACHE');
+    expect(SOURCE).toMatch(/'--cache',\s*\n?\s*NPM_CACHE/);
+  });
 });

--- a/scripts/corpus-scan.ts
+++ b/scripts/corpus-scan.ts
@@ -261,6 +261,15 @@ const BUDGET_FILE = path.join(ROOT, '.agent', 'corpus-findings-budget.json');
 const CACHE_HOME = resolveCacheHome();
 const WORK = path.join(CACHE_HOME, 'interlace-corpus-scan');
 const RIG = path.join(WORK, '_rig');
+/**
+ * npm's cache, private to the rig.
+ *
+ * In local mode `--install-links` packs each `file:` dependency into a tarball
+ * keyed `name@version`, and a rebuild does not bump the version — so the shared
+ * cache happily serves the previous build. Keeping the cache beside the rig
+ * means the rebuild path can drop it without touching the developer's own.
+ */
+const NPM_CACHE = path.join(WORK, '_npm-cache');
 
 interface Budget {
   /** Human note; ignored by the checker. */
@@ -409,9 +418,21 @@ function main(): number {
   // mode it is not — the version does not change when you rebuild — so the
   // fingerprint has to read the built artifact, or npm serves the previous
   // build out of its cache and the run silently measures stale code.
-  const fingerprint = PLUGINS.map((plugin) =>
-    local ? `${plugin}:local:${distHash(plugin)}` : `${plugin}@${publishedVersion(plugin)}`,
-  ).join('\n');
+  //
+  // `@interlace/eslint-devkit` is in the local fingerprint, and leaving it out
+  // was a live defect. Every plugin's dist requires the devkit at runtime, and
+  // `--install-links` COPIES rather than symlinks, so the rig holds a snapshot
+  // of it. Hashing only the plugins meant a devkit-only change left the rig
+  // stamped unchanged and the copy stale. Adding an export surfaced it loudly
+  // — `isGeneratedFile is not a function`, on 8 of 8 repositories — but the
+  // ordinary case is silent: change a shared predicate, and the scan measures
+  // the previous one while reporting a number against the new code.
+  const fingerprint = [
+    ...PLUGINS.map((plugin) =>
+      local ? `${plugin}:local:${distHash(plugin)}` : `${plugin}@${publishedVersion(plugin)}`,
+    ),
+    ...(local ? [`eslint-devkit:local:${distHash('eslint-devkit')}`] : []),
+  ].join('\n');
   const stampFile = path.join(RIG, '.plugin-fingerprint');
   if (
     existsSync(path.join(RIG, 'node_modules')) &&
@@ -420,6 +441,16 @@ function main(): number {
     log('Plugin versions changed — rebuilding the scan rig…');
     rmSync(path.join(RIG, 'node_modules'), { recursive: true, force: true });
     rmSync(path.join(RIG, 'package-lock.json'), { force: true });
+    // And npm's own cache for this rig. Deleting node_modules is not enough in
+    // LOCAL mode: `--install-links` packs each `file:` dependency into a
+    // tarball that npm caches under `name@version`, and a rebuild does not
+    // change the version. So the reinstall unpacked the PREVIOUS build of the
+    // devkit while the stamp said the rig was fresh — the exact staleness the
+    // fingerprint above exists to prevent, one layer further down.
+    //
+    // A private cache directory rather than `npm cache clean --force`, which
+    // would throw away the developer's whole cache to fix the rig's.
+    rmSync(NPM_CACHE, { recursive: true, force: true });
   }
 
 
@@ -436,6 +467,9 @@ function main(): number {
       // them instead of symlinking, so the rig is a snapshot of the tree as it
       // stood. Harmless otherwise.
       ...(local ? ['--install-links'] : []),
+      // Scoped to the rig, so wiping it above cannot touch anything else.
+      '--cache',
+      NPM_CACHE,
       '--silent',
       '--no-audit',
       '--no-fund',
@@ -479,6 +513,35 @@ function main(): number {
       ...PLUGINS.map((p) =>
         local ? `${p}@file:${path.join(ROOT, 'packages', p)}` : `${p}@${publishedVersion(p)}`,
       ),
+      // The devkit, from the working tree, in LOCAL mode only.
+      //
+      // Without this line `--local` did not measure the local tree. Every
+      // plugin declares `@interlace/eslint-devkit` as a SEMVER RANGE
+      // (`^1.11.0`), so npm resolved it from the registry and the rig ran
+      // local plugins against the PUBLISHED devkit. Everything that lives
+      // there — `isTestFilePath`, `createRule`'s skip flags, every shared
+      // detector — was therefore measured at whatever was last released,
+      // while the report said "local working tree".
+      //
+      // It surfaced as `isGeneratedFile is not a function` on 8 of 8 targets
+      // only because the change added a NEW export. A change to an EXISTING
+      // one is silent: the scan runs, produces a number, and the number
+      // describes code that is not in the tree.
+      //
+      // In published mode this is correctly absent — there the plugins' own
+      // dependency ranges are part of what is being measured.
+      // `packages/eslint-devkit/dist`, not the package root. The two publish
+      // differently: a plugin's `files` lists both `src/` and `dist/`, so
+      // packing its root yields a working tarball, while the devkit's lists
+      // only `src/` even though its `main` is `./dist/src/index.js`. The devkit
+      // is published FROM `dist/`, which carries its own package.json pointing
+      // at `./src/index.js`. Packing the root instead gives a tarball whose
+      // entry point is not in it.
+      ...(local
+        ? [
+            `@interlace/eslint-devkit@file:${path.join(ROOT, 'packages', 'eslint-devkit', 'dist')}`,
+          ]
+        : []),
     ],
     RIG,
   );


### PR DESCRIPTION
## Summary

`--local` did not measure the local working tree. Three layers of staleness, each hiding the next:

1. **The devkit came from npm.** Every plugin declares `@interlace/eslint-devkit` as a semver *range* (`^1.11.0`), so npm resolved it from the registry and the rig ran local plugins against the **published** devkit. Everything living there — `isTestFilePath`, `createRule`'s skip flags, every shared detector — was measured at whatever was last released, while the run logged `Installing scan rig — LOCAL WORKING TREE`.
2. **The fingerprint did not cover it.** `distHash` ran over the plugins only, so a devkit-only change left the rig stamped unchanged.
3. **npm's cache served the old tarball anyway.** `--install-links` packs each `file:` dependency under `name@version`, and a rebuild does not bump the version. The rig now uses a private cache directory, dropped whenever the fingerprint changes.

The install points at `packages/eslint-devkit/dist`, not the package root. The two publish differently: a plugin's `files` lists both `src/` and `dist/`, while the devkit's lists only `src/` even though its `main` is `./dist/src/index.js` — it is published *from* `dist/`, which carries its own package.json. Packing the root gives a tarball whose entry point is not in it.

### Why it went unnoticed

This surfaced loudly — `isGeneratedFile is not a function`, on **8 of 8 targets** — only because the change that exposed it added a **new** export. A change to an *existing* one is silent: the scan runs, produces a number, and the number describes code that is not in the tree.

### It resolves a documented unknown

`react-features/hooks-exhaustive-deps` read **84** on some runs and **91** on others. Plugin staleness, the npm cache, and filesystem case-sensitivity had each been ruled out by measurement, and the mechanism was written down as unknown. Against a correctly local rig it reads **84**. The 91 was the published devkit.

## The corpus, measured against the tree for the first time

Published budget → local. These are what the budgets ratchet down to on release.

| rule | budget | local |
|---|---:|---:|
| `maintainability/identical-functions` | 2,076 | **258** |
| `conventions/no-magic-numbers` | 1,635 | 1,421 |
| `maintainability/cognitive-complexity` | 671 | **227** |
| `modularity/ddd-anemic-domain-model` | 526 | **0** |
| `maintainability/max-parameters` | 185 | **74** |
| `conventions/no-commented-code` | 143 | 91 |
| `operability/no-debug-code-in-production` | 120 | 92 |
| `operability/no-console-log` | 107 | 82 |
| `react-features/hooks-exhaustive-deps` | 91 | 84 |
| `reliability/no-missing-null-checks` | 127 | **139** |

The last one is *over*, deliberately: the alias-laundering and ternary-null fixes catch 11 real null-dereferences that were previously missed. `--local --update` is refused, so the budget cannot be rewritten from a local run — it records published behaviour and moves on release.

## Test plan

- [x] `scripts/__tests__/corpus-scan-modes.test.ts` — three new assertions covering all three layers, and each fails if its line is removed.
- [x] Full scan runs clean: 8/8 targets, exit 1 on the single over-budget rule rather than exit 3 on total failure.
- [x] All repo script locks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)