### PR TITLE
chore(ci): re-enable the weekly npm token health check

### DIFF
--- a/.github/workflows/npm-token-health.yml
+++ b/.github/workflows/npm-token-health.yml
@@ -14,13 +14,21 @@ name: NPM Token Health Check
 # ═══════════════════════════════════════════════════════════════════════════════
 
 on:
-  # schedule: # DISABLED — quota conservation
-    # Every Monday at 9:00 AM UTC
-    # - cron: "0 9 * * 1"
+  schedule:
+    # Mon 09:15 UTC — weekly. Re-enabled: the "quota conservation" reason no
+    # longer applies, because this repository is public and GitHub Actions
+    # minutes are free for public repositories. Staggered 15 minutes off
+    # weekly-benchmark.yml, which holds 09:00 on the same day.
+    #
+    # This is the shape of check that belongs on a schedule rather than in the
+    # PR pipeline: it costs nothing per push, and its output is an action item
+    # (an issue naming an expiring token), not a gate. npm Granular Access
+    # Tokens expire after 90 days, and a lapsed one fails a release silently.
+    - cron: '15 9 * * 1'
   workflow_dispatch:
     inputs:
       create-issue:
-        description: "Create GitHub issue if token is invalid/missing"
+        description: 'Create GitHub issue if token is invalid/missing'
         required: false
         type: boolean
         default: true
@@ -35,7 +43,7 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
-      issues: write   # creates / comments on the failure issue
+      issues: write # creates / comments on the failure issue
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -44,8 +52,8 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version-file: .nvmrc
-          registry-url: "https://registry.npmjs.org/"
-          cache: "npm"
+          registry-url: 'https://registry.npmjs.org/'
+          cache: 'npm'
 
       - name: 🔍 Check NPM Token Status
         id: token-check


### PR DESCRIPTION
## Summary

`npm-token-health.yml` had its cron commented out:

```yaml
# schedule: # DISABLED — quota conservation
  # - cron: "0 9 * * 1"
```

**That reason no longer holds** — this repository is public, and GitHub Actions minutes are free for public repos. So the check has not run at all, while the thing it watches kept expiring.

npm Granular Access Tokens expire after 90 days. A lapsed one fails a release, and fails it *quietly* — the same shape as everything found this week: a system that looks healthy because nothing is asking it a question.

Moved to **Mon 09:15 UTC**. The original `0 9 * * 1` collided exactly with `weekly-benchmark.yml`; 15 minutes clear avoids two jobs starting together. Verified against every other cron in the repo — no remaining collisions.

## Fits the agreed split

Per your steer: nothing new in the CI/CD path, weekly schedulers that drive action items are fine. This is the second kind — zero cost per push, and its output is an issue naming an expiring token, not a gate.

Same shape as `integration-health.yml` (#680), which is `schedule` + `workflow_dispatch` only, with no `push` or `pull_request` trigger.

## Test plan

- [x] YAML parses; cron resolves to `15 9 * * 1`, `workflow_dispatch` preserved.
- [x] Collision-checked against all 13 crons in the repo.
- [x] No trigger added to the PR pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)