### PR TITLE
feat(docs): DS-grounded UX pass — scorecard, articles, changelog, playground

### DIFF
--- a/.changeset/ds-article-card-zero-views.md
+++ b/.changeset/ds-article-card-zero-views.md
@@ -1,0 +1,9 @@
+---
+'@interlace/ui': patch
+---
+
+fix: ArticleCard renders no views chip for zero views
+
+Sources that cannot report views (dev.to's public API) return 0, and the card
+displayed a literal "👁 0" on every article. A zero-view chip reads as product
+failure, not information — absence is the honest presentation of absence.

--- a/apps/docs/content/docs/getting-started/index.mdx
+++ b/apps/docs/content/docs/getting-started/index.mdx
@@ -14,6 +14,25 @@ import {
   CheckCircle,
 } from 'lucide-react';
 
+## Install in 30 seconds
+
+The most-adopted starting point — general secure-coding rules that work in any
+JavaScript or TypeScript project:
+
+<InstallSnippet packages="eslint-plugin-secure-coding" dev />
+
+Then enable the recommended preset and lint:
+
+```js
+// eslint.config.js
+import secureCoding from 'eslint-plugin-secure-coding';
+
+export default [secureCoding.configs.recommended];
+```
+
+Framework-specific plugins (Express, React, MongoDB, AI SDKs, …) are one
+[catalog](/plugins) away — every plugin installs the same way.
+
 ## What is ESLint Interlace?
 
 ESLint Interlace is a comprehensive ecosystem of **security and quality ESLint plugins** designed to protect your JavaScript and TypeScript applications from vulnerabilities while enforcing best practices.

--- a/apps/docs/src/__tests__/changelog-page-lock.test.tsx
+++ b/apps/docs/src/__tests__/changelog-page-lock.test.tsx
@@ -104,11 +104,19 @@ describe('Changelog page: structure', () => {
     expect(list).not.toMatch(/>\{entry\.title\}</);
   });
 
-  it('keeps the package filter to one row on mobile', () => {
-    // Wrapped, 32 chips are ~900px of filter before the first release at
-    // 375px wide. `md:flex-wrap` means the mobile default is a scroll strip.
-    expect(filters).toContain('overflow-x-auto');
-    expect(filters).toContain('md:flex-wrap');
+  it('collapses the chip cloud so releases stay on the first screen', () => {
+    // 34 wrapped chips are ~5 rows of filter before the first release — on
+    // desktop as well as mobile. The cloud lives inside a native <details>
+    // (zero JS, links stay in the DOM for crawlers), and the always-visible
+    // row carries only the reset chip and the active filter.
+    // JSX-shaped anchors (className present) so a docstring mentioning the
+    // elements can never satisfy this — the comment-trap lock-integrity hunts.
+    expect(filters).toContain('<details className=');
+    expect(filters).toContain('<summary className=');
+    // The reset + active-filter row must exist outside the disclosure.
+    expect(filters.indexOf('>All packages</Badge>')).toBeLessThan(
+      filters.indexOf('<details className='),
+    );
   });
 
   it('announces the active filter', () => {

--- a/apps/docs/src/__tests__/landscape-framing-scorecard.lock.test.ts
+++ b/apps/docs/src/__tests__/landscape-framing-scorecard.lock.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Landscape framing lock for the scorecard surfaces.
+ *
+ * The ecosystem's public voice is landscape/specialization — peers, never
+ * "competitors" (ECOSYSTEM_LANDSCAPE framing). STACK_LABELS renders on the
+ * /scorecard page AND in the generated markdown reports, and carried
+ * "Competitor (ESLint)" until 2026-08-24. Internal type keys keep their
+ * historical names; only reader-visible strings are constrained.
+ */
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const REPO = resolve(__dirname, '../../../..');
+
+describe('scorecard landscape framing', () => {
+  it('STACK_LABELS never says competitor', () => {
+    const src = readFileSync(
+      join(REPO, 'benchmarks/lib/flagship-snapshot.ts'),
+      'utf-8',
+    );
+    const block = /STACK_LABELS = \{[\s\S]*?\} as const;/.exec(src)?.[0] ?? '';
+    expect(block.length).toBeGreaterThan(0);
+    // Only reader-visible label VALUES are constrained — the internal
+    // `competitorEslint` key keeps its historical name on purpose.
+    const values = [...block.matchAll(/: '([^']*)'/g)].map((m) => m[1]);
+    expect(values.length).toBeGreaterThan(0);
+    for (const v of values) expect(v).not.toMatch(/[Cc]ompetitor/);
+    expect(values).toContain('Peer (ESLint)');
+  });
+
+  it('the scorecard page shows Peer columns, not Comp', () => {
+    const src = readFileSync(
+      join(REPO, 'apps/docs/src/app/scorecard/page.tsx'),
+      'utf-8',
+    );
+    expect(src).toContain('>Peer cold</th>');
+    expect(src).toContain('>Peer warm</th>');
+    expect(src).not.toMatch(/>Comp (cold|warm)</);
+  });
+});

--- a/apps/docs/src/app/(home)/play/page.tsx
+++ b/apps/docs/src/app/(home)/play/page.tsx
@@ -41,6 +41,7 @@ export default async function PlaygroundPage({
     <main>
       <Section spacing="comfortable" container="content">
         <SectionHeader
+          as="h1"
           eyebrow="Try it"
           title="Playground"
           tagline="Pick a flagship rule, edit the code, toggle the plugins, copy a real eslint.config.js. Live linting — edits trigger a real ESLint run in under 300 ms; plugin toggles drive the active rule set."

--- a/apps/docs/src/app/articles/page.tsx
+++ b/apps/docs/src/app/articles/page.tsx
@@ -14,7 +14,7 @@ import type { Metadata } from 'next';
 import articlesData from '@/data/articles.json';
 
 export const metadata: Metadata = {
-  title: 'Technical Articles',
+  title: 'Articles',
   description:
     'Deep dives into ESLint internals, security patterns, and high-performance JavaScript engineering by the Interlace team.',
   // Canonical pinned per SEO_PHILOSOPHY §1 — the page is URL-state-driven
@@ -22,7 +22,7 @@ export const metadata: Metadata = {
   // form rather than the cartesian product of facets (PAGINATION_PHILOSOPHY).
   alternates: { canonical: '/articles' },
   openGraph: {
-    title: 'Technical Articles | ESLint Interlace',
+    title: 'Articles | ESLint Interlace',
     description:
       'Deep dives into ESLint internals, security patterns, and high-performance JavaScript engineering.',
     type: 'website',

--- a/apps/docs/src/app/scorecard/page.tsx
+++ b/apps/docs/src/app/scorecard/page.tsx
@@ -91,38 +91,7 @@ export default function ScorecardPage() {
     >
       <Header />
 
-      <section aria-labelledby="provenance-heading" className="mt-8">
-        <h2 id="provenance-heading" className="text-lg font-semibold">
-          Provenance
-        </h2>
-        <dl className="mt-3 grid grid-cols-1 gap-x-6 gap-y-2 text-sm sm:grid-cols-2 lg:grid-cols-4">
-          <ProvenanceItem
-            label="Generated"
-            value={formatRunAt(snapshot.runAt)}
-          />
-          <ProvenanceItem
-            label="ESLint"
-            value={snapshot.eslintVersion || '—'}
-          />
-          <ProvenanceItem
-            label="oxlint"
-            value={snapshot.oxlintVersion || '—'}
-          />
-          <ProvenanceItem label="Node" value={snapshot.nodeVersion || '—'} />
-        </dl>
-        <p className="mt-4 text-sm text-fd-muted-foreground">
-          Source JSON:{' '}
-          <Link
-            href={`${GITHUB_RAW_BASE}/${snapshot.filename}`}
-            className="font-mono text-fd-primary underline hover:no-underline"
-            target="_blank"
-            rel="noreferrer"
-          >
-            benchmarks/results/ilb-flagship/{snapshot.filename}
-          </Link>{' '}
-          · Schema <code className="font-mono">{snapshot.schema}</code>.
-        </p>
-      </section>
+      <ScoreSummary rows={rows} runAt={snapshot.runAt} />
 
       <section aria-labelledby="latency-heading" className="mt-12">
         <h2 id="latency-heading" className="text-lg font-semibold">
@@ -135,8 +104,8 @@ export default function ScorecardPage() {
           <strong>Warm</strong> is the same command after a prior cold run with
           a stable cache location. <strong>oxlint</strong> caches implicitly via
           file mtime + content hash. A dash means the stack wasn&rsquo;t
-          exercised for that rule (green-field rules have no competitor; not
-          every rule has an oxlint port yet).
+          exercised for that rule (green-field rules have no peer
+          equivalent; not every rule has an oxlint port yet).
         </p>
         <div className="mt-4 overflow-x-auto rounded-lg border border-fd-border">
           <table className="w-full text-sm">
@@ -151,8 +120,8 @@ export default function ScorecardPage() {
                 <th className="px-3 py-2 text-right font-medium">
                   Ours findings
                 </th>
-                <th className="px-3 py-2 text-right font-medium">Comp cold</th>
-                <th className="px-3 py-2 text-right font-medium">Comp warm</th>
+                <th className="px-3 py-2 text-right font-medium">Peer cold</th>
+                <th className="px-3 py-2 text-right font-medium">Peer warm</th>
                 <th className="px-3 py-2 text-right font-medium">
                   oxlint cold
                 </th>
@@ -303,6 +272,39 @@ export default function ScorecardPage() {
         Re-run with <code className="font-mono">npm run ilb:flagship</code> at
         the repo root. Tracks {FLAGSHIP_RULES.length} rules per snapshot.
       </p>
+      <section aria-labelledby="provenance-heading" className="mt-8">
+        <h2 id="provenance-heading" className="text-lg font-semibold">
+          Provenance
+        </h2>
+        <dl className="mt-3 grid grid-cols-1 gap-x-6 gap-y-2 text-sm sm:grid-cols-2 lg:grid-cols-4">
+          <ProvenanceItem
+            label="Generated"
+            value={formatRunAt(snapshot.runAt)}
+          />
+          <ProvenanceItem
+            label="ESLint"
+            value={snapshot.eslintVersion || '—'}
+          />
+          <ProvenanceItem
+            label="oxlint"
+            value={snapshot.oxlintVersion || '—'}
+          />
+          <ProvenanceItem label="Node" value={snapshot.nodeVersion || '—'} />
+        </dl>
+        <p className="mt-4 text-sm text-fd-muted-foreground">
+          Source JSON:{' '}
+          <Link
+            href={`${GITHUB_RAW_BASE}/${snapshot.filename}`}
+            className="font-mono text-fd-primary underline hover:no-underline"
+            target="_blank"
+            rel="noreferrer"
+          >
+            benchmarks/results/ilb-flagship/{snapshot.filename}
+          </Link>{' '}
+          · Schema <code className="font-mono">{snapshot.schema}</code>.
+        </p>
+      </section>
+
     </Container>
   );
 }
@@ -329,6 +331,58 @@ function Header() {
         <StarButton stars={0} surface="flagship" />
       </div>
     </div>
+  );
+}
+
+
+/**
+ * The read of the page in three numbers, before any table. Every figure is
+ * derived from the loaded snapshot on the server — never hand-typed — and the
+ * age chip keeps the staleness honest instead of hiding it in Provenance.
+ */
+function ScoreSummary({
+  rows,
+  runAt,
+}: {
+  rows: ReturnType<typeof orderResultsByFlagshipSpec>;
+  runAt: string;
+}) {
+  const headToHead = rows.filter(
+    (r) =>
+      typeof r.runs.oursEslint?.warm?.ms === 'number' &&
+      typeof r.runs.competitorEslint?.warm?.ms === 'number',
+  );
+  const warmWins = headToHead.filter(
+    (r) => r.runs.oursEslint!.warm!.ms <= r.runs.competitorEslint!.warm!.ms,
+  ).length;
+  const greenField = rows.filter((r) => !r.runs.competitorEslint).length;
+  const ageDays = Math.max(
+    0,
+    Math.floor((Date.now() - new Date(runAt).getTime()) / 86_400_000),
+  );
+  const age =
+    ageDays < 45 ? `${ageDays} days ago` : `${Math.round(ageDays / 30)} months ago`;
+  return (
+    <section aria-label="Headline results" className="mt-6">
+      <dl className="grid grid-cols-1 gap-x-6 gap-y-3 rounded-lg border border-fd-border bg-fd-card/50 p-4 text-sm sm:grid-cols-3">
+        <div>
+          <dt className="text-fd-muted-foreground">Head-to-head (warm)</dt>
+          <dd className="mt-0.5 text-lg font-semibold">
+            {warmWins}/{headToHead.length} rules at or faster than the peer
+          </dd>
+        </div>
+        <div>
+          <dt className="text-fd-muted-foreground">Green-field rules</dt>
+          <dd className="mt-0.5 text-lg font-semibold">
+            {greenField}/{rows.length} with no peer equivalent
+          </dd>
+        </div>
+        <div>
+          <dt className="text-fd-muted-foreground">Snapshot age</dt>
+          <dd className="mt-0.5 text-lg font-semibold">{age}</dd>
+        </div>
+      </dl>
+    </section>
   );
 }
 

--- a/apps/docs/src/components/ArticlesClient.tsx
+++ b/apps/docs/src/components/ArticlesClient.tsx
@@ -236,7 +236,7 @@ export function ArticlesClient({
             <span data-testid="article-count">{totalArticles} Articles Published</span>
           </div>
           <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold tracking-tight text-fd-foreground dark:text-white dark:drop-shadow-lg" suppressHydrationWarning>
-            Technical Insights
+            Articles
           </h1>
           <p className="text-lg text-fd-muted-foreground dark:text-orange-100/80 leading-relaxed dark:drop-shadow" suppressHydrationWarning>
             Deep dives into ESLint security, JavaScript performance, and modern development practices.

--- a/apps/docs/src/components/changelog/changelog-filters.tsx
+++ b/apps/docs/src/components/changelog/changelog-filters.tsx
@@ -13,49 +13,74 @@ interface ChangelogFiltersProps {
  * Plain links, not a client-side control. The filter is URL state
  * (`/changelog?pkg=eslint-plugin-jwt-security`), which makes every filtered
  * view shareable, crawlable, and back-button correct — and costs no
- * JavaScript. A `<select>` would need hydration to navigate and would hide 31
- * of 32 options behind a click.
+ * JavaScript. A `<select>` would need hydration to navigate and would hide
+ * every option behind a click.
+ *
+ * The full chip cloud lives inside a native `<details>`: at 34 packages the
+ * wrapped cloud is ~5 rows — half the first desktop screen spent on filter
+ * before the reader sees a single release. The always-visible row carries the
+ * two things that matter without opening anything: the "All packages" reset
+ * and the currently active filter. `<details>` keeps every link in the DOM
+ * (crawlable), needs no hydration, and is keyboard-operable natively.
  *
  * `aria-current="page"` rather than a visual-only active state: the selected
  * filter has to be announced, and it is the one piece of state a screen-reader
  * user cannot infer from the list below.
  */
 export function ChangelogFilters({ packages, active }: ChangelogFiltersProps) {
+  const activePkg = packages.find((p) => p.short === active);
   return (
     <nav aria-label="Filter releases by package" className="mb-8">
-      {/* One scrolling row on mobile, wrapped on desktop. Wrapping at 375px
-          stacks 32 chips into ~900px — two and a half screens of filter before
-          the reader reaches a single release, which is the mobile failure mode
-          CLAUDE.md calls out. `flex` is nowrap by default, so the mobile case
-          is the absence of `flex-wrap` rather than an override. */}
-      <ul className="-mx-4 flex gap-2 overflow-x-auto px-4 pb-2 md:mx-0 md:flex-wrap md:overflow-visible md:px-0 md:pb-0">
-        <li className="shrink-0">
+      <div className="flex flex-wrap items-center gap-2">
+        <Link
+          href="/changelog"
+          aria-current={active ? undefined : 'page'}
+          className="focus-visible:ring-ring rounded-full focus-visible:ring-2 focus-visible:outline-none"
+        >
+          <Badge variant={active ? 'outline' : 'default'}>All packages</Badge>
+        </Link>
+        {activePkg ? (
           <Link
-            href="/changelog"
-            aria-current={active ? undefined : 'page'}
+            href={`/changelog?pkg=${activePkg.short}`}
+            aria-current="page"
             className="focus-visible:ring-ring rounded-full focus-visible:ring-2 focus-visible:outline-none"
           >
-            <Badge variant={active ? 'outline' : 'default'}>All packages</Badge>
+            <Badge variant="default">
+              {activePkg.short}
+              <span className="text-muted-foreground ml-1.5 tabular-nums">
+                {activePkg.count}
+              </span>
+            </Badge>
           </Link>
-        </li>
+        ) : null}
+      </div>
 
-        {packages.map((pkg) => (
-          <li key={pkg.short} className="shrink-0">
-            <Link
-              href={`/changelog?pkg=${pkg.short}`}
-              aria-current={active === pkg.short ? 'page' : undefined}
-              className="focus-visible:ring-ring rounded-full focus-visible:ring-2 focus-visible:outline-none"
-            >
-              <Badge variant={active === pkg.short ? 'default' : 'outline'}>
-                {pkg.short}
-                <span className="text-muted-foreground ml-1.5 tabular-nums">
-                  {pkg.count}
-                </span>
-              </Badge>
-            </Link>
-          </li>
-        ))}
-      </ul>
+      <details className="group mt-2">
+        <summary className="cursor-pointer list-none text-sm text-fd-muted-foreground hover:text-fd-foreground focus-visible:ring-2 focus-visible:ring-fd-primary focus-visible:outline-none rounded">
+          <span aria-hidden className="mr-1 inline-block transition-transform group-open:rotate-90">
+            ▸
+          </span>
+          Filter by package · {packages.length} packages
+        </summary>
+        <ul className="mt-3 flex flex-wrap gap-2">
+          {packages.map((pkg) => (
+            <li key={pkg.short} className="shrink-0">
+              <Link
+                href={`/changelog?pkg=${pkg.short}`}
+                aria-current={active === pkg.short ? 'page' : undefined}
+                className="focus-visible:ring-ring rounded-full focus-visible:ring-2 focus-visible:outline-none"
+              >
+                <Badge variant={active === pkg.short ? 'default' : 'outline'}>
+                  {pkg.short}
+                  <span className="text-muted-foreground ml-1.5 tabular-nums">
+                    {pkg.count}
+                  </span>
+                </Badge>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </details>
     </nav>
   );
 }

--- a/apps/docs/src/components/play/PluginToggleStrip.tsx
+++ b/apps/docs/src/components/play/PluginToggleStrip.tsx
@@ -56,7 +56,10 @@ export function PluginToggleStrip({
                 onClick={onCopyConfig}
                 aria-live="polite"
                 disabled={enabled.size === 0}
-                className="font-mono text-xs uppercase tracking-wider"
+                // No uppercase: the label is a literal filename, and
+                // eslint.config.js shouted as ESLINT.CONFIG.JS is a wrong
+                // name, not a style.
+                className="font-mono text-xs"
               >
                 {copied ? (
                   <>

--- a/benchmarks/lib/flagship-snapshot.ts
+++ b/benchmarks/lib/flagship-snapshot.ts
@@ -36,10 +36,15 @@ export const FLAGSHIP_RULES = [
 
 export type FlagshipRuleId = (typeof FLAGSHIP_RULES)[number];
 
+// "Peer", never "competitor": ECOSYSTEM_LANDSCAPE framing is
+// landscape/specialization, and these labels render on public surfaces
+// (the /scorecard page and the markdown report). The internal type keys
+// keep their historical names — renaming them would churn every snapshot
+// consumer for zero user-visible gain.
 export const STACK_LABELS = {
   oursEslint: 'Ours (ESLint)',
-  competitorEslint: 'Competitor (ESLint)',
-  oxlintNative: 'oxlint native (competitor)',
+  competitorEslint: 'Peer (ESLint)',
+  oxlintNative: 'oxlint native (peer)',
 } as const;
 
 export type Stack = keyof typeof STACK_LABELS;

--- a/packages/ui/src/blocks/article-card.tsx
+++ b/packages/ui/src/blocks/article-card.tsx
@@ -31,7 +31,12 @@ export interface ArticleCardMeta {
   comments?: number;
   /** Reading time in minutes. */
   readingTimeMinutes?: number;
-  /** Page-view count. Rendered abbreviated (e.g., `1.2k`) when ≥ 1000. */
+  /**
+   * Page-view count. Rendered abbreviated (e.g., `1.2k`) when ≥ 1000.
+   * A zero renders NOTHING: sources that cannot report views (dev.to's
+   * public API) return 0, and a "👁 0" chip on every card reads as product
+   * failure, not as data. Absence is the honest presentation of absence.
+   */
   views?: number;
 }
 
@@ -308,7 +313,7 @@ function MetaChips({
           {meta.readingTimeMinutes} min
         </span>
       ) : null}
-      {meta.views !== undefined ? (
+      {meta.views ? (
         <span
           data-testid="article-card-meta-views"
           className={cn(


### PR DESCRIPTION
## Summary

The experience pass over the site's tabs, implemented with `@interlace/ui` primitives and the documented philosophies (CTA, layout, landscape framing). Every change either uses an existing DS affordance or fixes one at its source.

### Scorecard — value before receipts, peers not competitors
- **`STACK_LABELS` said "Competitor (ESLint)"** on two public surfaces (the `/scorecard` page and the generated markdown reports) — a violation of the landscape framing rule. Now **Peer**; internal type keys keep their historical names. Locked by `landscape-framing-scorecard.lock.test.ts`, scoped to reader-visible values only.
- The page opened with **Provenance** — version numbers and a JSON path before any value statement. A new `ScoreSummary` strip leads instead: head-to-head warm wins, green-field count, and an honest **snapshot-age chip** — every figure derived server-side from the snapshot, never hand-typed. Provenance moves to the end, where receipts belong.

### Articles — one name, no zero-view chips
- One page, three names (nav *Articles* / title *Technical Articles* / h1 *Technical Insights*) → **Articles** everywhere.
- `@interlace/ui` **ArticleCard rendered "👁 0" on every card** (dev.to's public API reports zero views). The DS block now renders nothing for 0 — absence is the honest presentation of absence. Changeset included (`@interlace/ui` patch).

### Changelog — the cloud collapses, the constraints survive
- 34 filter chips wrapped into ~5 desktop rows before the first release. The cloud now lives in a **native `<details>`** — zero JS, links stay in the DOM for crawlers, keyboard-operable natively — with an always-visible row carrying only the reset chip and the active filter. The original design's constraints (URL state, no hydration, `aria-current`) are all preserved. The page lock evolved to pin the new invariant with JSX-shaped anchors (immune to the docstring trap).

### Playground + Getting Started
- `SectionHeader as="h1"` — the page had no h1; the DS block already supported the prop.
- The copy button uppercase-transformed a filename (`ESLINT.CONFIG.JS` is a wrong name, not a style).
- **Getting Started gets install-in-30-seconds above the fold** — the same inversion shipped for plugin overviews, with the instrumented `InstallSnippet`.

## Deliberately deferred

Docs-sidebar de-duplication (the 8 mirrored nav links): needs fumadocs `on:'nav'` semantics verified against the **deployed** 16.14.5 (local resolves 16.11.5), and a wrong guess silently breaks mobile navigation.

## Test plan

- [x] Full docs suite: **89 files, 1800 passed, 0 failed** — including the evolved changelog lock, the new framing lock, and all pre-existing scorecard/stats/articles locks.
- [x] New framing lock is comment-trap-proof (JSX/value-scoped anchors) and constrains only reader-visible strings.
- [x] All summary figures on the scorecard derive from the loaded snapshot at render time — nothing hand-typed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)