### PR TITLE
fix(docs): sever cross-origin opener links

### DIFF
--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -216,6 +216,17 @@ const config = {
           key: 'Strict-Transport-Security',
           value: 'max-age=63072000; includeSubDomains',
         },
+        // Severs the window.opener relationship with cross-origin openers, so
+        // this document cannot be reached from another browsing context group.
+        // Safe here: nothing in this app calls window.open, so there is no
+        // popup flow to break. Not pairing this with COEP — that would require
+        // every cross-origin image and font to opt in via CORP, which is a
+        // much larger change and buys cross-origin isolation we have no use
+        // for (no SharedArrayBuffer, no high-resolution timers).
+        {
+          key: 'Cross-Origin-Opener-Policy',
+          value: 'same-origin',
+        },
         ...cspReportOnlyHeaders(),
       ],
     },

--- a/apps/docs/src/__tests__/security-headers-lock.test.ts
+++ b/apps/docs/src/__tests__/security-headers-lock.test.ts
@@ -27,6 +27,7 @@ describe('security header contract', () => {
     // short max-age is meaningfully weaker than what ships today, and an
     // assertion on the directive alone would stay green through that edit.
     ['Strict-Transport-Security', 'max-age=63072000; includeSubDomains'],
+    ['Cross-Origin-Opener-Policy', 'same-origin'],
   ])('sends %s', (header, value) => {
     expect(CONFIG).toContain(header);
     expect(CONFIG).toContain(value);


### PR DESCRIPTION
## Summary

`Cross-Origin-Opener-Policy` was the one header absent from **all five** `interlace.tools` sites. Without it, a cross-origin page that opens one of ours keeps a live `window.opener` handle into it. `same-origin` closes that.

Checked before adding it: nothing in this app calls `window.open`, so there is no popup flow to break.

Deliberately **not** pairing this with COEP. That would require every cross-origin image and font to opt in via CORP — a much larger change — and it buys cross-origin isolation this site has no use for: no `SharedArrayBuffer`, no high-resolution timers.

Companion PRs adding the same header to the other four: ofri-peretz/interlace#47 (landing, ds, storybook) and ofri-peretz/serverless#62.

## Test plan

- [x] `security-headers-lock` extended with the header, so removing it goes red. 22 assertions green across it and `cache-invalidation-lock`.
- [x] Pre-push `typecheck` + `build-and-test` green against a real `npm ci`.

## After merge

`curl -I https://eslint.interlace.tools/` should show `cross-origin-opener-policy: same-origin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)