### PR TITLE
fix(browser-security): a flag is not a credential

### DIFF
--- a/.changeset/jwt-storage-flag-values.md
+++ b/.changeset/jwt-storage-flag-values.md
@@ -1,0 +1,25 @@
+---
+'eslint-plugin-browser-security': patch
+---
+
+A flag is not a credential.
+
+`no-jwt-in-storage` reported `sessionStorage.setItem(AUTO_SSO_ATTEMPTED_KEY, '1')`
+— a flag meaning single sign-on had already been attempted once. The key names
+`auth`, so the key heuristic fired; the value is the string `"1"`.
+
+Found on IGNF/cartes.gouv.fr-entree-carto, a French government mapping site that
+runs this plugin. It was one of five false positives that repository's maintainers
+were being shown.
+
+The key half of this rule is a heuristic by design — it reports because the key
+names a credential, not because it saw one. That is the right default and it stays.
+What it cannot survive is a value the code writes in front of it: nobody stores a
+JWT as `"1"`. A literal boolean, number, or one of the words that spell them
+(`true`, `false`, `yes`, `no`, `on`, `off`, `null`, `undefined`) is now proof the
+value is not a bearer credential, whatever the key is called.
+
+Deliberately narrow. A short opaque string like `'a1b2c3'` is NOT exempt, because
+that could be a real secret and the exemption has to be unarguable rather than
+generous. The value check still runs first, so a literal JWT reports however
+innocuous the key is spelled.

--- a/packages/eslint-plugin-browser-security/src/rules/no-jwt-in-storage/index.ts
+++ b/packages/eslint-plugin-browser-security/src/rules/no-jwt-in-storage/index.ts
@@ -71,6 +71,35 @@ const WEB_STORAGE: ReadonlySet<string> = new Set([
   'sessionStorage',
 ]);
 
+/**
+ * A literal value that CANNOT be a bearer credential.
+ *
+ * The key-name half of this rule is a heuristic — it reports because the key
+ * names a credential, not because it saw one. That is the right default, but it
+ * cannot survive a value the code writes in front of it: nobody stores a JWT as
+ * `'1'`.
+ *
+ * IGNF/cartes.gouv.fr-entree-carto, a French government mapping site running
+ * this rule, was shown two findings on
+ * `sessionStorage.setItem(AUTO_SSO_ATTEMPTED_KEY, '1')` — a flag meaning SSO was
+ * already tried once. The key names `auth`; the value is the string "1".
+ *
+ * Deliberately narrow: booleans, numbers, and the words that spell them. A short
+ * opaque string like `'a1b2c3'` is NOT exempted, because that could be a real
+ * secret and the point here is to be unarguable rather than generous.
+ */
+const NON_CREDENTIAL_LITERAL =
+  /^(?:true|false|yes|no|on|off|null|undefined|\d+)$/i;
+
+function isProvablyNotACredential(node: TSESTree.Node | undefined): boolean {
+  if (node === undefined) return false;
+  if (node.type !== AST_NODE_TYPES.Literal) return false;
+  const { value } = node;
+  if (typeof value === 'boolean' || typeof value === 'number') return true;
+  if (typeof value === 'string') return NON_CREDENTIAL_LITERAL.test(value);
+  return false;
+}
+
 export const noJwtInStorage = createRule<RuleOptions, MessageIds>({
   name: 'no-jwt-in-storage',
   meta: {
@@ -124,10 +153,8 @@ export const noJwtInStorage = createRule<RuleOptions, MessageIds>({
     context: TSESLint.RuleContext<MessageIds, RuleOptions>,
     [options = {}],
   ) {
-    const {
-      allowInTests = true,
-      bearerPatterns = BEARER_CREDENTIAL_TERMS,
-    } = options as Options;
+    const { allowInTests = true, bearerPatterns = BEARER_CREDENTIAL_TERMS } =
+      options as Options;
     const isTestFile = isTestFilePath(context.filename);
 
     if (allowInTests && isTestFile) {
@@ -149,6 +176,11 @@ export const noJwtInStorage = createRule<RuleOptions, MessageIds>({
         valueNode !== undefined &&
         hasProvableJwtValue(valueNode, context.sourceCode);
 
+      // A value the code writes beats a guess about the key. Checked before the
+      // key heuristic, and never against `jwtValue`, so a literal that IS a JWT
+      // still reports however the key is spelled.
+      if (!jwtValue && isProvablyNotACredential(valueNode)) return;
+
       if (
         !jwtValue &&
         (key === null || !namesBearerCredential(key, bearerPatterns))
@@ -169,7 +201,11 @@ export const noJwtInStorage = createRule<RuleOptions, MessageIds>({
         if (callee.type !== AST_NODE_TYPES.MemberExpression) return;
         if (memberName(callee, context.sourceCode) !== 'setItem') return;
 
-        const storage = resolveStorageArea(callee.object, context.sourceCode, WEB_STORAGE);
+        const storage = resolveStorageArea(
+          callee.object,
+          context.sourceCode,
+          WEB_STORAGE,
+        );
         if (storage === null) return;
 
         const keyArg = node.arguments[0];
@@ -185,7 +221,11 @@ export const noJwtInStorage = createRule<RuleOptions, MessageIds>({
       AssignmentExpression(node: TSESTree.AssignmentExpression) {
         if (node.left.type !== AST_NODE_TYPES.MemberExpression) return;
 
-        const storage = resolveStorageArea(node.left.object, context.sourceCode, WEB_STORAGE);
+        const storage = resolveStorageArea(
+          node.left.object,
+          context.sourceCode,
+          WEB_STORAGE,
+        );
         if (storage === null) return;
 
         // `localStorage.token = v` — the identifier IS the key.

--- a/packages/eslint-plugin-browser-security/src/rules/no-jwt-in-storage/no-jwt-in-storage.test.ts
+++ b/packages/eslint-plugin-browser-security/src/rules/no-jwt-in-storage/no-jwt-in-storage.test.ts
@@ -69,13 +69,19 @@ ruleTester.run('no-jwt-in-storage', noJwtInStorage, {
     {
       code: `localStorage.setItem('jwt', token);`,
       errors: [
-        { messageId: 'jwtInStorage', data: { key: 'jwt', storage: 'localStorage' } },
+        {
+          messageId: 'jwtInStorage',
+          data: { key: 'jwt', storage: 'localStorage' },
+        },
       ],
     },
     {
       code: `localStorage.setItem('token', authToken);`,
       errors: [
-        { messageId: 'jwtInStorage', data: { key: 'token', storage: 'localStorage' } },
+        {
+          messageId: 'jwtInStorage',
+          data: { key: 'token', storage: 'localStorage' },
+        },
       ],
     },
     {
@@ -118,7 +124,10 @@ ruleTester.run('no-jwt-in-storage', noJwtInStorage, {
     {
       code: `sessionStorage.setItem('jwt', token);`,
       errors: [
-        { messageId: 'jwtInStorage', data: { key: 'jwt', storage: 'sessionStorage' } },
+        {
+          messageId: 'jwtInStorage',
+          data: { key: 'jwt', storage: 'sessionStorage' },
+        },
       ],
     },
     {
@@ -134,21 +143,30 @@ ruleTester.run('no-jwt-in-storage', noJwtInStorage, {
     {
       code: `localStorage.setItem(k[0], 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c');`,
       errors: [
-        { messageId: 'jwtInStorage', data: { key: '<dynamic>', storage: 'localStorage' } },
+        {
+          messageId: 'jwtInStorage',
+          data: { key: '<dynamic>', storage: 'localStorage' },
+        },
       ],
     },
     // Value proof, innocuous key
     {
       code: `localStorage.setItem('data', '${EXAMPLE_JWT}');`,
       errors: [
-        { messageId: 'jwtInStorage', data: { key: 'data', storage: 'localStorage' } },
+        {
+          messageId: 'jwtInStorage',
+          data: { key: 'data', storage: 'localStorage' },
+        },
       ],
     },
     // Direct assignment
     {
       code: `localStorage['token'] = jwt;`,
       errors: [
-        { messageId: 'jwtInStorage', data: { key: 'token', storage: 'localStorage' } },
+        {
+          messageId: 'jwtInStorage',
+          data: { key: 'token', storage: 'localStorage' },
+        },
       ],
     },
     {
@@ -163,7 +181,10 @@ ruleTester.run('no-jwt-in-storage', noJwtInStorage, {
     {
       code: `localStorage.setItem('bearer', authBearer);`,
       errors: [
-        { messageId: 'jwtInStorage', data: { key: 'bearer', storage: 'localStorage' } },
+        {
+          messageId: 'jwtInStorage',
+          data: { key: 'bearer', storage: 'localStorage' },
+        },
       ],
     },
     // Test file with allowInTests: false
@@ -172,7 +193,10 @@ ruleTester.run('no-jwt-in-storage', noJwtInStorage, {
       filename: 'auth.test.ts',
       options: [{ allowInTests: false }],
       errors: [
-        { messageId: 'jwtInStorage', data: { key: 'jwt', storage: 'localStorage' } },
+        {
+          messageId: 'jwtInStorage',
+          data: { key: 'jwt', storage: 'localStorage' },
+        },
       ],
     },
     // Unresolvable identifier key falls back to its spelling — the only
@@ -189,7 +213,10 @@ ruleTester.run('no-jwt-in-storage', noJwtInStorage, {
     {
       code: `localStorage.jwt = tokenValue;`,
       errors: [
-        { messageId: 'jwtInStorage', data: { key: 'jwt', storage: 'localStorage' } },
+        {
+          messageId: 'jwtInStorage',
+          data: { key: 'jwt', storage: 'localStorage' },
+        },
       ],
     },
     {
@@ -273,7 +300,10 @@ ruleTester.run('lock: the global may be spelled out', noJwtInStorage, {
     {
       code: 'globalThis.sessionStorage["jwt"] = value;',
       errors: [
-        { messageId: 'jwtInStorage', data: { key: 'jwt', storage: 'sessionStorage' } },
+        {
+          messageId: 'jwtInStorage',
+          data: { key: 'jwt', storage: 'sessionStorage' },
+        },
       ],
     },
   ],
@@ -315,7 +345,10 @@ ruleTester.run('lock: computed and optional-chained sinks', noJwtInStorage, {
     {
       code: `sessionStorage?.['setItem']('jwt', t);`,
       errors: [
-        { messageId: 'jwtInStorage', data: { key: 'jwt', storage: 'sessionStorage' } },
+        {
+          messageId: 'jwtInStorage',
+          data: { key: 'jwt', storage: 'sessionStorage' },
+        },
       ],
     },
   ],
@@ -341,7 +374,10 @@ ruleTester.run('lock: JWT value evidence', noJwtInStorage, {
     {
       code: `localStorage.setItem('x', 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhIjoxfQ.sig');`,
       errors: [
-        { messageId: 'jwtInStorage', data: { key: 'x', storage: 'localStorage' } },
+        {
+          messageId: 'jwtInStorage',
+          data: { key: 'x', storage: 'localStorage' },
+        },
       ],
     },
     // Resolved through a binding.
@@ -351,14 +387,20 @@ ruleTester.run('lock: JWT value evidence', noJwtInStorage, {
         localStorage.setItem('x', value);
       `,
       errors: [
-        { messageId: 'jwtInStorage', data: { key: 'x', storage: 'localStorage' } },
+        {
+          messageId: 'jwtInStorage',
+          data: { key: 'x', storage: 'localStorage' },
+        },
       ],
     },
     // Expression-free template.
     {
       code: `localStorage.setItem('x', \`${EXAMPLE_JWT}\`);`,
       errors: [
-        { messageId: 'jwtInStorage', data: { key: 'x', storage: 'localStorage' } },
+        {
+          messageId: 'jwtInStorage',
+          data: { key: 'x', storage: 'localStorage' },
+        },
       ],
     },
     // A call into a module that mints JWTs.
@@ -368,7 +410,10 @@ ruleTester.run('lock: JWT value evidence', noJwtInStorage, {
         localStorage.setItem('x', jwt.sign(claims, key));
       `,
       errors: [
-        { messageId: 'jwtInStorage', data: { key: 'x', storage: 'localStorage' } },
+        {
+          messageId: 'jwtInStorage',
+          data: { key: 'x', storage: 'localStorage' },
+        },
       ],
     },
   ],
@@ -462,7 +507,9 @@ ruleTester.run('lock: adversarial wave', noJwtInStorage, {
       code: `const { crypto: store } = window; store.setItem('access_token', t);`,
     },
     // A plain (non-destructuring) local binding named after the global.
-    { code: `const localStorage = fakeStore; localStorage.setItem('access_token', t);` },
+    {
+      code: `const localStorage = fakeStore; localStorage.setItem('access_token', t);`,
+    },
     // A composed key behind a binding that resolves to nothing.
     { code: `const K = a() + b(); localStorage.setItem(K, t);` },
     // Both sides of a concatenated key are unresolvable.
@@ -551,22 +598,67 @@ ruleTester.run('lock: adversarial wave', noJwtInStorage, {
  * lock in `no-cookie-auth-tokens`. The value path (`hasProvableJwtValue`) is
  * independent of the list and keeps reporting either way.
  */
-ruleTester.run('lock: bearerPatterns replaces the default vocabulary', noJwtInStorage, {
-  valid: [
-    {
-      code: `localStorage.setItem('access_token', t);`,
-      options: [{ bearerPatterns: ['handle'] }],
-    },
-  ],
-  invalid: [
-    {
-      code: `localStorage.setItem('handle', h);`,
-      options: [{ bearerPatterns: ['handle'] }],
-      errors: [{ messageId: 'jwtInStorage' }],
-    },
-    {
-      code: `localStorage.setItem('access_token', t);`,
-      errors: [{ messageId: 'jwtInStorage' }],
-    },
-  ],
+ruleTester.run(
+  'lock: bearerPatterns replaces the default vocabulary',
+  noJwtInStorage,
+  {
+    valid: [
+      {
+        code: `localStorage.setItem('access_token', t);`,
+        options: [{ bearerPatterns: ['handle'] }],
+      },
+    ],
+    invalid: [
+      {
+        code: `localStorage.setItem('handle', h);`,
+        options: [{ bearerPatterns: ['handle'] }],
+        errors: [{ messageId: 'jwtInStorage' }],
+      },
+      {
+        code: `localStorage.setItem('access_token', t);`,
+        errors: [{ messageId: 'jwtInStorage' }],
+      },
+    ],
+  },
+);
+
+describe('a flag is not a credential', () => {
+  /**
+   * Provenance: IGNF/cartes.gouv.fr-entree-carto — a French government mapping
+   * site that RUNS this rule — src/composables/useAuthentication.js:34 and
+   * src/services/ServiceBase.js:188.
+   *
+   * The key names `auth`, so the key heuristic fires. The value is the string
+   * "1", a flag meaning SSO was already attempted. Nobody stores a JWT as "1",
+   * and a value the code writes beats a guess about what the key is called.
+   */
+  ruleTester.run('valid - literal flag values', noJwtInStorage, {
+    valid: [
+      "sessionStorage.setItem('auth:auto-sso-attempted', '1');",
+      "sessionStorage.setItem('keycloak:silent-sso-blocked', '1');",
+      "localStorage.setItem('authRetries', '3');",
+      "sessionStorage.setItem('auth:seen', true);",
+      "localStorage.setItem('token:checked', 'false');",
+      "localStorage.setItem('bearer:count', 42);",
+    ],
+    invalid: [],
+  });
+
+  /** The guard must not reach anything that is actually a credential. */
+  ruleTester.run('invalid - real credentials still report', noJwtInStorage, {
+    valid: [],
+    invalid: [
+      { code: "localStorage.setItem('token', jwt);", errors: 1 },
+      {
+        code: "localStorage.setItem('auth:token', resp.accessToken);",
+        errors: 1,
+      },
+      // A provable JWT reports however innocuous the key is spelled — the value
+      // check runs before the guard, not instead of it.
+      {
+        code: "localStorage.setItem('flag', 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.abc');",
+        errors: 1,
+      },
+    ],
+  });
 });

--- a/packages/eslint-plugin-browser-security/src/rules/no-jwt-in-storage/no-jwt-in-storage.test.ts
+++ b/packages/eslint-plugin-browser-security/src/rules/no-jwt-in-storage/no-jwt-in-storage.test.ts
@@ -659,6 +659,10 @@ describe('a flag is not a credential', () => {
         code: "localStorage.setItem('flag', 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.abc');",
         errors: 1,
       },
+      // A `null` literal is neither boolean, number, nor string, so it falls past
+      // the exemption and the key heuristic decides. Conservative on purpose: the
+      // exemption only covers values it can positively identify as harmless.
+      { code: "localStorage.setItem('auth:token', null);", errors: 1 },
     ],
   });
 });

--- a/packages/eslint-plugin-browser-security/src/rules/no-jwt-in-storage/partition-matrix.test.ts
+++ b/packages/eslint-plugin-browser-security/src/rules/no-jwt-in-storage/partition-matrix.test.ts
@@ -73,10 +73,7 @@ function reportingRules(code: string): string[] {
 /** shape → the single rule that owns it */
 const MATRIX: ReadonlyArray<readonly [string, RuleName]> = [
   // --- the 4-way storage cluster -------------------------------------------
-  [
-    `localStorage.setItem('auth_token', res.data.token);`,
-    'no-jwt-in-storage',
-  ],
+  [`localStorage.setItem('auth_token', res.data.token);`, 'no-jwt-in-storage'],
   [
     `sessionStorage.setItem('access_token', res.data.token);`,
     'no-jwt-in-storage',


### PR DESCRIPTION
## Summary

`no-jwt-in-storage` reported this:

```js
sessionStorage.setItem(AUTO_SSO_ATTEMPTED_KEY, '1');
```

A flag meaning single sign-on had already been attempted once. The key names
`auth`, so the key heuristic fired. The value is the string `"1"`.

**This one was already in front of a customer.** It was found on
[IGNF/cartes.gouv.fr-entree-carto](https://github.com/IGNF/cartes.gouv.fr-entree-carto)
— France's Institut National de l'Information Géographique et Forestière, a
government mapping site that runs this plugin — where it was one of five false
positives its maintainers are being shown today. Every other false positive fixed
this week was found by scanning strangers; this one is live at a consumer.

## The fix

The key half of this rule is a heuristic by design: it reports because the key
*names* a credential, not because it saw one. That is the right default and it
stays. What it cannot survive is a value the code writes in front of it — nobody
stores a JWT as `"1"`.

A literal boolean, number, or one of the words that spell them (`true`, `false`,
`yes`, `no`, `on`, `off`, `null`, `undefined`) is now proof the value is not a
bearer credential, whatever the key is called.

**Deliberately narrow.** A short opaque string like `'a1b2c3'` is *not* exempt —
that could be a real secret, and an exemption here has to be unarguable rather than
generous. The value check still runs first, so a literal JWT reports however
innocuous the key is spelled.

| input | before | after |
| --- | --- | --- |
| `setItem('auth:auto-sso-attempted', '1')` | reports | quiet |
| `setItem('authRetries', '3')` | reports | quiet |
| `setItem('auth:seen', true)` | reports | quiet |
| `setItem('token', jwt)` | reports | reports |
| `setItem('auth:token', resp.accessToken)` | reports | reports |
| `setItem('flag', 'eyJhbG….eyJzdWI….sig')` | reports | reports |

## Test plan

- [x] Regression tests pin both directions, including the literal-JWT-under-an-
      innocuous-key case so the guard cannot swallow a real finding
- [x] 2,897 `browser-security` tests pass
- [x] `rule-audit:gate` — 121 rules, no regressions
- [x] Verified against the customer's own files: `useAuthentication.js` and
      `ServiceBase.js` both report zero

## Still open at that customer

Three findings remain unread, and the other confirmed class —
`no-unsafe-buffer-alloc` calling `new Uint8Array(4 + data.length)` a CWE-789
"allocation size read off the wire" — is not fixed here. Until both are done they
stay `hold` in the customer monitor, which is the gate: we approach a customer only
when we know we expose it to no false positives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)