### PR TITLE
feat(scripts): list every PR in a release, in the release notes

### DIFF
--- a/.changeset/release-notes-list-prs.md
+++ b/.changeset/release-notes-list-prs.md
@@ -1,0 +1,22 @@
+---
+'eslint-plugin-node-security': patch
+---
+
+Release notes now list every pull request in the release.
+
+The changeset text says what changed in our words, which is the right thing to
+lead with. It does not answer the question a consumer actually arrives with —
+_which_ PRs are in the version I just installed — and that is the question asked
+by someone whose reported false positive stopped appearing, or by someone
+deciding whether an upgrade is worth it.
+
+`scripts/prs-since-release.ts` reads the package's own tags, walks the commits
+that touched that package since its previous release, and lists the squash-merge
+PRs. Per-package, because the repo's tags interleave every package and the
+question is always about one of them. Sorted by `-v:refname` so 5.1.10 ranks above
+5.1.9 rather than lexically below it, which would silently truncate the range to a
+single release.
+
+It reads git rather than the GitHub API: the tags and subjects are already in the
+checkout, and an API call would need a token and a rate-limit budget inside a
+matrix job that runs once per package.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -372,6 +372,10 @@ jobs:
           mkdir -p .release-notes
           notes_file=".release-notes/${tag_name//\//_}.md"
           npx tsx scripts/extract-changelog.ts "packages/${{ matrix.dir }}" "$PKG_VER" --fallback > "$notes_file"
+          # The changeset says what changed, in our words. This says which PRs it
+          # arrived in — the question someone asks when a false positive they
+          # reported stops appearing, and one a CHANGELOG entry cannot answer.
+          npx tsx scripts/prs-since-release.ts "packages/${{ matrix.dir }}" "$PKG_VER" >> "$notes_file"
           echo "TAG_NAME=$tag_name" >> "$GITHUB_ENV"
           echo "NOTES_FILE=$notes_file" >> "$GITHUB_ENV"
 

--- a/scripts/prs-since-release.ts
+++ b/scripts/prs-since-release.ts
@@ -40,11 +40,33 @@ if (!fs.existsSync(pkgPath)) {
 }
 const name = JSON.parse(fs.readFileSync(pkgPath, 'utf8')).name as string;
 
+/**
+ * Tags drop the scope. release.yml strips everything up to the last slash of the
+ * package name before joining it to the version, so `@interlace/eslint-devkit` is
+ * tagged `eslint-devkit@1.9.0`. Searching the full package name finds nothing for
+ * every scoped package, and — because a missing
+ * previous tag is legitimately "first release" — it would have reported the entire
+ * history as the range rather than erroring.
+ */
+const tagName = name.replace(/^@[^/]+\//, '');
+
+/**
+ * Fails loudly.
+ *
+ * The first version swallowed every git error into an empty string, which meant a
+ * broken `git log` produced an empty PR list and exited 0 — release notes that
+ * silently omit the thing they exist to show. That is the same failure shape as a
+ * lint harness that reports zero findings because it was wired to zero rules: the
+ * wrong answer is indistinguishable from the good one.
+ */
 const git = (...args: string[]): string => {
   try {
     return execFileSync('git', args, { encoding: 'utf8' }).trim();
-  } catch {
-    return '';
+  } catch (error) {
+    console.error(
+      `git ${args.join(' ')} failed: ${String(error).slice(0, 200)}`,
+    );
+    process.exit(1);
   }
 };
 
@@ -55,10 +77,10 @@ const git = (...args: string[]): string => {
  * above 5.1.9 — a plain sort puts 5.1.9 last and would silently truncate the
  * range to a single release.
  */
-const previous = git('tag', '--list', `${name}@*`, '--sort=-v:refname')
+const previous = git('tag', '--list', `${tagName}@*`, '--sort=-v:refname')
   .split('\n')
   .filter(Boolean)
-  .find((t) => t !== `${name}@${version}`);
+  .find((t) => t !== `${tagName}@${version}`);
 
 // No previous tag means this is the first release; the whole history is "since".
 const range = previous ? `${previous}..HEAD` : 'HEAD';

--- a/scripts/prs-since-release.ts
+++ b/scripts/prs-since-release.ts
@@ -1,0 +1,102 @@
+#!/usr/bin/env tsx
+
+/**
+ * prs-since-release.ts — every PR that touched a package since its last release.
+ *
+ * Release notes come from the changeset text, which says what changed in the
+ * author's words. That is the right thing to lead with, but it does not tell a
+ * consumer WHICH pull requests are in the version they just installed, and that
+ * is the question someone asks when a finding they reported stops appearing —
+ * or when one they depend on starts.
+ *
+ * Reads git history rather than the GitHub API: the tags and the squash-merge
+ * subjects are already local, the release job has them checked out, and an API
+ * call here would need a token and a rate-limit budget in a matrix job that runs
+ * once per package.
+ *
+ * Package tags are `<name>@<version>`, so the previous release of THIS package is
+ * found by sorting its own tags — not the repo's, which interleave every package.
+ *
+ * Usage:
+ *   tsx scripts/prs-since-release.ts <package-dir> <new-version>
+ *   tsx scripts/prs-since-release.ts packages/eslint-plugin-node-security 5.1.2
+ */
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const [dir, version] = process.argv.slice(2);
+
+if (!dir || !version) {
+  console.error('usage: prs-since-release.ts <package-dir> <new-version>');
+  process.exit(2);
+}
+
+const pkgPath = path.join(dir, 'package.json');
+if (!fs.existsSync(pkgPath)) {
+  console.error(`no package.json at ${pkgPath}`);
+  process.exit(2);
+}
+const name = JSON.parse(fs.readFileSync(pkgPath, 'utf8')).name as string;
+
+const git = (...args: string[]): string => {
+  try {
+    return execFileSync('git', args, { encoding: 'utf8' }).trim();
+  } catch {
+    return '';
+  }
+};
+
+/**
+ * The previous tag for THIS package.
+ *
+ * `--sort=-v:refname` orders by semver rather than lexically, so 5.1.10 sorts
+ * above 5.1.9 — a plain sort puts 5.1.9 last and would silently truncate the
+ * range to a single release.
+ */
+const tags = git('tag', '--list', `${name}@*`, '--sort=-v:refname')
+  .split('\n')
+  .filter(Boolean)
+  .filter((t) => t !== `${name}@${version}`);
+
+const previous = tags[0];
+
+// No previous tag means this is the first release; the whole history is "since".
+const range = previous ? `${previous}..HEAD` : 'HEAD';
+
+const log = git('log', range, '--no-merges', '--format=%s', '--', dir)
+  .split('\n')
+  .filter(Boolean);
+
+/** Squash merges end in `(#123)`; that is the PR this change arrived in. */
+const prs = new Map<string, string>();
+for (const subject of log) {
+  // The changesets bot's own "version packages" PR carries the bump and the
+  // CHANGELOG for this very release, so listing it tells the reader nothing they
+  // are not already looking at.
+  if (/^chore\(release\): version packages/.test(subject)) continue;
+  const m = subject.match(/^(.*?)\s*\(#(\d+)\)$/);
+  if (m) prs.set(m[2], m[1]);
+}
+
+if (prs.size === 0) {
+  // Silent rather than a heading with nothing under it — a release can legitimately
+  // carry only a dependency bump, and an empty section reads like a bug.
+  process.exit(0);
+}
+
+const repo = process.env.GITHUB_REPOSITORY ?? 'ofri-peretz/eslint';
+
+console.log('');
+console.log(
+  previous
+    ? `### Pull requests since ${previous.split('@').pop()}`
+    : '### Pull requests in this release',
+);
+console.log('');
+for (const [num, subject] of [...prs].sort(
+  (a, b) => Number(b[0]) - Number(a[0]),
+)) {
+  console.log(`- ${subject} — https://github.com/${repo}/pull/${num}`);
+}

--- a/scripts/prs-since-release.ts
+++ b/scripts/prs-since-release.ts
@@ -55,12 +55,10 @@ const git = (...args: string[]): string => {
  * above 5.1.9 — a plain sort puts 5.1.9 last and would silently truncate the
  * range to a single release.
  */
-const tags = git('tag', '--list', `${name}@*`, '--sort=-v:refname')
+const previous = git('tag', '--list', `${name}@*`, '--sort=-v:refname')
   .split('\n')
   .filter(Boolean)
-  .filter((t) => t !== `${name}@${version}`);
-
-const previous = tags[0];
+  .find((t) => t !== `${name}@${version}`);
 
 // No previous tag means this is the first release; the whole history is "since".
 const range = previous ? `${previous}..HEAD` : 'HEAD';
@@ -75,7 +73,7 @@ for (const subject of log) {
   // The changesets bot's own "version packages" PR carries the bump and the
   // CHANGELOG for this very release, so listing it tells the reader nothing they
   // are not already looking at.
-  if (/^chore\(release\): version packages/.test(subject)) continue;
+  if (subject.startsWith('chore(release): version packages')) continue;
   const m = subject.match(/^(.*?)\s*\(#(\d+)\)$/);
   if (m) prs.set(m[2], m[1]);
 }


### PR DESCRIPTION
## Summary

Release notes carried the changeset text and nothing else. That says what changed
in our words, which is the right thing to lead with — but it cannot answer the
question a consumer actually arrives with: **which pull requests are in the version
I just installed?**

That is the question asked by someone whose reported false positive stopped
appearing, and by anyone deciding whether an upgrade is worth the churn. This week
made it concrete: nine rule fixes shipped across two PRs, and nothing in the
release notes told a reader which.

`scripts/prs-since-release.ts` finds the package's **own** previous tag — the
repo's tags interleave every package, so a repo-wide "last release" is the wrong
boundary — and lists the squash-merge PRs that touched it since.

- Tags sort by `-v:refname`, so `5.1.10` ranks above `5.1.9`. A lexical sort puts
  `5.1.9` last and silently truncates the range to a single release, which reads
  as a quiet changelog rather than a broken script.
- Reads git, not the GitHub API: tags and subjects are already in the checkout, and
  an API call would need a token and a rate-limit budget in a matrix job that runs
  once per package.
- Skips the changesets bot's own version-packages commit, which carries the bump
  and CHANGELOG for this very release.
- Emits nothing when there are no PRs, rather than a heading with an empty list.

## Test plan

- [x] Verified against all three packages released 2026-08-23; each lists exactly
      the PRs that touched it since its previous tag
- [x] `node scripts/lint-workflows.ts` — 34 workflows pass
- [x] `oxlint` and `prettier` clean

## Not in scope

The tag race that stopped every GitHub Release on 2026-08-23 — every package
published to npm, then `gh release create` failed with "tag exists locally but has
not been pushed". #647 already fixed that with `--target`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release notes now include pull requests affecting each package since its previous release.
  * Pull-request references are automatically grouped by package and linked for easier access.
  * Release notes remain concise when no relevant pull requests are found.

* **Documentation**
  * Added release-note guidance describing how package-specific changes are identified and presented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->