### PR TITLE
fix(import-next): no-self-import — a suffix is not an extension

### DIFF
--- a/.changeset/no-self-import-extensions.md
+++ b/.changeset/no-self-import-extensions.md
@@ -1,0 +1,27 @@
+---
+'eslint-plugin-import-next': patch
+---
+
+`no-self-import`: a suffix is not an extension.
+
+The rule stripped the last dotted suffix from both the current filename and the
+resolved specifier, then compared. Those were the only two findings it produced
+on the pinned 8-repository corpus, and both were wrong:
+
+```
+main.jsx            importing './main.css'                  → both became `main`
+styleUtils.test.js  importing './styleUtils.test.constants' → both became `styleUtils.test`
+```
+
+A stylesheet is not this module, and `.constants` is not an extension at all —
+it is part of the module's name. `\.[^/.]+$` cannot tell the difference.
+
+Now: a specifier whose last segment carries a dotted suffix that is not a JS/TS
+module extension names a different file, full stop. Otherwise only real module
+extensions (`.js .jsx .mjs .cjs .ts .tsx .mts .cts`) are stripped before
+comparing. Genuine self-imports — `./real` and `./real.ts` from `real.ts` — are
+unaffected, and both are pinned as `invalid` fixtures.
+
+`allowInTests` also moves to the devkit's `isTestFilePath`. It matched
+`filename.includes('__tests__')`, which is true of any path containing those
+characters anywhere, `~/my__tests__project/src/a.ts` included.

--- a/packages/eslint-plugin-import-next/src/rules/no-self-import.ts
+++ b/packages/eslint-plugin-import-next/src/rules/no-self-import.ts
@@ -10,10 +10,18 @@
  */
 import * as path from 'node:path';
 import type { TSESTree, TSESLint } from '@interlace/eslint-devkit';
-import { createRule } from '@interlace/eslint-devkit';
+import { createRule, isTestFilePath } from '@interlace/eslint-devkit';
 import { formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
 
 type MessageIds = 'selfImport';
+
+/**
+ * The extensions a JS/TS module resolver will add on its own.
+ *
+ * A closed list, so `.css`, `.json`, `.graphql` and a dotted name segment like
+ * `.constants` are all treated as naming a different file — which they do.
+ */
+const MODULE_EXTENSION = /\.[cm]?[jt]sx?$/;
 
 export interface Options {
   /** Allow self-import in test files */
@@ -34,16 +42,17 @@ function isImportingSelf(
     return false;
   }
 
-  // Skip test files if allowed
+  // Skip test files if allowed.
+  //
+  // `filename.includes('__tests__')` matched any path containing those
+  // characters anywhere — `~/my__tests__project/src/a.ts` included — which is
+  // the substring-on-a-name defect CLAUDE.md puts first. It suppresses rather
+  // than reports, so it cost recall rather than trust, but the devkit already
+  // has the predicate: basename for `*.test.*`, exact path SEGMENT equality for
+  // the directory case.
   const [options] = context.options;
   const { allowInTests = false } = options || {};
-  if (
-    allowInTests &&
-    (filename.includes('.test.') ||
-      filename.includes('.spec.') ||
-      filename.includes('/__tests__/') ||
-      filename.includes('__tests__'))
-  ) {
+  if (allowInTests && isTestFilePath(filename)) {
     return false;
   }
 
@@ -62,9 +71,29 @@ function isImportingSelf(
     return false;
   }
 
-  // Compare resolved paths (normalize by removing extensions)
-  const normalizedCurrent = filename.replace(/\.[^/.]+$/, '');
-  const normalizedImport = resolvedPath.replace(/\.[^/.]+$/, '');
+  // A self-import means the specifier resolves to THIS file. Stripping "the
+  // last extension" from both sides was a crude stand-in for that and got two
+  // classes wrong on the pinned corpus, both of them the only two findings this
+  // rule produced there:
+  //
+  //   main.jsx        importing './main.css'                 -> both became `main`
+  //   styleUtils.test.js importing './styleUtils.test.constants'
+  //                                                          -> both became `styleUtils.test`
+  //
+  // A stylesheet is not this module, and `.constants` is not an extension at
+  // all — it is part of the module's NAME, and `\.[^/.]+$` cannot tell the
+  // difference.
+  //
+  // So: a specifier whose last segment carries a dotted suffix that is not a
+  // module extension names a different file, full stop. Otherwise strip only
+  // real module extensions from each side before comparing.
+  const trailingSuffix = /\.[^/.]+$/.exec(importPath);
+  if (trailingSuffix && !MODULE_EXTENSION.test(importPath)) {
+    return false;
+  }
+
+  const normalizedCurrent = filename.replace(MODULE_EXTENSION, '');
+  const normalizedImport = resolvedPath.replace(MODULE_EXTENSION, '');
 
   return normalizedCurrent === normalizedImport;
 }

--- a/packages/eslint-plugin-import-next/src/tests/no-self-import.test.ts
+++ b/packages/eslint-plugin-import-next/src/tests/no-self-import.test.ts
@@ -452,3 +452,97 @@ describe('no-self-import', () => {
     });
   });
 });
+
+/**
+ * A self-import is the specifier resolving to THIS file, not two paths that
+ * look alike once you cut their last dot off.
+ *
+ * These were the only two findings this rule produced on the pinned 8-repository
+ * corpus, and both were wrong:
+ *
+ *   main.jsx            importing './main.css'                → both became `main`
+ *   styleUtils.test.js  importing './styleUtils.test.constants'
+ *                                                             → both became `styleUtils.test`
+ *
+ * A stylesheet is not this module, and `.constants` is not an extension at all —
+ * it is part of the module's name. `\.[^/.]+$` cannot tell the difference, so
+ * only a closed list of real module extensions is stripped now.
+ */
+describe('no-self-import — a suffix is not an extension', () => {
+  ruleTester.run('extension handling', noSelfImport, {
+    valid: [
+      {
+        // A stylesheet beside a component of the same stem.
+        code: "import './main.css';",
+        filename: '/repo/src/main.jsx',
+      },
+      {
+        // `.constants` is a name segment, not an extension.
+        code: 'import { A } from "./styleUtils.test.constants";',
+        filename: '/repo/src/styleUtils.test.js',
+      },
+      {
+        code: "import data from './config.json';",
+        filename: '/repo/src/config.ts',
+      },
+      {
+        // A sibling module that merely shares a prefix.
+        code: "import { x } from './real.helpers';",
+        filename: '/repo/src/real.ts',
+      },
+    ],
+    invalid: [
+      {
+        // POSITIVE CONTROL: the extensionless self-import the rule exists for.
+        // Without it every valid case above passes on a rule that never fires.
+        code: "import { x } from './real';",
+        filename: '/repo/src/real.ts',
+        errors: [{ messageId: 'selfImport' }],
+      },
+      {
+        // And with the extension spelled out.
+        code: "import { x } from './real.ts';",
+        filename: '/repo/src/real.ts',
+        errors: [{ messageId: 'selfImport' }],
+      },
+    ],
+  });
+
+  /**
+   * `allowInTests` used `filename.includes('__tests__')`, which matches any
+   * path containing those characters anywhere. It suppresses rather than
+   * reports, so it cost recall rather than trust — but it is still the
+   * substring-on-a-name defect, and the devkit has the predicate.
+   */
+  ruleTester.run('allowInTests matches by segment', noSelfImport, {
+    valid: [
+      {
+        code: "import { x } from './a';",
+        filename: '/repo/src/__tests__/a.ts',
+        options: [{ allowInTests: true }],
+      },
+      {
+        code: "import { x } from './a';",
+        filename: '/repo/src/a.test.ts',
+        options: [{ allowInTests: true }],
+      },
+    ],
+    invalid: [
+      {
+        // A directory whose NAME merely contains the characters is not a test
+        // directory. This reported before only by luck of ordering.
+        code: "import { x } from './a';",
+        filename: '/repo/my__tests__project/src/a.ts',
+        options: [{ allowInTests: true }],
+        errors: [{ messageId: 'selfImport' }],
+      },
+      {
+        // CONTROL: the option off restores the finding in a real test file.
+        code: "import { x } from './a';",
+        filename: '/repo/src/__tests__/a.ts',
+        options: [{ allowInTests: false }],
+        errors: [{ messageId: 'selfImport' }],
+      },
+    ],
+  });
+});


### PR DESCRIPTION
## Summary

Batch 2 (`import-next`), first rule. The rule stripped the last dotted suffix from both the current filename and the resolved specifier, then compared what was left.

Those were the **only two findings** it produced on the pinned 8-repository corpus, and both were wrong:

| file | import | both became |
|---|---|---|
| `main.jsx` | `'./main.css'` | `main` |
| `styleUtils.test.js` | `'./styleUtils.test.constants'` | `styleUtils.test` |

A stylesheet is not this module. And `.constants` is not an extension **at all** — it is part of the module's name, and the specifier carries no extension in the source at all. `\.[^/.]+$` cannot tell the difference between an extension and a dotted name segment, because it never knew what an extension was.

### The fix

A specifier whose last segment carries a dotted suffix that is **not** a JS/TS module extension names a different file, full stop. Otherwise strip only real module extensions (`.js .jsx .mjs .cjs .ts .tsx .mts .cts`) from each side before comparing.

Genuine self-imports are unaffected — `./real` and `./real.ts` from `real.ts` both still report — and both are `invalid` fixtures, so the fix cannot decay into exempting everything.

### `allowInTests`

Moves to the devkit's `isTestFilePath`. It matched `filename.includes('__tests__')`, which is true of any path containing those characters anywhere — `~/my__tests__project/src/a.ts` counted as a test directory. It *suppresses* rather than reports, so it cost recall rather than trust, but it is the substring-on-a-name defect `CLAUDE.md` puts first and the shared predicate already existed.

## Test plan

- [x] Positive control established **before** the fix: `real.ts` importing `./real` and `./real.ts` both report, so the quiet cases carry information.
- [x] **5 of the 9 new fixtures fail on the unfixed rule** — verified by restoring `HEAD`'s version and re-running.
- [x] `import-next`: 1,327 passing, **100%** statements / branches / functions / lines.
- [x] CWE recall gate re-run in the same session: TP=69 FP=0 FN=0.
- [x] `lint:name-inference`: 314 rules scanned, no new site.

## Batch 2 context

`import-next` under `recommended` produces 18,573 findings across the corpus, but **12,051 of those (65%)** are `no-unresolved` and `no-extraneous-dependencies` — both in `UNMEASURABLE_RULES` because the scan rig never installs the targets' dependencies. Those two rules ship in `recommended` and have never been measured. That gap is worth its own change (a rig that installs each target), and it is the single biggest hole in the batch.

Remaining measurable: `order` 3,597 · `no-cycle` 1,340 · `newline-after-import` 835 · `first` 639 · `no-duplicates` 94, plus a tail. `no-duplicates` looks like the next real defect — several findings pair a type-only import with a value import from the same module, where merging them changes semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved self-import detection to recognize JavaScript and TypeScript extensions accurately.
  * Prevented false positives for stylesheet imports, dotted module names, and similarly named files.
  * Improved test-file detection for rules that allow imports within tests.

* **Tests**
  * Added coverage for valid self-imports, extension handling, sibling files, and test-path matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->