### PR TITLE
fix(docs): a release now invalidates every cache layer it owns

### DIFF
--- a/.changeset/remote-markdown-cache-tags.md
+++ b/.changeset/remote-markdown-cache-tags.md
@@ -1,0 +1,15 @@
+---
+'@interlace/ui': minor
+---
+
+`RemoteMarkdown` accepts `tags`, forwarded to the underlying fetch as
+`next.tags`.
+
+Vercel's runtime cache outlives a deployment. Without a tag the cached entry
+is untargetable, so shipping a fix to the remote document leaves the old copy
+served until `revalidate` happens to elapse and nothing can force it sooner.
+Tagging makes the entry reachable by `revalidateTag()` and
+`vercel cache invalidate --tag`, which is what lets a release actually
+invalidate it.
+
+Additive and optional — omitting `tags` keeps the previous behaviour.

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -192,6 +192,40 @@ jobs:
           echo "url=$url" >> "$GITHUB_OUTPUT"
           echo "Deployed to: $url"
 
+      # Vercel's runtime (data) cache is NOT scoped to a deployment — it
+      # outlives one. Everything else in the chain self-invalidates on
+      # release: HTML is `max-age=0, must-revalidate`, `/_next/static/*` is
+      # content-hashed so a build produces new URLs, `/images/*` revalidates
+      # (see next.config.mjs), and the CDN's static + prerender entries belong
+      # to the deployment. The runtime cache is the one layer that would
+      # otherwise keep serving pre-release remote markdown until its
+      # `revalidate` window happened to elapse. The `github-markdown` tag is
+      # applied at every RemoteMarkdown call site precisely so this command
+      # can reach it.
+      #
+      # Advisory, like the tweet-cache HEAD probe: the deploy has already
+      # succeeded by this point, and the failure mode is bounded (content is
+      # stale until `revalidate` elapses, an hour or two) — which does not
+      # justify wedging a shipped release. It warns loudly instead.
+      - name: Invalidate runtime cache for remote markdown
+        if: inputs.environment == 'production'
+        continue-on-error: true
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          set -uo pipefail
+          # Pinned separately from VERCEL_CLI_VERSION above: `cache invalidate`
+          # postdates that pin, and this step must not force a bump of the CLI
+          # that performs the actual build+deploy.
+          if npx --yes "vercel@59.4.0" cache invalidate \
+               --tag github-markdown --token="$VERCEL_TOKEN"; then
+            echo "Invalidated runtime cache tag: github-markdown"
+            echo "- Runtime cache: \`github-markdown\` invalidated" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::warning::Could not invalidate the 'github-markdown' runtime cache tag. Remote READMEs/CHANGELOGs may serve pre-release content until their revalidate window elapses. Check the Vercel CLI version and that VERCEL_TOKEN has cache scope."
+            echo "- Runtime cache: ⚠️ invalidation failed (see warning)" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Job summary
         if: always()
         env:

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -142,7 +142,10 @@ const config = {
     formats: ['image/avif', 'image/webp'],
     deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048],
     imageSizes: [16, 32, 48, 64, 96, 128, 256],
-    minimumCacheTTL: 31536000,
+    // One hour, not one year. The optimizer keys on the *source* URL, and
+    // those are stable paths under /images — so a year-long floor pinned the
+    // optimized derivative long after its source had changed.
+    minimumCacheTTL: 3600,
     // External hosts we render via next/image: badges in plugin READMEs,
     // dev.to article covers + author avatars, GitHub raw README assets.
     remotePatterns: [
@@ -223,21 +226,19 @@ const config = {
       ],
     },
     {
+      // NOT immutable, deliberately. `/_next/static/*` may be pinned for a
+      // year because its filenames carry a content hash — a new build means a
+      // new URL. These paths do not: `/images/og-jwt-security.png` is the same
+      // URL forever. `immutable` told every client never to revalidate it, so
+      // regenerating an OG image left the stale one live for up to a year with
+      // no way to evict it — and these images are fetched by Twitter,
+      // LinkedIn, Slack and GitHub's camo proxy from absolute URLs in package
+      // READMEs, which is exactly where a year-old social card is most visible
+      // and least noticed. `must-revalidate` costs one conditional request and
+      // returns 304 with no body, so a release propagates immediately.
       source: '/images/:path*',
       headers: [
-        { key: 'Cache-Control', value: 'public, max-age=31536000, immutable' },
-      ],
-    },
-    {
-      source: '/public/:path*',
-      headers: [
-        { key: 'Cache-Control', value: 'public, max-age=31536000, immutable' },
-      ],
-    },
-    {
-      source: '/_next/image/:path*',
-      headers: [
-        { key: 'Cache-Control', value: 'public, max-age=31536000, immutable' },
+        { key: 'Cache-Control', value: 'public, max-age=0, must-revalidate' },
       ],
     },
   ],

--- a/apps/docs/src/__tests__/cache-invalidation-lock.test.ts
+++ b/apps/docs/src/__tests__/cache-invalidation-lock.test.ts
@@ -28,15 +28,32 @@ const CONFIG = readFileSync(join(DOCS, 'next.config.mjs'), 'utf-8');
 /** Paths whose URLs change when their bytes change, so `immutable` is honest. */
 const CONTENT_ADDRESSED = ['/_next/static/:path*'];
 
-/** Every `{ source: '...', headers: [...] }` block, paired with its body. */
+/**
+ * Every `{ source: '...', headers: [...] }` block, paired with its body.
+ *
+ * Scoped to the `headers:` region of the config on purpose. `rewrites()` and
+ * `redirects()` also use a `source:` key, and a naive whole-file scan turns
+ * each of those into a phantom "header block" — harmless today, since none
+ * carries a Cache-Control, but it inflates the positive-control count below
+ * and would keep this test green for the wrong reason.
+ */
 function headerBlocks(): { source: string; body: string }[] {
+  const start = CONFIG.indexOf('headers: async');
+  expect(start, 'no headers() in next.config.mjs').toBeGreaterThan(-1);
+  const after = ['rewrites: async', 'redirects: async']
+    .map((k) => CONFIG.indexOf(k, start))
+    .filter((i) => i > -1);
+  const region = CONFIG.slice(
+    start,
+    after.length ? Math.min(...after) : CONFIG.length,
+  );
+
   const blocks: { source: string; body: string }[] = [];
-  const re = /source:\s*'([^']+)'/g;
-  const matches = [...CONFIG.matchAll(re)];
+  const matches = [...region.matchAll(/source:\s*'([^']+)'/g)];
   matches.forEach((m, i) => {
-    const start = m.index ?? 0;
-    const end = matches[i + 1]?.index ?? CONFIG.length;
-    blocks.push({ source: m[1], body: CONFIG.slice(start, end) });
+    const from = m.index ?? 0;
+    const to = matches[i + 1]?.index ?? region.length;
+    blocks.push({ source: m[1], body: region.slice(from, to) });
   });
   return blocks;
 }
@@ -82,9 +99,11 @@ describe('remote markdown stays reachable by cache tag', () => {
     ),
   )('%s tags its fetch with github-markdown', (file) => {
     const src = readFileSync(join(dir, file), 'utf-8');
+    // Quote-agnostic: the formatter enforces single quotes, but the lock
+    // should not be the thing that depends on that.
     expect(
       src,
       `${file} renders <RemoteMarkdown> without a 'github-markdown' tag — deploy-docs.yml invalidates that tag on release, and an untagged entry survives the deploy`,
-    ).toContain("'github-markdown'");
+    ).toMatch(/['"`]github-markdown['"`]/);
   });
 });

--- a/apps/docs/src/__tests__/cache-invalidation-lock.test.ts
+++ b/apps/docs/src/__tests__/cache-invalidation-lock.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Regression lock: a release must invalidate every cache layer it owns.
+ *
+ * The rule this encodes
+ * ─────────────────────
+ * `Cache-Control: immutable` is a promise that a URL's bytes will never
+ * change. It is only ever true for a *content-addressed* URL — one whose path
+ * carries a build or content hash, so that changing the bytes produces a
+ * different URL. `/_next/static/*` qualifies. `/images/og-jwt-security.png`
+ * does not: that URL is stable forever, so `immutable` told every client never
+ * to revalidate it and a regenerated image stayed stale for up to a year with
+ * no eviction path. Those images are fetched by Twitter, LinkedIn, Slack and
+ * GitHub's camo proxy from absolute URLs in package READMEs, so the stale copy
+ * is maximally visible and minimally noticed.
+ *
+ * This lock fails if `immutable` is ever attached to a source that isn't
+ * content-addressed, and if the remote-markdown call sites lose the cache tags
+ * that make the runtime cache reachable by `vercel cache invalidate`.
+ */
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const DOCS = join(__dirname, '../..');
+const CONFIG = readFileSync(join(DOCS, 'next.config.mjs'), 'utf-8');
+
+/** Paths whose URLs change when their bytes change, so `immutable` is honest. */
+const CONTENT_ADDRESSED = ['/_next/static/:path*'];
+
+/** Every `{ source: '...', headers: [...] }` block, paired with its body. */
+function headerBlocks(): { source: string; body: string }[] {
+  const blocks: { source: string; body: string }[] = [];
+  const re = /source:\s*'([^']+)'/g;
+  const matches = [...CONFIG.matchAll(re)];
+  matches.forEach((m, i) => {
+    const start = m.index ?? 0;
+    const end = matches[i + 1]?.index ?? CONFIG.length;
+    blocks.push({ source: m[1], body: CONFIG.slice(start, end) });
+  });
+  return blocks;
+}
+
+describe('immutable is only promised for content-addressed URLs', () => {
+  const immutable = headerBlocks().filter((b) =>
+    /Cache-Control[^\n]*immutable/.test(b.body),
+  );
+
+  it('finds the cache-control blocks to check', () => {
+    expect(immutable.length).toBeGreaterThan(0);
+  });
+
+  it.each(immutable)('$source is content-addressed', ({ source }) => {
+    expect(
+      CONTENT_ADDRESSED,
+      `${source} is pinned immutable but its URL does not carry a content hash, so a release cannot evict it`,
+    ).toContain(source);
+  });
+});
+
+describe('the image optimizer floor is not a year', () => {
+  it('keeps minimumCacheTTL bounded', () => {
+    const m = CONFIG.match(/minimumCacheTTL:\s*(\d+)/);
+    expect(m).not.toBeNull();
+    // The optimizer keys on the source URL, and those are stable paths — so
+    // this floor is how long a derivative outlives a changed source.
+    expect(Number(m![1])).toBeLessThanOrEqual(86_400);
+  });
+});
+
+describe('remote markdown stays reachable by cache tag', () => {
+  const dir = join(DOCS, 'src/components/docs');
+  const callSites = readdirSync(dir).filter((f) => f.startsWith('remote-'));
+
+  it('finds the remote-* components', () => {
+    expect(callSites.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it.each(
+    callSites.filter((f) =>
+      readFileSync(join(dir, f), 'utf-8').includes('<RemoteMarkdown'),
+    ),
+  )('%s tags its fetch with github-markdown', (file) => {
+    const src = readFileSync(join(dir, file), 'utf-8');
+    expect(
+      src,
+      `${file} renders <RemoteMarkdown> without a 'github-markdown' tag — deploy-docs.yml invalidates that tag on release, and an untagged entry survives the deploy`,
+    ).toContain("'github-markdown'");
+  });
+});

--- a/apps/docs/src/components/docs/remote-changelog.tsx
+++ b/apps/docs/src/components/docs/remote-changelog.tsx
@@ -17,9 +17,7 @@ interface RemoteChangelogProps {
 }
 
 function cleanChangelog(markdown: string, limit = 0): string {
-  let cleaned = markdown
-    .replace(/^\s*\n+/, '')
-    .replace(/^#\s+[^\n]+\n+/, '');
+  let cleaned = markdown.replace(/^\s*\n+/, '').replace(/^#\s+[^\n]+\n+/, '');
 
   if (limit > 0) {
     const lines = cleaned.split('\n');
@@ -66,6 +64,7 @@ export async function RemoteChangelog({
     <RemoteMarkdown
       url={url}
       revalidate={7200}
+      tags={['github-markdown', 'remote-changelog']}
       fallback={fallback}
       className="remote-changelog"
       source={{

--- a/apps/docs/src/components/docs/remote-readme.tsx
+++ b/apps/docs/src/components/docs/remote-readme.tsx
@@ -95,6 +95,7 @@ export async function RemoteReadme({
     <RemoteMarkdown
       url={url}
       revalidate={3600}
+      tags={['github-markdown', 'remote-readme']}
       fallback={fallback}
       className="remote-readme"
       source={{

--- a/apps/docs/src/components/docs/remote-rule-doc.tsx
+++ b/apps/docs/src/components/docs/remote-rule-doc.tsx
@@ -62,6 +62,7 @@ export async function RemoteRuleDoc({ plugin, rule }: RemoteRuleDocProps) {
     <RemoteMarkdown
       url={url}
       revalidate={21600}
+      tags={['github-markdown', 'remote-rule-doc']}
       fallback={fallback}
       className="remote-rule-doc"
       source={{

--- a/apps/docs/src/components/docs/remote-toc-provider.tsx
+++ b/apps/docs/src/components/docs/remote-toc-provider.tsx
@@ -2,7 +2,7 @@
 
 /**
  * RemoteTocProvider - Client-side TOC provider for remote content
- * 
+ *
  * Wraps remote content with Fumadocs' AnchorProvider to enable
  * TOC sidebar navigation for dynamically compiled content.
  */
@@ -18,11 +18,7 @@ interface RemoteTocProviderProps {
 }
 
 export function RemoteTocProvider({ toc, children }: RemoteTocProviderProps) {
-  return (
-    <AnchorProvider toc={toc}>
-      {children}
-    </AnchorProvider>
-  );
+  return <AnchorProvider toc={toc}>{children}</AnchorProvider>;
 }
 
 export default RemoteTocProvider;

--- a/packages/ui/src/fumadocs/remote-markdown.tsx
+++ b/packages/ui/src/fumadocs/remote-markdown.tsx
@@ -41,19 +41,35 @@ export interface RemoteMarkdownProps {
    * Pass an object to render `<RemoteSourceCallout>` with those props.
    */
   source?: false | Omit<RemoteSourceCalloutProps, 'className'>;
+  /**
+   * Cache tags applied to the underlying fetch.
+   *
+   * Without these the cached entry is untargetable: Vercel's runtime cache
+   * outlives a deployment, so shipping a fix to the *remote* document leaves
+   * the old copy served until `revalidate` happens to elapse, and nothing can
+   * force it sooner. Tagging makes `revalidateTag()` /
+   * `vercel cache invalidate --tag` able to reach it, which is what turns a
+   * release into a real invalidation instead of a wait.
+   */
+  tags?: string[];
 }
 
-// Next.js extends `fetch` with a `next.revalidate` option for ISR.
+// Next.js extends `fetch` with `next.revalidate` / `next.tags` options.
 // Type widening here keeps the package usable in plain React-server-component
 // environments without a hard dependency on Next types.
-type NextFetchInit = RequestInit & { next?: { revalidate?: number } };
+type NextFetchInit = RequestInit & {
+  next?: { revalidate?: number; tags?: string[] };
+};
 
 async function fetchSource(
   url: string,
   revalidate: number,
+  tags: string[] | undefined,
 ): Promise<string | null> {
   try {
-    const res = await fetch(url, { next: { revalidate } } as NextFetchInit);
+    const res = await fetch(url, {
+      next: { revalidate, ...(tags?.length ? { tags } : {}) },
+    } as NextFetchInit);
     if (!res.ok) {
       console.error(`[RemoteMarkdown] ${url} responded ${res.status}`);
       return null;
@@ -81,8 +97,9 @@ export async function RemoteMarkdown({
   className,
   as: Tag = 'article',
   source,
+  tags,
 }: RemoteMarkdownProps) {
-  const fetched = await fetchSource(url, revalidate);
+  const fetched = await fetchSource(url, revalidate, tags);
   if (fetched === null) return <>{fallback}</>;
   const processed = preprocess ? preprocess(fetched) : fetched;
   const { Body, toc } = await compile(processed);


### PR DESCRIPTION
## Summary

You asked whether we hard-invalidate every layer on release. We did not. I walked each layer between a deploy and a user's screen and verified its behaviour against the live site rather than reasoning from the config.

| Layer | Keyed by | Invalidated by a release? |
|---|---|---|
| Browser — HTML | — | ✅ `max-age=0, must-revalidate` |
| Browser — `/_next/static/*` | content hash in path | ✅ new build ⇒ new URL |
| Vercel CDN — static + prerender | deployment | ✅ per-deployment |
| Browser/scrapers — `/images/*` | **stable path** | ❌ **`immutable`, 1 year** |
| Image optimizer — `/_next/image` | source URL | ❌ **`minimumCacheTTL` = 1 year** |
| Vercel runtime (data) cache | URL + tags | ❌ **outlives the deployment, untagged ⇒ untargetable** |

### 1. `immutable` on URLs that are not content-addressed

`/_next/static/*` earns `immutable` because its filenames carry a content hash — new bytes mean a new URL. `/images/*` was pinned identically, and those URLs are stable forever. `immutable` tells clients never to revalidate, so a regenerated OG image stayed live-and-stale for up to a year with no eviction path.

That matters more than it first looks: these are the images **Twitter, LinkedIn, Slack and GitHub's camo proxy fetch from absolute URLs in package READMEs** (`generate-og-images.mjs` writes them for exactly that). A year-old social card is the most visible and least-noticed kind of stale. Now `public, max-age=0, must-revalidate` — one conditional request, 304 with no body.

### 2. `images.minimumCacheTTL` was a year

The optimizer keys on the *source* URL, and sources are stable paths under `/images`, so this floor governed how long a derivative outlived a changed source. Verified live:

```
/_next/image?url=%2Fimages%2Finterlace-hero.png&w=640&q=75
  → cache-control: public, max-age=31536000, immutable
```

Now `3600`.

### 3. Vercel's runtime cache outlives a deployment

The remote README/CHANGELOG/rule-doc fetches were untagged, so nothing could target them — a shipped fix waited for `revalidate` to elapse and there was no way to force it sooner. **This is why the plugin-README 404 fix in #619 did not appear the moment the deploy went green.**

Every `RemoteMarkdown` call site now tags its fetch (`github-markdown` plus a per-surface tag), and `deploy-docs.yml` runs `vercel cache invalidate --tag github-markdown` after a production deploy. That step is advisory, matching the tweet-cache HEAD-probe precedent in CLAUDE.md: the deploy has already succeeded by then and the failure mode is bounded staleness, which does not justify wedging a shipped release. It warns loudly and writes to the job summary.

The CLI for that step is pinned separately from `VERCEL_CLI_VERSION` — `cache invalidate` postdates that pin, and this must not force a bump of the CLI that performs the build and deploy.

### Also removed: two rules that never matched anything

- `/public/:path*` — Next serves `public/` at the root; verified `404` live.
- `/_next/image/:path*` — the optimizer serves at `/_next/image?url=…`, a query, not a path.

Both read as though they governed real assets. The real control is `minimumCacheTTL`, bounded above.

## The lock

`cache-invalidation-lock.test.ts` encodes the *rule* — `immutable` only on content-addressed sources — rather than a denylist of known-bad paths, so it catches the next one too. **It caught `/_next/image/:path*` in this very change, which I had missed.** It also fails if a `RemoteMarkdown` call site loses its cache tag, since an untagged entry silently survives the deploy the workflow step is trying to clear.

## Test plan

- [x] Lock verified **red** on a reintroduced `immutable` for `/images/*`, and red on `/_next/image/:path*` before that rule was removed. Green after.
- [x] `vitest` green in `apps/docs`; `deploy-docs.yml` re-parsed as YAML (12 steps, new step present).
- [x] Pre-push `typecheck` (32s) + `build-and-test` (102s) green against a real `npm ci`.
- [x] Every claim above checked with `curl` against production, not inferred from config.

## After merge

Re-probe `/images/og-*.png` and `/_next/image?url=…` to confirm the new headers land. The runtime-cache step only runs on `environment == production`, so it first exercises on the next production deploy — check the job summary line for `Runtime cache: github-markdown invalidated`.

Changeset included: `@interlace/ui` minor, `tags` is additive and optional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)