### PR TITLE
chore(scripts): gate that every detection-table entry is exercised by a test

### DIFF
--- a/.agent/detection-list-coverage-debt.json
+++ b/.agent/detection-list-coverage-debt.json
@@ -20,10 +20,13 @@
     "trackingallowed"
   ],
   "packages/eslint-plugin-conventions/src/rules/conventions/analytics-event-naming.ts#ACTION_VERBS": [
+    "add",
     "cancel",
     "click",
     "create",
     "delete",
+    "end",
+    "fail",
     "generate",
     "invite",
     "remove",
@@ -42,7 +45,8 @@
     "NOTICE",
     "PATENTS",
     "README",
-    "SECURITY"
+    "SECURITY",
+    "VERSION"
   ],
   "packages/eslint-plugin-express-security/src/rules/no-exposed-debug-endpoints/index.ts#DEFAULT_DEBUG_PATHS": [
     "/__debug__",
@@ -90,26 +94,13 @@
     "withdraw"
   ],
   "packages/eslint-plugin-express-security/src/rules/require-route-authentication/index.ts#DEFAULT_PUBLIC_PATHS": [
-    "activation",
-    "assets",
-    "callback",
     "confirm",
-    "docs",
-    "favicon",
     "forgot",
-    "livez",
     "logout",
-    "oauth",
-    "openapi",
-    "readyz",
-    "robots",
     "sign-in",
     "sign-up",
     "signin",
     "signup",
-    "sso",
-    "status",
-    "swagger",
     "verify"
   ],
   "packages/eslint-plugin-lambda-security/src/rules/no-exposed-debug-endpoints/index.ts#DEFAULT_DEBUG_PATHS": [
@@ -142,6 +133,20 @@
     "entity",
     "model",
     "models"
+  ],
+  "packages/eslint-plugin-modularity/src/rules/no-external-api-calls-in-utils.ts#DEFAULT_HTTP_MODULES": [
+    "axios",
+    "got",
+    "http",
+    "http2",
+    "https",
+    "ky",
+    "needle",
+    "node-fetch",
+    "phin",
+    "request",
+    "superagent",
+    "undici"
   ],
   "packages/eslint-plugin-modularity/src/rules/no-external-api-calls-in-utils.ts#DEFAULT_NETWORK_METHODS": [
     "all",
@@ -548,6 +553,13 @@
   "packages/eslint-plugin-secure-coding/src/rules/require-backend-authorization/index.ts#DEFAULT_BROWSER_GLOBALS": [
     "navigator",
     "sessionStorage"
+  ],
+  "packages/eslint-plugin-secure-coding/src/rules/require-backend-authorization/index.ts#DEFAULT_SERVER_MODULES": [
+    "@hapi/hapi",
+    "@nestjs/core",
+    "fastify",
+    "https",
+    "koa"
   ],
   "packages/eslint-plugin-secure-coding/src/rules/require-secure-defaults/index.ts#DEFAULT_COOKIE_ATTRIBUTES": [
     "expires",

--- a/.agent/detection-list-coverage-debt.json
+++ b/.agent/detection-list-coverage-debt.json
@@ -1,0 +1,556 @@
+{
+  "packages/eslint-plugin-browser-security/src/rules/no-client-side-auth-logic/index.ts#DEFAULT_AUTH_KEYWORDS": [
+    "isAuthenticated"
+  ],
+  "packages/eslint-plugin-browser-security/src/rules/no-innerhtml/index.ts#DEFAULT_SANITIZERS": [
+    "sanitizeHtml"
+  ],
+  "packages/eslint-plugin-browser-security/src/rules/no-missing-csrf-protection/index.ts#DEFAULT_CSRF_MIDDLEWARE_PATTERNS": [
+    "checkCsrf",
+    "validateCsrf"
+  ],
+  "packages/eslint-plugin-browser-security/src/rules/no-missing-csrf-protection/index.ts#CSRF_MODULES": [
+    "@dr.pogodin/csurf",
+    "csrf-csrf",
+    "edge-csrf",
+    "tiny-csrf"
+  ],
+  "packages/eslint-plugin-browser-security/src/rules/no-tracking-without-consent/index.ts#DEFAULT_CONSENT_IDENTIFIERS": [
+    "optin",
+    "trackingallowed"
+  ],
+  "packages/eslint-plugin-conventions/src/rules/conventions/analytics-event-naming.ts#ACTION_VERBS": [
+    "cancel",
+    "click",
+    "create",
+    "delete",
+    "generate",
+    "invite",
+    "remove",
+    "send",
+    "start",
+    "submit",
+    "update",
+    "view"
+  ],
+  "packages/eslint-plugin-conventions/src/rules/conventions/filename-case.ts#DEFAULT_ALLOWED_UPPERCASE_FILES": [
+    "AUTHORS",
+    "CHANGELOG",
+    "CONTRIBUTING",
+    "COPYING",
+    "LICENSE",
+    "NOTICE",
+    "PATENTS",
+    "README",
+    "SECURITY"
+  ],
+  "packages/eslint-plugin-express-security/src/rules/no-exposed-debug-endpoints/index.ts#DEFAULT_DEBUG_PATHS": [
+    "/__debug__",
+    "/_admin"
+  ],
+  "packages/eslint-plugin-express-security/src/rules/no-idor-resource-access/index.ts#DEFAULT_LOOKUP_METHODS": [
+    "deleteById",
+    "findByIdAndRemove",
+    "findByIdAndUpdate",
+    "findFirst",
+    "getById",
+    "replaceOne",
+    "updateOne"
+  ],
+  "packages/eslint-plugin-express-security/src/rules/no-missing-csrf-protection/index.ts#DEFAULT_CSRF_MIDDLEWARE_PATTERNS": [
+    "checkCsrf",
+    "csrfToken",
+    "csurf",
+    "validateCsrf",
+    "verifyCsrfToken"
+  ],
+  "packages/eslint-plugin-express-security/src/rules/require-express-body-parser-limits/index.ts#DEFAULT_EXCESSIVE_LIMITS": [
+    "500MB",
+    "500mb"
+  ],
+  "packages/eslint-plugin-express-security/src/rules/require-rate-limiting/index.ts#RATE_LIMIT_PACKAGES": [
+    "expressBrute",
+    "expressRateLimit",
+    "slowDown"
+  ],
+  "packages/eslint-plugin-express-security/src/rules/require-route-authentication/index.ts#DEFAULT_CRITICAL_PATHS": [
+    "2fa",
+    "api-key",
+    "apikey",
+    "backup",
+    "charge",
+    "deploy",
+    "export",
+    "mfa",
+    "migrate",
+    "private",
+    "refund",
+    "restore",
+    "role",
+    "withdraw"
+  ],
+  "packages/eslint-plugin-express-security/src/rules/require-route-authentication/index.ts#DEFAULT_PUBLIC_PATHS": [
+    "activation",
+    "assets",
+    "callback",
+    "confirm",
+    "docs",
+    "favicon",
+    "forgot",
+    "livez",
+    "logout",
+    "oauth",
+    "openapi",
+    "readyz",
+    "robots",
+    "sign-in",
+    "sign-up",
+    "signin",
+    "signup",
+    "sso",
+    "status",
+    "swagger",
+    "verify"
+  ],
+  "packages/eslint-plugin-lambda-security/src/rules/no-exposed-debug-endpoints/index.ts#DEFAULT_DEBUG_PATHS": [
+    "/_admin",
+    "/health",
+    "/test"
+  ],
+  "packages/eslint-plugin-lambda-security/src/rules/no-hardcoded-credentials-sdk/index.ts#CREDENTIAL_PROPERTY_NAMES": [
+    "awsAccessKeyId",
+    "awsSecretAccessKey"
+  ],
+  "packages/eslint-plugin-lambda-security/src/rules/no-missing-authorization-check/index.ts#AUTHORIZATION_CHECK_PATTERNS": [
+    "principalId",
+    "requestContext.identity",
+    "scope"
+  ],
+  "packages/eslint-plugin-lambda-security/src/rules/no-unvalidated-event-body/index.ts#DANGEROUS_EVENT_PROPERTIES": [
+    "headers",
+    "multiValueHeaders",
+    "multiValueQueryStringParameters",
+    "rawPath",
+    "rawQueryString"
+  ],
+  "packages/eslint-plugin-modularity/src/rules/ddd-anemic-domain-model.ts#DEFAULT_DOMAIN_PATHS": [
+    "aggregate",
+    "aggregates",
+    "domain",
+    "domains",
+    "entities",
+    "entity",
+    "model",
+    "models"
+  ],
+  "packages/eslint-plugin-modularity/src/rules/no-external-api-calls-in-utils.ts#DEFAULT_NETWORK_METHODS": [
+    "all",
+    "delete",
+    "fetch",
+    "get",
+    "head",
+    "options",
+    "patch",
+    "post",
+    "put",
+    "request",
+    "stream"
+  ],
+  "packages/eslint-plugin-mongodb-security/src/rules/no-unsafe-populate/index.ts#USER_INPUT_PATTERNS": [
+    "ctx.params",
+    "ctx.query",
+    "ctx.request.body",
+    "req.params",
+    "request.body",
+    "request.params",
+    "request.query"
+  ],
+  "packages/eslint-plugin-mongodb-security/src/rules/no-unsafe-query/index.ts#QUERY_METHODS": [
+    "findByIdAndDelete",
+    "findByIdAndUpdate",
+    "findOneAndReplace",
+    "updateMany"
+  ],
+  "packages/eslint-plugin-mongodb-security/src/rules/no-unsafe-query/index.ts#USER_INPUT_PATTERNS": [
+    "ctx.params"
+  ],
+  "packages/eslint-plugin-mongodb-security/src/rules/no-unsafe-regex-query/index.ts#USER_INPUT_PATTERNS": [
+    "ctx.params",
+    "ctx.query",
+    "ctx.request.body",
+    "req.params",
+    "request.body",
+    "request.params",
+    "request.query"
+  ],
+  "packages/eslint-plugin-nestjs-security/src/rules/no-exposed-private-fields/index.ts#DEFAULT_SENSITIVE_TERMS": [
+    "accessKey",
+    "cardNumber",
+    "clientSecret",
+    "creditCard",
+    "cvc",
+    "cvv",
+    "mfaSecret",
+    "otp",
+    "passwd",
+    "pwd",
+    "sessionToken",
+    "ssn",
+    "totpSecret"
+  ],
+  "packages/eslint-plugin-nestjs-security/src/rules/require-guards/index.ts#DEFAULT_PUBLIC_ROUTES": [
+    ".well-known",
+    "confirm",
+    "forgot",
+    "forgot-password",
+    "healthz",
+    "logout",
+    "oauth",
+    "readiness",
+    "registration",
+    "reset-password",
+    "robots",
+    "robots.txt",
+    "sign-in",
+    "sign-out",
+    "sign-up",
+    "signin",
+    "signout",
+    "signup",
+    "sso",
+    "verify",
+    "verify-email"
+  ],
+  "packages/eslint-plugin-nestjs-security/src/rules/require-throttler/index.ts#SENSITIVE_ROUTE_TOKENS": [
+    "2fa",
+    "confirm",
+    "forgot",
+    "invitation",
+    "invite",
+    "logout",
+    "passwd",
+    "recover",
+    "refresh",
+    "registration",
+    "session",
+    "sign-in",
+    "sign-up",
+    "signin",
+    "signup",
+    "totp",
+    "verification"
+  ],
+  "packages/eslint-plugin-node-security/src/rules/detect-child-process/index.ts#DEFAULT_TAINT_SOURCES": [
+    "ctx",
+    "event"
+  ],
+  "packages/eslint-plugin-node-security/src/rules/detect-non-literal-fs-filename/index.ts#SENSITIVE_SEGMENTS": [
+    ".aws/credentials",
+    ".git/config",
+    ".npmrc",
+    ".ssh/authorized_keys",
+    ".ssh/id_dsa",
+    "etc/hosts",
+    "etc/sudoers",
+    "proc/self",
+    "windows/system32/config/sam"
+  ],
+  "packages/eslint-plugin-node-security/src/rules/no-buffer-overread/index.ts#DEFAULT_BUFFER_METHODS": [
+    "readBigInt64BE",
+    "readBigInt64LE",
+    "readBigUInt64LE",
+    "readDoubleBE",
+    "readDoubleLE",
+    "readFloatBE",
+    "readFloatLE",
+    "readInt16BE",
+    "readInt16LE",
+    "readInt32BE",
+    "readInt32LE",
+    "readInt8",
+    "readIntBE",
+    "readIntLE",
+    "readUIntBE",
+    "readUIntLE",
+    "writeUInt32LE",
+    "writeUInt8"
+  ],
+  "packages/eslint-plugin-node-security/src/rules/no-math-random-crypto/index.ts#CRYPTO_WORDS": [
+    "cipher",
+    "jwt",
+    "mnemonic",
+    "passphrase",
+    "passwd",
+    "salt",
+    "secrets",
+    "signature",
+    "tokens",
+    "verify"
+  ],
+  "packages/eslint-plugin-node-security/src/rules/no-ssrf/index.ts#USER_INPUT_SUBSTRINGS": [
+    "href",
+    "link"
+  ],
+  "packages/eslint-plugin-node-security/src/rules/no-timing-unsafe-compare/index.ts#DEFAULT_SECRET_PATTERNS": [
+    "auth_token",
+    "encryption-key",
+    "encryption_key",
+    "private-key",
+    "private_key",
+    "refresh-token",
+    "refresh_token",
+    "session-id",
+    "session_id",
+    "social-security",
+    "social_security"
+  ],
+  "packages/eslint-plugin-node-security/src/rules/no-timing-unsafe-compare/index.ts#DEFAULT_NON_SECRET_WORDS": [
+    "authored",
+    "authoring",
+    "authors",
+    "authorship",
+    "hashtag",
+    "hashtags"
+  ],
+  "packages/eslint-plugin-node-security/src/rules/no-timing-unsafe-compare/index.ts#DEFAULT_NON_SECRET_TAILS": [
+    "addresses",
+    "cost",
+    "endpoints",
+    "hostname",
+    "limits",
+    "origin",
+    "pathnames",
+    "paths",
+    "percent",
+    "price",
+    "quota",
+    "rank",
+    "total"
+  ],
+  "packages/eslint-plugin-node-security/src/rules/no-weak-hash-algorithm/index.ts#DEFAULT_SECURITY_USE_NAMES": [
+    "apikey",
+    "authorization",
+    "certs",
+    "csrf",
+    "encryptionkey",
+    "hmac",
+    "integrity",
+    "jwt",
+    "nonce",
+    "passwd",
+    "privatekey",
+    "salt",
+    "secretkey",
+    "secrets",
+    "session",
+    "signingkey",
+    "tokens"
+  ],
+  "packages/eslint-plugin-node-security/src/rules/no-zip-slip/index.ts#DEFAULT_ARCHIVE_MODULES": [
+    "7zip-min",
+    "archiver",
+    "decompress",
+    "extract-zip",
+    "gunzip-maybe",
+    "jszip",
+    "node-7z",
+    "node-stream-zip",
+    "tar-fs",
+    "tar-stream",
+    "unzip-stream",
+    "yazl",
+    "zip-stream"
+  ],
+  "packages/eslint-plugin-react-a11y/src/rules/control-has-associated-label.ts#DEFAULT_IGNORE_ELEMENTS": [
+    "audio",
+    "canvas",
+    "embed",
+    "tr",
+    "video"
+  ],
+  "packages/eslint-plugin-react-a11y/src/rules/control-has-associated-label.ts#DEFAULT_IGNORE_ROLES": [
+    "grid",
+    "listbox",
+    "menu",
+    "menubar",
+    "radiogroup",
+    "row",
+    "tablist",
+    "toolbar",
+    "tree",
+    "treegrid"
+  ],
+  "packages/eslint-plugin-react-a11y/src/rules/no-noninteractive-element-interactions.ts#INTERACTIVE_HANDLERS": [
+    "onClick",
+    "onKeyDown",
+    "onKeyPress",
+    "onKeyUp",
+    "onMouseDown",
+    "onMouseUp"
+  ],
+  "packages/eslint-plugin-react-a11y/src/rules/no-static-element-interactions.ts#INTERACTIVE_HANDLERS": [
+    "onClick",
+    "onKeyDown",
+    "onKeyPress",
+    "onKeyUp",
+    "onMouseDown",
+    "onMouseUp"
+  ],
+  "packages/eslint-plugin-react-features/src/rules/react/sort-comp.ts#DEFAULT_ORDER": [
+    "everything-else",
+    "instance-variables",
+    "lifecycle",
+    "render",
+    "static-methods",
+    "static-variables"
+  ],
+  "packages/eslint-plugin-react-features/src/rules/react/static-property-placement.ts#DEFAULT_GROUPS": [
+    "childContextTypes",
+    "contextType",
+    "contextTypes",
+    "defaultProps",
+    "propTypes",
+    "propTypes"
+  ],
+  "packages/eslint-plugin-secure-coding/src/rules/detect-weak-password-validation/index.ts#PASSWORD_WORDS": [
+    "passwd"
+  ],
+  "packages/eslint-plugin-secure-coding/src/rules/no-format-string-injection/index.ts#DEFAULT_USER_INPUT_ALIASES": [
+    "userparam",
+    "userparams",
+    "uservar"
+  ],
+  "packages/eslint-plugin-secure-coding/src/rules/no-graphql-injection/index.ts#GRAPHQL_SCHEMA_KEYWORDS": [
+    "scalar"
+  ],
+  "packages/eslint-plugin-secure-coding/src/rules/no-hardcoded-credentials/index.ts#DEFAULT_PLACEHOLDER_WORDS": [
+    "dummy",
+    "notreal",
+    "redacted",
+    "replaceme",
+    "tbd",
+    "todo",
+    "yours"
+  ],
+  "packages/eslint-plugin-secure-coding/src/rules/no-hardcoded-credentials/index.ts#PUBLISHABLE_VENDORS": [
+    "bugsnag-js",
+    "bugsnag-sourcemaps"
+  ],
+  "packages/eslint-plugin-secure-coding/src/rules/no-ldap-injection/index.ts#DEFAULT_LDAP_PACKAGES": [
+    "ldap-authentication",
+    "ldap-escape",
+    "ldap-filter",
+    "ldapauth-fork",
+    "node-ldap",
+    "passport-ldapauth"
+  ],
+  "packages/eslint-plugin-secure-coding/src/rules/no-ldap-injection/index.ts#DEFAULT_LDAP_FUNCTIONS": [
+    "compare",
+    "modifyDN",
+    "searchAsync",
+    "searchPaginated"
+  ],
+  "packages/eslint-plugin-secure-coding/src/rules/no-ldap-injection/index.ts#DEFAULT_ESCAPE_FUNCTIONS": [
+    "dnEscape",
+    "dnValue",
+    "escape.dnValue",
+    "filterEscape"
+  ],
+  "packages/eslint-plugin-secure-coding/src/rules/no-log-injection/index.ts#DEFAULT_LOGGER_RECEIVERS": [
+    "bunyan",
+    "pino",
+    "winston"
+  ],
+  "packages/eslint-plugin-secure-coding/src/rules/no-log-injection/index.ts#DEFAULT_REQUEST_PROPERTIES": [
+    "cookies"
+  ],
+  "packages/eslint-plugin-secure-coding/src/rules/no-missing-authentication/index.ts#DEFAULT_AUTH_MIDDLEWARE_PATTERNS": [
+    "checkAuth",
+    "ensureAuthenticated"
+  ],
+  "packages/eslint-plugin-secure-coding/src/rules/no-missing-authentication/index.ts#DEFAULT_PUBLIC_ROUTE_PATTERNS": [
+    "callback",
+    "favicon",
+    "forgot-password",
+    "logout",
+    "oauth",
+    "password-reset",
+    "reset-password",
+    "sign-in",
+    "sign-up",
+    "signin",
+    "signup",
+    "verify-email"
+  ],
+  "packages/eslint-plugin-secure-coding/src/rules/no-missing-authentication/index.ts#DEFAULT_ROUTE_HANDLER_PATTERNS": [
+    "patch"
+  ],
+  "packages/eslint-plugin-secure-coding/src/rules/no-missing-authentication/index.ts#ROUTER_NAME_WORDS": [
+    "fastify",
+    "hapi"
+  ],
+  "packages/eslint-plugin-secure-coding/src/rules/no-sensitive-data-exposure/index.ts#DESCRIPTOR_SEGMENTS": [
+    "hint",
+    "notice",
+    "placeholder",
+    "prompt",
+    "warning"
+  ],
+  "packages/eslint-plugin-secure-coding/src/rules/no-sql-injection/index.ts#REQUEST_PROPERTIES": [
+    "cookies",
+    "url"
+  ],
+  "packages/eslint-plugin-secure-coding/src/rules/no-template-injection/index.ts#DEFAULT_TEMPLATE_ENGINES": [
+    "Dust",
+    "consolidate",
+    "doT",
+    "dust",
+    "jade",
+    "swig"
+  ],
+  "packages/eslint-plugin-secure-coding/src/rules/no-template-injection/index.ts#DEFAULT_REQUEST_ROOTS": [
+    "event"
+  ],
+  "packages/eslint-plugin-secure-coding/src/rules/no-template-injection/index.ts#DEFAULT_REQUEST_PROPERTIES": [
+    "cookies",
+    "headers",
+    "params",
+    "url"
+  ],
+  "packages/eslint-plugin-secure-coding/src/rules/no-template-injection/index.ts#DEFAULT_UNTRUSTED_NAME_WORDS": [
+    "client",
+    "external"
+  ],
+  "packages/eslint-plugin-secure-coding/src/rules/no-unsafe-deserialization/index.ts#DEFAULT_NON_EXECUTING_PACKAGES": [
+    "@msgpack/msgpack",
+    "cbor",
+    "msgpackr",
+    "protobufjs"
+  ],
+  "packages/eslint-plugin-secure-coding/src/rules/no-xpath-injection/index.ts#DEFAULT_XPATH_PACKAGES": [
+    "@xmldom/xmldom",
+    "libxmljs",
+    "libxmljs2",
+    "xmldom-xpath"
+  ],
+  "packages/eslint-plugin-secure-coding/src/rules/no-xxe-injection/index.ts#DEFAULT_XML_MODULES": [
+    "xml2json",
+    "xpath"
+  ],
+  "packages/eslint-plugin-secure-coding/src/rules/no-xxe-injection/index.ts#DEFAULT_XML_PARSE_METHODS": [
+    "parseStringPromise",
+    "parseXmlAsync"
+  ],
+  "packages/eslint-plugin-secure-coding/src/rules/require-backend-authorization/index.ts#DEFAULT_AUTH_PROPERTIES": [
+    "isAuthenticated",
+    "isAuthorized"
+  ],
+  "packages/eslint-plugin-secure-coding/src/rules/require-backend-authorization/index.ts#DEFAULT_BROWSER_GLOBALS": [
+    "navigator",
+    "sessionStorage"
+  ],
+  "packages/eslint-plugin-secure-coding/src/rules/require-secure-defaults/index.ts#DEFAULT_COOKIE_ATTRIBUTES": [
+    "expires",
+    "path"
+  ]
+}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -123,6 +123,11 @@ jobs:
       # sources, and each runs in well under a second. A separate job would
       # spend more time on checkout and setup than on the check.
       - run: npm run lint:name-inference
+      # Third gate on the same question, one layer down: a rule's DETECTION
+      # TABLE is a list of claims, and this asks whether anything exercises
+      # each one. #659 added twelve credential spellings and three reached the
+      # PR with no test — removing them from the rule left the suite green.
+      - run: npm run lint:detection-list-coverage
       # The FULL rule-audit ratchet. The pre-commit hook runs a scoped version
       # that only sees rules whose own files changed; a shared-util edit can
       # move a rule's findings without touching it, so this run — every rule,

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "rule-ledger": "tsx scripts/build-rule-ledger.ts",
     "rule-audit:gate": "tsx scripts/rule-audit-gate.ts",
     "probe-rule": "tsx scripts/probe-rule.mts",
+    "lint:detection-list-coverage": "tsx scripts/lint-detection-list-coverage.ts",
     "lint:name-inference": "tsx scripts/lint-name-inference.ts",
     "lint:severity-consistency": "tsx scripts/lint-severity-consistency.ts",
     "lint:seal": "tsx scripts/lint-seal.ts",

--- a/scripts/__tests__/detection-list-coverage.test.ts
+++ b/scripts/__tests__/detection-list-coverage.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Unit lock for the detection-list coverage gate.
+ *
+ * The apostrophe case below is the one that matters. Without comment
+ * stripping, this gate skipped `DEFAULT_SECURITY_USE_NAMES` — the 41-entry
+ * table whose gaps are the reason the gate exists — and reported a clean run.
+ * A checker that silently drops its own motivating case is worse than no
+ * checker, because it converts "unmeasured" into "measured and fine".
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  extractLists,
+  isDetectionToken,
+  stripComments,
+  uncoveredEntries,
+} from '../lint-detection-list-coverage';
+
+const FILE = 'rule.ts';
+
+describe('isDetectionToken', () => {
+  it('accepts bare tokens', () => {
+    for (const t of ['passphrase', 'readInt16LE', 'tar-fs', '@mui/material', 'sign-in'])
+      expect(isDetectionToken(t)).toBe(true);
+  });
+
+  it('rejects prose, which shares the array syntax with detection entries', () => {
+    // The first reading of this gate counted these as uncovered "entries".
+    for (const t of ['Moment.js is in maintenance mode.', '10-15 minutes', 'Use named imports'])
+      expect(isDetectionToken(t)).toBe(false);
+  });
+
+  it('rejects URLs', () => {
+    expect(isDetectionToken('https://example.com/a')).toBe(false);
+  });
+});
+
+describe('stripComments', () => {
+  it('removes a whole-line comment', () => {
+    expect(stripComments("  // note\n'a',")).not.toContain('note');
+  });
+
+  it('does not let a comment-opener inside a line comment start a block', () => {
+    const glob = ['src/', '*', '*'].join('');
+    const out = stripComments(`  // paths under ${glob}\nconst A = ['x'];`);
+    expect(out).toContain("const A = ['x']");
+  });
+});
+
+describe('extractLists', () => {
+  it('finds a detection table', () => {
+    const src = "const NAMES = ['alpha', 'beta', 'gamma', 'delta', 'epsilon'];";
+    expect(extractLists(src, FILE)).toEqual([
+      { file: FILE, name: 'NAMES', entries: ['alpha', 'beta', 'gamma', 'delta', 'epsilon'] },
+    ]);
+  });
+
+  it('still finds the table when a comment between entries contains an apostrophe', () => {
+    // THE REGRESSION. `makeNameTest`'s apostrophe paired with the next entry's
+    // opening quote, captured four lines of prose as a string literal, and
+    // dropped the token ratio below the threshold — so the table vanished.
+    const src = [
+      'const NAMES = [',
+      "  'alpha', 'beta', 'gamma',",
+      "  // chosen against `makeNameTest`'s mechanics rather than by feel: an",
+      '  // entry under 6 characters matches whole words only, which is why the',
+      '  // compound spellings are listed whole.',
+      "  'delta', 'epsilon',",
+      '];',
+    ].join('\n');
+    const [list] = extractLists(src, FILE);
+    expect(list).toBeDefined();
+    expect(list.entries).toEqual(['alpha', 'beta', 'gamma', 'delta', 'epsilon']);
+  });
+
+  it('ignores a table that is mostly prose', () => {
+    const src =
+      "const MSGS = ['Use named imports for tree-shaking', 'Moment.js is in maintenance mode', 'a', 'b', 'c', 'd'];";
+    expect(extractLists(src, FILE)).toEqual([]);
+  });
+
+  it('ignores a handful of special cases', () => {
+    expect(extractLists("const A = ['x', 'y'];", FILE)).toEqual([]);
+  });
+});
+
+describe('uncoveredEntries', () => {
+  const list = { file: FILE, name: 'N', entries: ['totp', 'recoverycode', 'mnemonic'] };
+
+  it('reports entries no test mentions', () => {
+    expect(uncoveredEntries(list, "const a = 'mnemonic';")).toEqual(['totp', 'recoverycode']);
+  });
+
+  it('counts an entry embedded in a longer identifier, which is how tests spell them', () => {
+    expect(uncoveredEntries(list, 'userTotp recoveryCode mnemonic')).toEqual([]);
+  });
+
+  it('is case-insensitive, since tests use camelCase for snake-cased entries', () => {
+    expect(uncoveredEntries({ ...list, entries: ['recoverycode'] }, 'const recoveryCode = 1;')).toEqual(
+      [],
+    );
+  });
+});

--- a/scripts/__tests__/detection-list-coverage.test.ts
+++ b/scripts/__tests__/detection-list-coverage.test.ts
@@ -15,10 +15,14 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import {
   extractLists,
   isDetectionToken,
   stripComments,
+  testTextFor,
   uncoveredEntries,
 } from '../lint-detection-list-coverage';
 
@@ -36,14 +40,48 @@ describe('isDetectionToken', () => {
       expect(isDetectionToken(t)).toBe(false);
   });
 
-  it('rejects URLs', () => {
+  it('rejects URLs, via the character class rather than a prefix test', () => {
+    // ':' is not in the class, so URLs are excluded without a `startsWith`
+    // check — which is what matters, because such a check also excluded
+    // `http-server`, `http2` and `http`, all real entries in
+    // `DEFAULT_HTTP_MODULES`. They were dropped from both the coverage check
+    // and the debt ledger, so they read as covered.
     expect(isDetectionToken('https://example.com/a')).toBe(false);
+  });
+
+  it('keeps http-prefixed tokens, which are real detection entries', () => {
+    for (const t of ['http', 'http2', 'http-server']) expect(isDetectionToken(t)).toBe(true);
   });
 });
 
 describe('stripComments', () => {
   it('removes a whole-line comment', () => {
     expect(stripComments("  // note\n'a',")).not.toContain('note');
+  });
+
+  it('strips an INLINE comment after an entry', () => {
+    // Whole-line stripping missed this: TypeScript allows a comment after an
+    // entry, and an apostrophe in one corrupts quote pairing exactly as the
+    // between-entries case did.
+    // The comment must sit INSIDE the brackets. A trailing one after the
+    // closing `]` is outside the captured region entirely, so a test using
+    // that shape passes with or without inline stripping — it would be a test
+    // that is green on the broken code.
+    const src = [
+      'const NAMES = [',
+      "  'alpha', // it's the first one",
+      "  'beta', 'gamma', 'delta', 'epsilon',",
+      '];',
+    ].join('\n');
+    const [list] = extractLists(src, FILE);
+    expect(list).toBeDefined();
+    expect(list.entries).toEqual(['alpha', 'beta', 'gamma', 'delta', 'epsilon']);
+  });
+
+  it('leaves a // that lives inside a string, so a docs.url survives', () => {
+    // suggestions-meta-lock documents this regression: truncating at any `//`
+    // eats the one in `https://`.
+    expect(stripComments("url: 'https://example.com/docs',")).toContain('https://example.com/docs');
   });
 
   it('does not let a comment-opener inside a line comment start a block', () => {
@@ -105,5 +143,44 @@ describe('uncoveredEntries', () => {
     expect(uncoveredEntries({ ...list, entries: ['recoverycode'] }, 'const recoveryCode = 1;')).toEqual(
       [],
     );
+  });
+});
+
+describe('testTextFor', () => {
+  /**
+   * The contamination this closes: for a FLAT rule file, reading every test
+   * under `dirname` meant scanning all of `src/rules`, so a token in another
+   * rule's test marked this rule's entry covered — failing in the flattering
+   * direction, which is the one direction this gate must never fail in.
+   */
+  it('does not read a sibling rule\'s tests for a flat rule file', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dlc-'));
+    fs.writeFileSync(path.join(dir, 'mine.ts'), '');
+    fs.writeFileSync(path.join(dir, 'mine.test.ts'), 'MINE_TOKEN');
+    fs.writeFileSync(path.join(dir, 'other.test.ts'), 'OTHER_TOKEN');
+
+    const text = testTextFor(path.join(dir, 'mine.ts'));
+    expect(text).toContain('MINE_TOKEN');
+    expect(text).not.toContain('OTHER_TOKEN');
+  });
+
+  it('reads the whole directory for a rule that owns one', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dlc-'));
+    fs.mkdirSync(path.join(dir, 'nested'));
+    fs.writeFileSync(path.join(dir, 'index.ts'), '');
+    fs.writeFileSync(path.join(dir, 'a.test.ts'), 'A_TOKEN');
+    fs.writeFileSync(path.join(dir, 'nested', 'b.test.ts'), 'B_TOKEN');
+
+    const text = testTextFor(path.join(dir, 'index.ts'));
+    expect(text).toContain('A_TOKEN');
+    expect(text).toContain('B_TOKEN');
+  });
+
+  it('picks up the flat rule\'s own extra suites', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dlc-'));
+    fs.writeFileSync(path.join(dir, 'mine.ts'), '');
+    fs.writeFileSync(path.join(dir, 'mine.coverage.test.ts'), 'COVERAGE_TOKEN');
+
+    expect(testTextFor(path.join(dir, 'mine.ts'))).toContain('COVERAGE_TOKEN');
   });
 });

--- a/scripts/lint-detection-list-coverage.ts
+++ b/scripts/lint-detection-list-coverage.ts
@@ -60,7 +60,7 @@ const DEBT_FILE = path.join(ROOT, '.agent', 'detection-list-coverage-debt.json')
  * "10-15 minutes". Requiring no whitespace is what separates the two.
  */
 export const isDetectionToken = (value: string): boolean =>
-  /^[A-Za-z0-9@._/-]{2,40}$/.test(value) && !value.startsWith('http');
+  /^[A-Za-z0-9@._/-]{2,40}$/.test(value);
 
 /** A table is a detection table when it is overwhelmingly tokens. */
 const TOKEN_RATIO = 0.8;
@@ -98,7 +98,41 @@ export interface DetectionList {
  * opens a block that swallows everything to the next close-comment.
  */
 export const stripComments = (source: string): string =>
-  source.replaceAll(/^[ \t]*\/\/.*$/gm, '').replaceAll(/\/\*[\s\S]*?\*\//g, '');
+  source
+    .replaceAll(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .map(stripLineComment)
+    .join('\n');
+
+/**
+ * Truncate a line at the first `//` that is not inside a string literal.
+ *
+ * Whole-line stripping was not enough: TypeScript allows a comment AFTER an
+ * entry, and an apostrophe in one corrupts quote pairing exactly as the
+ * between-entries case did. Truncating at any `//` is not enough either — that
+ * eats the `//` in a `docs.url`, and `suggestions-meta-lock` documents that
+ * exact regression. Tracking quotes is what distinguishes them.
+ */
+function stripLineComment(line: string): string {
+  let quote: string | null = null;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === '\\') {
+      i++;
+      continue;
+    }
+    if (quote) {
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === "'" || ch === '"' || ch === '`') {
+      quote = ch;
+      continue;
+    }
+    if (ch === '/' && line[i + 1] === '/') return line.slice(0, i);
+  }
+  return line;
+}
 
 export function extractLists(rawSource: string, file: string): DetectionList[] {
   const source = stripComments(rawSource);
@@ -136,21 +170,56 @@ function collectListsUnder(dir: string): DetectionList[] {
   return out;
 }
 
-/** Every test file beside the rule — the tests that could plausibly cover it. */
-function testTextBeside(file: string): string {
+/**
+ * The tests for THIS rule, and only this rule.
+ *
+ * Both layouts in the repo are covered, and the difference matters:
+ *
+ *   `src/rules/<rule>/index.ts` — the rule owns its directory, so every test
+ *      under it belongs to it. Recurse.
+ *   `src/rules/<rule>.ts` (and `src/rules/<cat>/<rule>.ts`) — the rule is a
+ *      flat file among siblings. Recursing from its dirname would read every
+ *      test in `src/rules`, and a token in ANOTHER rule's test would mark this
+ *      rule's entry covered. Match by the rule's own basename instead.
+ *
+ * Getting this wrong makes coverage look better than it is, which is the one
+ * direction this gate must never fail in.
+ */
+export function testTextFor(file: string): string {
+  const dir = path.dirname(file);
+  const base = path.basename(file, '.ts');
   let text = '';
-  const collect = (dir: string) => {
-    if (!fs.existsSync(dir)) return;
-    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-      const full = path.join(dir, entry.name);
+
+  const readTestsUnder = (d: string) => {
+    if (!fs.existsSync(d)) return;
+    for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
+      const full = path.join(d, entry.name);
       if (entry.isDirectory()) {
-        collect(full);
+        readTestsUnder(full);
         continue;
       }
       if (/\.(test|spec)\.tsx?$/.test(entry.name)) text += fs.readFileSync(full, 'utf8');
     }
   };
-  collect(path.dirname(file));
+
+  if (base === 'index') {
+    readTestsUnder(dir);
+    return text;
+  }
+
+  // Flat rule: `<rule>.test.ts`, `<rule>.coverage.test.ts`, and a `__tests__`
+  // sibling holding `<rule>.test.ts`.
+  const owns = (name: string) =>
+    new RegExp(`^${base.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\.[^/]*\\.(test|spec)\\.tsx?$|^${base.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\.(test|spec)\\.tsx?$`).test(
+      name,
+    );
+  for (const d of [dir, path.join(dir, '__tests__')]) {
+    if (!fs.existsSync(d)) continue;
+    for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
+      if (entry.isDirectory()) continue;
+      if (owns(entry.name)) text += fs.readFileSync(path.join(d, entry.name), 'utf8');
+    }
+  }
   return text;
 }
 
@@ -171,7 +240,7 @@ function main(): void {
   let entryCount = 0;
   for (const list of lists) {
     entryCount += list.entries.length;
-    const missing = uncoveredEntries(list, testTextBeside(list.file));
+    const missing = uncoveredEntries(list, testTextFor(list.file));
     if (missing.length) current[keyOf(list)] = missing.sort();
   }
 

--- a/scripts/lint-detection-list-coverage.ts
+++ b/scripts/lint-detection-list-coverage.ts
@@ -1,0 +1,224 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Every entry in a rule's detection table is a CLAIM. This gate asks whether
+ * anything ever exercised it.
+ *
+ * The failure it exists to stop, from #659: twelve credential spellings were
+ * added to `no-weak-hash-algorithm`'s name table and three of them —
+ * `totp`, `recoverycode`, `backupcode` — reached the PR with no test case.
+ * Removing all three from the rule left the suite **green**. A quarter of that
+ * change's recall claim rested on nothing, and no gate in the repo could tell.
+ *
+ * Measured across the plugins the first time this ran: 78 detection tables,
+ * 762 entries, **347 of them (46%) appearing in no test at all**.
+ *
+ * ## What this proves, and what it does NOT
+ *
+ * The check is a substring match against the test sources beside the rule.
+ * That is deliberately the FLOOR, not proof of coverage:
+ *
+ *   - it catches "this entry is mentioned nowhere", which is the #659 defect;
+ *   - it does NOT prove a test asserts the rule REPORTS on the entry. An entry
+ *     named only in a `valid` fixture passes.
+ *
+ * The second gap is real and has already bitten. `totpSecret` looks like a
+ * perfect case for `totp` — and `secret` is separately in the same table, so
+ * the case reports whether or not `totp` was ever added. Appearance is not
+ * evidence; only a case that fails when the entry is removed is evidence.
+ * Closing that properly means mutation (drop the entry, expect a red suite),
+ * which is too slow for a per-push gate. This gate is the cheap half, and it
+ * is written down here so nobody reads a green run as "the table is covered".
+ *
+ * ## Ratchet
+ *
+ * `.agent/detection-list-coverage-debt.json` records what is uncovered today.
+ * The build fails on a NEW uncovered entry, and equally on a debt entry that
+ * is now covered — a ledger nobody prunes stops describing the repo, which is
+ * the same bidirectional shape `lint:severity-consistency` uses.
+ *
+ *   npm run lint:detection-list-coverage
+ *   npm run lint:detection-list-coverage -- --update
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const ROOT = path.resolve(__dirname, '..');
+const PACKAGES = path.join(ROOT, 'packages');
+const DEBT_FILE = path.join(ROOT, '.agent', 'detection-list-coverage-debt.json');
+
+/**
+ * A detection entry is a bare token — a method name, a package name, a route
+ * fragment. Prose is not: the same array syntax also holds message text and
+ * remediation advice, and counting those produced a first reading of 597
+ * uncovered "entries" that included "Moment.js is in maintenance mode" and
+ * "10-15 minutes". Requiring no whitespace is what separates the two.
+ */
+export const isDetectionToken = (value: string): boolean =>
+  /^[A-Za-z0-9@._/-]{2,40}$/.test(value) && !value.startsWith('http');
+
+/** A table is a detection table when it is overwhelmingly tokens. */
+const TOKEN_RATIO = 0.8;
+/** Below this a table is a handful of special cases, not a claim surface. */
+const MIN_ENTRIES = 5;
+
+export interface DetectionList {
+  file: string;
+  name: string;
+  entries: string[];
+}
+
+/**
+ * Pull `const UPPER_NAME = [ 'a', 'b', … ]` tables out of a rule source.
+ *
+ * Regex rather than AST on purpose: it runs over ~600 files on every push, it
+ * needs no type information, and a table it fails to see costs a missed claim
+ * rather than a false failure. The repo's rule against regexing PRINTED SOURCE
+ * governs what a RULE may do to user code — this is a repo gate reading our
+ * own sources, and it reports on tables, never on user findings.
+ */
+/**
+ * Drop comments before any quote pairing. This is not tidiness — without it
+ * this gate silently skipped the very table that motivated it.
+ *
+ * `DEFAULT_SECURITY_USE_NAMES` carries an explanatory comment BETWEEN its
+ * entries, and that comment contains an apostrophe (`makeNameTest`'s). The
+ * apostrophe pairs with the next entry's opening quote, so four lines of prose
+ * were captured as a "string literal", the token ratio fell to 0.73, and the
+ * 41-entry table fell below the threshold and was never checked. The gate
+ * reported a clean run over the exact list whose gaps prompted it.
+ *
+ * LINE comments first, and the order is load-bearing for the same reason it is
+ * in `suggestions-meta-lock`: a slash-star sequence inside a line comment
+ * opens a block that swallows everything to the next close-comment.
+ */
+export const stripComments = (source: string): string =>
+  source.replaceAll(/^[ \t]*\/\/.*$/gm, '').replaceAll(/\/\*[\s\S]*?\*\//g, '');
+
+export function extractLists(rawSource: string, file: string): DetectionList[] {
+  const source = stripComments(rawSource);
+  const out: DetectionList[] = [];
+  for (const m of source.matchAll(/const\s+([A-Z][A-Z0-9_]{2,})\s*(?::[^=]+)?=\s*\[([^\]]*)\]/g)) {
+    const all = [...m[2].matchAll(/'([^']+)'/g)].map((x) => x[1]);
+    const tokens = all.filter(isDetectionToken);
+    if (tokens.length < MIN_ENTRIES) continue;
+    if (tokens.length / all.length < TOKEN_RATIO) continue;
+    out.push({ file, name: m[1], entries: tokens });
+  }
+  return out;
+}
+
+/** Entries of `list` that appear nowhere in `testText`. Case-insensitive. */
+export function uncoveredEntries(list: DetectionList, testText: string): string[] {
+  const haystack = testText.toLowerCase();
+  return list.entries.filter((e) => !haystack.includes(e.toLowerCase()));
+}
+
+const isRuleSource = (name: string) =>
+  name.endsWith('.ts') && !/\.(test|spec|d)\.ts$/.test(name);
+
+function collectListsUnder(dir: string): DetectionList[] {
+  const out: DetectionList[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...collectListsUnder(full));
+      continue;
+    }
+    if (!isRuleSource(entry.name)) continue;
+    out.push(...extractLists(fs.readFileSync(full, 'utf8'), full));
+  }
+  return out;
+}
+
+/** Every test file beside the rule — the tests that could plausibly cover it. */
+function testTextBeside(file: string): string {
+  let text = '';
+  const collect = (dir: string) => {
+    if (!fs.existsSync(dir)) return;
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        collect(full);
+        continue;
+      }
+      if (/\.(test|spec)\.tsx?$/.test(entry.name)) text += fs.readFileSync(full, 'utf8');
+    }
+  };
+  collect(path.dirname(file));
+  return text;
+}
+
+const keyOf = (list: DetectionList) =>
+  `${path.relative(ROOT, list.file)}#${list.name}`;
+
+function main(): void {
+  const update = process.argv.includes('--update');
+
+  const lists: DetectionList[] = [];
+  for (const pkg of fs.readdirSync(PACKAGES).sort()) {
+    if (!pkg.startsWith('eslint-plugin-')) continue;
+    const rulesDir = path.join(PACKAGES, pkg, 'src', 'rules');
+    if (fs.existsSync(rulesDir)) lists.push(...collectListsUnder(rulesDir));
+  }
+
+  const current: Record<string, string[]> = {};
+  let entryCount = 0;
+  for (const list of lists) {
+    entryCount += list.entries.length;
+    const missing = uncoveredEntries(list, testTextBeside(list.file));
+    if (missing.length) current[keyOf(list)] = missing.sort();
+  }
+
+  if (update) {
+    fs.mkdirSync(path.dirname(DEBT_FILE), { recursive: true });
+    fs.writeFileSync(DEBT_FILE, `${JSON.stringify(current, null, 2)}\n`);
+    const total = Object.values(current).reduce((a, e) => a + e.length, 0);
+    console.log(`Recorded ${total} uncovered entries across ${Object.keys(current).length} tables.`);
+    return;
+  }
+
+  const debt: Record<string, string[]> = fs.existsSync(DEBT_FILE)
+    ? JSON.parse(fs.readFileSync(DEBT_FILE, 'utf8'))
+    : {};
+
+  const added: string[] = [];
+  const fixed: string[] = [];
+  for (const [key, missing] of Object.entries(current)) {
+    const known = new Set(debt[key] ?? []);
+    for (const entry of missing) if (!known.has(entry)) added.push(`${key} → ${entry}`);
+  }
+  for (const [key, known] of Object.entries(debt)) {
+    const missing = new Set(current[key] ?? []);
+    for (const entry of known) if (!missing.has(entry)) fixed.push(`${key} → ${entry}`);
+  }
+
+  const totalUncovered = Object.values(current).reduce((a, e) => a + e.length, 0);
+  console.log(
+    `${lists.length} detection tables, ${entryCount} entries, ${totalUncovered} uncovered.`,
+  );
+
+  if (added.length) {
+    console.error(`\n✗ ${added.length} detection entry/entries no test exercises:\n`);
+    for (const line of added) console.error(`    ${line}`);
+    console.error(
+      '\n  Add a case that FAILS when the entry is removed from the table.\n' +
+        '  Beware a case that passes for another reason — `totpSecret` covers\n' +
+        '  `secret`, not `totp`, when both are in the same table.\n',
+    );
+  }
+  if (fixed.length) {
+    console.error(`\n✗ ${fixed.length} debt entry/entries are now covered — prune the ledger:\n`);
+    for (const line of fixed) console.error(`    ${line}`);
+    console.error('\n  Run: npm run lint:detection-list-coverage -- --update\n');
+  }
+  if (added.length || fixed.length) process.exit(1);
+  console.log('✅ No new unexercised detection entries.');
+}
+
+if (require.main === module) main();


### PR DESCRIPTION
## Summary

Every entry in a rule's detection table is a **claim**. Nothing checked whether anything exercised it.

[#659](https://github.com/ofri-peretz/eslint/pull/659) is the shape: twelve credential spellings went into `no-weak-hash-algorithm`'s name table, and three — `totp`, `recoverycode`, `backupcode` — reached the PR with no test case. Removing all three from the rule left the suite **green**. A quarter of that change's recall claim rested on nothing, and no gate in the repo could say so.

It is not three entries:

| | |
|---|---:|
| detection tables across the plugins | 83 |
| entries in them | 923 |
| **entries appearing in no test at all** | **414 (45%)** |

`DEFAULT_BUFFER_METHODS` (`readInt16LE`, `readBigUInt64LE`, …), `DEFAULT_ARCHIVE_MODULES` (`yazl`, `tar-fs`, `extract-zip`, …), `DEFAULT_SENSITIVE_TERMS` — real tables, each entry a detection promise, none of them exercised.

## Shape

Ratchet in `.agent/detection-list-coverage-debt.json`, matching `lint:severity-consistency`: the build fails on a **new** uncovered entry, and equally on a **debt entry that is now covered**, because a ledger nobody prunes stops describing the repo. Runs beside `lint:taxonomy` and `lint:name-inference` in `quality.yml` — that job's own comment says both gates answer *"is this rule allowed to claim what it claims"*. This is the same question one layer down: on the table, not the rule.

## Two limits, both written into the script

**1. Appearance is not coverage.** A substring match proves the entry is *mentioned*, not that a test asserts the rule **reports** on it; an entry named only in a `valid` fixture passes. That gap has already bitten — `totpSecret` is the natural case for `totp`, and `secret` is separately in the same table, so it passes whether or not `totp` was ever added. Closing it properly means mutation (drop the entry, expect red), which is too slow for a per-push gate. This is the cheap half, and the script says so rather than letting a green run read as "the table is covered".

**2. The gate first shipped committing the fault it polices.** Without comment stripping it skipped `DEFAULT_SECURITY_USE_NAMES` entirely — the 41-entry table that motivated the whole thing. An apostrophe in an in-array comment (`` `makeNameTest`'s ``) paired with the next entry's opening quote, four lines of prose were captured as a string literal, and the token ratio fell to 0.73, under the 0.8 threshold. The gate reported a clean run over the exact list whose gaps prompted it. Stripping comments recovered 4 tables and 67 further uncovered entries — the first reading of 347 was itself an undercount.

## Test plan

- [x] `scripts/__tests__/detection-list-coverage.test.ts` — 12 tests, including the apostrophe regression. Verified it **fails on the unfixed extractor**: neutering `stripComments` turns exactly that test red, 11 others stay green.
- [x] Positive control: added `zzunexercisedtoken` to the motivating table — gate fails and names it.
- [x] Reverse control: mentioned a debt entry (`7zip-min`) in a test — gate fails with "now covered — prune the ledger".
- [x] `npm run lint:workflows` — 34 workflow files pass conventions.

## After merge

Nothing ships; repo tooling. The 414 are recorded as debt, not fixed here — burning them down is per-rule work, and the mutation half is the follow-on that would make a green run mean what it looks like it means.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Quality Improvements**
  * Added automated validation to identify detection rules that lack corresponding test coverage.
  * Integrated coverage checks into the quality workflow to prevent new untested detection entries.
  * Added reporting for existing coverage gaps and tracking of remediation progress.

* **Tests**
  * Added comprehensive validation tests for detection-list parsing, matching, comments, and uncovered-entry reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->