### PR TITLE
feat(docs): let synthetic monitoring opt in, and tag it when it does

### DIFF
--- a/apps/docs/src/__tests__/posthog-provider-lock.test.tsx
+++ b/apps/docs/src/__tests__/posthog-provider-lock.test.tsx
@@ -147,7 +147,22 @@ describe('PostHog: Init contract (ANALYTICS_PHILOSOPHY.md)', () => {
     // filter it — the UA is a plain Chrome string — so navigator.webdriver is
     // the only signal that separates a scripted browser from a person.
     expect(initSrc).toMatch(/navigator\.webdriver === true/);
-    expect(initSrc).toMatch(/if \(isAutomatedBrowser\(\)\) return false;/);
+    // Excluded unless a synthetic check has deliberately opted in — the
+    // escape hatch must not become a way for CI to drift back into the data.
+    expect(initSrc).toMatch(
+      /if \(isAutomatedBrowser\(\) && !isSyntheticCheck\(\)\) return false;/,
+    );
+  });
+  it('synthetic monitoring can opt in, and is tagged when it does', () => {
+    // The webdriver guard removed the only way to prove capture still works.
+    // The escape hatch restores it — but marks the events, because synthetic
+    // traffic that looks real is the same defect as unfiltered CI traffic.
+    expect(initSrc).toMatch(/interlace_synthetic_check/);
+    expect(initSrc).toMatch(/isAutomatedBrowser\(\) && !isSyntheticCheck\(\)/);
+    // Anchored to the register call, not the phrase: the docstring above the
+    // option also contains `is_synthetic: true`, so a looser pattern passes
+    // even with the tagging deleted.
+    expect(initSrc).toMatch(/ph\.register\(\{ is_synthetic: true \}\)/);
   });
   it('local-environment short-circuit before init (with localStorage opt-in)', () => {
     expect(initSrc).toMatch(/isLocalEnvironment/);

--- a/apps/docs/src/lib/posthog-init.ts
+++ b/apps/docs/src/lib/posthog-init.ts
@@ -119,13 +119,39 @@ function isAutomatedBrowser(): boolean {
   }
 }
 
+/**
+ * Deliberate opt-in for synthetic monitoring.
+ *
+ * The `navigator.webdriver` guard above drops automated traffic, which is
+ * correct for CI but removes the only way to prove end-to-end that capture
+ * still works — a scripted browser can no longer answer "are events still
+ * flowing?". That question matters most precisely when something is broken.
+ *
+ * A synthetic check sets this key before navigating:
+ *
+ *   await page.addInitScript(() =>
+ *     localStorage.setItem('interlace_synthetic_check', '1'))
+ *
+ * Events then flow, but carry `is_synthetic: true` (see `loaded` below), so
+ * they are filterable rather than quietly mixed into real traffic. Allowing
+ * synthetic events without marking them would reintroduce the exact problem
+ * the webdriver guard exists to solve.
+ */
+function isSyntheticCheck(): boolean {
+  try {
+    return localStorage.getItem('interlace_synthetic_check') === '1';
+  } catch {
+    return false;
+  }
+}
+
 function isTrackingAllowed(): boolean {
   if (typeof window === 'undefined') return false;
   if (typeof navigator === 'undefined') return false;
   // Local dev short-circuit (ANALYTICS_PHILOSOPHY principle 9).
   if (isLocalEnvironment() && !isLocalOptIn()) return false;
   // CI and scripted browsers are not visitors.
-  if (isAutomatedBrowser()) return false;
+  if (isAutomatedBrowser() && !isSyntheticCheck()) return false;
   const dnt = navigator.doNotTrack;
   if (dnt === '1' || dnt === 'yes') return false;
   const gpc = (
@@ -256,6 +282,9 @@ export function initPostHog(): void {
     loaded: (ph) => {
       try {
         ph.register({ app: APP_ID });
+        // Marked, not hidden: a synthetic check that looked like a real
+        // visitor would be the same defect as unfiltered CI traffic.
+        if (isSyntheticCheck()) ph.register({ is_synthetic: true });
         if (
           typeof localStorage !== 'undefined' &&
           localStorage.getItem('interlace_internal') === '1'


### PR DESCRIPTION
## The gap this closes

The `navigator.webdriver` guard merged an hour ago ([#637](https://github.com/ofri-peretz/eslint/pull/637)) correctly drops CI traffic — but it also removed the only way to prove end-to-end that capture still works. A scripted browser can no longer answer *"are events still flowing?"*, and that question matters most precisely when something is broken.

I found this by using an automated browser to verify the guard, and realising I'd just destroyed the technique I was using.

## The escape hatch

```ts
await page.addInitScript(() =>
  localStorage.setItem('interlace_synthetic_check', '1'))
```

Events then flow — and carry **`is_synthetic: true`** as a super-property.

**Marked, not merely allowed.** Synthetic traffic that looked like a real visitor would be the same defect the webdriver guard exists to fix, just with a friendlier origin. Tagged events stay filterable out of every real metric.

## Mutation-tested, and the first attempt was wrong

Both branches verified by deleting them and confirming the lock fails.

The tagging assertion was **vacuous on the first pass**: deleting the `ph.register({ is_synthetic: true })` call still passed, because the docstring above the option contains the same phrase. That's the identical trap as the `persistence: 'memory'` comment earlier today. Re-anchored to the call itself and re-verified — removing the tag now fails, restoring it passes.

47/47, `tsc` clean.

## Deliberately not estate-wide

The guard had to go everywhere, because partial coverage makes cross-property comparison silently wrong. An escape hatch is different: it only matters where a synthetic check would actually run, and putting it on all six properties would be five more surfaces for CI to drift back in through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)