### PR TITLE
fix(ci): cache invalidation needs --yes or it never runs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -217,8 +217,12 @@ jobs:
           # Pinned separately from VERCEL_CLI_VERSION above: `cache invalidate`
           # postdates that pin, and this step must not force a bump of the CLI
           # that performs the actual build+deploy.
+          # `--yes` is required, not cosmetic: without it the CLI stops at an
+          # interactive confirmation ("You are about to invalidate all cached
+          # content associated with tag github-markdown") and exits non-zero
+          # in CI, so the invalidation silently never happens.
           if npx --yes "vercel@59.4.0" cache invalidate \
-               --tag github-markdown --token="$VERCEL_TOKEN"; then
+               --tag github-markdown --yes --token="$VERCEL_TOKEN"; then
             echo "Invalidated runtime cache tag: github-markdown"
             echo "- Runtime cache: \`github-markdown\` invalidated" >> "$GITHUB_STEP_SUMMARY"
           else


### PR DESCRIPTION
## Summary

The runtime-cache invalidation step shipped in #628 warned on its very first production deploy. The log named the cause exactly:

```
Vercel CLI 59.4.0 (Node.js 24.19.0)
Retrieving project…
You are about to invalidate all cached content associated with tag
github-markdown for project eslint. To continue, run
`vercel cache invalidate --tag github-markdown --yes`.
```

`vercel cache invalidate` stops at an interactive confirmation and exits non-zero in CI, so the tag was never actually invalidated. Adding `--yes`.

Worth noting the rest behaved correctly: the step is advisory by design, so an invalidation that could not complete did **not** wedge a shipped release — it warned, wrote to the job summary, and the deploy went green. That is the tweet-cache HEAD-probe precedent from CLAUDE.md doing its job on the first try.

## Test plan

- [x] `deploy-docs.yml` re-parsed as YAML after the edit.
- [x] Cause taken from the actual failing run ([32606813179](https://github.com/ofri-peretz/eslint/actions/runs/32606813179)), not inferred.
- [ ] Verified on the next production deploy — the job summary should read `Runtime cache: github-markdown invalidated` instead of the warning. I'll confirm after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)