### PR TITLE
fix(docs): plugin READMEs 404 in production, and the headers that never regress

### DIFF
--- a/apps/docs/content/docs/security/plugin-jwt-security/changelog.mdx
+++ b/apps/docs/content/docs/security/plugin-jwt-security/changelog.mdx
@@ -12,7 +12,7 @@ import { RemoteChangelog } from '@/components/docs/remote-changelog';
   on GitHub and cached for 2 hours.
 </Callout>
 
-<RemoteChangelog plugin="jwt" />
+<RemoteChangelog plugin="jwt-security" />
 
 <a
   href="https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-jwt-security/CHANGELOG.md"

--- a/apps/docs/content/docs/security/plugin-jwt-security/index.mdx
+++ b/apps/docs/content/docs/security/plugin-jwt-security/index.mdx
@@ -36,7 +36,7 @@ import { Cards, Card } from 'fumadocs-ui/components/card';
 
 ---
 
-<RemoteReadme plugin="jwt" sections={['full']} />
+<RemoteReadme plugin="jwt-security" sections={['full']} />
 
 <a
   href="https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-jwt-security/README.md"

--- a/apps/docs/content/docs/security/plugin-postgresql-security/changelog.mdx
+++ b/apps/docs/content/docs/security/plugin-postgresql-security/changelog.mdx
@@ -12,7 +12,7 @@ import { RemoteChangelog } from '@/components/docs/remote-changelog';
   on GitHub and cached for 2 hours.
 </Callout>
 
-<RemoteChangelog plugin="pg" />
+<RemoteChangelog plugin="postgresql-security" />
 
 <a
   href="https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-postgresql-security/CHANGELOG.md"

--- a/apps/docs/content/docs/security/plugin-postgresql-security/index.mdx
+++ b/apps/docs/content/docs/security/plugin-postgresql-security/index.mdx
@@ -36,7 +36,7 @@ import { Cards, Card } from 'fumadocs-ui/components/card';
 
 ---
 
-<RemoteReadme plugin="pg" sections={['full']} />
+<RemoteReadme plugin="postgresql-security" sections={['full']} />
 
 <a
   href="https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-postgresql-security/README.md"

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -4,7 +4,9 @@ import { fileURLToPath } from 'node:url';
 import fs from 'node:fs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, 'package.json'), 'utf-8'));
+const pkg = JSON.parse(
+  fs.readFileSync(path.join(__dirname, 'package.json'), 'utf-8'),
+);
 // Set to monorepo root (where package-lock.json is)
 const monorepoRoot = path.resolve(__dirname, '../..');
 
@@ -49,8 +51,14 @@ function cspReportOnlyHeaders() {
     // MDX can inline a remote badge directly.
     "img-src 'self' data: blob: https:",
     "font-src 'self' data:",
-    // Same-origin covers /ingest (PostHog) and /_vercel (Vercel Analytics).
-    "connect-src 'self' https://api.github.com https://api.npmjs.org",
+    // Same-origin covers /ingest (PostHog) and /_vercel (Vercel Analytics) for
+    // the capture path. posthog-js still reaches a few endpoints directly
+    // rather than through the proxy — remote config, surveys, the toolbar —
+    // and session replay opens a WebSocket, so those origins are named
+    // explicitly. Supabase is absent on purpose: impact data is read
+    // server-side in `lib/impact-source.ts` and never from the browser.
+    "connect-src 'self' https://api.github.com https://api.npmjs.org " +
+      'https://us.i.posthog.com https://us-assets.i.posthog.com wss://us.i.posthog.com',
     `report-uri /ingest/report/?token=${token}`,
   ].join('; ');
   return [{ key: 'Content-Security-Policy-Report-Only', value: policy }];
@@ -154,7 +162,13 @@ const config = {
   },
 
   experimental: {
-    optimizePackageImports: ['lucide-react', 'motion', 'motion/react', 'fumadocs-ui', 'fumadocs-core'],
+    optimizePackageImports: [
+      'lucide-react',
+      'motion',
+      'motion/react',
+      'fumadocs-ui',
+      'fumadocs-core',
+    ],
     webVitalsAttribution: ['CLS', 'LCP', 'FID', 'INP', 'TTFB'],
   },
 
@@ -181,9 +195,23 @@ const config = {
         { key: 'X-Frame-Options', value: 'DENY' },
         { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
         { key: 'X-DNS-Prefetch-Control', value: 'on' },
-        { 
-          key: 'Permissions-Policy', 
-          value: 'camera=(), microphone=(), geolocation=(), interest-cohort=()' 
+        {
+          key: 'Permissions-Policy',
+          // `browsing-topics`, not `interest-cohort`: FLoC was withdrawn and
+          // no shipping browser reads the old token any more. The Topics API
+          // that replaced it reads this one.
+          value: 'camera=(), microphone=(), geolocation=(), browsing-topics=()',
+        },
+        // Vercel already sends HSTS, but without `includeSubDomains`. Adding
+        // it costs nothing here and covers anything ever served under
+        // *.eslint.interlace.tools. Note the apex (`interlace.tools`) is the
+        // host that would need this to protect the sibling subdomains — that
+        // header lives in the interlace repo, not this one. `preload` is
+        // deliberately omitted: it is a browser-baked commitment that is very
+        // hard to unwind.
+        {
+          key: 'Strict-Transport-Security',
+          value: 'max-age=63072000; includeSubDomains',
         },
         ...cspReportOnlyHeaders(),
       ],

--- a/apps/docs/src/__tests__/remote-markdown-slug-lock.test.ts
+++ b/apps/docs/src/__tests__/remote-markdown-slug-lock.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Regression lock: every `<RemoteReadme plugin="X" />` / `<RemoteChangelog
+ * plugin="X" />` in the docs content must name a package that actually exists
+ * at `packages/eslint-plugin-X/` with the file it intends to render.
+ *
+ * Why this exists
+ * ───────────────
+ * Those components build a raw.githubusercontent.com URL from the `plugin`
+ * prop and fetch it at render time against `main`. A wrong prop is invisible
+ * locally, invisible in CI, and invisible in the build — it only fails in
+ * production, as a 404 inside the page. When `eslint-plugin-jwt` was renamed
+ * to `eslint-plugin-jwt-security` (and `-pg` to `-postgresql-security`) the
+ * two doc pages kept the old prop and served a broken README to 106 users for
+ * six weeks before anyone noticed.
+ *
+ * This is the "content / data drift" class from CLAUDE.md: the source of
+ * truth (the packages directory) and the reference to it (the MDX prop) live
+ * far apart and drift silently. Renaming a package now fails here instead of
+ * in production.
+ */
+
+import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = join(__dirname, '../../../..');
+const CONTENT_DIR = join(REPO_ROOT, 'apps/docs/content/docs');
+const PACKAGES_DIR = join(REPO_ROOT, 'packages');
+
+/** `<RemoteReadme plugin="x" ...>` / `<RemoteChangelog plugin="x" ...>` */
+const USAGE = /<Remote(Readme|Changelog)\b[^>]*?plugin="([^"]+)"/g;
+
+function mdxFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) return mdxFiles(full);
+    return entry.endsWith('.mdx') ? [full] : [];
+  });
+}
+
+interface Usage {
+  file: string;
+  component: string;
+  plugin: string;
+}
+
+function collectUsages(): Usage[] {
+  return mdxFiles(CONTENT_DIR).flatMap((file) => {
+    const source = readFileSync(file, 'utf-8');
+    return [...source.matchAll(USAGE)].map(([, component, plugin]) => ({
+      file: file.slice(REPO_ROOT.length + 1),
+      component,
+      plugin,
+    }));
+  });
+}
+
+describe('remote markdown slugs resolve to real packages', () => {
+  const usages = collectUsages();
+
+  // Guard against the scan silently finding nothing — an empty scan asserted
+  // over an empty array passes just as green as a correct one.
+  it('finds remote-markdown usages to check', () => {
+    expect(usages.length).toBeGreaterThan(10);
+  });
+
+  it.each(usages)(
+    '$file → eslint-plugin-$plugin ($component)',
+    ({ component, plugin }) => {
+      const pkg = join(PACKAGES_DIR, `eslint-plugin-${plugin}`);
+      const file = component === 'Readme' ? 'README.md' : 'CHANGELOG.md';
+
+      expect(
+        existsSync(pkg),
+        `packages/eslint-plugin-${plugin}/ does not exist — the prop is stale or the package was renamed`,
+      ).toBe(true);
+      expect(
+        existsSync(join(pkg, file)),
+        `packages/eslint-plugin-${plugin}/${file} does not exist — production will render a 404`,
+      ).toBe(true);
+    },
+  );
+});

--- a/apps/docs/src/__tests__/security-headers-lock.test.ts
+++ b/apps/docs/src/__tests__/security-headers-lock.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Regression lock: the response-header contract in `next.config.mjs`.
+ *
+ * CLAUDE.md makes these headers part of the deploy contract — "don't loosen
+ * them to make a feature work, find a different feature path". Nothing
+ * enforced that. This lock reads the config as source text (the module can't
+ * be imported here: it pulls in fumadocs' MDX plugin, which needs a real
+ * build context) and asserts the parts that must not silently regress.
+ *
+ * Scope note: this pins the *policy*, not the delivery. That a header reaches
+ * the browser is verified by the Playwright smoke gate against a real
+ * deployment; this catches the edit that removes it long before then.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const CONFIG = readFileSync(join(__dirname, '../../next.config.mjs'), 'utf-8');
+
+describe('security header contract', () => {
+  it.each([
+    ['X-Content-Type-Options', 'nosniff'],
+    ['X-Frame-Options', 'DENY'],
+    ['Referrer-Policy', 'strict-origin-when-cross-origin'],
+    ['Strict-Transport-Security', 'includeSubDomains'],
+  ])('sends %s', (header, value) => {
+    expect(CONFIG).toContain(header);
+    expect(CONFIG).toContain(value);
+  });
+
+  it('opts out of the Topics API with the live token, not withdrawn FLoC', () => {
+    expect(CONFIG).toContain('browsing-topics=()');
+    expect(CONFIG).not.toContain('interest-cohort=()');
+  });
+
+  it('keeps poweredByHeader off and compression on', () => {
+    expect(CONFIG).toMatch(/poweredByHeader:\s*false/);
+    expect(CONFIG).toMatch(/compress:\s*true/);
+  });
+});
+
+describe('CSP directives that must never loosen', () => {
+  it.each([
+    "object-src 'none'",
+    "frame-ancestors 'none'",
+    "base-uri 'self'",
+    "default-src 'self'",
+    "form-action 'self'",
+  ])('pins %s', (directive) => {
+    expect(CONFIG).toContain(directive);
+  });
+
+  it("does not allow 'unsafe-eval' in the enforcing header", () => {
+    // The report-only header carries it deliberately (see the TODO in the
+    // config). Promoting the policy must not carry it across — this fails the
+    // moment an enforcing `Content-Security-Policy` is added while the
+    // eval escape hatch is still in the policy string.
+    const enforcing = /key:\s*'Content-Security-Policy'/.test(CONFIG);
+    if (enforcing) expect(CONFIG).not.toContain('unsafe-eval');
+  });
+});
+
+describe('image and cache policy', () => {
+  it('never wildcards a remote image host', () => {
+    expect(CONFIG).not.toMatch(/hostname:\s*'\*/);
+    expect(CONFIG).toMatch(/remotePatterns/);
+  });
+
+  it('serves immutable build output with a one-year max-age', () => {
+    expect(CONFIG).toContain('public, max-age=31536000, immutable');
+  });
+});

--- a/apps/docs/src/__tests__/security-headers-lock.test.ts
+++ b/apps/docs/src/__tests__/security-headers-lock.test.ts
@@ -23,7 +23,10 @@ describe('security header contract', () => {
     ['X-Content-Type-Options', 'nosniff'],
     ['X-Frame-Options', 'DENY'],
     ['Referrer-Policy', 'strict-origin-when-cross-origin'],
-    ['Strict-Transport-Security', 'includeSubDomains'],
+    // Pin the full value, not just the directive: `includeSubDomains` with a
+    // short max-age is meaningfully weaker than what ships today, and an
+    // assertion on the directive alone would stay green through that edit.
+    ['Strict-Transport-Security', 'max-age=63072000; includeSubDomains'],
   ])('sends %s', (header, value) => {
     expect(CONFIG).toContain(header);
     expect(CONFIG).toContain(value);
@@ -52,10 +55,13 @@ describe('CSP directives that must never loosen', () => {
   });
 
   it("does not allow 'unsafe-eval' in the enforcing header", () => {
-    // The report-only header carries it deliberately (see the TODO in the
-    // config). Promoting the policy must not carry it across — this fails the
-    // moment an enforcing `Content-Security-Policy` is added while the
-    // eval escape hatch is still in the policy string.
+    // VACUOUS BY DESIGN, TODAY. The policy is report-only, so `enforcing` is
+    // false and the expectation below never runs. That is the intent, not an
+    // oversight: the report-only header carries 'unsafe-eval' deliberately
+    // (see the TODO in the config) so the violation stream isn't drowned by
+    // it. This lock is armed for the promotion — it fails the moment an
+    // enforcing `Content-Security-Policy` is added while the eval escape
+    // hatch is still in the policy string.
     const enforcing = /key:\s*'Content-Security-Policy'/.test(CONFIG);
     if (enforcing) expect(CONFIG).not.toContain('unsafe-eval');
   });


### PR DESCRIPTION
## Summary

Came out of a Supabase + Vercel audit. Three things, all free.

**1. A broken storefront page, live for six weeks.** `eslint-plugin-jwt` was renamed to `eslint-plugin-jwt-security` (and `-pg` → `-postgresql-security`), but the `RemoteReadme` / `RemoteChangelog` props in the docs content kept the old slug. Those components build a `raw.githubusercontent.com` URL against `main` and fetch it at render time, so production 404'd. Vercel runtime errors: **147 occurrences across 106 users, 2026-07-06 → 2026-08-22.** A wrong prop is invisible locally, in CI, and in the build — it only fails in production.

**2. Two locks**, per the regression policy in CLAUDE.md:

- `remote-markdown-slug-lock` — resolves every `RemoteReadme`/`RemoteChangelog` prop in the docs content to `packages/eslint-plugin-<slug>/<FILE>.md` on disk. It also asserts the scan found usages at all, so it can't pass vacuously by pointing at the wrong directory.
- `security-headers-lock` — pins the header contract CLAUDE.md already calls undroppable but nothing enforced: the four security headers, the CSP directives that must never loosen, no wildcard image host, the immutable cache policy. The `unsafe-eval` assertion is conditional — it stays quiet while the policy is report-only and fires the moment someone promotes it to enforcing without dropping the eval escape hatch.

**3. Header fixes**, from probing what all five production sites actually send:

- `Permissions-Policy` was opting out of `interest-cohort` — a dead token, FLoC was withdrawn. Replaced with `browsing-topics`, which is what the Topics API that replaced it actually reads.
- HSTS now carries `includeSubDomains` (Vercel's default omits it). `preload` deliberately not added — it's a browser-baked commitment that's very hard to unwind.
- `connect-src` now names the PostHog origins `posthog-js` reaches directly rather than through the `/ingest` proxy — remote config, surveys, toolbar — plus the session-replay WebSocket, so the report-only stream measures the policy rather than the proxy. Supabase is deliberately **absent**: impact data is read server-side in `lib/impact-source.ts`, never from the browser.

## Test plan

- [x] `vitest run` in `apps/docs` — **84 files, 1833 passed**, 53 skipped.
- [x] New slug lock verified **red on the unfixed prop** (`packages/eslint-plugin-jwt/ does not exist`) and green on the fix.
- [x] `tsc --noEmit` clean; `oxlint` clean on all changed files; `prettier --write` applied.
- [x] Full `build-and-test` + `typecheck` pre-push hooks green against a real `npm ci` install (109s).

## After merge

Auto-deploy fires `deploy-docs.yml`. Once live, `/docs/security/plugin-jwt-security` and `/docs/security/plugin-postgresql-security` should render their READMEs instead of the error boundary, and the runtime-error count for `[RemoteMarkdown]` should fall to zero.

**Not in this PR** — `storybook.interlace.tools` and `ds.interlace.tools` ship no `X-Frame-Options` at all and are clickjackable today. Their `vercel.json` files don't exist on `main` (those apps are still local-branch only), and the live Vercel projects are git-linked to `ofri-peretz/interlace` — so that fix belongs in the interlace repo. Use `SAMEORIGIN`, not `DENY`: Storybook embeds its own `iframe.html` and `DENY` would break the canvas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)