### PR TITLE
feat(conventions): no-magic-numbers stops reading machine-packed output

### DIFF
--- a/.changeset/skip-minified-files.md
+++ b/.changeset/skip-minified-files.md
@@ -1,0 +1,37 @@
+---
+'eslint-plugin-conventions': minor
+'@interlace/eslint-devkit': minor
+---
+
+`no-magic-numbers` stops reading machine-packed output.
+
+8 minified bundles carried **2,446 of this rule's 10,129 findings** on the
+pinned corpus, and one of them — `assets/speedscope/import.bcbb2033.js` — was
+1,973 by itself. "Name this constant" is advice to whoever edits the file, and
+nobody edits a bundle.
+
+Corpus: **10,129 → 7,532.**
+
+`@interlace/eslint-devkit` gains `isMinifiedFile` and a `skipMinifiedFiles`
+flag on `createRule`, joining `skipTestFiles` and `skipGeneratedFiles`.
+
+**Decided from the file's own shape, never its path.** `dist/`, `.min.js` and
+`vendor/` are conventions a stranger's repository is free to ignore, and the
+largest offender announces nothing in its name.
+
+**Average line length, not maximum** — and that distinction is the whole
+predicate. 13 corpus files had a line over 1,000 characters and only 8 were
+minified; the rest were ordinary source with one long line, including SVG icon
+components whose `d` attribute is a single 1,600-character path. Skipping those
+would have been silent recall loss in application code.
+
+| | average line |
+|---|---:|
+| minified bundles | 712 – 203,807 |
+| hand-written source | 32 – 58 |
+
+A 2 KB floor sits under the average, because a short file can exceed it without
+being packed — a one-line barrel re-export is not a bundle.
+
+Security rules must not set this: a bundle ships and runs, and a minified
+bundle is exactly where a supply-chain problem would hide.

--- a/benchmarks/results/ilb-cwe-corpus/2026-08-23.json
+++ b/benchmarks/results/ilb-cwe-corpus/2026-08-23.json
@@ -1,0 +1,8090 @@
+{
+  "bench": "ILB-CWE-Corpus",
+  "benchVersion": "1.0",
+  "timestamp": "2026-08-23T03:46:37.586Z",
+  "methodologyHash": "sha256:ef8ea3b0b761f29a4b92403985a71a1e7cf7e55682aecc72f8c100c310c554b0",
+  "methodologyPaths": [
+    "benchmarks/suites/ilb-cwe-corpus/run.ts",
+    "benchmarks/lib/methodology.ts",
+    "benchmarks/lib/toolchain.ts"
+  ],
+  "toolchain": {
+    "node": "24.18.0",
+    "eslint": "10.8.1",
+    "typescript": "6.0.3",
+    "tsCompiler": "tsc-go",
+    "typescriptEslint": "8.54.0",
+    "platform": "darwin-arm64"
+  },
+  "environment": {
+    "nodeVersion": "v24.18.0",
+    "eslintVersion": "10.8.1",
+    "platform": "darwin",
+    "arch": "arm64"
+  },
+  "corpus": [
+    {
+      "cwe": "CWE-020",
+      "name": "Improper Input Validation (validation-bypass cluster)",
+      "owasp": "A03:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-browser-security"
+      ],
+      "counts": {
+        "vulnerable": 5,
+        "safe": 5
+      }
+    },
+    {
+      "cwe": "CWE-022",
+      "name": "Path Traversal",
+      "owasp": "A01:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-073",
+      "name": "External Control of File Name or Path (template object injection via res.render)",
+      "owasp": "A03:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-express-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 1
+      }
+    },
+    {
+      "cwe": "CWE-078",
+      "name": "OS Command Injection",
+      "owasp": "A03:2021",
+      "severity": "CRITICAL",
+      "expectedPlugins": [
+        "eslint-plugin-secure-coding",
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-079",
+      "name": "Cross-Site Scripting (XSS)",
+      "owasp": "A03:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-browser-security",
+        "eslint-plugin-secure-coding"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-088",
+      "name": "Argument Injection",
+      "owasp": "A03:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-089",
+      "name": "SQL Injection",
+      "owasp": "A03:2021",
+      "severity": "CRITICAL",
+      "expectedPlugins": [
+        "eslint-plugin-secure-coding",
+        "eslint-plugin-pg"
+      ],
+      "counts": {
+        "vulnerable": 3,
+        "safe": 3
+      }
+    },
+    {
+      "cwe": "CWE-094",
+      "name": "Improper Control of Generation of Code (Code Injection)",
+      "owasp": "A03:2021",
+      "severity": "CRITICAL",
+      "expectedPlugins": [
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-099",
+      "name": "Improper Control of Resource Identifiers (Environment Injection)",
+      "owasp": "A03:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 1,
+        "safe": 1
+      }
+    },
+    {
+      "cwe": "CWE-1007",
+      "name": "Insufficient Visual Distinction of Homoglyphs Presented to User",
+      "owasp": "A07:2021",
+      "severity": "MEDIUM",
+      "expectedPlugins": [
+        "eslint-plugin-secure-coding"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-116",
+      "name": "Improper Encoding or Escaping of Output (broken sanitizers)",
+      "owasp": "A03:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-secure-coding"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-117",
+      "name": "Improper Output Neutralization for Logs (log injection)",
+      "owasp": "A09:2021",
+      "severity": "MEDIUM",
+      "expectedPlugins": [
+        "eslint-plugin-secure-coding"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-1333",
+      "name": "Inefficient Regular Expression Complexity (ReDoS)",
+      "owasp": "A05:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-secure-coding"
+      ],
+      "counts": {
+        "vulnerable": 3,
+        "safe": 3
+      }
+    },
+    {
+      "cwe": "CWE-178",
+      "name": "Improper Handling of Case Sensitivity (auth-guard path bypass)",
+      "owasp": "A01:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-express-security"
+      ],
+      "counts": {
+        "vulnerable": 1,
+        "safe": 1
+      }
+    },
+    {
+      "cwe": "CWE-209",
+      "name": "Generation of Error Message Containing Sensitive Information (stack-trace exposure)",
+      "owasp": "A05:2021",
+      "severity": "MEDIUM",
+      "expectedPlugins": [
+        "eslint-plugin-express-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 1
+      }
+    },
+    {
+      "cwe": "CWE-248",
+      "name": "Uncaught Exception (Unhandled Stream Error)",
+      "owasp": "A04:2021",
+      "severity": "MEDIUM",
+      "expectedPlugins": [
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-295",
+      "name": "Improper Certificate Validation",
+      "owasp": "A07:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-327",
+      "name": "Use of a Broken or Risky Cryptographic Algorithm",
+      "owasp": "A02:2021",
+      "severity": "CRITICAL",
+      "expectedPlugins": [
+        "eslint-plugin-jwt",
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 4,
+        "safe": 4
+      }
+    },
+    {
+      "cwe": "CWE-346",
+      "name": "Origin Validation Error (postMessage wildcard)",
+      "owasp": "A01:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-browser-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-377",
+      "name": "Insecure Temporary File",
+      "owasp": "A04:2021",
+      "severity": "MEDIUM",
+      "expectedPlugins": [
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 1
+      }
+    },
+    {
+      "cwe": "CWE-409",
+      "name": "Improper Handling of Highly Compressed Data (Decompression Bomb)",
+      "owasp": "A05:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 1,
+        "safe": 1
+      }
+    },
+    {
+      "cwe": "CWE-444",
+      "name": "Inconsistent Interpretation of HTTP Requests (HTTP Request Smuggling)",
+      "owasp": "A03:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-548",
+      "name": "Exposure of Information Through Directory Listing",
+      "owasp": "A01:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-express-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 1
+      }
+    },
+    {
+      "cwe": "CWE-598",
+      "name": "Use of GET Request Method With Sensitive Query Strings",
+      "owasp": "A09:2021",
+      "severity": "MEDIUM",
+      "expectedPlugins": [
+        "eslint-plugin-express-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 1
+      }
+    },
+    {
+      "cwe": "CWE-636",
+      "name": "Not Failing Securely ('Failing Open')",
+      "owasp": "A07:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-secure-coding"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-640",
+      "name": "Weak Password Recovery Mechanism (host-header poisoning in reset links)",
+      "owasp": "A07:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-express-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 1
+      }
+    },
+    {
+      "cwe": "CWE-770",
+      "name": "Allocation of Resources Without Limits or Throttling",
+      "owasp": "A05:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 1
+      }
+    },
+    {
+      "cwe": "CWE-798",
+      "name": "Hardcoded Credentials",
+      "owasp": "A07:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-secure-coding",
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 5,
+        "safe": 4
+      }
+    },
+    {
+      "cwe": "CWE-843",
+      "name": "Access of Resource Using Incompatible Type (req.query type confusion)",
+      "owasp": "A03:2021",
+      "severity": "MEDIUM",
+      "expectedPlugins": [
+        "eslint-plugin-express-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 1
+      }
+    },
+    {
+      "cwe": "CWE-918",
+      "name": "Server-Side Request Forgery (SSRF)",
+      "owasp": "A10:2021",
+      "severity": "HIGH",
+      "expectedPlugins": [
+        "eslint-plugin-node-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    },
+    {
+      "cwe": "CWE-943",
+      "name": "Improper Neutralization of Special Elements in Data Query Logic (NoSQL Injection)",
+      "owasp": "A03:2021",
+      "severity": "CRITICAL",
+      "expectedPlugins": [
+        "eslint-plugin-mongodb-security"
+      ],
+      "counts": {
+        "vulnerable": 2,
+        "safe": 2
+      }
+    }
+  ],
+  "plugins": {
+    "interlace": {
+      "displayName": "Interlace ESLint Ecosystem",
+      "perCwe": {
+        "CWE-020": {
+          "name": "Improper Input Validation (validation-bypass cluster)",
+          "owasp": "A03:2021",
+          "TP": 5,
+          "FP": 0,
+          "FN": 0,
+          "TN": 5,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "incomplete-hostname-regexp.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "browser-security/no-insecure-redirects": 1
+              }
+            },
+            {
+              "file": "incomplete-url-scheme-check.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "browser-security/no-incomplete-url-sanitization": 1
+              }
+            },
+            {
+              "file": "incorrect-suffix-check.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "browser-security/no-incomplete-url-sanitization": 1
+              }
+            },
+            {
+              "file": "missing-regexp-anchor.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "browser-security/require-postmessage-origin-check": 1
+              }
+            },
+            {
+              "file": "url-substring-sanitization.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "browser-security/no-incomplete-url-sanitization": 2
+              }
+            },
+            {
+              "file": "anchored-origin-regexp.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "endswith-boundary.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "escaped-anchored-hostname.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "scheme-allowlist.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "url-parse-hostname.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-022": {
+          "name": "Path Traversal",
+          "owasp": "A01:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 2,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "path-join-user.js",
+              "expectedVulnerable": true,
+              "findings": 3,
+              "ruleHits": {
+                "node-security/detect-non-literal-fs-filename": 1,
+                "node-security/no-arbitrary-file-access": 1,
+                "secure-coding/no-unlimited-resource-allocation": 1
+              }
+            },
+            {
+              "file": "readfile-concat.js",
+              "expectedVulnerable": true,
+              "findings": 3,
+              "ruleHits": {
+                "node-security/detect-non-literal-fs-filename": 1,
+                "node-security/no-arbitrary-file-access": 1,
+                "secure-coding/no-unlimited-resource-allocation": 1
+              }
+            },
+            {
+              "file": "dirname-path.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-path.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-073": {
+          "name": "External Control of File Name or Path (template object injection via res.render)",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 1,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "render-body-spread.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "express-security/no-user-controlled-render-locals": 1
+              }
+            },
+            {
+              "file": "render-query-spread.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "express-security/no-user-controlled-render-locals": 1
+              }
+            },
+            {
+              "file": "render-explicit-locals.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-078": {
+          "name": "OS Command Injection",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 2,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "exec-concat.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "node-security/detect-child-process": 1,
+                "node-security/no-shell-injection": 1
+              }
+            },
+            {
+              "file": "exec-template.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "node-security/no-shell-injection": 1
+              }
+            },
+            {
+              "file": "exec-static.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "execFile-array.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-079": {
+          "name": "Cross-Site Scripting (XSS)",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 2,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "document-write-dynamic.js",
+              "expectedVulnerable": true,
+              "findings": 3,
+              "ruleHits": {
+                "browser-security/no-innerhtml": 1,
+                "secure-coding/no-improper-sanitization": 2
+              }
+            },
+            {
+              "file": "innerhtml-user-input.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "browser-security/no-innerhtml": 1
+              }
+            },
+            {
+              "file": "static-innerhtml.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "textcontent-safe.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-088": {
+          "name": "Argument Injection",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 2,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "git-ls-remote-arg-injection.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "node-security/detect-child-process": 1
+              }
+            },
+            {
+              "file": "tar-user-args.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "node-security/detect-child-process": 1
+              }
+            },
+            {
+              "file": "literal-argv.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "separator-guard.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-089": {
+          "name": "SQL Injection",
+          "owasp": "A03:2021",
+          "TP": 3,
+          "FP": 0,
+          "FN": 0,
+          "TN": 3,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "dynamic-column.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "secure-coding/no-sql-injection": 1
+              }
+            },
+            {
+              "file": "string-concat.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "secure-coding/no-sql-injection": 1
+              }
+            },
+            {
+              "file": "template-literal.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "secure-coding/no-sql-injection": 1
+              }
+            },
+            {
+              "file": "parameterized.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "prepared-statement.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-query.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-094": {
+          "name": "Improper Control of Generation of Code (Code Injection)",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 2,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "vm-run-user-string.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "node-security/detect-eval-with-expression": 1
+              }
+            },
+            {
+              "file": "vm2-run-user-code.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "node-security/detect-eval-with-expression": 1
+              }
+            },
+            {
+              "file": "vm-literal-script.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "worker-isolation.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-099": {
+          "name": "Improper Control of Resource Identifiers (Environment Injection)",
+          "owasp": "A03:2021",
+          "TP": 1,
+          "FP": 0,
+          "FN": 0,
+          "TN": 1,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "env-key-from-user.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "node-security/no-env-injection": 1
+              }
+            },
+            {
+              "file": "env-allowlisted-key.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-1007": {
+          "name": "Insufficient Visual Distinction of Homoglyphs Presented to User",
+          "owasp": "A07:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 2,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "cyrillic-homoglyph-identifier.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "secure-coding/no-homoglyph-identifiers": 2
+              }
+            },
+            {
+              "file": "zero-width-in-auth-string.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "secure-coding/no-homoglyph-identifiers": 1
+              }
+            },
+            {
+              "file": "ascii-identifiers.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "i18n-ui-copy.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-116": {
+          "name": "Improper Encoding or Escaping of Output (broken sanitizers)",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 2,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "single-pass-replace.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "browser-security/no-innerhtml": 1,
+                "secure-coding/no-improper-sanitization": 1
+              }
+            },
+            {
+              "file": "tag-filter-regexp.js",
+              "expectedVulnerable": true,
+              "findings": 3,
+              "ruleHits": {
+                "secure-coding/no-redos-vulnerable-regex": 1,
+                "browser-security/no-innerhtml": 1,
+                "secure-coding/no-improper-sanitization": 1
+              }
+            },
+            {
+              "file": "dompurify-sanitize.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "replace-until-stable.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-117": {
+          "name": "Improper Output Neutralization for Logs (log injection)",
+          "owasp": "A09:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 2,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "newline-in-log-message.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "secure-coding/no-log-injection": 2
+              }
+            },
+            {
+              "file": "template-literal-log.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "secure-coding/no-log-injection": 2
+              }
+            },
+            {
+              "file": "stripped-newlines.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "structured-logging.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-1333": {
+          "name": "Inefficient Regular Expression Complexity (ReDoS)",
+          "owasp": "A05:2021",
+          "TP": 3,
+          "FP": 0,
+          "FN": 0,
+          "TN": 3,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "real-cve.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "secure-coding/no-redos-vulnerable-regex": 1
+              }
+            },
+            {
+              "file": "self-loop.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "secure-coding/no-redos-vulnerable-regex": 1
+              }
+            },
+            {
+              "file": "trade-off.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "secure-coding/no-redos-vulnerable-regex": 1
+              }
+            },
+            {
+              "file": "atomic-equivalent.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "literal-match.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "simple-anchored.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-178": {
+          "name": "Improper Handling of Case Sensitivity (auth-guard path bypass)",
+          "owasp": "A01:2021",
+          "TP": 1,
+          "FP": 0,
+          "FN": 0,
+          "TN": 1,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "case-sensitive-admin-guard.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "express-security/require-case-insensitive-path-guard": 1
+              }
+            },
+            {
+              "file": "normalized-path-guard.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-209": {
+          "name": "Generation of Error Message Containing Sensitive Information (stack-trace exposure)",
+          "owasp": "A05:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 1,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "error-object-in-json.js",
+              "expectedVulnerable": true,
+              "findings": 3,
+              "ruleHits": {
+                "express-security/require-route-authentication": 1,
+                "express-security/no-error-details-in-response": 2
+              }
+            },
+            {
+              "file": "stack-in-response.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "express-security/no-error-details-in-response": 2
+              }
+            },
+            {
+              "file": "generic-error-response.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-248": {
+          "name": "Uncaught Exception (Unhandled Stream Error)",
+          "owasp": "A04:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 2,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "multipart-pipe-no-handler.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "node-security/require-stream-error-handler": 1,
+                "node-security/no-data-in-temp-storage": 1
+              }
+            },
+            {
+              "file": "pipe-no-error-listener.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "node-security/detect-non-literal-fs-filename": 1,
+                "node-security/require-stream-error-handler": 1
+              }
+            },
+            {
+              "file": "pipe-with-error-listener.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "pipeline-promises.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-295": {
+          "name": "Improper Certificate Validation",
+          "owasp": "A07:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 2,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "reject-unauthorized-false.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "node-security/no-self-signed-certs": 1,
+                "browser-security/no-disabled-certificate-validation": 1
+              }
+            },
+            {
+              "file": "tls-checkserveridentity-noop.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "browser-security/no-disabled-certificate-validation": 1
+              }
+            },
+            {
+              "file": "tls-checkserveridentity-validates.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-default-verification.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-327": {
+          "name": "Use of a Broken or Risky Cryptographic Algorithm",
+          "owasp": "A02:2021",
+          "TP": 4,
+          "FP": 0,
+          "FN": 0,
+          "TN": 4,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "gcm-decipher-no-final.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "node-security/require-aead-tag-verification": 1
+              }
+            },
+            {
+              "file": "gcm-decrypt-no-authtag.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "node-security/require-aead-tag-verification": 1
+              }
+            },
+            {
+              "file": "sign-alg-none.js",
+              "expectedVulnerable": true,
+              "findings": 4,
+              "ruleHits": {
+                "jwt-security/require-expiration": 1,
+                "jwt-security/no-weak-secret": 1,
+                "jwt-security/no-hardcoded-secret": 1,
+                "jwt-security/no-algorithm-none": 1
+              }
+            },
+            {
+              "file": "verify-allows-none.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "jwt-security/no-algorithm-none": 1
+              }
+            },
+            {
+              "file": "gcm-decrypt-verified.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-encrypt-authtag.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "sign-rs256.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "verify-allowlist.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-346": {
+          "name": "Origin Validation Error (postMessage wildcard)",
+          "owasp": "A01:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 2,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "iframe-wildcard.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "browser-security/no-postmessage-wildcard-origin": 1
+              }
+            },
+            {
+              "file": "window-parent-wildcard.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "browser-security/no-postmessage-wildcard-origin": 1
+              }
+            },
+            {
+              "file": "explicit-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "self-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-377": {
+          "name": "Insecure Temporary File",
+          "owasp": "A04:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 1,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "static-tmp-write.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "node-security/no-data-in-temp-storage": 1
+              }
+            },
+            {
+              "file": "tmpdir-static-name.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "node-security/no-data-in-temp-storage": 1
+              }
+            },
+            {
+              "file": "mkdtemp-write.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-409": {
+          "name": "Improper Handling of Highly Compressed Data (Decompression Bomb)",
+          "owasp": "A05:2021",
+          "TP": 1,
+          "FP": 0,
+          "FN": 0,
+          "TN": 1,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "gunzip-no-limit.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "node-security/no-unbounded-decompression": 1
+              }
+            },
+            {
+              "file": "gunzip-limited.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-444": {
+          "name": "Inconsistent Interpretation of HTTP Requests (HTTP Request Smuggling)",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 2,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "request-insecure-parser.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "node-security/no-insecure-http-parser": 1
+              }
+            },
+            {
+              "file": "server-insecure-parser.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "node-security/no-insecure-http-parser": 1
+              }
+            },
+            {
+              "file": "request-default-parser.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "server-default-parser.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-548": {
+          "name": "Exposure of Information Through Directory Listing",
+          "owasp": "A01:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 1,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "serve-index-root.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "express-security/no-static-root-exposure": 2
+              }
+            },
+            {
+              "file": "static-root-dirname.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "express-security/no-static-root-exposure": 1,
+                "express-security/no-exposed-debug-endpoints": 1
+              }
+            },
+            {
+              "file": "static-public-dir.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-598": {
+          "name": "Use of GET Request Method With Sensitive Query Strings",
+          "owasp": "A09:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 1,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "login-via-query.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "express-security/no-sensitive-data-in-query": 1
+              }
+            },
+            {
+              "file": "token-in-query.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "express-security/require-route-authentication": 1,
+                "express-security/no-sensitive-data-in-query": 1
+              }
+            },
+            {
+              "file": "login-via-body-post.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-636": {
+          "name": "Not Failing Securely ('Failing Open')",
+          "owasp": "A07:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 2,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "catch-returns-true.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "secure-coding/no-fail-open-auth": 1
+              }
+            },
+            {
+              "file": "empty-catch-continues.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "secure-coding/no-fail-open-auth": 1
+              }
+            },
+            {
+              "file": "catch-denies.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "catch-rethrows.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-640": {
+          "name": "Weak Password Recovery Mechanism (host-header poisoning in reset links)",
+          "owasp": "A07:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 1,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "reset-link-forwarded-host.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "express-security/no-host-header-in-links": 1
+              }
+            },
+            {
+              "file": "reset-link-host-header.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "express-security/no-host-header-in-links": 1
+              }
+            },
+            {
+              "file": "reset-link-config-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-770": {
+          "name": "Allocation of Resources Without Limits or Throttling",
+          "owasp": "A05:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 1,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "array-length-user.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "node-security/no-unsafe-buffer-alloc": 1,
+                "secure-coding/no-unlimited-resource-allocation": 1
+              }
+            },
+            {
+              "file": "buffer-alloc-user.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "node-security/no-unsafe-buffer-alloc": 1,
+                "secure-coding/no-unlimited-resource-allocation": 1
+              }
+            },
+            {
+              "file": "buffer-alloc-clamped.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-798": {
+          "name": "Hardcoded Credentials",
+          "owasp": "A07:2021",
+          "TP": 5,
+          "FP": 0,
+          "FN": 0,
+          "TN": 4,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "api-key-in-source.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "secure-coding/no-hardcoded-credentials": 1
+              }
+            },
+            {
+              "file": "aws-access-key-literal.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "secure-coding/no-hardcoded-credentials": 1
+              }
+            },
+            {
+              "file": "github-token-literal.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "secure-coding/no-hardcoded-credentials": 1
+              }
+            },
+            {
+              "file": "jwt-signing-secret-literal.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "secure-coding/no-hardcoded-credentials": 2
+              }
+            },
+            {
+              "file": "password-in-config.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "secure-coding/no-hardcoded-credentials": 1
+              }
+            },
+            {
+              "file": "env-credentials.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "password-label.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "provider-env-credentials.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "test-placeholder-values.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-843": {
+          "name": "Access of Resource Using Incompatible Type (req.query type confusion)",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 1,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "query-object-spread.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "express-security/require-query-type-guard": 1
+              }
+            },
+            {
+              "file": "query-string-methods.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "express-security/require-query-type-guard": 1
+              }
+            },
+            {
+              "file": "guarded-query-type.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-918": {
+          "name": "Server-Side Request Forgery (SSRF)",
+          "owasp": "A10:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 2,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "axios-user-url.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "node-security/no-ssrf": 1
+              }
+            },
+            {
+              "file": "fetch-user-url.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "node-security/no-ssrf": 1
+              }
+            },
+            {
+              "file": "fetch-static-url.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-validated-url.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-943": {
+          "name": "Improper Neutralization of Special Elements in Data Query Logic (NoSQL Injection)",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 2,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "user-input-in-find.js",
+              "expectedVulnerable": true,
+              "findings": 3,
+              "ruleHits": {
+                "mongodb-security/no-select-sensitive-fields": 1,
+                "mongodb-security/no-unsafe-query": 2
+              }
+            },
+            {
+              "file": "where-string.js",
+              "expectedVulnerable": true,
+              "findings": 3,
+              "ruleHits": {
+                "mongodb-security/no-unbounded-find": 1,
+                "mongodb-security/no-unsafe-query": 1,
+                "mongodb-security/no-unsafe-where": 1
+              }
+            },
+            {
+              "file": "explicit-eq.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-filter.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        }
+      },
+      "aggregate": {
+        "TP": 69,
+        "FP": 0,
+        "FN": 0,
+        "TN": 60,
+        "precision": 100,
+        "recall": 100,
+        "f1": 100,
+        "bas": 100
+      }
+    },
+    "eslint-plugin-security": {
+      "displayName": "eslint-plugin-security",
+      "perCwe": {
+        "CWE-020": {
+          "name": "Improper Input Validation (validation-bypass cluster)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 1,
+          "FN": 5,
+          "TN": 4,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": -20,
+          "fixtures": [
+            {
+              "file": "incomplete-hostname-regexp.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "incomplete-url-scheme-check.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "incorrect-suffix-check.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "missing-regexp-anchor.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "url-substring-sanitization.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "anchored-origin-regexp.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "endswith-boundary.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "escaped-anchored-hostname.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-unsafe-regex": 1
+              }
+            },
+            {
+              "file": "scheme-allowlist.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "url-parse-hostname.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-022": {
+          "name": "Path Traversal",
+          "owasp": "A01:2021",
+          "TP": 2,
+          "FP": 1,
+          "FN": 0,
+          "TN": 1,
+          "precision": 66.7,
+          "recall": 100,
+          "f1": 80,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "path-join-user.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-non-literal-fs-filename": 1
+              }
+            },
+            {
+              "file": "readfile-concat.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-non-literal-fs-filename": 1
+              }
+            },
+            {
+              "file": "dirname-path.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-non-literal-fs-filename": 1
+              }
+            },
+            {
+              "file": "static-path.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-073": {
+          "name": "External Control of File Name or Path (template object injection via res.render)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "render-body-spread.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "render-query-spread.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "render-explicit-locals.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-078": {
+          "name": "OS Command Injection",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 2,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "exec-concat.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-child-process": 1
+              }
+            },
+            {
+              "file": "exec-template.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-child-process": 1
+              }
+            },
+            {
+              "file": "exec-static.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "execFile-array.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-079": {
+          "name": "Cross-Site Scripting (XSS)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "document-write-dynamic.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "innerhtml-user-input.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-innerhtml.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "textcontent-safe.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-088": {
+          "name": "Argument Injection",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "git-ls-remote-arg-injection.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tar-user-args.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "literal-argv.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "separator-guard.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-089": {
+          "name": "SQL Injection",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 3,
+          "TN": 3,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "dynamic-column.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "string-concat.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "template-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "parameterized.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "prepared-statement.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-query.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-094": {
+          "name": "Improper Control of Generation of Code (Code Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "vm-run-user-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "vm2-run-user-code.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "vm-literal-script.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "worker-isolation.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-099": {
+          "name": "Improper Control of Resource Identifiers (Environment Injection)",
+          "owasp": "A03:2021",
+          "TP": 1,
+          "FP": 1,
+          "FN": 0,
+          "TN": 0,
+          "precision": 50,
+          "recall": 100,
+          "f1": 66.7,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "env-key-from-user.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-object-injection": 1
+              }
+            },
+            {
+              "file": "env-allowlisted-key.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-object-injection": 1
+              }
+            }
+          ]
+        },
+        "CWE-1007": {
+          "name": "Insufficient Visual Distinction of Homoglyphs Presented to User",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 1,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": -50,
+          "fixtures": [
+            {
+              "file": "cyrillic-homoglyph-identifier.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "zero-width-in-auth-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "ascii-identifiers.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "i18n-ui-copy.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-object-injection": 1
+              }
+            }
+          ]
+        },
+        "CWE-116": {
+          "name": "Improper Encoding or Escaping of Output (broken sanitizers)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "single-pass-replace.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tag-filter-regexp.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "dompurify-sanitize.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "replace-until-stable.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-117": {
+          "name": "Improper Output Neutralization for Logs (log injection)",
+          "owasp": "A09:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "newline-in-log-message.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "template-literal-log.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "stripped-newlines.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "structured-logging.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-1333": {
+          "name": "Inefficient Regular Expression Complexity (ReDoS)",
+          "owasp": "A05:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 1,
+          "TN": 3,
+          "precision": 100,
+          "recall": 66.7,
+          "f1": 80,
+          "bas": 66.7,
+          "fixtures": [
+            {
+              "file": "real-cve.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-unsafe-regex": 1
+              }
+            },
+            {
+              "file": "self-loop.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-unsafe-regex": 1
+              }
+            },
+            {
+              "file": "trade-off.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "atomic-equivalent.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "literal-match.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "simple-anchored.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-178": {
+          "name": "Improper Handling of Case Sensitivity (auth-guard path bypass)",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "case-sensitive-admin-guard.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "normalized-path-guard.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-209": {
+          "name": "Generation of Error Message Containing Sensitive Information (stack-trace exposure)",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "error-object-in-json.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "stack-in-response.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "generic-error-response.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-248": {
+          "name": "Uncaught Exception (Unhandled Stream Error)",
+          "owasp": "A04:2021",
+          "TP": 2,
+          "FP": 2,
+          "FN": 0,
+          "TN": 0,
+          "precision": 50,
+          "recall": 100,
+          "f1": 66.7,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "multipart-pipe-no-handler.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-non-literal-fs-filename": 1
+              }
+            },
+            {
+              "file": "pipe-no-error-listener.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-non-literal-fs-filename": 1
+              }
+            },
+            {
+              "file": "pipe-with-error-listener.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-non-literal-fs-filename": 1
+              }
+            },
+            {
+              "file": "pipeline-promises.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-non-literal-fs-filename": 1
+              }
+            }
+          ]
+        },
+        "CWE-295": {
+          "name": "Improper Certificate Validation",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "reject-unauthorized-false.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-checkserveridentity-noop.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-checkserveridentity-validates.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-default-verification.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-327": {
+          "name": "Use of a Broken or Risky Cryptographic Algorithm",
+          "owasp": "A02:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 4,
+          "TN": 4,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "gcm-decipher-no-final.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-decrypt-no-authtag.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "sign-alg-none.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "verify-allows-none.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-decrypt-verified.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-encrypt-authtag.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "sign-rs256.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "verify-allowlist.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-346": {
+          "name": "Origin Validation Error (postMessage wildcard)",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "iframe-wildcard.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "window-parent-wildcard.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "explicit-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "self-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-377": {
+          "name": "Insecure Temporary File",
+          "owasp": "A04:2021",
+          "TP": 1,
+          "FP": 1,
+          "FN": 1,
+          "TN": 0,
+          "precision": 50,
+          "recall": 50,
+          "f1": 50,
+          "bas": -50,
+          "fixtures": [
+            {
+              "file": "static-tmp-write.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tmpdir-static-name.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-non-literal-fs-filename": 1
+              }
+            },
+            {
+              "file": "mkdtemp-write.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "security/detect-non-literal-fs-filename": 1
+              }
+            }
+          ]
+        },
+        "CWE-409": {
+          "name": "Improper Handling of Highly Compressed Data (Decompression Bomb)",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "gunzip-no-limit.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gunzip-limited.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-444": {
+          "name": "Inconsistent Interpretation of HTTP Requests (HTTP Request Smuggling)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "request-insecure-parser.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "server-insecure-parser.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "request-default-parser.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "server-default-parser.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-548": {
+          "name": "Exposure of Information Through Directory Listing",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "serve-index-root.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-root-dirname.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-public-dir.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-598": {
+          "name": "Use of GET Request Method With Sensitive Query Strings",
+          "owasp": "A09:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "login-via-query.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "token-in-query.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "login-via-body-post.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-636": {
+          "name": "Not Failing Securely ('Failing Open')",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "catch-returns-true.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "empty-catch-continues.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "catch-denies.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "catch-rethrows.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-640": {
+          "name": "Weak Password Recovery Mechanism (host-header poisoning in reset links)",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "reset-link-forwarded-host.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "reset-link-host-header.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "reset-link-config-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-770": {
+          "name": "Allocation of Resources Without Limits or Throttling",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "array-length-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "buffer-alloc-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "buffer-alloc-clamped.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-798": {
+          "name": "Hardcoded Credentials",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 5,
+          "TN": 4,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "api-key-in-source.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "aws-access-key-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "github-token-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "jwt-signing-secret-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "password-in-config.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "env-credentials.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "password-label.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "provider-env-credentials.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "test-placeholder-values.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-843": {
+          "name": "Access of Resource Using Incompatible Type (req.query type confusion)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "query-object-spread.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "query-string-methods.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "guarded-query-type.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-918": {
+          "name": "Server-Side Request Forgery (SSRF)",
+          "owasp": "A10:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "axios-user-url.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-user-url.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-static-url.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-validated-url.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-943": {
+          "name": "Improper Neutralization of Special Elements in Data Query Logic (NoSQL Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "user-input-in-find.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "where-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "explicit-eq.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-filter.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        }
+      },
+      "aggregate": {
+        "TP": 10,
+        "FP": 7,
+        "FN": 59,
+        "TN": 53,
+        "precision": 58.8,
+        "recall": 14.5,
+        "f1": 23.3,
+        "bas": 2.8
+      }
+    },
+    "security-node": {
+      "displayName": "eslint-plugin-security-node",
+      "perCwe": {
+        "CWE-020": {
+          "name": "Improper Input Validation (validation-bypass cluster)",
+          "owasp": "A03:2021",
+          "TP": 1,
+          "FP": 1,
+          "FN": 4,
+          "TN": 4,
+          "precision": 50,
+          "recall": 20,
+          "f1": 28.6,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "incomplete-hostname-regexp.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security-node/detect-dangerous-redirects": 1
+              }
+            },
+            {
+              "file": "incomplete-url-scheme-check.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "incorrect-suffix-check.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "missing-regexp-anchor.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "url-substring-sanitization.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "anchored-origin-regexp.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "endswith-boundary.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "escaped-anchored-hostname.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "security-node/detect-dangerous-redirects": 1
+              }
+            },
+            {
+              "file": "scheme-allowlist.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "url-parse-hostname.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-022": {
+          "name": "Path Traversal",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "path-join-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "readfile-concat.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "dirname-path.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-path.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-073": {
+          "name": "External Control of File Name or Path (template object injection via res.render)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "render-body-spread.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "render-query-spread.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "render-explicit-locals.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-078": {
+          "name": "OS Command Injection",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 1,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": -50,
+          "fixtures": [
+            {
+              "file": "exec-concat.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "exec-template.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "exec-static.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "execFile-array.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "security-node/detect-crlf": 1
+              }
+            }
+          ]
+        },
+        "CWE-079": {
+          "name": "Cross-Site Scripting (XSS)",
+          "owasp": "A03:2021",
+          "TP": 1,
+          "FP": 0,
+          "FN": 1,
+          "TN": 2,
+          "precision": 100,
+          "recall": 50,
+          "f1": 66.7,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "document-write-dynamic.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security-node/detect-html-injection": 1
+              }
+            },
+            {
+              "file": "innerhtml-user-input.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-innerhtml.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "textcontent-safe.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-088": {
+          "name": "Argument Injection",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "git-ls-remote-arg-injection.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tar-user-args.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "literal-argv.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "separator-guard.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-089": {
+          "name": "SQL Injection",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 3,
+          "TN": 3,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "dynamic-column.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "string-concat.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "template-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "parameterized.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "prepared-statement.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-query.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-094": {
+          "name": "Improper Control of Generation of Code (Code Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "vm-run-user-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "vm2-run-user-code.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "vm-literal-script.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "worker-isolation.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-099": {
+          "name": "Improper Control of Resource Identifiers (Environment Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "env-key-from-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "env-allowlisted-key.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-1007": {
+          "name": "Insufficient Visual Distinction of Homoglyphs Presented to User",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "cyrillic-homoglyph-identifier.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "zero-width-in-auth-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "ascii-identifiers.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "i18n-ui-copy.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-116": {
+          "name": "Improper Encoding or Escaping of Output (broken sanitizers)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "single-pass-replace.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tag-filter-regexp.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "dompurify-sanitize.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "replace-until-stable.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-117": {
+          "name": "Improper Output Neutralization for Logs (log injection)",
+          "owasp": "A09:2021",
+          "TP": 1,
+          "FP": 0,
+          "FN": 1,
+          "TN": 2,
+          "precision": 100,
+          "recall": 50,
+          "f1": 66.7,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "newline-in-log-message.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "template-literal-log.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security-node/detect-crlf": 1
+              }
+            },
+            {
+              "file": "stripped-newlines.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "structured-logging.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-1333": {
+          "name": "Inefficient Regular Expression Complexity (ReDoS)",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 3,
+          "TN": 3,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "real-cve.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "self-loop.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "trade-off.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "atomic-equivalent.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "literal-match.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "simple-anchored.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-178": {
+          "name": "Improper Handling of Case Sensitivity (auth-guard path bypass)",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "case-sensitive-admin-guard.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "normalized-path-guard.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-209": {
+          "name": "Generation of Error Message Containing Sensitive Information (stack-trace exposure)",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "error-object-in-json.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "stack-in-response.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "generic-error-response.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-248": {
+          "name": "Uncaught Exception (Unhandled Stream Error)",
+          "owasp": "A04:2021",
+          "TP": 0,
+          "FP": 1,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": -50,
+          "fixtures": [
+            {
+              "file": "multipart-pipe-no-handler.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "pipe-no-error-listener.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "pipe-with-error-listener.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "pipeline-promises.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "security-node/detect-unhandled-async-errors": 1
+              }
+            }
+          ]
+        },
+        "CWE-295": {
+          "name": "Improper Certificate Validation",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "reject-unauthorized-false.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-checkserveridentity-noop.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-checkserveridentity-validates.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-default-verification.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-327": {
+          "name": "Use of a Broken or Risky Cryptographic Algorithm",
+          "owasp": "A02:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 4,
+          "TN": 4,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "gcm-decipher-no-final.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-decrypt-no-authtag.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "sign-alg-none.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "verify-allows-none.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-decrypt-verified.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-encrypt-authtag.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "sign-rs256.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "verify-allowlist.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-346": {
+          "name": "Origin Validation Error (postMessage wildcard)",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "iframe-wildcard.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "window-parent-wildcard.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "explicit-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "self-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-377": {
+          "name": "Insecure Temporary File",
+          "owasp": "A04:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "static-tmp-write.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tmpdir-static-name.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "mkdtemp-write.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-409": {
+          "name": "Improper Handling of Highly Compressed Data (Decompression Bomb)",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "gunzip-no-limit.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gunzip-limited.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-444": {
+          "name": "Inconsistent Interpretation of HTTP Requests (HTTP Request Smuggling)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "request-insecure-parser.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "server-insecure-parser.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "request-default-parser.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "server-default-parser.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-548": {
+          "name": "Exposure of Information Through Directory Listing",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "serve-index-root.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-root-dirname.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-public-dir.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-598": {
+          "name": "Use of GET Request Method With Sensitive Query Strings",
+          "owasp": "A09:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "login-via-query.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "token-in-query.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "login-via-body-post.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-636": {
+          "name": "Not Failing Securely ('Failing Open')",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "catch-returns-true.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "empty-catch-continues.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "catch-denies.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "catch-rethrows.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-640": {
+          "name": "Weak Password Recovery Mechanism (host-header poisoning in reset links)",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "reset-link-forwarded-host.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "reset-link-host-header.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "reset-link-config-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-770": {
+          "name": "Allocation of Resources Without Limits or Throttling",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "array-length-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "buffer-alloc-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "buffer-alloc-clamped.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-798": {
+          "name": "Hardcoded Credentials",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 5,
+          "TN": 4,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "api-key-in-source.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "aws-access-key-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "github-token-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "jwt-signing-secret-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "password-in-config.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "env-credentials.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "password-label.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "provider-env-credentials.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "test-placeholder-values.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-843": {
+          "name": "Access of Resource Using Incompatible Type (req.query type confusion)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "query-object-spread.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "query-string-methods.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "guarded-query-type.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-918": {
+          "name": "Server-Side Request Forgery (SSRF)",
+          "owasp": "A10:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "axios-user-url.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-user-url.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-static-url.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-validated-url.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-943": {
+          "name": "Improper Neutralization of Special Elements in Data Query Logic (NoSQL Injection)",
+          "owasp": "A03:2021",
+          "TP": 1,
+          "FP": 0,
+          "FN": 1,
+          "TN": 2,
+          "precision": 100,
+          "recall": 50,
+          "f1": 66.7,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "user-input-in-find.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "where-string.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "security-node/detect-nosql-injection": 1
+              }
+            },
+            {
+              "file": "explicit-eq.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-filter.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        }
+      },
+      "aggregate": {
+        "TP": 4,
+        "FP": 3,
+        "FN": 65,
+        "TN": 57,
+        "precision": 57.1,
+        "recall": 5.8,
+        "f1": 10.5,
+        "bas": 0.8
+      }
+    },
+    "sonarjs": {
+      "displayName": "eslint-plugin-sonarjs",
+      "perCwe": {
+        "CWE-020": {
+          "name": "Improper Input Validation (validation-bypass cluster)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 1,
+          "FN": 5,
+          "TN": 4,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": -20,
+          "fixtures": [
+            {
+              "file": "incomplete-hostname-regexp.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "incomplete-url-scheme-check.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "incorrect-suffix-check.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "missing-regexp-anchor.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "url-substring-sanitization.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "anchored-origin-regexp.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "endswith-boundary.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "escaped-anchored-hostname.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "scheme-allowlist.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/no-ignored-exceptions": 1
+              }
+            },
+            {
+              "file": "url-parse-hostname.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-022": {
+          "name": "Path Traversal",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "path-join-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "readfile-concat.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "dirname-path.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-path.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-073": {
+          "name": "External Control of File Name or Path (template object injection via res.render)",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 1,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "render-body-spread.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/x-powered-by": 1
+              }
+            },
+            {
+              "file": "render-query-spread.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/x-powered-by": 1
+              }
+            },
+            {
+              "file": "render-explicit-locals.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-078": {
+          "name": "OS Command Injection",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 2,
+          "FN": 2,
+          "TN": 0,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": -100,
+          "fixtures": [
+            {
+              "file": "exec-concat.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "exec-template.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "exec-static.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/no-os-command-from-path": 1
+              }
+            },
+            {
+              "file": "execFile-array.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/no-os-command-from-path": 1
+              }
+            }
+          ]
+        },
+        "CWE-079": {
+          "name": "Cross-Site Scripting (XSS)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "document-write-dynamic.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "innerhtml-user-input.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-innerhtml.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "textcontent-safe.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-088": {
+          "name": "Argument Injection",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 2,
+          "FN": 0,
+          "TN": 0,
+          "precision": 50,
+          "recall": 100,
+          "f1": 66.7,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "git-ls-remote-arg-injection.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/no-os-command-from-path": 1
+              }
+            },
+            {
+              "file": "tar-user-args.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/no-os-command-from-path": 1
+              }
+            },
+            {
+              "file": "literal-argv.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/no-os-command-from-path": 1
+              }
+            },
+            {
+              "file": "separator-guard.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/no-os-command-from-path": 1
+              }
+            }
+          ]
+        },
+        "CWE-089": {
+          "name": "SQL Injection",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 3,
+          "TN": 3,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "dynamic-column.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "string-concat.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "template-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "parameterized.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "prepared-statement.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-query.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-094": {
+          "name": "Improper Control of Generation of Code (Code Injection)",
+          "owasp": "A03:2021",
+          "TP": 1,
+          "FP": 1,
+          "FN": 1,
+          "TN": 1,
+          "precision": 50,
+          "recall": 50,
+          "f1": 50,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "vm-run-user-string.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/code-eval": 1
+              }
+            },
+            {
+              "file": "vm2-run-user-code.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "vm-literal-script.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/code-eval": 1
+              }
+            },
+            {
+              "file": "worker-isolation.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-099": {
+          "name": "Improper Control of Resource Identifiers (Environment Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "env-key-from-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "env-allowlisted-key.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-1007": {
+          "name": "Insufficient Visual Distinction of Homoglyphs Presented to User",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "cyrillic-homoglyph-identifier.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "zero-width-in-auth-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "ascii-identifiers.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "i18n-ui-copy.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-116": {
+          "name": "Improper Encoding or Escaping of Output (broken sanitizers)",
+          "owasp": "A03:2021",
+          "TP": 1,
+          "FP": 1,
+          "FN": 1,
+          "TN": 1,
+          "precision": 50,
+          "recall": 50,
+          "f1": 50,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "single-pass-replace.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tag-filter-regexp.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/super-linear-regex": 1
+              }
+            },
+            {
+              "file": "dompurify-sanitize.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "replace-until-stable.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/super-linear-regex": 1
+              }
+            }
+          ]
+        },
+        "CWE-117": {
+          "name": "Improper Output Neutralization for Logs (log injection)",
+          "owasp": "A09:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "newline-in-log-message.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "template-literal-log.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "stripped-newlines.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "structured-logging.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-1333": {
+          "name": "Inefficient Regular Expression Complexity (ReDoS)",
+          "owasp": "A05:2021",
+          "TP": 3,
+          "FP": 0,
+          "FN": 0,
+          "TN": 3,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "real-cve.js",
+              "expectedVulnerable": true,
+              "findings": 6,
+              "ruleHits": {
+                "sonarjs/slow-regex": 1,
+                "sonarjs/regex-complexity": 1,
+                "sonarjs/single-char-in-character-classes": 1,
+                "sonarjs/concise-regex": 3
+              }
+            },
+            {
+              "file": "self-loop.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/slow-regex": 1
+              }
+            },
+            {
+              "file": "trade-off.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/super-linear-regex": 1
+              }
+            },
+            {
+              "file": "atomic-equivalent.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "literal-match.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "simple-anchored.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-178": {
+          "name": "Improper Handling of Case Sensitivity (auth-guard path bypass)",
+          "owasp": "A01:2021",
+          "TP": 1,
+          "FP": 0,
+          "FN": 0,
+          "TN": 1,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "case-sensitive-admin-guard.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/x-powered-by": 1
+              }
+            },
+            {
+              "file": "normalized-path-guard.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-209": {
+          "name": "Generation of Error Message Containing Sensitive Information (stack-trace exposure)",
+          "owasp": "A05:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 1,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "error-object-in-json.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/x-powered-by": 1
+              }
+            },
+            {
+              "file": "stack-in-response.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/x-powered-by": 1
+              }
+            },
+            {
+              "file": "generic-error-response.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-248": {
+          "name": "Uncaught Exception (Unhandled Stream Error)",
+          "owasp": "A04:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "multipart-pipe-no-handler.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "pipe-no-error-listener.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "pipe-with-error-listener.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "pipeline-promises.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-295": {
+          "name": "Improper Certificate Validation",
+          "owasp": "A07:2021",
+          "TP": 1,
+          "FP": 0,
+          "FN": 1,
+          "TN": 2,
+          "precision": 100,
+          "recall": 50,
+          "f1": 66.7,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "reject-unauthorized-false.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "sonarjs/unverified-certificate": 1,
+                "sonarjs/unverified-hostname": 1
+              }
+            },
+            {
+              "file": "tls-checkserveridentity-noop.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-checkserveridentity-validates.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-default-verification.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-327": {
+          "name": "Use of a Broken or Risky Cryptographic Algorithm",
+          "owasp": "A02:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 2,
+          "TN": 4,
+          "precision": 100,
+          "recall": 50,
+          "f1": 66.7,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "gcm-decipher-no-final.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-decrypt-no-authtag.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "sign-alg-none.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "sonarjs/insecure-jwt-token": 1,
+                "sonarjs/hardcoded-secret-signatures": 1
+              }
+            },
+            {
+              "file": "verify-allows-none.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/insecure-jwt-token": 1
+              }
+            },
+            {
+              "file": "gcm-decrypt-verified.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-encrypt-authtag.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "sign-rs256.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "verify-allowlist.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-346": {
+          "name": "Origin Validation Error (postMessage wildcard)",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "iframe-wildcard.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "window-parent-wildcard.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "explicit-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "self-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-377": {
+          "name": "Insecure Temporary File",
+          "owasp": "A04:2021",
+          "TP": 1,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 100,
+          "recall": 50,
+          "f1": 66.7,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "static-tmp-write.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/publicly-writable-directories": 1
+              }
+            },
+            {
+              "file": "tmpdir-static-name.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "mkdtemp-write.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-409": {
+          "name": "Improper Handling of Highly Compressed Data (Decompression Bomb)",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "gunzip-no-limit.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gunzip-limited.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-444": {
+          "name": "Inconsistent Interpretation of HTTP Requests (HTTP Request Smuggling)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "request-insecure-parser.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "server-insecure-parser.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "request-default-parser.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "server-default-parser.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-548": {
+          "name": "Exposure of Information Through Directory Listing",
+          "owasp": "A01:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 1,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "serve-index-root.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/x-powered-by": 1
+              }
+            },
+            {
+              "file": "static-root-dirname.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/x-powered-by": 1
+              }
+            },
+            {
+              "file": "static-public-dir.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-598": {
+          "name": "Use of GET Request Method With Sensitive Query Strings",
+          "owasp": "A09:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 1,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "login-via-query.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/x-powered-by": 1
+              }
+            },
+            {
+              "file": "token-in-query.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/x-powered-by": 1
+              }
+            },
+            {
+              "file": "login-via-body-post.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-636": {
+          "name": "Not Failing Securely ('Failing Open')",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "catch-returns-true.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "empty-catch-continues.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "catch-denies.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "catch-rethrows.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-640": {
+          "name": "Weak Password Recovery Mechanism (host-header poisoning in reset links)",
+          "owasp": "A07:2021",
+          "TP": 2,
+          "FP": 1,
+          "FN": 0,
+          "TN": 0,
+          "precision": 66.7,
+          "recall": 100,
+          "f1": 80,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "reset-link-forwarded-host.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "sonarjs/x-powered-by": 1,
+                "sonarjs/no-clear-text-protocols": 1
+              }
+            },
+            {
+              "file": "reset-link-host-header.js",
+              "expectedVulnerable": true,
+              "findings": 2,
+              "ruleHits": {
+                "sonarjs/x-powered-by": 1,
+                "sonarjs/no-clear-text-protocols": 1
+              }
+            },
+            {
+              "file": "reset-link-config-origin.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/no-clear-text-protocols": 1
+              }
+            }
+          ]
+        },
+        "CWE-770": {
+          "name": "Allocation of Resources Without Limits or Throttling",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "array-length-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "buffer-alloc-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "buffer-alloc-clamped.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-798": {
+          "name": "Hardcoded Credentials",
+          "owasp": "A07:2021",
+          "TP": 3,
+          "FP": 0,
+          "FN": 2,
+          "TN": 4,
+          "precision": 100,
+          "recall": 60,
+          "f1": 75,
+          "bas": 60,
+          "fixtures": [
+            {
+              "file": "api-key-in-source.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/no-hardcoded-secrets": 1
+              }
+            },
+            {
+              "file": "aws-access-key-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "github-token-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "jwt-signing-secret-literal.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/no-hardcoded-secrets": 1
+              }
+            },
+            {
+              "file": "password-in-config.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/no-hardcoded-passwords": 1
+              }
+            },
+            {
+              "file": "env-credentials.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "password-label.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "provider-env-credentials.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "test-placeholder-values.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-843": {
+          "name": "Access of Resource Using Incompatible Type (req.query type confusion)",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 1,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "query-object-spread.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/x-powered-by": 1
+              }
+            },
+            {
+              "file": "query-string-methods.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "sonarjs/x-powered-by": 1
+              }
+            },
+            {
+              "file": "guarded-query-type.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-918": {
+          "name": "Server-Side Request Forgery (SSRF)",
+          "owasp": "A10:2021",
+          "TP": 0,
+          "FP": 1,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": -50,
+          "fixtures": [
+            {
+              "file": "axios-user-url.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-user-url.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-static-url.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-validated-url.js",
+              "expectedVulnerable": false,
+              "findings": 2,
+              "ruleHits": {
+                "sonarjs/no-unused-vars": 1,
+                "sonarjs/no-dead-store": 1
+              }
+            }
+          ]
+        },
+        "CWE-943": {
+          "name": "Improper Neutralization of Special Elements in Data Query Logic (NoSQL Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "user-input-in-find.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "where-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "explicit-eq.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-filter.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        }
+      },
+      "aggregate": {
+        "TP": 27,
+        "FP": 9,
+        "FN": 42,
+        "TN": 51,
+        "precision": 75,
+        "recall": 39.1,
+        "f1": 51.4,
+        "bas": 24.1
+      }
+    },
+    "microsoft-sdl": {
+      "displayName": "@microsoft/eslint-plugin-sdl",
+      "perCwe": {
+        "CWE-020": {
+          "name": "Improper Input Validation (validation-bypass cluster)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 5,
+          "TN": 5,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "incomplete-hostname-regexp.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "incomplete-url-scheme-check.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "incorrect-suffix-check.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "missing-regexp-anchor.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "url-substring-sanitization.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "anchored-origin-regexp.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "endswith-boundary.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "escaped-anchored-hostname.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "scheme-allowlist.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "url-parse-hostname.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-022": {
+          "name": "Path Traversal",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "path-join-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "readfile-concat.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "dirname-path.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-path.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-073": {
+          "name": "External Control of File Name or Path (template object injection via res.render)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "render-body-spread.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "render-query-spread.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "render-explicit-locals.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-078": {
+          "name": "OS Command Injection",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "exec-concat.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "exec-template.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "exec-static.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "execFile-array.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-079": {
+          "name": "Cross-Site Scripting (XSS)",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 1,
+          "FN": 0,
+          "TN": 1,
+          "precision": 66.7,
+          "recall": 100,
+          "f1": 80,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "document-write-dynamic.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "@microsoft/sdl/no-document-write": 1
+              }
+            },
+            {
+              "file": "innerhtml-user-input.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "@microsoft/sdl/no-inner-html": 1
+              }
+            },
+            {
+              "file": "static-innerhtml.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "@microsoft/sdl/no-inner-html": 1
+              }
+            },
+            {
+              "file": "textcontent-safe.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-088": {
+          "name": "Argument Injection",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "git-ls-remote-arg-injection.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tar-user-args.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "literal-argv.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "separator-guard.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-089": {
+          "name": "SQL Injection",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 3,
+          "TN": 3,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "dynamic-column.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "string-concat.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "template-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "parameterized.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "prepared-statement.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-query.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-094": {
+          "name": "Improper Control of Generation of Code (Code Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "vm-run-user-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "vm2-run-user-code.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "vm-literal-script.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "worker-isolation.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-099": {
+          "name": "Improper Control of Resource Identifiers (Environment Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "env-key-from-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "env-allowlisted-key.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-1007": {
+          "name": "Insufficient Visual Distinction of Homoglyphs Presented to User",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "cyrillic-homoglyph-identifier.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "zero-width-in-auth-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "ascii-identifiers.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "i18n-ui-copy.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-116": {
+          "name": "Improper Encoding or Escaping of Output (broken sanitizers)",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 1,
+          "FN": 0,
+          "TN": 1,
+          "precision": 66.7,
+          "recall": 100,
+          "f1": 80,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "single-pass-replace.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "@microsoft/sdl/no-inner-html": 1
+              }
+            },
+            {
+              "file": "tag-filter-regexp.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "@microsoft/sdl/no-inner-html": 1
+              }
+            },
+            {
+              "file": "dompurify-sanitize.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "@microsoft/sdl/no-inner-html": 1
+              }
+            },
+            {
+              "file": "replace-until-stable.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-117": {
+          "name": "Improper Output Neutralization for Logs (log injection)",
+          "owasp": "A09:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "newline-in-log-message.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "template-literal-log.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "stripped-newlines.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "structured-logging.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-1333": {
+          "name": "Inefficient Regular Expression Complexity (ReDoS)",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 3,
+          "TN": 3,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "real-cve.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "self-loop.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "trade-off.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "atomic-equivalent.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "literal-match.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "simple-anchored.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-178": {
+          "name": "Improper Handling of Case Sensitivity (auth-guard path bypass)",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "case-sensitive-admin-guard.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "normalized-path-guard.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-209": {
+          "name": "Generation of Error Message Containing Sensitive Information (stack-trace exposure)",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "error-object-in-json.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "stack-in-response.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "generic-error-response.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-248": {
+          "name": "Uncaught Exception (Unhandled Stream Error)",
+          "owasp": "A04:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "multipart-pipe-no-handler.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "pipe-no-error-listener.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "pipe-with-error-listener.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "pipeline-promises.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-295": {
+          "name": "Improper Certificate Validation",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "reject-unauthorized-false.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-checkserveridentity-noop.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-checkserveridentity-validates.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-default-verification.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-327": {
+          "name": "Use of a Broken or Risky Cryptographic Algorithm",
+          "owasp": "A02:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 4,
+          "TN": 4,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "gcm-decipher-no-final.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-decrypt-no-authtag.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "sign-alg-none.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "verify-allows-none.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-decrypt-verified.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-encrypt-authtag.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "sign-rs256.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "verify-allowlist.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-346": {
+          "name": "Origin Validation Error (postMessage wildcard)",
+          "owasp": "A01:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 2,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "iframe-wildcard.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "@microsoft/sdl/no-postmessage-star-origin": 1
+              }
+            },
+            {
+              "file": "window-parent-wildcard.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "@microsoft/sdl/no-postmessage-star-origin": 1
+              }
+            },
+            {
+              "file": "explicit-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "self-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-377": {
+          "name": "Insecure Temporary File",
+          "owasp": "A04:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "static-tmp-write.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tmpdir-static-name.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "mkdtemp-write.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-409": {
+          "name": "Improper Handling of Highly Compressed Data (Decompression Bomb)",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "gunzip-no-limit.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gunzip-limited.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-444": {
+          "name": "Inconsistent Interpretation of HTTP Requests (HTTP Request Smuggling)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "request-insecure-parser.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "server-insecure-parser.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "request-default-parser.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "server-default-parser.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-548": {
+          "name": "Exposure of Information Through Directory Listing",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "serve-index-root.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-root-dirname.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-public-dir.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-598": {
+          "name": "Use of GET Request Method With Sensitive Query Strings",
+          "owasp": "A09:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "login-via-query.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "token-in-query.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "login-via-body-post.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-636": {
+          "name": "Not Failing Securely ('Failing Open')",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "catch-returns-true.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "empty-catch-continues.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "catch-denies.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "catch-rethrows.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-640": {
+          "name": "Weak Password Recovery Mechanism (host-header poisoning in reset links)",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "reset-link-forwarded-host.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "reset-link-host-header.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "reset-link-config-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-770": {
+          "name": "Allocation of Resources Without Limits or Throttling",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "array-length-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "buffer-alloc-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "buffer-alloc-clamped.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-798": {
+          "name": "Hardcoded Credentials",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 5,
+          "TN": 4,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "api-key-in-source.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "aws-access-key-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "github-token-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "jwt-signing-secret-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "password-in-config.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "env-credentials.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "password-label.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "provider-env-credentials.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "test-placeholder-values.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-843": {
+          "name": "Access of Resource Using Incompatible Type (req.query type confusion)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "query-object-spread.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "query-string-methods.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "guarded-query-type.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-918": {
+          "name": "Server-Side Request Forgery (SSRF)",
+          "owasp": "A10:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "axios-user-url.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-user-url.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-static-url.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-validated-url.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-943": {
+          "name": "Improper Neutralization of Special Elements in Data Query Logic (NoSQL Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "user-input-in-find.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "where-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "explicit-eq.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-filter.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        }
+      },
+      "aggregate": {
+        "TP": 6,
+        "FP": 2,
+        "FN": 63,
+        "TN": 58,
+        "precision": 75,
+        "recall": 8.7,
+        "f1": 15.6,
+        "bas": 5.4
+      }
+    },
+    "no-unsanitized": {
+      "displayName": "eslint-plugin-no-unsanitized",
+      "perCwe": {
+        "CWE-020": {
+          "name": "Improper Input Validation (validation-bypass cluster)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 5,
+          "TN": 5,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "incomplete-hostname-regexp.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "incomplete-url-scheme-check.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "incorrect-suffix-check.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "missing-regexp-anchor.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "url-substring-sanitization.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "anchored-origin-regexp.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "endswith-boundary.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "escaped-anchored-hostname.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "scheme-allowlist.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "url-parse-hostname.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-022": {
+          "name": "Path Traversal",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "path-join-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "readfile-concat.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "dirname-path.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-path.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-073": {
+          "name": "External Control of File Name or Path (template object injection via res.render)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "render-body-spread.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "render-query-spread.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "render-explicit-locals.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-078": {
+          "name": "OS Command Injection",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "exec-concat.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "exec-template.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "exec-static.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "execFile-array.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-079": {
+          "name": "Cross-Site Scripting (XSS)",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 0,
+          "FN": 0,
+          "TN": 2,
+          "precision": 100,
+          "recall": 100,
+          "f1": 100,
+          "bas": 100,
+          "fixtures": [
+            {
+              "file": "document-write-dynamic.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "no-unsanitized/method": 1
+              }
+            },
+            {
+              "file": "innerhtml-user-input.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "no-unsanitized/property": 1
+              }
+            },
+            {
+              "file": "static-innerhtml.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "textcontent-safe.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-088": {
+          "name": "Argument Injection",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "git-ls-remote-arg-injection.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tar-user-args.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "literal-argv.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "separator-guard.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-089": {
+          "name": "SQL Injection",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 3,
+          "TN": 3,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "dynamic-column.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "string-concat.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "template-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "parameterized.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "prepared-statement.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-query.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-094": {
+          "name": "Improper Control of Generation of Code (Code Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "vm-run-user-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "vm2-run-user-code.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "vm-literal-script.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "worker-isolation.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-099": {
+          "name": "Improper Control of Resource Identifiers (Environment Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "env-key-from-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "env-allowlisted-key.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-1007": {
+          "name": "Insufficient Visual Distinction of Homoglyphs Presented to User",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "cyrillic-homoglyph-identifier.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "zero-width-in-auth-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "ascii-identifiers.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "i18n-ui-copy.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-116": {
+          "name": "Improper Encoding or Escaping of Output (broken sanitizers)",
+          "owasp": "A03:2021",
+          "TP": 2,
+          "FP": 1,
+          "FN": 0,
+          "TN": 1,
+          "precision": 66.7,
+          "recall": 100,
+          "f1": 80,
+          "bas": 50,
+          "fixtures": [
+            {
+              "file": "single-pass-replace.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "no-unsanitized/property": 1
+              }
+            },
+            {
+              "file": "tag-filter-regexp.js",
+              "expectedVulnerable": true,
+              "findings": 1,
+              "ruleHits": {
+                "no-unsanitized/property": 1
+              }
+            },
+            {
+              "file": "dompurify-sanitize.js",
+              "expectedVulnerable": false,
+              "findings": 1,
+              "ruleHits": {
+                "no-unsanitized/property": 1
+              }
+            },
+            {
+              "file": "replace-until-stable.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-117": {
+          "name": "Improper Output Neutralization for Logs (log injection)",
+          "owasp": "A09:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "newline-in-log-message.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "template-literal-log.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "stripped-newlines.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "structured-logging.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-1333": {
+          "name": "Inefficient Regular Expression Complexity (ReDoS)",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 3,
+          "TN": 3,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "real-cve.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "self-loop.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "trade-off.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "atomic-equivalent.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "literal-match.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "simple-anchored.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-178": {
+          "name": "Improper Handling of Case Sensitivity (auth-guard path bypass)",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "case-sensitive-admin-guard.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "normalized-path-guard.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-209": {
+          "name": "Generation of Error Message Containing Sensitive Information (stack-trace exposure)",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "error-object-in-json.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "stack-in-response.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "generic-error-response.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-248": {
+          "name": "Uncaught Exception (Unhandled Stream Error)",
+          "owasp": "A04:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "multipart-pipe-no-handler.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "pipe-no-error-listener.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "pipe-with-error-listener.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "pipeline-promises.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-295": {
+          "name": "Improper Certificate Validation",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "reject-unauthorized-false.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-checkserveridentity-noop.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-checkserveridentity-validates.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tls-default-verification.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-327": {
+          "name": "Use of a Broken or Risky Cryptographic Algorithm",
+          "owasp": "A02:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 4,
+          "TN": 4,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "gcm-decipher-no-final.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-decrypt-no-authtag.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "sign-alg-none.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "verify-allows-none.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-decrypt-verified.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gcm-encrypt-authtag.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "sign-rs256.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "verify-allowlist.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-346": {
+          "name": "Origin Validation Error (postMessage wildcard)",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "iframe-wildcard.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "window-parent-wildcard.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "explicit-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "self-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-377": {
+          "name": "Insecure Temporary File",
+          "owasp": "A04:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "static-tmp-write.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "tmpdir-static-name.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "mkdtemp-write.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-409": {
+          "name": "Improper Handling of Highly Compressed Data (Decompression Bomb)",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 1,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "gunzip-no-limit.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "gunzip-limited.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-444": {
+          "name": "Inconsistent Interpretation of HTTP Requests (HTTP Request Smuggling)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "request-insecure-parser.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "server-insecure-parser.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "request-default-parser.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "server-default-parser.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-548": {
+          "name": "Exposure of Information Through Directory Listing",
+          "owasp": "A01:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "serve-index-root.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-root-dirname.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-public-dir.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-598": {
+          "name": "Use of GET Request Method With Sensitive Query Strings",
+          "owasp": "A09:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "login-via-query.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "token-in-query.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "login-via-body-post.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-636": {
+          "name": "Not Failing Securely ('Failing Open')",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "catch-returns-true.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "empty-catch-continues.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "catch-denies.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "catch-rethrows.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-640": {
+          "name": "Weak Password Recovery Mechanism (host-header poisoning in reset links)",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "reset-link-forwarded-host.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "reset-link-host-header.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "reset-link-config-origin.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-770": {
+          "name": "Allocation of Resources Without Limits or Throttling",
+          "owasp": "A05:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "array-length-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "buffer-alloc-user.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "buffer-alloc-clamped.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-798": {
+          "name": "Hardcoded Credentials",
+          "owasp": "A07:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 5,
+          "TN": 4,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "api-key-in-source.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "aws-access-key-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "github-token-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "jwt-signing-secret-literal.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "password-in-config.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "env-credentials.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "password-label.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "provider-env-credentials.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "test-placeholder-values.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-843": {
+          "name": "Access of Resource Using Incompatible Type (req.query type confusion)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 1,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "query-object-spread.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "query-string-methods.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "guarded-query-type.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-918": {
+          "name": "Server-Side Request Forgery (SSRF)",
+          "owasp": "A10:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "axios-user-url.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-user-url.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-static-url.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "fetch-validated-url.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        },
+        "CWE-943": {
+          "name": "Improper Neutralization of Special Elements in Data Query Logic (NoSQL Injection)",
+          "owasp": "A03:2021",
+          "TP": 0,
+          "FP": 0,
+          "FN": 2,
+          "TN": 2,
+          "precision": 0,
+          "recall": 0,
+          "f1": 0,
+          "bas": 0,
+          "fixtures": [
+            {
+              "file": "user-input-in-find.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "where-string.js",
+              "expectedVulnerable": true,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "explicit-eq.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            },
+            {
+              "file": "static-filter.js",
+              "expectedVulnerable": false,
+              "findings": 0,
+              "ruleHits": {}
+            }
+          ]
+        }
+      },
+      "aggregate": {
+        "TP": 4,
+        "FP": 1,
+        "FN": 65,
+        "TN": 59,
+        "precision": 80,
+        "recall": 5.8,
+        "f1": 10.8,
+        "bas": 4.1
+      }
+    }
+  }
+}

--- a/packages/eslint-devkit/src/rule-creation/index.ts
+++ b/packages/eslint-devkit/src/rule-creation/index.ts
@@ -6,6 +6,7 @@
 
 // Rule creation utilities for building ESLint rules
 export * from './generated-file';
+export * from './minified-file';
 export * from './rule-creator';
 export * from './mock-context';
 // Shared CWE-89 detector — see sql-injection-rule.ts for why it lives here

--- a/packages/eslint-devkit/src/rule-creation/minified-file.ts
+++ b/packages/eslint-devkit/src/rule-creation/minified-file.ts
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+import type { TSESLint } from '@typescript-eslint/utils';
+
+/**
+ * The average line length above which a file is machine-packed rather than
+ * written.
+ *
+ * AVERAGE, deliberately, and the first attempt at this used the MAXIMUM and was
+ * wrong. Measured on the pinned corpus, 13 files had a line over 1,000
+ * characters and only 8 of them were minified. The other five were ordinary
+ * source with one long line — SVG icon components whose `d` attribute is a
+ * single 1,600-character path, and a hand-written vendor recorder. Skipping
+ * those would have been a silent recall loss in real application code.
+ *
+ * The average separates them with room to spare:
+ *
+ *   minified bundles       712 – 203,807 characters per line
+ *   hand-written source     32 – 58
+ *
+ * There is no threshold to tune between those. 200 sits in the empty middle.
+ */
+const MINIFIED_AVERAGE_LINE_LENGTH = 200;
+
+/**
+ * The size below which the average says nothing.
+ *
+ * A short file can exceed the average without being packed — a single-line
+ * barrel re-export, a one-line config, a test fixture. Those are not bundles,
+ * and skipping them would be recall loss in the smallest files rather than the
+ * largest. Caught by the conventions suite: six existing fixtures were one long
+ * line each and went silent the moment the average alone decided.
+ *
+ * Every minified file on the pinned corpus is tens of kilobytes; the largest is
+ * 407 KB on two lines. 2 KB is far below all of them and far above a one-liner.
+ */
+const MINIFIED_MINIMUM_BYTES = 2000;
+
+/**
+ * Is this file machine-packed output rather than something a person edits?
+ *
+ * Decided from the file's own shape — no path matching. `dist/`, `.min.js` and
+ * `vendor/` are conventions a stranger's repository is free to ignore, and
+ * `assets/speedscope/import.bcbb2033.js` announces nothing in its name; it was
+ * still 1,973 of the corpus's `no-magic-numbers` findings on its own.
+ *
+ * Only for rules that give MAINTAINABILITY advice. A security rule must not use
+ * this: a bundle ships and runs, so an injection inside one is a live
+ * vulnerability no matter how the bytes got there — and a minified bundle is
+ * exactly where a supply-chain problem would hide.
+ */
+export function isMinifiedFile(sourceCode: Readonly<TSESLint.SourceCode>): boolean {
+  const lines = sourceCode.lines;
+  // `lines` is never empty for a parsed file — ESLint yields [''] for an empty
+  // one — so there is no zero-division branch to guard, and adding one would be
+  // a branch no input can reach.
+  let total = 0;
+  for (const line of lines) total += line.length;
+  if (total < MINIFIED_MINIMUM_BYTES) return false;
+  return total / lines.length > MINIFIED_AVERAGE_LINE_LENGTH;
+}

--- a/packages/eslint-devkit/src/rule-creation/mock-context.ts
+++ b/packages/eslint-devkit/src/rule-creation/mock-context.ts
@@ -88,6 +88,12 @@ export function createWithMockContext(
     // rule defensive about a shape ESLint always provides. That would add a
     // branch no real input can take, which in a repo held at 100% coverage is
     // a permanent hole. Fix the mock instead.
+    // A real SourceCode exposes `lines`, so the mock must too — `isMinifiedFile`
+    // reads it, and without this the synthetic-AST tests die with "lines is not
+    // iterable". Second time this mock has been short of the real shape; the
+    // fix is the same as it was for getAllComments: complete the mock rather
+    // than make the predicate defensive about something ESLint always provides.
+    lines: (opts.sourceText ?? '').split('\n'),
     getAllComments: () => (opts.ast as { comments?: unknown[] } | undefined)?.comments ?? [],
     getFirstToken: () =>
       (opts.ast as { tokens?: unknown[] } | undefined)?.tokens?.[0] ?? null,

--- a/packages/eslint-devkit/src/rule-creation/rule-creator.ts
+++ b/packages/eslint-devkit/src/rule-creation/rule-creator.ts
@@ -20,6 +20,7 @@
  * the upstream one on every run so the port can't silently drift.
  */
 import { isGeneratedFile } from './generated-file';
+import { isMinifiedFile } from './minified-file';
 import type { TSESLint } from '@typescript-eslint/utils';
 
 // The `TSESLint` import above is type-only — it is erased at compile time and
@@ -154,6 +155,23 @@ export interface RuleCreateAndOptions<
    * live vulnerability regardless of what typed it.
    */
   skipGeneratedFiles?: boolean;
+
+  /**
+   * Skip machine-packed output — minified bundles and the like.
+   *
+   * The third member of this family, and opt-in for the same reason as the
+   * other two. Decided from the file's own shape rather than its path: `dist/`,
+   * `.min.js` and `vendor/` are conventions a stranger's repository is free to
+   * ignore, and the single largest offender on the pinned corpus is called
+   * `assets/speedscope/import.bcbb2033.js`, which announces nothing.
+   *
+   * Measured there: 8 files carried 2,446 of `no-magic-numbers`' findings.
+   *
+   * Only for rules that give MAINTAINABILITY advice. A security rule must not
+   * set this — a bundle ships and runs, and a minified bundle is exactly where
+   * a supply-chain problem would hide.
+   */
+  skipMinifiedFiles?: boolean;
 }
 
 export interface RuleWithMeta<
@@ -241,6 +259,7 @@ function createRuleInternal<
   name,
   skipTestFiles,
   skipGeneratedFiles,
+  skipMinifiedFiles,
 }: Readonly<RuleWithMeta<Options, MessageIds, Docs>>): RuleModuleWithName<
   MessageIds,
   Options,
@@ -256,6 +275,7 @@ function createRuleInternal<
       // After the filename test, which is string work, and before anything
       // that walks the AST.
       if (skipGeneratedFiles && isGeneratedFile(context.sourceCode)) return {};
+      if (skipMinifiedFiles && isMinifiedFile(context.sourceCode)) return {};
       return create(
         context,
         applyDefault(resolvedDefaultOptions, context.options),

--- a/packages/eslint-devkit/src/rule-creation/skip-minified-files.test.ts
+++ b/packages/eslint-devkit/src/rule-creation/skip-minified-files.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * The third scope predicate, after test files and generated files.
+ *
+ * Decided from the file's own shape — no path matching. `dist/`, `.min.js` and
+ * `vendor/` are conventions a stranger's repository is free to ignore, and the
+ * single largest offender on the pinned corpus is called
+ * `assets/speedscope/import.bcbb2033.js`, which announces nothing in its name
+ * and carried 1,973 `no-magic-numbers` findings by itself.
+ *
+ * AVERAGE line length, not maximum, and that distinction is the whole test.
+ * Thirteen corpus files had a line over 1,000 characters and only eight were
+ * minified; the others were ordinary source with one long line — SVG icon
+ * components whose `d` attribute is a single 1,600-character path. Skipping
+ * those would have been silent recall loss in application code.
+ *
+ *   minified bundles       712 – 203,807 characters per line
+ *   hand-written source     32 – 58
+ */
+import { describe, it, expect } from 'vitest';
+import { Linter } from 'eslint';
+import { createRule } from './rule-creator';
+import { isMinifiedFile } from './minified-file';
+
+/**
+ * A line of roughly `n` characters of real-looking code.
+ *
+ * The identifier is indexed. A first draft repeated `const x` and `const y`,
+ * which is a redeclaration error — the file never parsed, every rule reported
+ * nothing, and two of these tests "passed" for a reason that had nothing to do
+ * with the gate. The CONTROL case is what caught it.
+ */
+const wide = (n: number, i: number) =>
+  `const w${i} = ${'"' + 'a'.repeat(Math.max(n - 16, 1)) + '"'};`;
+
+function run(code: string, skipMinifiedFiles: boolean): number {
+  const probe = createRule<[], 'hit'>({
+    name: 'probe',
+    meta: {
+      type: 'problem',
+      docs: { description: 'probe' },
+      schema: [],
+      messages: { hit: 'hit' },
+    },
+    skipMinifiedFiles,
+    defaultOptions: [],
+    create: (context) => ({
+      VariableDeclarator: (node) => context.report({ node, messageId: 'hit' }),
+    }),
+  });
+  return new Linter({ configType: 'flat' })
+    .verify(
+      code,
+      [
+        {
+          files: ['**/*.{js,mjs,cjs,jsx,ts,tsx,mts,cts}'],
+          plugins: { p: { rules: { probe } } },
+          rules: { 'p/probe': 'error' },
+        },
+      ] as never,
+      'src/anything.js',
+    )
+    .filter((m) => m.ruleId).length;
+}
+
+describe('createRule skipMinifiedFiles gate', () => {
+  const minified = [wide(5000, 1), wide(5000, 2)].join('\n');
+  const iconLike = [
+    ...Array.from({ length: 40 }, (_, i) => `const y${i} = 1;`),
+    wide(1600, 99),
+  ].join('\n');
+
+  it('suppresses in a machine-packed file', () => {
+    expect(run(minified, true)).toBe(0);
+  });
+
+  it('does NOT suppress a file with one long line among normal ones', () => {
+    // The SVG-icon shape. Its maximum line is 1,600 characters and its average
+    // is under 60 — the case that made `max` the wrong statistic.
+    expect(run(iconLike, true)).toBeGreaterThan(0);
+  });
+
+  it('still reports in ordinary source when opted in', () => {
+    expect(run('const a = 1;', true)).toBe(1);
+  });
+
+  it('CONTROL: reports in a minified file when NOT opted in', () => {
+    // If this returns 0 the flag has become a no-op and the assertions above
+    // would pass on a rule that never had the gate.
+    expect(run(minified, false)).toBe(2);
+  });
+});
+
+describe('isMinifiedFile', () => {
+  it('is a property of the bytes, not the path', () => {
+    // Both of these are named like source and neither name is consulted.
+    const linter = new Linter({ configType: 'flat' });
+    const seen: boolean[] = [];
+    for (const code of [wide(5000, 1), 'const a = 1;']) {
+      linter.verify(
+        code,
+        [
+          {
+            files: ['**/*.js'],
+            plugins: {
+              p: {
+                rules: {
+                  check: {
+                    create(context: { sourceCode: never }) {
+                      seen.push(isMinifiedFile(context.sourceCode));
+                      return {};
+                    },
+                  },
+                },
+              },
+            },
+            rules: { 'p/check': 'error' },
+          },
+        ] as never,
+        'src/index.js',
+      );
+    }
+    expect(seen).toEqual([true, false]);
+  });
+});

--- a/packages/eslint-plugin-conventions/src/rules/conventions/no-magic-numbers.ts
+++ b/packages/eslint-plugin-conventions/src/rules/conventions/no-magic-numbers.ts
@@ -128,6 +128,12 @@ function nearestStatement(node: TSESTree.Node): TSESTree.Statement | null {
 
 export const noMagicNumbers = createRule<RuleOptions, MessageIds>({
   name: 'no-magic-numbers',
+  // 8 minified bundles carried 2,446 of this rule's 10,129 findings on the
+  // pinned corpus — one of them, `assets/speedscope/import.bcbb2033.js`, was
+  // 1,973 by itself. "Name this constant" is advice to whoever edits the file,
+  // and nobody edits a bundle: it is rebuilt from a source that lives
+  // elsewhere, if it is in the repository at all.
+  skipMinifiedFiles: true,
   meta: {
     type: 'suggestion',
     docs: {

--- a/packages/eslint-plugin-conventions/src/tests/conventions/no-magic-numbers.test.ts
+++ b/packages/eslint-plugin-conventions/src/tests/conventions/no-magic-numbers.test.ts
@@ -301,3 +301,70 @@ describe('no-magic-numbers — ignoreArrayIndexes checks the VALUE', () => {
     ],
   });
 });
+
+/**
+ * `no-magic-numbers` does not look at machine-packed output.
+ *
+ * 8 minified bundles carried 2,446 of this rule's 10,129 findings on the pinned
+ * corpus, and one of them — `assets/speedscope/import.bcbb2033.js` — was 1,973
+ * on its own. "Name this constant" is advice to whoever edits the file, and
+ * nobody edits a bundle: it is rebuilt from a source that lives elsewhere, if
+ * it is in the repository at all.
+ *
+ * Decided from the file's own average line length, not its path and not its
+ * longest line. The SVG icon components in okta-signin-widget have a single
+ * 1,600-character `d` attribute and an average under 60; they still report, and
+ * that is pinned below.
+ */
+describe('no-magic-numbers — machine-packed output', () => {
+  // `if (res.status === N)` rather than `const n = N` or `x.length === N`.
+  // Assigning a literal to a named constant is exempt by design — that IS the
+  // fix the rule asks for — and `.length ===` is exempt via
+  // `ignoreLengthComparisons`. Two drafts of this fixture reported nothing for
+  // those reasons before landing on a shape the rule actually flags.
+  const packed = [
+    `const bundle1 = ${JSON.stringify('x'.repeat(3000))}; if (res.status === 4242) { throw new Error('a'); }`,
+    `const bundle2 = ${JSON.stringify('y'.repeat(3000))}; if (res.status === 8484) { throw new Error('b'); }`,
+  ].join('\n');
+
+  // The SVG-icon shape: one very long line among ordinary ones.
+  //
+  // Padded to ~200 lines on purpose: that is the shape of the real files, and
+  // it is what makes the average low. A first draft was five lines, one of them
+  // 1,600 characters, which averages ~335 and genuinely does look packed — the
+  // predicate was right to skip it and the fixture was wrong.
+  const iconLike = [
+    `const d = ${JSON.stringify('M' + '1 2 '.repeat(400))};`,
+    ...Array.from({ length: 200 }, (_, i) => `const p${i} = d;`),
+    'export function render(res) {',
+    '  if (res.status === 4242) { return d; }',
+    '  return null;',
+    '}',
+  ].join('\n');
+
+  ruleTester.run('minified', noMagicNumbers, {
+    valid: [{ code: packed }],
+    invalid: [
+      {
+        // POSITIVE CONTROL: the same comparisons in ordinary source still
+        // report, so the valid case is not passing on a rule gone quiet.
+        code: "if (res.status === 4242) { throw new Error('a'); }\nif (res.status === 8484) { throw new Error('b'); }",
+        errors: 2,
+      },
+    ],
+  });
+
+  ruleTester.run('one long line is not minified', noMagicNumbers, {
+    valid: [],
+    invalid: [
+      {
+        // FN GUARD. The longest line here is over 1,600 characters while the
+        // average is well under the threshold — the case that made `max` the
+        // wrong statistic to key on. Skipping this would be recall loss in
+        // ordinary application code.
+        code: iconLike,
+        errors: 1,
+      },
+    ],
+  });
+});


### PR DESCRIPTION
## Summary

Batch 3. `conventions` is one rule in practice — `no-magic-numbers` is **10,129 of its 10,588** corpus findings — and reading them showed two classes rather than a precision problem:

| class | findings | files |
|---|---:|---:|
| test files | 6,328 (62%) | 793 |
| **minified bundles** | **2,589 (26%)** | **13** |
| hand-written production | 1,212 (12%) | 558 |

Eight bundles carried 2,446 of them, and `assets/speedscope/import.bcbb2033.js` was **1,973 on its own**. "Name this constant" is advice to whoever edits the file, and nobody edits a bundle.

**Corpus: 10,129 → 7,532.**

## `isMinifiedFile`, and why it is the average

devkit gains `isMinifiedFile` plus a `skipMinifiedFiles` flag on `createRule`, joining `skipTestFiles` and `skipGeneratedFiles`.

**Decided from the file's own shape, never its path.** `dist/`, `.min.js` and `vendor/` are conventions a stranger's repo is free to ignore, and the largest offender announces nothing in its name.

**My first draft used the maximum line length and was wrong.** 13 corpus files had a line over 1,000 characters and only 8 were minified. The others were ordinary source with one long line — SVG icon components whose `d` attribute is a single 1,600-character path. Skipping those would have been silent recall loss in application code.

| | average line length |
|---|---:|
| minified bundles | 712 – 203,807 |
| hand-written source (incl. SVG icons) | 32 – 58 |

No threshold to tune between those; 200 sits in the empty middle. Verified in both directions on the real files: `GoogleStoreIcon.tsx` keeps its 28 findings, `import.bcbb2033.js` loses all 1,973.

A **2 KB floor** sits under the average, because a short file can exceed it without being packed — a one-line barrel re-export is not a bundle. The conventions suite caught that: six existing fixtures are one long line each and went silent the moment the average alone decided.

## Two things I got wrong and the tests caught

1. **Max vs average** — above. Caught by looking at the 13 files rather than trusting the threshold.
2. **My own test fixtures didn't parse.** The first `minified` fixture repeated `const x` and `const y`, which is a redeclaration error — the file never parsed, every rule reported nothing, and two tests "passed" for a reason unrelated to the gate. The CONTROL case is what exposed it.

Also, the synthetic-AST mock gained `lines`. Second time it has been short of the real `SourceCode` shape; same fix as for `getAllComments` — complete the mock rather than make the predicate defensive about something ESLint always provides.

## Not for security rules

Documented on the flag and in the predicate: a bundle ships and runs, and a minified bundle is exactly where a supply-chain problem would hide.

## Test plan

- [x] `conventions` 484 passing, `eslint-devkit` 1,759 passing — both **100%** statements / branches / functions / lines.
- [x] Devkit gate test with the three-way control, plus an explicit "one long line among normal ones is NOT minified" case.
- [x] Rule-level FN guard padded to ~200 lines to match the real icon files.
- [x] CWE recall gate re-run in the same session: TP=69 FP=0 FN=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)