### PR TITLE
fix(import-next): recommended drops the formatting-only rules

### DIFF
--- a/.changeset/recommended-drops-formatting.md
+++ b/.changeset/recommended-drops-formatting.md
@@ -1,0 +1,31 @@
+---
+'eslint-plugin-import-next': minor
+---
+
+`recommended` no longer enables `order`, `first` or `newline-after-import`.
+
+All three are pure formatting, fully auto-fixable, and together produced
+**5,071** of this plugin's findings on the pinned 8-repository corpus —
+`order` 3,597, `newline-after-import` 835, `first` 639.
+
+A consumer who installs a security-positioned ecosystem and is met by four
+thousand import-ordering warnings does not read them and does not keep the
+plugin. The README's own FP/FN section makes the argument: an ignored tool has
+zero recall regardless of what it detects.
+
+This is parity with upstream rather than a novel opinion.
+`eslint-plugin-import`'s `recommended` is eight rules and excludes all three
+deliberately, and ESLint core deprecated its own formatting rules in 8.53 on
+the same reasoning — formatting belongs to a formatter.
+
+**Nothing is removed from the plugin.** `import-style` and `strict` already
+carry all three, so opting back in is one config line:
+
+```js
+import importNext from 'eslint-plugin-import-next';
+
+export default [
+  importNext.configs.recommended,
+  importNext.configs['import-style'], // ← restores order / first / newline-after-import
+];
+```

--- a/packages/eslint-plugin-import-next/src/index.ts
+++ b/packages/eslint-plugin-import-next/src/index.ts
@@ -229,9 +229,25 @@ export const configs = {
       'import-next/no-amd': 'warn',
 
       // Import Style - Recommended
-      'import-next/order': 'warn',
-      'import-next/first': 'warn',
-      'import-next/newline-after-import': 'warn',
+      //
+      // `order`, `first` and `newline-after-import` are NOT here, and their
+      // absence is the point. They are pure formatting, they are fully
+      // auto-fixable, and on the pinned 8-repository corpus they produced 5,071
+      // of this plugin's findings — `order` 3,597, `newline-after-import` 835,
+      // `first` 639. A consumer who installs a security-positioned ecosystem
+      // and is met by four thousand import-ordering warnings does not read them
+      // and does not keep the plugin; the README's own FP/FN section makes the
+      // argument, and an ignored tool has zero recall regardless of what it
+      // detects.
+      //
+      // This also restores parity with upstream. `eslint-plugin-import`'s
+      // `recommended` is eight rules and excludes all three deliberately, and
+      // ESLint core deprecated its own formatting rules in 8.53 on the same
+      // reasoning: formatting belongs to a formatter.
+      //
+      // They are not removed from the plugin. `import-style` already carries
+      // all three, and `strict` carries them too, so opting back in is one
+      // config line.
       'import-next/no-empty-named-blocks': 'warn',
 
       // Dependency Management

--- a/packages/eslint-plugin-import-next/src/recommended-scope.test.ts
+++ b/packages/eslint-plugin-import-next/src/recommended-scope.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * What `recommended` is allowed to contain.
+ *
+ * `order`, `first` and `newline-after-import` are pure formatting, fully
+ * auto-fixable, and produced **5,071** of this plugin's findings on the pinned
+ * 8-repository corpus — `order` 3,597, `newline-after-import` 835, `first` 639.
+ *
+ * A consumer who installs a security-positioned ecosystem and is met by four
+ * thousand import-ordering warnings does not read them and does not keep the
+ * plugin. The README's own FP/FN section makes the argument: an ignored tool
+ * has zero recall regardless of what it detects.
+ *
+ * This is also parity with upstream rather than a novel opinion.
+ * `eslint-plugin-import`'s `recommended` is eight rules and excludes all three,
+ * and ESLint core deprecated its own formatting rules in 8.53 on the same
+ * reasoning — formatting belongs to a formatter.
+ *
+ * They are still shipped. `import-style` and `strict` both carry them, so
+ * opting back in is one config line, and this test pins that too: removing a
+ * rule from `recommended` without leaving it reachable would be a capability
+ * regression rather than a scope decision.
+ */
+import { describe, it, expect } from 'vitest';
+import { configs, rules as allRules } from './index';
+
+const FORMATTING_ONLY = ['order', 'first', 'newline-after-import'] as const;
+
+function rulesOf(name: string): Record<string, unknown> {
+  const config = (configs as Record<string, unknown>)[name];
+  if (Array.isArray(config)) {
+    return Object.assign({}, ...config.map((c) => (c as { rules?: object }).rules ?? {}));
+  }
+  return ((config as { rules?: Record<string, unknown> })?.rules ?? {}) as Record<
+    string,
+    unknown
+  >;
+}
+
+describe('recommended scope', () => {
+  it('does not enable formatting-only rules', () => {
+    const recommended = rulesOf('recommended');
+    const enabled = FORMATTING_ONLY.filter(
+      (rule) => recommended[`import-next/${rule}`] !== undefined,
+    );
+    expect(enabled).toEqual([]);
+  });
+
+  it('still ships them, reachable from import-style and strict', () => {
+    // The counterpart assertion. Without it, "not in recommended" also passes
+    // on a plugin that deleted the rules outright.
+    for (const config of ['import-style', 'strict']) {
+      const rules = rulesOf(config);
+      for (const rule of FORMATTING_ONLY) {
+        expect(rules[`import-next/${rule}`]).toBeDefined();
+      }
+    }
+    for (const rule of FORMATTING_ONLY) {
+      expect((allRules as Record<string, unknown>)[rule]).toBeDefined();
+    }
+  });
+
+  it('keeps the rules that detect defects rather than style', () => {
+    // The floor. `recommended` losing `no-cycle` or `export` would be a real
+    // regression, and this change is only about the formatting three.
+    const recommended = rulesOf('recommended');
+    for (const rule of ['no-unresolved', 'no-duplicates', 'export', 'no-cycle', 'no-self-import']) {
+      expect(recommended[`import-next/${rule}`]).toBeDefined();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`recommended` no longer enables `order`, `first` or `newline-after-import`.

| rule | corpus findings |
|---|---:|
| `order` | 3,597 |
| `newline-after-import` | 835 |
| `first` | 639 |
| **total** | **5,071** |

All three are pure formatting and fully auto-fixable. A consumer who installs a security-positioned ecosystem and is met by four thousand import-ordering warnings does not read them and does not keep the plugin. The README's own FP/FN section makes the argument: **an ignored tool has zero recall regardless of what it detects.**

## This is parity, not an opinion

I checked upstream before changing a published config rather than trusting my memory of it:

```
eslint-plugin-import recommended (8 rules):
  no-unresolved, named, namespace, default, export,
  no-named-as-default, no-named-as-default-member, no-duplicates
```

All three formatting rules are **deliberately absent** upstream. Ours had 16 rules and included them. ESLint core deprecated its own formatting rules in 8.53 on the same reasoning — formatting belongs to a formatter.

## Nothing is removed from the plugin

`import-style` and `strict` already carried all three. Opting back in is one config line:

```js
export default [
  importNext.configs.recommended,
  importNext.configs['import-style'], // ← restores all three
];
```

## The lock asserts both halves

- `order` / `first` / `newline-after-import` are **not** in `recommended`
- they are **still reachable** from `import-style`, from `strict`, and as rules

Without the second assertion, "not in recommended" would also pass on a plugin that deleted the rules outright — a capability regression rather than a scope decision. A third assertion pins the floor: `recommended` keeps `no-cycle`, `export`, `no-unresolved`, `no-duplicates`, `no-self-import`, which detect defects rather than style.

Verified the lock fails on the unchanged config.

## The corpus budget is unchanged, deliberately

It records **published** behaviour. These three keep their entries until this ships.

## Test plan

- [x] `import-next`: 1,336 passing, **100%** statements / branches / functions / lines.
- [x] New `recommended-scope.test.ts`, mutation-checked against the unchanged config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)