### PR TITLE
chore(scripts): measure rule throughput by attribution, not subtraction

### DIFF
--- a/benchmarks/rule-corpus/browser-security__no-eval/SEAL.json
+++ b/benchmarks/rule-corpus/browser-security__no-eval/SEAL.json
@@ -6,7 +6,7 @@
     "ecmaVersion": 2022,
     "typescript": "6.0.3",
     "eslint": "10.8.1",
-    "plugin": "eslint-plugin-browser-security@2.0.1",
+    "plugin": "eslint-plugin-browser-security@2.0.5",
     "node": "24"
   },
   "axes": {
@@ -61,8 +61,8 @@
       "command": "npx vitest run --coverage src/rules/no-eval"
     },
     "throughput": {
-      "state": "unmet",
-      "evidence": "marginal over a no-op control: 257L +0.62±0.34ms · 1028L +2.29±1.28ms · 4112L +6.02±2.54ms — NOT ESTABLISHED: fewer than two sizes clear the instrument's own measured error, so no growth curve can be read",
+      "state": "met",
+      "evidence": "attributed to the rule's own frames: 10x 5.15ms (67 samples) · 20x 4.66ms (106 samples) · 40x 7.32ms (171 samples) · 80x 12.91ms (284 samples) — 1.66x cost for 2.0x work (40x→80x), linear or better",
       "command": "npx tsx scripts/seal-audit.mts browser-security/no-eval"
     },
     "recorded": {

--- a/benchmarks/rule-corpus/node-security__detect-non-literal-fs-filename/SEAL.json
+++ b/benchmarks/rule-corpus/node-security__detect-non-literal-fs-filename/SEAL.json
@@ -6,7 +6,7 @@
     "ecmaVersion": 2022,
     "typescript": "6.0.3",
     "eslint": "10.8.1",
-    "plugin": "eslint-plugin-node-security@5.1.1",
+    "plugin": "eslint-plugin-node-security@5.2.1",
     "node": "24"
   },
   "axes": {
@@ -61,8 +61,8 @@
       "command": "npx vitest run --coverage src/rules/detect-non-literal-fs-filename"
     },
     "throughput": {
-      "state": "unmet",
-      "evidence": "NOT REPRODUCIBLE: two consecutive measurements disagreed — linear then not-established. First: 164L +0.31±0.08ms · 656L +0.81±0.03ms · 2624L +4.82±3.95ms — 5.9x time for 4.0x lines (656→2624), linear",
+      "state": "met",
+      "evidence": "attributed to the rule's own frames: 10x 5.82ms (75 samples) · 20x 7.98ms (132 samples) · 40x 10.75ms (215 samples) · 80x 16.94ms (428 samples) — 1.99x cost for 2.0x work (40x→80x), linear or better",
       "command": "npx tsx scripts/seal-audit.mts node-security/detect-non-literal-fs-filename"
     },
     "recorded": {

--- a/benchmarks/rule-corpus/secure-coding__detect-non-literal-regexp/SEAL.json
+++ b/benchmarks/rule-corpus/secure-coding__detect-non-literal-regexp/SEAL.json
@@ -6,7 +6,7 @@
     "ecmaVersion": 2022,
     "typescript": "6.0.3",
     "eslint": "10.8.1",
-    "plugin": "eslint-plugin-secure-coding@5.1.0",
+    "plugin": "eslint-plugin-secure-coding@5.1.2",
     "node": "24"
   },
   "axes": {
@@ -62,7 +62,7 @@
     },
     "throughput": {
       "state": "unmet",
-      "evidence": "marginal over a no-op control: 445L +0.00±0.77ms · 1780L +3.10±2.85ms · 7120L +7.64±5.68ms — NOT ESTABLISHED: fewer than two sizes clear the instrument's own measured error, so no growth curve can be read",
+      "evidence": "NOT REPRODUCIBLE: two consecutive measurements disagreed — superlinear then linear. First: 10x 2.96ms (53 samples) · 20x 4.97ms (97 samples) · 40x 4.12ms (91 samples) · 80x 11.63ms (292 samples) — 3.21x cost for 2.0x work (40x→80x), SUPERLINEAR",
       "command": "npx tsx scripts/seal-audit.mts secure-coding/detect-non-literal-regexp"
     },
     "recorded": {

--- a/benchmarks/rule-corpus/secure-coding__detect-object-injection/SEAL.json
+++ b/benchmarks/rule-corpus/secure-coding__detect-object-injection/SEAL.json
@@ -6,7 +6,7 @@
     "ecmaVersion": 2022,
     "typescript": "6.0.3",
     "eslint": "10.8.1",
-    "plugin": "eslint-plugin-secure-coding@5.1.0",
+    "plugin": "eslint-plugin-secure-coding@5.1.2",
     "node": "24"
   },
   "axes": {
@@ -61,8 +61,8 @@
       "command": "npx vitest run --coverage src/rules/detect-object-injection"
     },
     "throughput": {
-      "state": "unmet",
-      "evidence": "NOT REPRODUCIBLE: two consecutive measurements disagreed — linear then not-established. First: 502L +1.19±0.16ms · 2008L +4.02±3.23ms · 8032L +15.29±7.71ms — 3.4x time for 4.0x lines (502→2008), linear",
+      "state": "met",
+      "evidence": "attributed to the rule's own frames: 10x 7.48ms (152 samples) · 20x 10.03ms (232 samples) · 40x 15.87ms (382 samples) · 80x 23.82ms (651 samples) — 1.70x cost for 2.0x work (40x→80x), linear or better",
       "command": "npx tsx scripts/seal-audit.mts secure-coding/detect-object-injection"
     },
     "recorded": {

--- a/benchmarks/rule-corpus/secure-coding__no-redos-vulnerable-regex/SEAL.json
+++ b/benchmarks/rule-corpus/secure-coding__no-redos-vulnerable-regex/SEAL.json
@@ -6,7 +6,7 @@
     "ecmaVersion": 2022,
     "typescript": "6.0.3",
     "eslint": "10.8.1",
-    "plugin": "eslint-plugin-secure-coding@5.1.0",
+    "plugin": "eslint-plugin-secure-coding@5.1.2",
     "node": "24"
   },
   "axes": {
@@ -61,8 +61,8 @@
       "command": "npx vitest run --coverage src/rules/no-redos-vulnerable-regex"
     },
     "throughput": {
-      "state": "unmet",
-      "evidence": "NOT REPRODUCIBLE: two consecutive measurements disagreed — linear then not-established. First: 440L +2.24±0.48ms · 1760L +10.98±1.96ms · 7040L +24.23±1.27ms — 2.2x time for 4.0x lines (1760→7040), linear",
+      "state": "met",
+      "evidence": "attributed to the rule's own frames: 10x 7.59ms (115 samples) · 20x 6.16ms (144 samples) · 40x 9.80ms (244 samples) · 80x 16.30ms (418 samples) — 1.71x cost for 2.0x work (40x→80x), linear or better",
       "command": "npx tsx scripts/seal-audit.mts secure-coding/no-redos-vulnerable-regex"
     },
     "recorded": {

--- a/benchmarks/rule-corpus/secure-coding__no-unlimited-resource-allocation/SEAL.json
+++ b/benchmarks/rule-corpus/secure-coding__no-unlimited-resource-allocation/SEAL.json
@@ -6,7 +6,7 @@
     "ecmaVersion": 2022,
     "typescript": "6.0.3",
     "eslint": "10.8.1",
-    "plugin": "eslint-plugin-secure-coding@5.1.0",
+    "plugin": "eslint-plugin-secure-coding@5.1.2",
     "node": "24"
   },
   "axes": {
@@ -61,8 +61,8 @@
       "command": "npx vitest run --coverage src/rules/no-unlimited-resource-allocation"
     },
     "throughput": {
-      "state": "unmet",
-      "evidence": "NOT REPRODUCIBLE: two consecutive measurements disagreed — linear then not-established. First: 404L +0.60±0.09ms · 1616L +1.36±4.03ms · 6464L +3.73±2.43ms — 2.3x time for 4.0x lines (404→1616), linear",
+      "state": "met",
+      "evidence": "attributed to the rule's own frames: 10x 8.42ms (113 samples) · 20x 6.95ms (167 samples) · 40x 8.53ms (213 samples) · 80x 15.52ms (434 samples) — 2.04x cost for 2.0x work (40x→80x), linear or better",
       "command": "npx tsx scripts/seal-audit.mts secure-coding/no-unlimited-resource-allocation"
     },
     "recorded": {

--- a/scripts/seal-audit.mts
+++ b/scripts/seal-audit.mts
@@ -31,6 +31,7 @@
  *   npx tsx scripts/seal-audit.mts <plugin>/<rule> …   # just these
  *   npx tsx scripts/seal-audit.mts --skip-coverage     # the slow axis
  */
+import { Session } from 'node:inspector/promises';
 import { Linter } from 'eslint';
 import tsParser from '@typescript-eslint/parser';
 import { execFileSync } from 'node:child_process';
@@ -113,8 +114,8 @@ const run = (file: string, args: string[]): string => {
  */
 const LINTABLE = '**/*.{js,jsx,mjs,cjs,ts,tsx,mts,cts}';
 
-const throughputOf = (ruleId: string, rule: unknown, dir: string): Axis => {
-  const [, ruleName] = ruleId.split('/');
+const throughputOf = async (ruleId: string, rule: unknown, dir: string): Promise<Axis> => {
+  const [prefix, ruleName] = ruleId.split('/');
   // Kept as SEPARATE files, not concatenated.
   //
   // Joining them into one source was the fourth defect in this measurement.
@@ -182,220 +183,204 @@ const throughputOf = (ruleId: string, rule: unknown, dir: string): Axis => {
   // whose own cost then falls under the instrument's error report NOT
   // ESTABLISHED, which is the honest answer and already the answer for most of
   // them.
-  const SIZE_MULTIPLES = [1, 4, 16];
-  const NOISE_FLOOR_MS = 0.2;
-  const PASSES = 3;
-  const best = (r: unknown, files: number): number => {
-    const config = configFor(r);
-    const run = (): void => {
-      for (let rep = 0; rep < files; rep += 1) {
-        fixtureFiles.forEach((f, i) => linter.verify(f.code, config, `perf${rep}-${i}${f.ext}`));
-      }
-    };
-    run();
-    let min = Infinity;
-    for (let pass = 0; pass < PASSES; pass += 1) {
-      const started = process.hrtime.bigint();
-      run();
-      min = Math.min(min, Number(process.hrtime.bigint() - started) / 1e6);
-    }
-    return min;
-  };
-
-  // Per size, the rule's marginal cost is a small difference between two large
-  // timings, so ONE difference is not a measurement — it is a sample of a noisy
-  // quantity. Take K paired trials, alternating rule and no-op so both see the
-  // same machine, and report the MEDIAN difference with the median absolute
-  // deviation as its error.
-  //
-  // Two weaker versions of this shipped first, both wrong in the flattering
-  // direction. A fixed 0.2ms floor let the SAME unchanged rule read
-  // "0.0x, linear, met" and "12.9x, SUPERLINEAR, unmet" on consecutive runs —
-  // the 2000-line point drifted across the constant, which moved the judged
-  // pair, which flipped the published verdict. Replacing the constant with a
-  // single no-op-vs-no-op control was no better: that control is itself one
-  // sample, and it read 0.20 / 1.53 / 8.57 ms for one rule at one size on three
-  // consecutive runs. An error bar estimated from one draw is not an error bar.
-  const TRIALS = 5;
-  const median = (xs: number[]): number => {
-    const sorted = [...xs].sort((a, b) => a - b);
-    return sorted[Math.floor(sorted.length / 2)];
-  };
-
-  // Scale the workload by adding FILES, not by growing one file.
-  //
-  // Three earlier shapes of this measurement were wrong, each in the flattering
-  // direction, and the third is the subtle one:
-  //
-  //  1. `lines.slice(0, target)` cut through the middle of a function or an
-  //     unterminated comment. A source that does not parse is a source the rule
-  //     never runs on, so it timed at ~0ms and PASSED. Of four sizes,
-  //     `detect-object-injection` parsed at exactly one; its "linear, met" came
-  //     from a pair whose larger half was "Parsing error: '*/' expected".
-  //
-  //  2. A fixed 0.2ms noise floor let the SAME unchanged rule read "linear, met"
-  //     and "SUPERLINEAR, unmet" on consecutive runs, and a floor estimated from
-  //     a single no-op-vs-no-op control was no better — that control itself read
-  //     0.20 / 1.53 / 8.57 ms for one rule at one size on three runs.
-  //
-  //  3. Repeating one fixture N times into ONE file does not make a workload N
-  //     times bigger for a scope-sensitive rule — it makes one module scope with
-  //     N copies of every top-level name, so each variable's reference list
-  //     grows with N and any per-variable scan turns quadratic. Real code never
-  //     has that shape. Measured on `detect-object-injection`, same total lines:
-  //
-  //         2008L   one file  2.8ms    4 files   2.6ms
-  //         8032L   one file  9.5ms   16 files   9.9ms
-  //        32128L   one file 76.2ms   64 files  39.3ms
-  //
-  //     One file reads 8x for 4x lines — SUPERLINEAR, and it is an artifact of
-  //     the harness. Across files the same rule is 4.0x for 4x lines: linear.
-  //     A control rule that reports at the same rate but does no analysis holds
-  //     flat at ~2-7µs per report either way, which is what proved the growth
-  //     belonged to the workload shape rather than to ESLint.
-  //
-  // Files are also what ESLint actually does, so this is the shape the number is
-  // meant to describe.
+  /**
+   * MEASURED BY ATTRIBUTION, NOT BY SUBTRACTION.
+   *
+   * The previous engine timed the corpus with the rule and again with a no-op
+   * and subtracted. That is sound in principle and unusable in practice here:
+   * the rule's cost is a small difference between two large, noisy numbers
+   * dominated by the parser. On the ledger it produced 64 rules reading
+   * "marginal over a no-op control — NOT ESTABLISHED" and 22 reading "NOT
+   * REPRODUCIBLE", so 86 of 95 throughput failures were the instrument's, not
+   * the rule's.
+   *
+   * The comment it replaced named its own successor: "a CPU profile
+   * attributing samples to the rule's own frames". That is this. V8's sampling
+   * profiler records which frame was executing, so the rule's cost is read
+   * DIRECTLY off the samples whose script URL is the rule's own bundle — a
+   * positive quantity, never a difference.
+   *
+   * Measured on `detect-object-injection`, the rule the old engine could not
+   * decide:
+   *
+   *   no-op control      0 samples   0.00ms   0.0%   ← attribution is clean
+   *   run 1            108 samples  15.55ms   2.9%
+   *   run 2            109 samples  15.68ms   3.0%
+   *   run 3            102 samples  14.73ms   2.9%
+   *
+   * where the old engine gave "0.0x, linear, met" and "12.9x, SUPERLINEAR,
+   * unmet" on consecutive runs of the same unchanged rule.
+   *
+   * THE NO-OP CONTROL IS KEPT, as an assertion rather than a subtrahend. A
+   * no-op must attribute exactly zero samples; anything else means attribution
+   * is leaking (a bundler inlining rule code into another URL would do it),
+   * and a leaking instrument reports parser time as rule time. The axis fails
+   * loudly in that case instead of publishing the number.
+   */
+  /** A source that does not parse is a source the rule never ran on. */
   const parses = (source: string, name: string): boolean =>
     !linter
-      .verify(source, [{ files: [LINTABLE], languageOptions: { parser: tsParser, ecmaVersion: 2022 as const, sourceType: 'module' as const, parserOptions: { ecmaFeatures: { jsx: true } } }, rules: {} }], name)
+      .verify(
+        source,
+        [
+          {
+            files: [LINTABLE],
+            languageOptions: {
+              parser: tsParser,
+              ecmaVersion: 2022 as const,
+              sourceType: 'module' as const,
+              parserOptions: { ecmaFeatures: { jsx: true } },
+            },
+            rules: {},
+          },
+        ],
+        name,
+      )
       .some((m) => m.fatal);
 
-  // A verdict that does not reproduce is not a verdict.
-  //
-  // Three revisions of this axis were tuned by widening the noise floor — a
-  // constant, then one MAD-derived estimate, then five MADs — and each time the
-  // same unchanged rule still read `linear, met` on one run and
-  // `NOT ESTABLISHED` on the next, because the estimate of the noise is itself
-  // noisy. No multiplier fixes that; it is the wrong knob.
-  //
-  // So the property is tested directly: measure twice, and publish a verdict
-  // only when both measurements agree on it. Disagreement is not a tie to be
-  // broken, it is the finding — this harness cannot resolve that rule's cost
-  // today, and NOT ESTABLISHED says so.
-  const measureOnce = (): Axis => {
-    const marginal: number[] = [];
-    const floors: number[] = [];
-    const timings: string[] = [];
-    const usable: boolean[] = [];
-    const actual: number[] = [];
-    for (const multiple of SIZE_MULTIPLES) {
-      const files = multiple;
-      actual.push(files * unit.length);
-      // A fixture that is never LINTED is worse than one that never parses: it
-      // costs nothing, so it times as fast and the axis passes on an empty run.
-      // Proven reachable — the previous revision's glob left every .jsx and .ts
-      // fixture unmatched, and the numbers it published were measuring nothing.
-      const unlinted = fixtureFiles.findIndex((f, i) => {
-        const seen = linter.verify(f.code, configFor(rule), `lintcheck${i}${f.ext}`);
-        return seen.some((m) => /No matching configuration/.test(m.message));
-      });
-      if (unlinted !== -1) {
-        throw new Error(
-          `fixture #${unlinted} (${fixtureFiles[unlinted].ext}) is not matched by the throughput config for ${ruleId} — ` +
-            `it would be timed as a zero-cost run. Add its extension to LINTABLE.`,
-        );
-      }
+  const WORK_MULTIPLES = [10, 20, 40, 80];
+  /**
+   * Microseconds. V8's default is 1000µs, which is far too coarse here — the
+   * rule is a thin slice of a parser-dominated run, and at 100µs a cheap rule
+   * still landed only 26-48 samples, where a ratio carries ±30% noise and the
+   * verdict flapped between runs. Resolution is the cheap axis to buy: 20µs
+   * multiplies the sample count fivefold at the same work, where forcing the
+   * same counts through more work costs five times the wall clock.
+   */
+  const SAMPLING_INTERVAL_US = 20;
+  /**
+   * Below this the sample count is too small for a ratio to mean anything —
+   * at 5 samples one scheduling hiccup moves the growth figure by 20%.
+   */
+  const MIN_SAMPLES = 60;
+  /** Bounded so a rule that genuinely costs nothing terminates rather than looping. */
+  const MAX_ESCALATIONS = 3;
 
-      const broken = fixtureFiles.findIndex((f, i) => !parses(f.code, `probe${i}${f.ext}`));
-      if (broken !== -1) {
-        usable.push(false);
-        marginal.push(0);
-        floors.push(Infinity);
-        timings.push(`${actual[actual.length - 1]}L VOID (fixture #${broken} does not parse)`);
-        continue;
-      }
-      usable.push(true);
-
-      // Per size the rule's marginal cost is a small difference between two large
-      // timings, so ONE difference is not a measurement — it is a sample of a
-      // noisy quantity. Take K paired trials, alternating rule and no-op so both
-      // see the same machine, and report the MEDIAN with the median absolute
-      // deviation as its error.
-      const differences: number[] = [];
-      for (let trial = 0; trial < TRIALS; trial += 1) {
-        differences.push(best(rule, files) - best(noop, files));
-      }
-      const centre = median(differences);
-      const cost = Math.max(0, centre);
-      const mad = median(differences.map((d) => Math.abs(d - centre))) * 1.4826;
-      // Five MADs, not three.
-      //
-      // At three, `detect-object-injection` read +8.10±2.39ms at one size on one
-      // run and +0.30±3.72ms on the next, landing just above the floor once and
-      // well below it the other time — so the axis said "linear, met" and then
-      // "NOT ESTABLISHED" for unchanged code. That is the moving ruler this
-      // instrument has already been fixed for twice.
-      //
-      // A wider floor costs some `met` verdicts on rules whose cost genuinely
-      // sits in the borderline band, and buys a verdict that does not depend on
-      // which run you looked at. NOT ESTABLISHED is the honest answer for a cost
-      // this harness cannot separate from its own noise, and it is never the
-      // flattering one.
-      const floor = Math.max(mad * 5, NOISE_FLOOR_MS);
-      marginal.push(cost);
-      floors.push(floor);
-      timings.push(`${actual[actual.length - 1]}L +${cost.toFixed(2)}±${mad.toFixed(2)}ms`);
+  const runWork = (r: unknown, multiple: number): void => {
+    const config = configFor(r);
+    for (let rep = 0; rep < multiple; rep += 1) {
+      fixtureFiles.forEach((f, i) => linter.verify(f.code, config, `perf${rep}-${i}${f.ext}`));
     }
-
-    // Judge the growth on the largest PAIR of sizes whose smaller member is above
-    // the noise floor, and compare it against that pair's own line ratio.
-    //
-    // Dividing the 8000-line cost by the 500-line one looks obvious and is wrong
-    // whenever the 500-line cost rounds to zero: the ratio is undefined, and the
-    // first version of this check silently substituted 1 and called it linear.
-    // `detect-object-injection` measures +0.00 / +0.30 / +18.41 ms — a 61x rise
-    // across a 4x rise in lines, reported as "1.0x, linear". Three checks in this
-    // session have now failed in the flattering direction; a comparison that
-    // cannot be made must be reported as such, never resolved to a pass.
-    let verdict: Axis;
-    let index = SIZE_MULTIPLES.length - 2;
-    while (index >= 0 && (!usable[index] || !usable[index + 1] || marginal[index] < floors[index])) index -= 1;
-
-    if (index < 0) {
-      // Fewer than two sizes are above the noise floor, so there is no curve to
-      // read. That is NOT a pass — it is an unmeasurable, and the difference
-      // matters: `detect-object-injection` measures +0.01 / +0.03 / +11.30 ms,
-      // where the first two are noise and the third is real, and an earlier
-      // version of this branch called that "below the noise floor at every size"
-      // and marked it met.
-      //
-      // The subtraction itself is sound; the sizes are wrong. Harness cost at
-      // 8000 lines is ~70 ms, so a sub-millisecond rule cost is below the
-      // resolution of a difference between two ~70 ms measurements — the same
-      // rule measured +1.50 ms and +0.00 ms at 500 lines on consecutive runs.
-      // Measuring this properly needs either sizes large enough to lift the rule
-      // cost above the floor at more than one point, or a CPU profile attributing
-      // samples to the rule's own frames. Until one of those is built, the axis
-      // reports what it is: not established.
-      verdict = {
-        state: 'unmet',
-        evidence:
-          `marginal over a no-op control: ${timings.join(' · ')} — NOT ESTABLISHED: ` +
-          `fewer than two sizes clear the instrument's own measured error, so no growth curve can be read`,
-        command: `npx tsx scripts/seal-audit.mts ${ruleId}`,
-      };
-    } else {
-      const lineRatio = actual[index + 1] / actual[index];
-      const growth = marginal[index + 1] / marginal[index];
-      // 1.6x headroom over the line ratio absorbs measurement noise without
-      // absorbing an order of growth.
-      const linear = growth <= lineRatio * 1.6;
-      verdict = {
-        state: linear ? 'met' : 'unmet',
-        evidence:
-          `marginal over a no-op control: ${timings.join(' · ')} — ` +
-          `${growth.toFixed(1)}x time for ${lineRatio.toFixed(1)}x lines (${actual[index]}→${actual[index + 1]}), ` +
-          `${linear ? 'linear' : 'SUPERLINEAR'}`,
-        command: `npx tsx scripts/seal-audit.mts ${ruleId}`,
-      };
-    }
-
-    return verdict;
   };
 
-  const first = measureOnce();
-  const second = measureOnce();
+  /** Samples attributed to the rule's own bundle, and the wall time they cover. */
+  const profile = async (r: unknown, multiple: number): Promise<{ samples: number; ms: number }> => {
+    const session = new Session();
+    session.connect();
+    try {
+      await session.post('Profiler.enable');
+      await session.post('Profiler.setSamplingInterval', { interval: SAMPLING_INTERVAL_US });
+      await session.post('Profiler.start');
+      runWork(r, multiple);
+      const { profile: prof } = (await session.post('Profiler.stop')) as {
+        profile: {
+          nodes: { id: number; callFrame: { url: string } }[];
+          samples?: number[];
+          startTime: number;
+          endTime: number;
+        };
+      };
+      const urlOf = new Map(prof.nodes.map((n) => [n.id, n.callFrame.url || '']));
+      const taken = prof.samples ?? [];
+      const usPerSample = (prof.endTime - prof.startTime) / Math.max(taken.length, 1);
+      const ownBundle = `eslint-plugin-${prefix}${path.sep}dist`;
+      let samples = 0;
+      for (const id of taken) if ((urlOf.get(id) ?? '').includes(ownBundle)) samples += 1;
+      return { samples, ms: (samples * usPerSample) / 1000 };
+    } finally {
+      session.disconnect();
+    }
+  };
+
+  const measureOnce = async (): Promise<Axis> => {
+    // A fixture that is never LINTED is worse than one that never parses: it
+    // costs nothing, so it times as fast and the axis passes on an empty run.
+    const unlinted = fixtureFiles.findIndex((f, i) => {
+      const seen = linter.verify(f.code, configFor(rule), `lintcheck${i}${f.ext}`);
+      return seen.some((m) => /No matching configuration/.test(m.message));
+    });
+    if (unlinted !== -1) {
+      throw new Error(
+        `fixture #${unlinted} (${fixtureFiles[unlinted].ext}) is not matched by the throughput config for ${ruleId} — ` +
+          `it would be timed as a zero-cost run. Add its extension to LINTABLE.`,
+      );
+    }
+    const broken = fixtureFiles.findIndex((f, i) => !parses(f.code, `probe${i}${f.ext}`));
+    if (broken !== -1) {
+      return {
+        state: 'unmet',
+        evidence: `fixture #${broken} (${fixtureFiles[broken].ext}) does not parse, so the rule never ran on it`,
+        command: `npx tsx scripts/seal-audit.mts ${ruleId}`,
+      };
+    }
+
+    // Warm the parser and the rule so first-call compilation is not attributed.
+    runWork(rule, 2);
+
+    const control = await profile(noop, WORK_MULTIPLES[WORK_MULTIPLES.length - 1]);
+    if (control.samples !== 0) {
+      return {
+        state: 'unmet',
+        evidence:
+          `INSTRUMENT LEAKING: a no-op rule attributed ${control.samples} sample(s) to the rule bundle, so ` +
+          `attribution cannot separate rule frames from harness frames. No throughput figure from this run is usable`,
+        command: `npx tsx scripts/seal-audit.mts ${ruleId}`,
+      };
+    }
+
+    // ESCALATE UNTIL THE RULE IS BIG ENOUGH TO SEE.
+    //
+    // A single fixed work size cannot serve both ends of the ecosystem. At
+    // 10x-80x, `detect-object-injection` yields 132 samples at the top and
+    // `no-eval` yields 9 — and a rule sitting near the threshold flips between
+    // "linear" and "not established" on consecutive runs, which is the
+    // non-reproducibility the old engine was retired for. Cheap rules are not
+    // unmeasurable; they need more work to sample.
+    //
+    // So scale the whole ladder by 4 until the top point has comfortably
+    // cleared MIN_SAMPLES, bounded so a genuinely free rule terminates.
+    let scale = 1;
+    let points: { multiple: number; samples: number; ms: number }[] = [];
+    for (let attempt = 0; attempt < MAX_ESCALATIONS; attempt += 1) {
+      points = [];
+      for (const multiple of WORK_MULTIPLES)
+        points.push({ multiple: multiple * scale, ...(await profile(rule, multiple * scale)) });
+      if (points[points.length - 1].samples >= MIN_SAMPLES * 2) break;
+      scale *= 4;
+    }
+    const readable = `attributed to the rule's own frames: ${points
+      .map((p) => `${p.multiple}x ${p.ms.toFixed(2)}ms (${p.samples} samples)`)
+      .join(' · ')}`;
+
+    // Read the slope over the LARGEST adjacent pair that clears MIN_SAMPLES.
+    // The small end carries fixed first-run costs the big end amortises, so a
+    // ratio taken there flatters the rule.
+    let i = points.length - 2;
+    while (i >= 0 && (points[i].samples < MIN_SAMPLES || points[i + 1].samples < MIN_SAMPLES)) i -= 1;
+    if (i < 0) {
+      return {
+        state: 'unmet',
+        evidence:
+          `${readable} — NOT ESTABLISHED: no adjacent pair reaches ${MIN_SAMPLES} samples after escalating work ` +
+          `${scale}x, so this rule's own cost stays under the profiler's resolution`,
+        command: `npx tsx scripts/seal-audit.mts ${ruleId}`,
+      };
+    }
+
+    const workRatio = points[i + 1].multiple / points[i].multiple;
+    const growth = points[i + 1].samples / points[i].samples;
+    const superlinear = growth > workRatio * 1.5;
+    return {
+      state: superlinear ? 'unmet' : 'met',
+      evidence:
+        `${readable} — ${growth.toFixed(2)}x cost for ${workRatio.toFixed(1)}x work ` +
+        `(${points[i].multiple}x→${points[i + 1].multiple}x), ${superlinear ? 'SUPERLINEAR' : 'linear or better'}`,
+      command: `npx tsx scripts/seal-audit.mts ${ruleId}`,
+    };
+  };
+
+  const first = await measureOnce();
+  const second = await measureOnce();
   const classify = (axis: Axis): string =>
     /NOT ESTABLISHED/.test(axis.evidence) ? 'not-established' : /SUPERLINEAR/.test(axis.evidence) ? 'superlinear' : 'linear';
 
@@ -405,7 +390,7 @@ const throughputOf = (ruleId: string, rule: unknown, dir: string): Axis => {
       evidence:
         `NOT REPRODUCIBLE: two consecutive measurements disagreed — ` +
         `${classify(first)} then ${classify(second)}. ` +
-        `First: ${first.evidence.replace(/^marginal over a no-op control: /, '')}`,
+        `First: ${first.evidence.replace(/^attributed to the rule's own frames: /, '')}`,
       command: `npx tsx scripts/seal-audit.mts ${ruleId}`,
     };
   }
@@ -489,7 +474,7 @@ for (const dir of dirs) {
   }
   const mod = await import(path.join(pkg, 'dist/src/index.js'));
   const plugin = mod.default ?? mod;
-  const throughput = throughputOf(ruleId, plugin.rules[ruleName], path.join(CORPUS, dir));
+  const throughput = await throughputOf(ruleId, plugin.rules[ruleName], path.join(CORPUS, dir));
 
   // realSource, from the case ledger
   const casesFile = path.join(CORPUS, dir, 'CASES.json');

--- a/scripts/seal-audit.mts
+++ b/scripts/seal-audit.mts
@@ -151,7 +151,6 @@ const throughputOf = async (ruleId: string, rule: unknown, dir: string): Promise
       command: `npx tsx scripts/seal-audit.mts ${ruleId}`,
     };
   }
-  const unit = fixtures.split('\n');
   const linter = new Linter({ configType: 'flat' });
   const configFor = (r: unknown) => [
     {


### PR DESCRIPTION
## The problem

The throughput axis was failing rules for **the instrument's** reasons, not the rules'. Across the 101 seal records it is unmet on 95, and 86 of those read one of two things:

| evidence | rules |
|---|---:|
| "marginal over a no-op control — NOT ESTABLISHED" | 64 |
| "NOT REPRODUCIBLE: two consecutive measurements disagreed" | 22 |

Neither is a verdict about a rule. The old engine timed the corpus with the rule and again with a no-op and subtracted — sound in principle, unusable here, because the rule's cost is a small difference between two large numbers dominated by the parser.

## The fix, which the old comment named itself

> *"Measuring this properly needs either sizes large enough to lift the rule cost above the floor at more than one point, or a CPU profile attributing samples to the rule's own frames."*

This is the second one. V8's sampling profiler records which frame was executing, so the rule's cost is read **directly** off the samples whose script URL is the rule's own bundle — a positive quantity, never a difference.

On `detect-object-injection`, the rule the old engine could not decide:

```
no-op control      0 samples   0.00ms   0.0%   <- attribution is clean
run 1            108 samples  15.55ms   2.9%
run 2            109 samples  15.68ms   3.0%
run 3            102 samples  14.73ms   2.9%
```

The old engine gave `0.0x, linear, met` and `12.9x, SUPERLINEAR, unmet` on consecutive runs of the same unchanged rule.

**The no-op control is kept — as an assertion, not a subtrahend.** A no-op must attribute exactly zero samples. Anything else means attribution is leaking (a bundler inlining rule code under another URL would do it), and a leaking instrument reports parser time as rule time. The axis then fails loudly rather than publishing the number.

## Two tuning decisions, measured rather than guessed

**20µs sampling**, against V8's 1000µs default. At 100µs a cheap rule landed 26–48 samples; a ratio there carries ±30% and the verdict flapped run to run. Resolution is the cheap axis to buy — 20µs multiplies sample counts fivefold at the same work, where forcing the same counts through more work costs five times the wall clock. `no-eval` then read met/met/met across three runs at 272–331 samples, having flapped before.

**Work escalates 4× until the top point clears the sample floor**, bounded so a genuinely free rule terminates. One fixed size cannot serve both ends: at the same setting `detect-object-injection` yields 132 samples and `no-eval` yields 9.

The superlinear tolerance is **1.5×, tightened** from the old engine's 1.6×, not loosened.

## Sampled effect

| rule | verdict |
|---|---|
| `secure-coding/detect-object-injection` | met — 1.70x cost for 2.0x work |
| `secure-coding/no-redos-vulnerable-regex` | met — 1.71x / 2.0x |
| `node-security/detect-non-literal-fs-filename` | met — 1.99x / 2.0x |
| `secure-coding/no-unlimited-resource-allocation` | met — 2.04x / 2.0x |
| `browser-security/no-eval` | met, stable over 3 runs |
| `secure-coding/detect-non-literal-regexp` | **NOT REPRODUCIBLE** — 2.97x against a 3.0x bar |

The last row is the instrument working, not failing: a verdict that does not reproduce is not a verdict, and it refuses to pick one.

## Scope and honesty about it

Six records are re-measured here — **not** all 101. A full re-run is ~100 rules × the escalating profile and belongs in its own pass. The ledger is therefore mixed, and deliberately self-describing: `attributed to the rule's own frames` versus `marginal over a no-op control` says which engine produced each number.

This unblocks one axis. It seals nothing on its own — `effectiveFp` and `recorded` are unmet on **all 101**, and several axes (`oracle`, `corpus`, `reachability`) require human adjudication by design.

## Test plan

- [x] No-op control attributes exactly 0 samples — attribution does not leak parser time.
- [x] Reproducibility: 3 consecutive runs on `detect-object-injection` (2.9/3.0/2.9%) and on `no-eval` (met/met/met) where the old engine disagreed with itself.
- [x] Discrimination: rules land between 1.24x and 3.86x growth rather than all collapsing to "not established".
- [x] Existing two-run agreement check retained; the borderline rule is still caught by it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)