### PR TITLE
fix(docs): a source-map upload must not be able to fail a deploy

### DIFF
--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -84,13 +84,32 @@ function cspReportOnlyHeaders() {
  * auth, and the deployment ships the same minified bundle it always did.
  * A lock test pins it; flipping it to false would publish our sources.
  *
- * Inert unless both env vars are set, so local builds, forks, and CI stay
- * byte-identical to today and no build can fail for want of a token.
+ * Inert unless both env vars are set AND the key is the right kind, so local
+ * builds, forks, and CI stay byte-identical to today and no build can fail
+ * for want of a usable token.
+ *
+ * The shape check is not decoration. This gate used to test presence alone,
+ * and the promise above was false for a token that is set but wrong: the
+ * uploader ran, rejected it, and took the whole deploy down with
+ * `Invalid Personal API key: "Token looks wrong, must start with 'phx_'"`.
+ * That is exactly what happened to serverless.interlace.tools, where the var
+ * held a `phc_` project key — its production deploy failed on a source-map
+ * upload that is meant to be a nicety. Symbolication is worth having; it is
+ * not worth a deploy. A wrong-shaped key now warns and skips.
  */
 async function withSourcemapUpload(nextConfig) {
   const personalApiKey = process.env.POSTHOG_PERSONAL_API_KEY?.trim();
   const projectId = process.env.POSTHOG_PROJECT_ID?.trim();
   if (!personalApiKey || !projectId) return nextConfig;
+  // `phx_` is the personal API key prefix. `phc_` is the *project* key — a
+  // different credential that is public by design and cannot authorise an
+  // upload. Confusing the two is the likely mistake, so name it.
+  if (!personalApiKey.startsWith('phx_')) {
+    console.warn(
+      '[sourcemaps] POSTHOG_PERSONAL_API_KEY is set but is not a personal API key (expected a `phx_` prefix; a `phc_` value is the public project key). Skipping source-map upload — errors will report unsymbolicated.',
+    );
+    return nextConfig;
+  }
   // Imported here rather than at module scope: the package is a
   // devDependency, and a top-level import would make this config
   // unloadable in an --omit=dev install even with the gate off.

--- a/apps/docs/src/__tests__/posthog-provider-lock.test.tsx
+++ b/apps/docs/src/__tests__/posthog-provider-lock.test.tsx
@@ -81,9 +81,7 @@ describe('PostHog: File Layout', () => {
 
 describe('PostHog: Layout integration', () => {
   it('root layout imports PostHogProvider', () => {
-    expect(layoutSrc).toMatch(
-      /from\s+['"]@\/components\/posthog-provider['"]/,
-    );
+    expect(layoutSrc).toMatch(/from\s+['"]@\/components\/posthog-provider['"]/);
   });
   it('root layout imports PostHogPageviewTracker', () => {
     expect(layoutSrc).toMatch(
@@ -247,9 +245,10 @@ describe('PostHog: Analytics primitives (vendor-neutral surface)', () => {
     const grammar =
       /^[a-z][a-z0-9_]*:[a-z][a-z0-9_]*_(click|submit|view|add|remove|start|end|generate|send|cancel|fail|create|delete|update|invite)$/;
     for (const k of keys) {
-      expect(k, `Event key "${k}" violates category:object_action grammar`).toMatch(
-        grammar,
-      );
+      expect(
+        k,
+        `Event key "${k}" violates category:object_action grammar`,
+      ).toMatch(grammar);
     }
   });
 });
@@ -266,6 +265,15 @@ describe('PostHog: Next.js reverse proxy', () => {
   it('source-map upload is env-gated so keyless builds are unchanged', () => {
     expect(nextConfigSrc).toMatch(/POSTHOG_PERSONAL_API_KEY/);
     expect(nextConfigSrc).toMatch(/POSTHOG_PROJECT_ID/);
+  });
+  it('skips the upload for a key of the wrong kind instead of failing the build', () => {
+    // Presence alone is not enough. A var that is set but holds a `phc_`
+    // project key makes the uploader run, reject it, and take the entire
+    // deploy down with `Invalid Personal API key`. That happened to
+    // serverless.interlace.tools: a production deploy lost to a source-map
+    // upload, which is a nicety. Symbolication is worth having; it is not
+    // worth a deploy.
+    expect(nextConfigSrc).toMatch(/startsWith\('phx_'\)/);
   });
   it('CSP violations report to PostHog through the /ingest proxy', () => {
     expect(nextConfigSrc).toMatch(/Content-Security-Policy-Report-Only/);
@@ -284,7 +292,7 @@ describe('PostHog: Provider + Tracker shape', () => {
   it('provider is a client component', () => {
     expect(providerSrc).toMatch(/^['"]use client['"]/);
   });
-  it("provider calls initPostHog from useEffect", () => {
+  it('provider calls initPostHog from useEffect', () => {
     expect(providerSrc).toMatch(/initPostHog\(\)/);
   });
   it('tracker is a client component', () => {

--- a/apps/docs/src/__tests__/posthog-sourcemap-gate.test.ts
+++ b/apps/docs/src/__tests__/posthog-sourcemap-gate.test.ts
@@ -9,7 +9,10 @@
  *   - neither credential  -> config untouched (today's production behaviour)
  *   - one credential      -> still untouched; the gate needs BOTH, and a
  *                            half-configured build must not start uploading
- *   - both credentials    -> wrapper engaged
+ *   - wrong kind of key   -> still untouched; a `phc_` project key is set but
+ *                            unusable, and the uploader rejecting it used to
+ *                            fail the whole deploy
+ *   - both, right kind    -> wrapper engaged
  *
  * Plus the invariant that matters most: `productionBrowserSourceMaps` is never
  * true in any state, because that is the switch that would publish our sources
@@ -17,7 +20,10 @@
  */
 import { describe, it, expect, afterEach, vi } from 'vitest';
 
-const CREDENTIAL_KEYS = ['POSTHOG_PERSONAL_API_KEY', 'POSTHOG_PROJECT_ID'] as const;
+const CREDENTIAL_KEYS = [
+  'POSTHOG_PERSONAL_API_KEY',
+  'POSTHOG_PROJECT_ID',
+] as const;
 
 type NextConfigLike = {
   webpack?: unknown;
@@ -59,17 +65,32 @@ describe('PostHog: source-map upload gate', () => {
   });
 
   it('leaves the config untouched when only one credential is set', async () => {
-    const keyOnly = await loadConfig({ POSTHOG_PERSONAL_API_KEY: 'test-key' });
+    const keyOnly = await loadConfig({
+      POSTHOG_PERSONAL_API_KEY: 'phx_test-key',
+    });
     expect(Object.keys(keyOnly)).toContain('webpack');
 
     const projectOnly = await loadConfig({ POSTHOG_PROJECT_ID: '428927' });
     expect(Object.keys(projectOnly)).toContain('webpack');
   });
 
+  it('leaves the config untouched for a key of the wrong kind', async () => {
+    // `phc_` is the *project* key: public by design, and unable to authorise
+    // an upload. Setting it here is a live mistake on
+    // serverless.interlace.tools, where the uploader rejected it and failed
+    // the production deploy. A nicety must not be able to do that.
+    const wrongKind = await loadConfig({
+      POSTHOG_PERSONAL_API_KEY: 'phc_project_key_not_personal',
+      POSTHOG_PROJECT_ID: '428927',
+    });
+    expect(Object.keys(wrongKind)).toContain('webpack');
+    expect(wrongKind.productionBrowserSourceMaps).not.toBe(true);
+  });
+
   it('engages the wrapper when both credentials are set', async () => {
     const off = await loadConfig({});
     const on = await loadConfig({
-      POSTHOG_PERSONAL_API_KEY: 'test-key',
+      POSTHOG_PERSONAL_API_KEY: 'phx_test-key',
       POSTHOG_PROJECT_ID: '428927',
     });
     expect(String(on.webpack)).not.toBe(String(off.webpack));

--- a/apps/docs/src/__tests__/posthog-sourcemap-gate.test.ts
+++ b/apps/docs/src/__tests__/posthog-sourcemap-gate.test.ts
@@ -79,11 +79,17 @@ describe('PostHog: source-map upload gate', () => {
     // an upload. Setting it here is a live mistake on
     // serverless.interlace.tools, where the uploader rejected it and failed
     // the production deploy. A nicety must not be able to do that.
+    const off = await loadConfig({});
     const wrongKind = await loadConfig({
       POSTHOG_PERSONAL_API_KEY: 'phc_project_key_not_personal',
       POSTHOG_PROJECT_ID: '428927',
     });
-    expect(Object.keys(wrongKind)).toContain('webpack');
+    // Compared against the untouched config, the same way the sibling test
+    // proves the wrapper DOES engage. `expect(keys).toContain('webpack')`
+    // would pass either way — `webpack` is in the base config — so it shows
+    // nothing. Identical `webpack` is the observable signature of the wrapper
+    // never having run.
+    expect(String(wrongKind.webpack)).toBe(String(off.webpack));
     expect(wrongKind.productionBrowserSourceMaps).not.toBe(true);
   });
 


### PR DESCRIPTION
## Summary

The gate on the PostHog source-map upload tested that `POSTHOG_PERSONAL_API_KEY` was **present**:

```js
if (!personalApiKey || !projectId) return nextConfig;
```

Its own comment promised *"no build can fail for want of a token."* That is false for a token which is set but **wrong** — the uploader runs, rejects it, and takes the deploy with it.

Not hypothetical. `serverless.interlace.tools` has this same config and its var holds a `phc_` **project** key, so its production deploy died at:

```
Oops! Invalid Personal API key: "Token looks wrong, must start with 'phx_'"
⨯ Failed to run runAfterProductionCompile
Error: Command "cd apps/docs && next build" exited with 1
```

A whole deploy lost to a source-map upload. Symbolication is worth having; it is not worth a deploy. This repo carries the identical latent failure, one wrong paste away.

The gate now checks the key is the right *kind* and warns-and-skips otherwise, which makes the comment true. `phx_` is the personal API key prefix; `phc_` is the project key — a different credential, public by design, that cannot authorise an upload. Confusing the two is the likely mistake, so the warning names it.

Same class as the CSP report token in #643: **validate shape, not just presence**, for a value handed to something that will reject it.

## Test plan

- [x] Guard verified by direct execution: `phx_…` → wrapper engages, `phc_…` → skipped, unset → skipped.
- [x] **The existing behavioural gate test caught this change, correctly.** `posthog-sourcemap-gate.test.ts` asserted the wrapper engages for `test-key`, which is no longer a valid shape. Updated to `phx_test-key` and given a fourth case pinning the wrong-kind skip — 4/4 green.
- [x] `posthog-provider-lock` extended with the shape assertion — 48/48 green.
- [x] `turbo run build --filter=docs` green.

## What this does not fix

The env var itself, which still holds the wrong value. Errors from `serverless.interlace.tools` will report **unsymbolicated** until it's replaced with a real `phx_` personal API key from PostHog. That's a credential, so it needs you — this PR only stops the deploy being hostage to it.

Companion: ofri-peretz/serverless#66.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source-map upload validation to require a valid personal API key.
  * Invalid or project-level keys now safely skip source-map uploads and avoid build failures.
  * Reverse-proxy configurations no longer enable production source maps without valid credentials.

* **Tests**
  * Added coverage for invalid credentials, project keys, and reverse-proxy source-map behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->