### PR TITLE
ci(release): the checkout carries the token, which is what the push uses

### DIFF
--- a/.github/workflows/changesets-pr.yml
+++ b/.github/workflows/changesets-pr.yml
@@ -49,6 +49,25 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          # THIS is the credential the Version PR's push actually uses.
+          #
+          # `actions/checkout` persists a git credential, and every later `git
+          # push` in the job uses it — regardless of what token the changesets
+          # action is handed in `env`. Setting only the env var (the previous
+          # change) was necessary and not sufficient: the push still went out as
+          # `GITHUB_TOKEN`, GitHub suppressed the workflow triggers it would
+          # otherwise fire, and the Version PR kept opening with ZERO checks.
+          # Measured: PR #600 sat at 0 checks through a full changesets run with
+          # the env var already set.
+          #
+          # `docs-data.yml` has had this right all along and its comment
+          # describes the same failure; the release workflow simply never got
+          # the same treatment. That workflow's PR (#578) is authored by
+          # `ofri-peretz` and carries 28 checks, which is the proof that the
+          # token in this chain has write access to this repository.
+          #
+          # `github.token` stays last, so this cannot be worse than today.
+          token: ${{ secrets.RELEASE_BOT_PAT || secrets.AGENTS_REPO_PAT || github.token }}
       - uses: ./.github/actions/setup
         with:
           turbo-cache: "false"


### PR DESCRIPTION
## Summary

[#642](https://github.com/ofri-peretz/eslint/pull/642) set the changesets action's `GITHUB_TOKEN` env var. **Necessary, and not sufficient.**

`actions/checkout` persists a git credential, and every later `git push` in the job uses *that* — regardless of what token the action is handed in `env`. So the push still went out as `GITHUB_TOKEN`, GitHub suppressed the workflow triggers it would otherwise fire, and the Version PR kept opening with **zero checks**.

Measured directly: after #642 merged, a full changesets run fired and force-pushed `changeset-release/main` at 04:17:34. I watched #600 for 10 minutes. Still 0 checks.

## No new credential is needed, and the proof was already in the repo

`docs-data.yml` has had this right all along — its checkout passes the token, and its comment describes this exact failure mode. The release workflow simply never got the same treatment.

The evidence that the existing token works here:

| | |
|---|---|
| PR opened by `docs-data.yml` | [#578](https://github.com/ofri-peretz/eslint/pull/578) |
| author | **`ofri-peretz`** — not `github-actions[bot]` |
| checks | **28** |
| workflow runs today | 5, all success |

`RELEASE_BOT_PAT` is unset, so that chain resolves to **`AGENTS_REPO_PAT`** — which therefore has write access to `ofri-peretz/eslint`, despite being named for a different repository. That was the open question, and it is answered by observation rather than by asking.

## The change

```yaml
- uses: actions/checkout@…
  with:
    fetch-depth: 0
    token: ${{ secrets.RELEASE_BOT_PAT || secrets.AGENTS_REPO_PAT || github.token }}
```

`github.token` stays last, so this cannot be worse than today.

## What should happen after merge

This is a push to `main`, so it triggers a changesets run — using the merged workflow. If the diagnosis is right, the next force-push of `changeset-release/main` comes from a real token and **#600 opens with checks for the first time**. That is falsifiable within minutes of merge, and I will report the outcome either way.

## Test plan

- [x] All 1,315 repo script locks pass.
- [x] Chain falls through to `github.token`, so no behaviour change if every secret is empty.
- [x] The token in the chain is demonstrated to work on this repo by #578's 28 checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)