### PR TITLE
chore(docs): sync generated data

### DIFF
--- a/apps/docs/src/data/articles.json
+++ b/apps/docs/src/data/articles.json
@@ -11,8 +11,8 @@
       "readable_publish_date": "Aug 20",
       "reading_time_minutes": 3,
       "page_views_count": 0,
-      "public_reactions_count": 1,
-      "positive_reactions_count": 1,
+      "public_reactions_count": 3,
+      "positive_reactions_count": 3,
       "comments_count": 0,
       "tag_list": [
         "react",
@@ -1685,6 +1685,6 @@
     }
   ],
   "total": 82,
-  "lastUpdated": "2026-08-23T05:33:13.585Z",
+  "lastUpdated": "2026-08-25T01:38:03.000Z",
   "source": "public"
 }

--- a/apps/docs/src/data/plugin-rules/_sync-summary.json
+++ b/apps/docs/src/data/plugin-rules/_sync-summary.json
@@ -1,12 +1,12 @@
 {
-  "lastSynced": "2026-08-15T18:33:15.709Z",
+  "lastSynced": "2026-08-25T01:38:02.208Z",
   "plugins": 9,
   "success": 9,
   "errors": 0,
   "details": {
     "success": [
       "browser-security: 46 rules",
-      "express-security: 24 rules",
+      "express-security: 28 rules",
       "jwt-security: 13 rules",
       "lambda-security: 14 rules",
       "mongodb-security: 16 rules",

--- a/apps/docs/src/data/plugin-rules/express-security.json
+++ b/apps/docs/src/data/plugin-rules/express-security.json
@@ -153,6 +153,51 @@
       "href": "/docs/express-security/rules/no-insecure-cookie-options"
     },
     {
+      "name": "no-missing-cors-check",
+      "cwe": "CWE-346",
+      "owasp": "",
+      "cvss": "",
+      "description": "Detects missing CORS validation (wildcard CORS, missing origin check)",
+      "typeStatus": "unaware",
+      "recommended": false,
+      "warns": false,
+      "fixable": false,
+      "hasSuggestions": false,
+      "deprecated": false,
+      "category": "General",
+      "href": "/docs/express-security/rules/no-missing-cors-check"
+    },
+    {
+      "name": "no-missing-csrf-protection",
+      "cwe": "CWE-352",
+      "owasp": "",
+      "cvss": "",
+      "description": "Detects missing CSRF token validation in POST/PUT/DELETE requests",
+      "typeStatus": "unaware",
+      "recommended": false,
+      "warns": false,
+      "fixable": false,
+      "hasSuggestions": false,
+      "deprecated": false,
+      "category": "General",
+      "href": "/docs/express-security/rules/no-missing-csrf-protection"
+    },
+    {
+      "name": "no-missing-security-headers",
+      "cwe": "CWE-693",
+      "owasp": "",
+      "cvss": "",
+      "description": "Detects missing security headers in HTTP responses",
+      "typeStatus": "unaware",
+      "recommended": false,
+      "warns": false,
+      "fixable": false,
+      "hasSuggestions": false,
+      "deprecated": false,
+      "category": "General",
+      "href": "/docs/express-security/rules/no-missing-security-headers"
+    },
+    {
       "name": "no-permissive-cors",
       "cwe": "CWE-942",
       "owasp": "",
@@ -226,6 +271,21 @@
       "deprecated": false,
       "category": "General",
       "href": "/docs/express-security/rules/no-unsafe-csp-directives"
+    },
+    {
+      "name": "no-user-controlled-redirect",
+      "cwe": "CWE-601",
+      "owasp": "",
+      "cvss": "",
+      "description": "Disallow res.redirect() with values directly from req.query / req.body / req.params",
+      "typeStatus": "unaware",
+      "recommended": true,
+      "warns": false,
+      "fixable": false,
+      "hasSuggestions": false,
+      "deprecated": false,
+      "category": "General",
+      "href": "/docs/express-security/rules/no-user-controlled-redirect"
     },
     {
       "name": "no-user-controlled-render-locals",
@@ -363,6 +423,6 @@
       "href": "/docs/express-security/rules/require-strict-transport-security"
     }
   ],
-  "totalRules": 24,
-  "lastSynced": "2026-08-15T18:33:15.702Z"
+  "totalRules": 28,
+  "lastSynced": "2026-08-25T01:38:02.203Z"
 }


### PR DESCRIPTION
Regenerated apps/docs/src/data/ (trigger: push). Opened by the Docs Data Sync workflow; contents come entirely from the apps/docs/scripts/sync-* scripts, so review the diff rather than hand-editing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Updated reaction counts for the first article.
  * Refreshed the article’s last-updated timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->