### PR TITLE
fix(docs): remote CHANGELOGs are markdown, not MDX

### DIFF
--- a/apps/docs/src/__tests__/remote-markdown-is-not-mdx.test.ts
+++ b/apps/docs/src/__tests__/remote-markdown-is-not-mdx.test.ts
@@ -36,7 +36,7 @@ const SRC = readFileSync(
 describe('remote markdown is compiled as markdown, not MDX', () => {
   it('both remote compilers pass format: md', () => {
     const remoteFns = SRC.split(/export async function /).filter((chunk) =>
-      /^compileRemote/.test(chunk),
+      chunk.startsWith('compileRemote'),
     );
     expect(remoteFns).toHaveLength(2);
     for (const fn of remoteFns) {

--- a/apps/docs/src/__tests__/remote-markdown-is-not-mdx.test.ts
+++ b/apps/docs/src/__tests__/remote-markdown-is-not-mdx.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SRC = readFileSync(
+  resolve(dirname(fileURLToPath(import.meta.url)), '..', 'lib', 'mdx-compiler.tsx'),
+  'utf-8',
+);
+
+/**
+ * Remote content is markdown, and compiling it as MDX broke the build.
+ *
+ * `compileRemoteMDX` and `compileRemoteMarkdown` render CHANGELOG.md and
+ * README.md FETCHED FROM GITHUB at build time. Those are CommonMark assembled
+ * from arbitrary changeset prose, so every `{...}` in a release note became a
+ * JSX expression to evaluate.
+ *
+ * A changeset merged on 2026-08-23 contained an inline code span with an
+ * escaped backtick inside it. Markdown does not honour backslash escapes inside
+ * a code span, so the inner backtick closed it early, `{id}` fell outside, and
+ * three plugins' changelog pages died with `ReferenceError: id is not defined`.
+ *
+ * Two things made it worse than a normal build break:
+ *
+ *   - the content is fetched from `main`, so the break arrived with NO code
+ *     change and no PR to revert;
+ *   - the pre-push hook runs this same build, so it could not be fixed by
+ *     editing the file locally either — the build re-fetched the broken text.
+ *     Fixing the three changelogs by hand would also have been whack-a-mole,
+ *     since the next changeset containing a brace would do it again.
+ *
+ * `format: 'md'` removes the class: braces are literal, and nothing in a
+ * fetched README or CHANGELOG is meant to be executable anyway.
+ */
+describe('remote markdown is compiled as markdown, not MDX', () => {
+  it('both remote compilers pass format: md', () => {
+    const remoteFns = SRC.split(/export async function /).filter((chunk) =>
+      /^compileRemote/.test(chunk),
+    );
+    expect(remoteFns).toHaveLength(2);
+    for (const fn of remoteFns) {
+      expect(fn).toMatch(/createCompiler\(\{\s*\n\s*format: 'md',/);
+    }
+  });
+
+  it('every compiler this module exports is a remote one', () => {
+    // Both exported functions render content fetched from GitHub, so both need
+    // the flag. The assertion above iterates whatever it finds rather than
+    // naming them, and this pins that the set has not grown a third compiler
+    // that quietly skipped it. (The local variable inside each is called
+    // `localCompiler`, which is a binding name, not a scope claim.)
+    const exported = SRC.match(/^export async function (\w+)/gm) ?? [];
+    expect(exported).toEqual([
+      'export async function compileRemoteMDX',
+      'export async function compileRemoteMarkdown',
+    ]);
+  });
+
+});

--- a/apps/docs/src/lib/mdx-compiler.tsx
+++ b/apps/docs/src/lib/mdx-compiler.tsx
@@ -195,7 +195,12 @@ export async function compileRemoteMDX(
   }
   
   // Create compiler instance with our dynamic remark plugins
+  // `format: 'md'` — see the note on compileRemoteMarkdown below. This path
+  // renders CHANGELOG.md fetched from GitHub at build time, and a CHANGELOG is
+  // CommonMark assembled from arbitrary changeset prose. Compiling it as MDX
+  // makes every `{...}` in someone's release note a JSX expression to evaluate.
   const localCompiler = createCompiler({
+    format: 'md',
     remarkPlugins,
     remarkImageOptions: REMARK_IMAGE_OPTIONS,
   });
@@ -230,8 +235,26 @@ export async function compileRemoteMarkdown(
     remarkPlugins.push(remarkRelativeLinks(options));
   }
   
-  // Create compiler instance with our dynamic remark plugins
+  // Create compiler instance with our dynamic remark plugins.
+  //
+  // `format: 'md'` — this path renders CHANGELOG.md and README.md fetched from
+  // GitHub, and those are CommonMark, not MDX. Compiling them as MDX makes
+  // every `{...}` in someone's release note a JSX expression to evaluate.
+  //
+  // That is not hypothetical. A changeset merged on 2026-08-23 contained
+  //
+  //     `body: \`client_id=${id}&...\``
+  //
+  // and markdown does not honour backslash escapes inside a code span, so the
+  // inner backtick closed it early and `{id}` fell outside. The docs build died
+  // with `ReferenceError: id is not defined` on three plugins' changelog pages.
+  //
+  // The build FETCHES this content from `main` at build time, so the break
+  // arrived with no code change and could not be fixed by editing the file
+  // locally — the pre-push hook runs this same build, which re-fetches the
+  // broken text. Parsing as markdown removes the whole class.
   const localCompiler = createCompiler({
+    format: 'md',
     remarkPlugins,
     remarkImageOptions: REMARK_IMAGE_OPTIONS,
   });


### PR DESCRIPTION
## main was red, and could not be fixed by editing a file

The docs build died on three plugins' changelog pages:

```
Error occurred prerendering page "/docs/security/plugin-browser-security/changelog"
ReferenceError: id is not defined
```

`compileRemoteMDX` and `compileRemoteMarkdown` render `CHANGELOG.md` and `README.md` **fetched from GitHub at build time**. A CHANGELOG is CommonMark assembled from arbitrary changeset prose, so compiling it as MDX makes every `{...}` in someone's release note a JSX expression to evaluate.

The trigger was a changeset merged today:

```
`body: \`client_id=${id}&client_secret=${s}&token=${t}\``
```

Markdown does not honour backslash escapes inside a code span, so the inner backtick **closed the span early** and `{id}` fell outside it.

### Why this was worse than an ordinary break

- The content is **fetched from `main`**, so the break arrived with **no code change** and no PR to revert.
- The **pre-push hook runs this same build**, which re-fetches the broken text — so it could not be fixed by editing the changelog locally either. The repository was effectively unpushable until the *class* was removed rather than the instance.

## The fix

`format: 'md'` on both remote compilers. Braces become literal, and nothing in a fetched README or CHANGELOG was ever meant to be executable.

- Both changelog pages now render `client_id=${id}` as **text** — verified in the emitted HTML.
- Build is **20/20 tasks**.

I first hand-fixed the three CHANGELOGs and **reverted that**: it is whack-a-mole against the next changeset containing a brace, and hand-editing generated files is churn.

## The lock

It iterates whatever compilers the module exports rather than naming them, plus a second assertion pinning that the set is still exactly those two — so a third compiler cannot quietly skip the flag.

Note for readers: the local variable inside each is called `localCompiler`, which is a binding name and not a scope claim. Both functions are remote.

## Test plan

- [x] `docs` build green, 20/20, from a forced rebuild.
- [x] Changelog HTML inspected — braces render literally.
- [x] The lock fails on the unfixed compiler, verified by restoring `HEAD`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering of remotely fetched Markdown by consistently treating it as standard Markdown.
  * Prevented braces and code-span content in Markdown from being incorrectly interpreted as executable expressions.

* **Tests**
  * Added regression coverage to verify remote Markdown uses the correct parsing format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->