### PR TITLE
fix(docs): TOC landmark must be grid-transparent — layout broke on xl+

### DIFF
--- a/apps/docs/src/__tests__/toc-layout-lock.test.ts
+++ b/apps/docs/src/__tests__/toc-layout-lock.test.ts
@@ -1,0 +1,29 @@
+/**
+ * TOC layout lock.
+ *
+ * The docs page is a CSS grid; fumadocs' `#nd-toc` positions itself with
+ * `[grid-area:toc]`, which only applies to DIRECT grid children. TocNav wraps
+ * the TOC in a <nav> landmark (the axe `region` fix from #653) — and without
+ * `display: contents` that wrapper becomes the grid child: unstyled,
+ * auto-placed, rendering as a ~1000px block over the article on every xl+
+ * viewport. Shipped broken on 2026-08-24; this pins the one class that keeps
+ * the landmark AND the grid placement.
+ */
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const SRC = readFileSync(
+  join(resolve(__dirname, '../..'), 'src/components/docs/toc-nav.tsx'),
+  'utf-8',
+);
+
+describe('TocNav grid transparency', () => {
+  it('the landmark wrapper is display:contents so #nd-toc stays a grid child', () => {
+    expect(SRC).toMatch(/<nav className="contents" aria-label="On this page">/);
+  });
+
+  it('still wraps the stock TOC (the landmark must not replace the slot)', () => {
+    expect(SRC).toMatch(/<TOC \{\.\.\.props\} \/>/);
+  });
+});

--- a/apps/docs/src/components/docs/toc-nav.tsx
+++ b/apps/docs/src/components/docs/toc-nav.tsx
@@ -27,7 +27,17 @@ import { TOC } from 'fumadocs-ui/layouts/docs/page/slots/toc';
 
 export function TocNav(props: ComponentProps<typeof TOC>) {
   return (
-    <nav aria-label="On this page">
+    // `contents` is load-bearing, not cosmetic. The docs page is a CSS grid
+    // and the stock `#nd-toc` places itself with `[grid-area:toc]` — but
+    // grid-area only works on DIRECT grid children. A plain <nav> wrapper
+    // becomes the grid child instead: unstyled, auto-placed into the first
+    // free cell, where it rendered as a full-height block overlapping the
+    // article on every xl+ viewport (the TOC is `max-xl:hidden`, which is
+    // why small screens never showed it). `display: contents` removes the
+    // nav's box so `#nd-toc` is the grid item again, while the navigation
+    // landmark and its accessible name stay exposed — verified with axe
+    // (0 violations, `region` included) at 1728×1117.
+    <nav className="contents" aria-label="On this page">
       <TOC {...props} />
     </nav>
   );


### PR DESCRIPTION
## Summary

**Production regression, every docs page, xl+ viewports only** (reported on a 16" MacBook): the table of contents renders as an unstyled ~1016px-wide, viewport-tall block overlapping the article.

Root cause: the docs page is a CSS **grid**, and fumadocs' `#nd-toc` positions itself with `[grid-area:toc]` — which only applies to **direct grid children**. The `TocNav` landmark wrapper introduced in #653 (the axe `region` fix that rode in on a deps bump) became the grid child instead: no classes, auto-placed into the first free cell. The TOC is `max-xl:hidden`, so any laptop under 1280px never showed it — which is how it survived review, and why it only appears on big screens.

The fix is one class: `display: contents` removes the nav's box, making `#nd-toc` the grid item again while the navigation landmark and its accessible name stay exposed.

## Test plan

- [x] **Reproduced live at 1728×1117** before touching code: nav at x=356, w=1016, h=941, overlapping the article (x=414).
- [x] **Fix proven by DOM surgery on production first**: setting `display:contents` on the live nav snapped `#nd-toc` to its proper 268px column at x=1372, zero overlap.
- [x] **The #653 landmark fix is preserved**: axe 4.10.2 on the patched DOM at 1728×1117 → **0 violations**, `region` included.
- [x] Locked by `toc-layout-lock.test.ts`; mutation-verified — reverting to a bare `<nav>` turns it red.
- [x] Full docs suite: 88 files, 1798 passed, 0 failed.
- [x] `className="contents"` is an established pattern in this app — `#main-content` itself uses it.

## After merge

Auto-deploy → verify https://eslint.interlace.tools/docs at ≥1280px width: TOC on the right at 268px, no article overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)