### PR TITLE
fix(release): verify the tag push instead of narrating a guess

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -339,7 +339,31 @@ jobs:
           else
             git tag -a "$tag_name" -m "Release $tag_name"
           fi
-          git push origin "$tag_name" || echo "(tag push failed — likely already on remote)"
+          # Push the tag, then VERIFY it landed. The previous line was
+          #
+          #   git push origin "$tag_name" || echo "(tag push failed — likely already on remote)"
+          #
+          # which asserted the reassuring guess instead of checking it. Nine
+          # matrix jobs push tags to the same remote at once; five of nine lost
+          # that race on 2026-08-23, the `||` reported "likely already on
+          # remote", and the release step three lines below then died with
+          # "tag exists locally but has not been pushed". npm had every package;
+          # GitHub had no tag and no release for five of them.
+          #
+          # Contention is expected here, so retry — and if the tag still is not
+          # on the remote afterwards, say so rather than continue.
+          for attempt in 1 2 3; do
+            if git ls-remote --exit-code --tags origin "refs/tags/$tag_name" >/dev/null 2>&1; then
+              echo "✅ tag $tag_name is on the remote"
+              break
+            fi
+            echo "pushing tag $tag_name (attempt $attempt)…"
+            git push origin "$tag_name" 2>&1 || true
+            sleep $(( attempt * 3 ))
+          done
+          if ! git ls-remote --exit-code --tags origin "refs/tags/$tag_name" >/dev/null 2>&1; then
+            echo "::warning::tag $tag_name never reached the remote; the release step will create it from $GITHUB_SHA"
+          fi
 
           # Stash the tag name + the per-version CHANGELOG slice for the
           # GitHub Release step that follows. We use --fallback so a missing
@@ -379,7 +403,14 @@ jobs:
             if [ "$DIST_TAG" != "latest" ]; then
               extra_flags+=(--prerelease)
             fi
+            # `--target` is what makes this survive a lost tag-push race: with
+            # it, GitHub creates the tag itself from the commit rather than
+            # requiring one to already be on the remote. Without it the step
+            # fails AFTER a successful npm publish, which is the worst place to
+            # fail — the package is public and unrecallable while the repo has
+            # no tag to diff against.
             gh release create "$TAG_NAME" \
+              --target "$GITHUB_SHA" \
               --title "$PKG_NAME@$PKG_VER" \
               --notes-file "$NOTES_FILE" \
               --latest=false \

--- a/scripts/__tests__/release-tag-push-lock.test.ts
+++ b/scripts/__tests__/release-tag-push-lock.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const RELEASE = readFileSync(resolve(ROOT, '.github/workflows/release.yml'), 'utf-8');
+
+/**
+ * Comment lines removed before matching for the forbidden shape.
+ *
+ * The fix's own comment quotes the line that caused the bug, which is worth
+ * keeping — and a checker matching printed source would flag the workflow for
+ * DESCRIBING the defect it fixed. That exact trap cost a CI run earlier the
+ * same day in `suggestions-meta-lock`, so this one strips first.
+ */
+const RELEASE_CODE = RELEASE.split('\n')
+  .filter((line) => !/^\s*#/.test(line))
+  .join('\n');
+
+/**
+ * Locks for the tag-push race that broke the 2026-08-23 release AFTER publish.
+ *
+ * The workflow fans out one job per package. Nine of them pushed tags to the
+ * same remote at once, five lost the race, and the line
+ *
+ *   git push origin "$tag_name" || echo "(tag push failed — likely already on remote)"
+ *
+ * reported the reassuring guess instead of checking. `gh release create` three
+ * lines below then died with "tag exists locally but has not been pushed".
+ *
+ * The failure landed in the worst possible place: npm had all nine packages,
+ * public and unrecallable, while GitHub had no tag and no release for five of
+ * them. `release.yml` compares versions against npm to decide what to publish,
+ * so it would never have retried them either.
+ *
+ * Two independent defences, because either alone can still lose:
+ *   1. verify the tag actually reached the remote, and retry — never assert it
+ *   2. `gh release create --target`, so GitHub creates the tag from the commit
+ *      if the push lost anyway
+ */
+describe('release.yml tag handling', () => {
+  it('never claims a failed tag push is "already on remote"', () => {
+    // The exact shape that shipped the bug: a bare `||` swallowing the failure
+    // and narrating a cause it did not check.
+    expect(RELEASE_CODE).not.toMatch(/git push origin "\$tag_name" \|\| echo/);
+  });
+
+  it('verifies the tag reached the remote rather than assuming', () => {
+    expect(RELEASE).toContain('git ls-remote --exit-code --tags origin "refs/tags/$tag_name"');
+  });
+
+  it('retries the push, because contention is expected with a matrix fan-out', () => {
+    expect(RELEASE).toMatch(/for attempt in 1 2 3; do/);
+  });
+
+  it('warns when the tag never landed, instead of continuing silently', () => {
+    expect(RELEASE).toMatch(/::warning::tag \$tag_name never reached the remote/);
+  });
+
+  it('creates the release against an explicit target commit', () => {
+    // The second defence. Without it the step needs a tag already on the
+    // remote, which is precisely what a lost race denies it.
+    expect(RELEASE).toMatch(/gh release create "\$TAG_NAME" \\\n\s*--target "\$GITHUB_SHA"/);
+  });
+});


### PR DESCRIPTION
## The failure

Today's release published **all nine packages to npm**, then failed **five of nine jobs** at `Create GitHub Release`:

```
tag eslint-plugin-modularity@2.2.0 exists locally but has not been pushed
to ofri-peretz/eslint, please push it before continuing
```

One line caused it:

```bash
git push origin "$tag_name" || echo "(tag push failed — likely already on remote)"
```

Nine matrix jobs push tags to the same remote simultaneously. Five lost the race, and the `||` **asserted the reassuring cause instead of checking it**.

It landed in the worst possible place: npm had every package — public and unrecallable — while GitHub had no tag and no release for five of them. And `release.yml` decides what to publish by comparing against npm, so it would never have retried. I repaired the five by hand.

## Two independent defences

**1. Verify, don't assume.** `git ls-remote --exit-code --tags` confirms the tag actually reached the remote, retried three times with a backoff since contention is *expected* with a fan-out. If it still isn't there, the step warns rather than continuing quietly.

**2. `gh release create --target "$GITHUB_SHA"`.** GitHub creates the tag from the commit, so the release no longer needs one on the remote at all — which is what I used for the manual repair.

## A note on the lock

It strips comment lines before matching the forbidden shape. The fix's own comment quotes the buggy line — worth keeping for the next reader — and a checker matching printed source would otherwise flag the workflow for *describing* the defect it fixed. That exact trap cost a CI run earlier today in `suggestions-meta-lock`.

## Test plan

- [x] **All 5 assertions fail on the unfixed workflow**, verified by restoring `HEAD`.
- [x] 1,320 repo script locks pass.
- [x] Manual repair already done — all 9 tags and releases exist, with notes from each package's CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)