### PR TITLE
feat(release): the rollup claims the Latest badge, and can open a discussion

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -123,6 +123,22 @@ range by hand:
 npm run release:verify-notes -- --latest=10
 ```
 
+## GitHub Release conventions
+
+- **The rollup holds the "Latest" badge**, explicitly. Every per-package release
+  passes `--latest=false`; before this was set, GitHub awarded the badge to
+  whichever release happened to be created last, so the repo's front page
+  pointed at an arbitrary single package.
+- **Release discussions are opt-in.** Set the repo variable
+  `RELEASE_DISCUSSION_CATEGORY` to a Discussions category name (e.g. `Releases`)
+  and every rollup opens a feedback thread. Requires Discussions enabled on the
+  repository. If the variable is unset, or the category is missing, the release
+  is created exactly as before — the flag errors outright when Discussions is
+  off, and a feedback thread is not worth failing a release whose packages are
+  already on npm.
+
+Both are locked by `scripts/__tests__/release-workflow-lock.test.ts`.
+
 ## Prereleases and snapshots
 
 ```bash

--- a/.changeset/release-latest-and-discussions.md
+++ b/.changeset/release-latest-and-discussions.md
@@ -1,0 +1,23 @@
+---
+---
+
+feat(release): the rollup claims the Latest badge, and can open a discussion
+
+Two things GitHub Releases offers that we were not using.
+
+**The "Latest" badge was arbitrary.** Every per-package release passes
+`--latest=false` and nothing claimed the badge, so GitHub awarded it to whichever
+release was created last. It currently sits on a rollup by luck; a publish job
+finishing after would have moved it to a random single package. The rollup is the
+one release that describes the whole thing, so it now claims the badge on
+purpose — on the create paths and on the idempotent re-run edit.
+
+**Releases can now open a feedback thread.** Set the repo variable
+`RELEASE_DISCUSSION_CATEGORY` to a Discussions category name and each rollup
+creates one. Discussions is currently disabled on this repository, which is a
+repo setting rather than a code change — until it is enabled and the variable is
+set, this path is inert and the release is created exactly as before. The flag
+errors outright when Discussions is off, so the call falls back rather than
+failing a release whose packages are already published.
+
+No published package behaviour changes.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -586,6 +586,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COUNT: ${{ needs.detect.outputs.count }}
+          # Optional. Set this repo variable to a Discussions category name
+          # (e.g. `Releases`) to open a feedback thread on every rollup. Left
+          # empty — or with Discussions disabled — the release is created
+          # exactly as before.
+          DISCUSSION_CATEGORY: ${{ vars.RELEASE_DISCUSSION_CATEGORY }}
         run: |
           set -euo pipefail
           # Date-stamped tag, disambiguated by the short SHA so two releases on
@@ -594,13 +599,41 @@ jobs:
           tag="release-$(git log -1 --format=%cd --date=format:%Y-%m-%d)-$(git rev-parse --short HEAD)"
 
           if gh release view "$tag" >/dev/null 2>&1; then
-            gh release edit "$tag" --notes-file rollup-notes.md
+            gh release edit "$tag" --notes-file rollup-notes.md --latest
             echo "↻ Updated rollup release $tag"
           else
-            gh release create "$tag" \
-              --title "Release $tag · ${COUNT} package(s)" \
-              --notes-file rollup-notes.md
-            echo "🆕 Created rollup release $tag"
+            # `--latest` explicitly. Every per-package release passes
+            # `--latest=false`, and nothing claimed the badge — so which release
+            # GitHub showed as "Latest" was decided by whichever job happened to
+            # finish last. The rollup is the one release that describes the
+            # whole thing, so it should hold the badge on purpose.
+            #
+            # `--discussion-category` is attempted only when the variable is
+            # set, and falls back to a plain create: the flag errors outright if
+            # Discussions is disabled or the category does not exist, and a
+            # feedback thread is not worth failing a release that already
+            # published to npm.
+            created=false
+            if [ -n "${DISCUSSION_CATEGORY:-}" ]; then
+              if gh release create "$tag" \
+                   --title "Release $tag · ${COUNT} package(s)" \
+                   --notes-file rollup-notes.md \
+                   --latest \
+                   --discussion-category "$DISCUSSION_CATEGORY"; then
+                created=true
+                echo "🆕 Created rollup release $tag (with discussion)"
+              else
+                echo "::warning::Could not open a release discussion in category '${DISCUSSION_CATEGORY}'. Is Discussions enabled and the category present? Creating the release without one."
+              fi
+            fi
+
+            if [ "$created" = "false" ]; then
+              gh release create "$tag" \
+                --title "Release $tag · ${COUNT} package(s)" \
+                --notes-file rollup-notes.md \
+                --latest
+              echo "🆕 Created rollup release $tag"
+            fi
           fi
           # Idempotent: --clobber replaces the asset on a re-run.
           gh release upload "$tag" rollup.json --clobber

--- a/scripts/__tests__/release-workflow-lock.test.ts
+++ b/scripts/__tests__/release-workflow-lock.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Lock for two release-workflow intents that are invisible in review and
+ * silent when they break.
+ *
+ * **The "Latest" badge.** Every per-package release passes `--latest=false`,
+ * so if the rollup does not claim the badge explicitly, GitHub awards it to
+ * whichever release happened to be created last — an arbitrary single package
+ * rather than the release that describes the whole thing. Nothing fails when
+ * that happens; the repo's front page just points somewhere unhelpful.
+ *
+ * **The discussion fallback.** `--discussion-category` errors outright when
+ * Discussions is disabled or the category is missing. Without the fallback
+ * path, turning that variable on would fail a release *after* the packages
+ * were already published to npm.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const WORKFLOW = join(
+  resolve(__dirname, '..', '..'),
+  '.github/workflows/release.yml',
+);
+
+describe('release.yml — GitHub Release intents', () => {
+  let source: string;
+  beforeAll(() => {
+    source = readFileSync(WORKFLOW, 'utf-8');
+  });
+
+  it('per-package releases decline the Latest badge', () => {
+    expect(source).toContain('--latest=false');
+  });
+
+  it('every rollup release call claims it — not just most of them', () => {
+    const rollup = source.slice(
+      source.indexOf('Publish rollup GitHub Release'),
+    );
+
+    // Counting with a floor is not enough. The block has three call sites
+    // (edit, create-with-discussion, create-fallback), so a `>= 2` assertion
+    // passes with one silently downgraded — verified by sabotage: the first
+    // version of this test went green on a workflow I had deliberately broken.
+    //
+    // Comments have to go first. The block explains *why* per-package releases
+    // pass `--latest=false`, and a naive scan counts that prose as code — the
+    // second version of this test failed on a correct workflow for exactly
+    // that reason.
+    const code = rollup
+      .split('\n')
+      .filter((line) => !/^\s*#/.test(line))
+      .join('\n');
+
+    expect(code).not.toContain('--latest=false');
+
+    const calls = code.match(/gh release (?:create|edit)\b/g)?.length ?? 0;
+    const claims = code.match(/--latest\b(?!=)/g)?.length ?? 0;
+
+    expect(calls).toBeGreaterThan(0);
+    expect(claims).toBe(calls);
+  });
+
+  it('a missing discussion category cannot fail a published release', () => {
+    const rollup = source.slice(
+      source.indexOf('Publish rollup GitHub Release'),
+    );
+    expect(rollup).toContain('--discussion-category');
+    // The guard: only attempted when set, and a failure warns rather than
+    // aborting — the packages are already on npm by this point.
+    expect(rollup).toContain('if [ -n "${DISCUSSION_CATEGORY:-}" ]');
+    expect(rollup).toContain('::warning::');
+    expect(rollup).toMatch(/created=false/);
+  });
+});


### PR DESCRIPTION
## Summary

Two things GitHub Releases offers that we weren't using.

**1. The "Latest" badge was arbitrary.** Every per-package release passes `--latest=false`, and nothing claimed the badge — so GitHub awarded it to whichever release happened to be created last. It currently sits on `release-2026-08-23-6642b061` by luck; a publish job finishing later would have moved it to a random single package, and the repo's front page would point at `eslint-plugin-mysql-security@0.2.1` instead of the release that describes the whole thing.

The rollup now claims it deliberately — on both create paths and on the idempotent re-run `edit`.

**2. Releases can open a feedback thread.** Set the repo variable `RELEASE_DISCUSSION_CATEGORY` to a Discussions category name and each rollup creates one. For an ecosystem converting silent npm installs into visible adoption, "did this break anything for you?" attached to the release is the cheapest feedback channel available.

**This needs one thing from you:** Discussions is currently disabled on the repository (`has_discussions: false`). That's a repo *setting*, not a code change, so I haven't touched it. Until it's enabled and the variable is set, this path is inert and releases are created exactly as before. The flag errors outright when Discussions is off, so the call falls back rather than failing a release whose packages are already on npm.

## The lock took three tries, and the first two were wrong in useful ways

- **v1** counted `--latest` occurrences with a `>= 2` floor. It **passed on a workflow I had deliberately broken** — the block has three call sites, so one silently downgrading still cleared the floor. Exactly the vacuous-lock trap in CLAUDE.md.
- **v2** replaced the floor with strict equality. It then **failed on a correct workflow**, because the block explains *why* per-package releases pass `` `--latest=false` `` in a comment — and the scan counted prose as code.
- **v3** strips comment lines first, then asserts the invariant: nothing opts out, every call opts in.

Verified by sabotage: **passes clean → fails broken → passes restored.** I only trust it because I broke it on purpose.

## Test plan

- [x] `vitest run` on the three release-tooling suites — **50 pass**.
- [x] Sabotage cycle on the new lock, as above.
- [x] `lint-workflows` — 35 workflows pass; YAML parses.
- [x] `changeset:lint`, prettier, markdownlint clean.

## Not adopted, deliberately

- `linked` / `fixed` — would force 30 plugins onto one version line, destroying the independent versioning that makes `eslint-plugin-jwt-security@3.0.2` meaningful.
- `onlyUpdatePeerDependentsWhenOutOfRange` — I expected this to cut version churn. It wouldn't: devkit is a regular `dependency`, not a peer, and **0 of 458 releases are dependency-only**. Checked before recommending.
- GitHub's `generate_release_notes` wholesale — it's a commit-title dump; ours are written for someone deciding whether to upgrade. Its "New Contributors" section is worth borrowing later, when external contributions are frequent enough to justify it (there are 2 today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)