### PR TITLE
fix(docs): cookieless mode instead of memory persistence

### DIFF
--- a/apps/docs/src/__tests__/posthog-provider-lock.test.tsx
+++ b/apps/docs/src/__tests__/posthog-provider-lock.test.tsx
@@ -121,6 +121,18 @@ describe('PostHog: Init contract (ANALYTICS_PHILOSOPHY.md)', () => {
   it('dead-click capture enabled (capture_dead_clicks: true)', () => {
     expect(initSrc).toMatch(/capture_dead_clicks:\s*true/);
   });
+  it('cookieless mode, not memory persistence', () => {
+    // `persistence: 'memory'` gave every page load a fresh anonymous person
+    // (1.2 pageviews per "person"), which silently zeroed funnels, paths,
+    // retention and replay. Cookieless mode keeps the no-cookie property
+    // without discarding identity. It only works while the project has
+    // cookieless_server_hash_mode enabled — if someone reverts one, this
+    // fails and points at the other.
+    expect(initSrc).toMatch(/^\s*cookieless_mode:\s*'always',/m);
+    // Anchored to a config line, not a mention: the comment above the option
+    // names `persistence: 'memory'` to explain what it replaced.
+    expect(initSrc).not.toMatch(/^\s*persistence:\s*'memory',/m);
+  });
   it('cross-subdomain cookie on .interlace.tools', () => {
     expect(initSrc).toMatch(/cross_subdomain_cookie:\s*true/);
     expect(initSrc).toMatch(/['"]\.interlace\.tools['"]/);

--- a/apps/docs/src/lib/posthog-init.ts
+++ b/apps/docs/src/lib/posthog-init.ts
@@ -31,11 +31,10 @@ import posthog, { type PostHogConfig } from 'posthog-js';
 export const APP_ID = 'eslint_docs' as const;
 
 /**
- * Same-eTLD+1 cookie scope so `*.interlace.tools` shares one anonymous
- * `distinct_id`. `cross_subdomain_cookie: true` makes posthog-js set the
- * cookie domain to the eTLD+1 of the current page automatically (so on
- * `eslint.interlace.tools` it becomes `.interlace.tools` — no explicit
- * config needed). Documented here as the intended scope.
+ * Kept only as documentation of intended scope. `cross_subdomain_cookie: true`
+ * below is a no-op while `cookieless_mode` is active — cookieless mode writes
+ * no cookie at all, so there is no cookie to scope. It stays set because it is
+ * the correct value the moment cookieless mode is ever turned off.
  */
 const COOKIE_DOMAIN = '.interlace.tools';
 void COOKIE_DOMAIN;
@@ -167,11 +166,21 @@ export function initPostHog(): void {
     api_host: '/ingest',
     ui_host: 'https://us.posthog.com',
     person_profiles: 'identified_only',
-    // Cookie-free mode: no `ph_` cookie is set, so no GDPR consent banner
-    // is required for EU visitors. Cross-session person stitching is lost
-    // (each page load is anonymous) but for a public docs site with no
-    // logged-in users this is the right trade-off.
-    persistence: 'memory',
+    // Cookieless mode: PostHog sets no cookie and touches no local or session
+    // storage, so no GDPR consent banner is required — and, unlike the
+    // `persistence: 'memory'` this replaces, identity is not thrown away.
+    //
+    // `persistence: 'memory'` meant every page load was a brand new anonymous
+    // person: 2,254 pageviews across 1,863 "people" in 30 days, 1.2 pageviews
+    // each, which made funnels, paths, retention, and session replay measure
+    // nothing. Cookieless mode instead derives identity from a
+    // privacy-preserving hash computed on PostHog's servers, so sessions and
+    // people are real again with no client-side storage.
+    //
+    // REQUIRES `cookieless_server_hash_mode` on the PostHog project (set to 2,
+    // Stateful, on 2026-08-22). Without it every cookieless event is silently
+    // DROPPED — the two must be changed together, project setting first.
+    cookieless_mode: 'always',
     capture_pageview: false,
     capture_pageleave: true,
     capture_performance: true,


### PR DESCRIPTION
## The bug

`posthog-init.ts` set `cross_subdomain_cookie: true` and documented identity stitching across `*.interlace.tools` — then set `persistence: 'memory'`, which writes no cookie at all. The two cancelled out.

The data shows which one won:

| | 30 days |
|---|---|
| `$pageview` events | 2,254 |
| distinct "people" | 1,863 |
| **pageviews per person** | **1.2** |

Every page load was a brand-new anonymous person. Funnels, paths, retention, and session replay were all measuring a population that resets on navigation.

## The fix

`cookieless_mode: 'always'` keeps the property that motivated the original choice — no cookie, no local or session storage, **no GDPR banner** — and gets identity back by deriving it from a privacy-preserving hash computed on PostHog's servers.

## ⚠️ This half does not work alone

`cookieless_server_hash_mode` must be enabled on the project or PostHog **silently drops every cookieless event**. It is now set to `2` (Stateful) on project 428927, applied *before* this commit.

**Project setting first, code second. Never revert one without the other.** The lock test points at this relationship so the next person finds it.

## Test plan

- [x] `posthog-provider-lock.test.tsx` — 45/45.
- [x] New lock asserts `cookieless_mode: 'always'` present and `persistence: 'memory'` absent, anchored to config lines (`/^\s*.../m`) rather than mentions, so the explanatory comment doesn't satisfy it.
- [x] **Verified non-vacuous by mutation**: restoring `persistence: 'memory'` fails the lock; reverting passes.
- [ ] After deploy: pageviews-per-person should climb well above 1.2, and session replay should start producing multi-page sessions rather than one-page fragments.

## Watch after merge

Event volume should be unchanged. If `$pageview` drops to zero, the project setting is the thing to check first — that is the failure mode this pairing has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)