### PR TITLE
chore(docs): sync generated data

### DIFF
--- a/apps/docs/src/data/changelog.json
+++ b/apps/docs/src/data/changelog.json
@@ -1,9 +1,44 @@
 {
-  "releaseCount": 458,
+  "releaseCount": 460,
   "packageCount": 34,
-  "entryCount": 1554,
+  "entryCount": 1557,
   "oldestYear": 2024,
   "releases": [
+    {
+      "package": "docs",
+      "short": "docs",
+      "version": "1.2.0",
+      "date": "2026-08-24T04:53:12Z",
+      "isApp": true,
+      "isPrivate": true,
+      "entries": [
+        {
+          "kind": "feature",
+          "title": "plugin changelogs render from build-time data, not a runtime fetch",
+          "pr": 679
+        },
+        {
+          "kind": "fix",
+          "title": "the changelog API returned `\"date\": \"Unknown\"` for every modern release",
+          "pr": 682
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-import-next",
+      "short": "eslint-plugin-import-next",
+      "version": "2.5.0",
+      "date": "2026-08-24T04:48:31Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "feature",
+          "title": "`no-cycle` no longer reports inside generated files.",
+          "pr": 686
+        }
+      ]
+    },
     {
       "package": "docs",
       "short": "docs",
@@ -8913,7 +8948,7 @@
       "package": "@interlace/eslint-formatter",
       "short": "eslint-formatter",
       "version": "0.1.0",
-      "date": "2026-05-11T00:35:17-05:00",
+      "date": "2026-05-03T00:00:00Z",
       "isApp": false,
       "isPrivate": true,
       "entries": [

--- a/apps/docs/src/data/plugin-stats.json
+++ b/apps/docs/src/data/plugin-stats.json
@@ -173,7 +173,7 @@
       "rules": 55,
       "description": "ESLint plugin for imports and module boundaries — drop-in replacement for eslint-plugin-import, 3.1x faster end-to-end, zero-config migration",
       "category": "architecture",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "published": true
     },
     {


### PR DESCRIPTION
Regenerated apps/docs/src/data/ (trigger: push). Opened by the Docs Data Sync workflow; contents come entirely from the apps/docs/scripts/sync-* scripts, so review the diff rather than hand-editing.