### PR TITLE
fix(ci): pin changesets/action to a real v1 — nothing could publish

### DIFF
--- a/.github/workflows/changesets-pr.yml
+++ b/.github/workflows/changesets-pr.yml
@@ -123,7 +123,22 @@ jobs:
       - name: Open / refresh Version PR
         id: changesets
         if: steps.pending.outputs.releases != '0'
-        uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v1
+        # PINNED TO v1 ON PURPOSE, and the SHA is the thing that matters.
+        #
+        # changesets/action v2 requires Changesets CLI v3 and refuses to run
+        # against v2 — "This version of the Changesets action is designed to work
+        # with Changesets CLI v3". This repo is on @changesets/cli ^2.31.1.
+        #
+        # #579 bumped this SHA across that major as part of a 10-action group
+        # update and left the `# v1` comment untouched, so the pin READ as v1
+        # while resolving to v2.1.1. The Version PR then stopped being created —
+        # silently, because a missing PR looks identical to "nothing to release".
+        # Two customer-facing false-positive fixes sat unpublishable behind it.
+        #
+        # Moving to v2 means upgrading the CLI to v3 first. Until then this stays
+        # on v1.9.0, and the comment states the constraint so the next bump has to
+        # confront it rather than sail past it.
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           # `version` runs `npm run changeset:version`, which bumps versions
           # AND regenerates the lockfile so the PR diff is complete.


### PR DESCRIPTION
## Summary

**Nothing can publish right now.** The Version Packages PR stopped being created,
and six changesets have accumulated on `main` behind it — including the two
customer-facing false-positive fixes ([#651](https://github.com/ofri-peretz/eslint/pull/651),
[#654](https://github.com/ofri-peretz/eslint/pull/654)) for a French government
site that is being shown both of them today.

`changesets-pr.yml` has been failing since 17:03 with:

> This version of the Changesets action is designed to work with Changesets CLI
> v3. Changesets CLI v2 is not supported; use Changesets action v1 instead.

This repo is on `@changesets/cli ^2.31.1`.

## Cause

The workflow read as pinned to v1:

```yaml
uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v1
```

That SHA is **v2.1.1**. #579 bumped it across a major as part of a 10-action group
update and left the `# v1` comment untouched, so the pin looked correct in review
and in every subsequent read of the file.

## Why it went unnoticed

A missing Version PR is indistinguishable from "nothing to release". The workflow
failed, no PR appeared, and the repo looked exactly as it does on a quiet day —
the same failure shape as a lint harness reporting zero findings because it was
wired to zero rules.

## Fix

Pinned to **v1.9.0** by commit SHA, with the CLI constraint written beside it so
the next automated bump has to confront it rather than sail past it. Moving to v2
requires upgrading the CLI to v3 first, which is its own change with its own risk.

## Test plan

- [x] `node scripts/lint-workflows.ts` — 34 workflows pass
- [x] `changesets/action` appears in no other workflow
- [x] Pinned SHA verified against the tag: `a45c4d5` is `v1.9.0`; the previous
      `8488615` reports `"version": "2.1.1"` in its own `package.json`
- [ ] Confirmed by the Version PR reappearing after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)