### PR TITLE
fix(import-next): no-duplicates — a type-only import is not a duplicate

### DIFF
--- a/.changeset/no-duplicates-import-kind.md
+++ b/.changeset/no-duplicates-import-kind.md
@@ -1,0 +1,23 @@
+---
+'eslint-plugin-import-next': patch
+---
+
+`no-duplicates`: a type-only import is not a duplicate of a value import.
+
+The rule grouped imports by module specifier alone, so
+
+```ts
+import type { ActiveConfig } from '../project/active-config.js';
+import { selectActiveConfig } from '../project/active-config.js';
+```
+
+was reported as a duplicate. It is not. The type-only form is erased at compile
+time, so folding it into the value import creates a runtime dependency that was
+not there — which is what `verbatimModuleSyntax` exists to prevent and what
+tree-shaking relies on. The two declarations are separate on purpose.
+
+Grouping is now keyed by specifier **and** `importKind`, matching ESLint core's
+`import/no-duplicates`. Two type-only imports from the same module are still
+duplicates of each other and still merge.
+
+On the pinned 8-repository corpus: **94 → 40 findings**.

--- a/packages/eslint-plugin-import-next/src/rules/no-duplicates.ts
+++ b/packages/eslint-plugin-import-next/src/rules/no-duplicates.ts
@@ -44,7 +44,14 @@ export const noDuplicates = createRule<RuleOptions, MessageIds>({
 
     return {
       ImportDeclaration(node: TSESTree.ImportDeclaration) {
-        const source = node.source.value;
+        // Keyed by source AND importKind. `import type { T } from 'm'` beside
+        // `import { v } from 'm'` is not a duplicate: the type-only form is
+        // erased at compile time, so folding it into the value import creates a
+        // runtime dependency that was not there and defeats
+        // `verbatimModuleSyntax` and tree-shaking. 42 of the 94 findings on the
+        // pinned corpus — 45% — were this shape. ESLint core's
+        // `import/no-duplicates` separates them the same way.
+        const source = `${node.source.value}\u0000${node.importKind ?? 'value'}`;
         let sourceNodes = imports.get(source);
         if (!sourceNodes) {
           sourceNodes = [];

--- a/packages/eslint-plugin-import-next/src/tests/no-duplicates.test.ts
+++ b/packages/eslint-plugin-import-next/src/tests/no-duplicates.test.ts
@@ -1,4 +1,5 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
+import { RuleTester as ESLintRuleTester } from 'eslint';
 import { describe, it, afterAll } from 'vitest';
 import parser from '@typescript-eslint/parser';
 import { noDuplicates } from '../rules/no-duplicates';
@@ -27,6 +28,73 @@ describe('no-duplicates', () => {
         code: "import { merge } from 'lodash'; import { find } from 'lodash';",
         output: "import { merge, find } from 'lodash'; ", // Fixer remove might leave trailing space or newline depending on whitespace
         errors: [{ messageId: 'noDuplicates' }],
+      },
+    ],
+  });
+});
+
+/**
+ * A type-only import is not a duplicate of a value import.
+ *
+ * `import type { T } from 'm'` is erased at compile time. Folding it into
+ * `import { v } from 'm'` creates a runtime dependency that was not there,
+ * which is what `verbatimModuleSyntax` exists to prevent and what tree-shaking
+ * relies on. The declarations are separate on purpose.
+ *
+ * 42 of the 94 findings on the pinned 8-repository corpus — 45% — were this
+ * shape. ESLint core's `import/no-duplicates` separates them the same way.
+ */
+describe('no-duplicates — importKind is part of the identity', () => {
+  ruleTester.run('type vs value', noDuplicates, {
+    valid: [
+      {
+        code: "import type { T } from './m';\nimport { v } from './m';\nexport const x: T = v;",
+      },
+      {
+        // Order does not matter.
+        code: "import { v } from './m';\nimport type { T } from './m';\nexport const x: T = v;",
+      },
+    ],
+    invalid: [
+      {
+        // POSITIVE CONTROL: two value imports still merge. Without this the
+        // valid cases above pass on a rule that stopped reporting entirely.
+        code: "import { a } from './m';\nimport { b } from './m';",
+        errors: [{ messageId: 'noDuplicates' }],
+        output: "import { a, b } from './m';\n",
+      },
+      {
+        // Two TYPE-only imports are duplicates of each other, and merge.
+        code: "import type { A } from './m';\nimport type { B } from './m';",
+        errors: [{ messageId: 'noDuplicates' }],
+        output: "import type { A, B } from './m';\n",
+      },
+    ],
+  });
+});
+
+/**
+ * The plugin runs on plain JavaScript too, where espree leaves `importKind`
+ * undefined rather than `'value'`. The `?? 'value'` fallback in the group key
+ * is what keeps every JS import in one bucket instead of a bucket keyed on
+ * `undefined` — reachable, so pinned.
+ */
+describe('no-duplicates — plain JavaScript, no importKind', () => {
+  // ESLint's own RuleTester, deliberately. `@typescript-eslint/rule-tester`
+  // installs the TS parser by default even when none is given, so a block
+  // written there would still see `importKind: 'value'` and the fallback would
+  // stay unreached.
+  const jsRuleTester = new ESLintRuleTester({
+    languageOptions: { ecmaVersion: 2022, sourceType: 'module' },
+  });
+
+  jsRuleTester.run('espree', noDuplicates as never, {
+    valid: ["import { a, b } from './m';"],
+    invalid: [
+      {
+        code: "import { a } from './m';\nimport { b } from './m';",
+        errors: [{ messageId: 'noDuplicates' }],
+        output: "import { a, b } from './m';\n",
       },
     ],
   });


### PR DESCRIPTION
## Summary

Batch 2, second rule. `no-duplicates` grouped imports by module specifier alone, so this was reported as a duplicate:

```ts
import type { ActiveConfig } from '../project/active-config.js';
import { selectActiveConfig } from '../project/active-config.js';
```

It is not one. The type-only form is **erased at compile time**, so folding it into the value import creates a runtime dependency that was not there — exactly what `verbatimModuleSyntax` exists to prevent, and what tree-shaking relies on. The two declarations are separate on purpose.

Grouping is now keyed by specifier **and** `importKind`, matching ESLint core's `import/no-duplicates`. Two type-only imports from the same module are still duplicates of each other and still merge.

### Corpus

| | |
|---|---:|
| before | 94 |
| after | **40** |

A line-based classification predicted *at least* 42 of the 94 were this shape. The AST-based fix removed 54 — the heuristic could not classify 16 multiline imports, and most of those were type-only too.

## The `?? 'value'` fallback is real, and pinned

espree leaves `importKind` **undefined** on plain JavaScript. Without the fallback every JS import would key on `undefined` — which happens to work, but only by accident.

Its test uses **ESLint's own `RuleTester`**, not `@typescript-eslint/rule-tester`: the latter installs the TS parser even when none is given, so a test written there would still see `importKind: 'value'` and leave the branch unreached while appearing to cover it. Verified by watching branch coverage stay at 94.44% until the parser was actually removed.

## What I deliberately did NOT change

The rule also reports two shapes that **cannot be written as one statement**:

- `import * as ns from 'm'` beside `import { v } from 'm'` — 8 findings, every one a test file holding a namespace for spying and named bindings for use
- two default imports from the same module

The fixer already returns `null` for both, so the rule raises a finding whose own fix says *impossible* while its message says *merge duplicate imports*.

**I implemented the fix for these, then reverted it.** Two existing tests pin the current behaviour, and on the merits both really are redundant — `a` and `b` from two default imports are the same value under two names, and a developer should collapse them by hand. Whether the *advice* is actionable is an `effectiveFp` question, and not one to settle from 8 findings and my own read of an idiom. Recorded here so the next pass has the measurement.

## Test plan

- [x] Positive control established **before** the fix: all four shapes reported, so the quiet cases carry information.
- [x] **2 of the new locks fail on the unfixed rule** — verified by restoring `HEAD`'s version.
- [x] `import-next`: 1,333 passing, **100%** statements / branches / functions / lines.
- [x] CWE recall gate re-run in the same session: TP=69 FP=0 FN=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)