### PR TITLE
fix(workspace): a template engine is not a response, a setting is not a route

### DIFF
--- a/.changeset/render-receiver-and-settings-getter.md
+++ b/.changeset/render-receiver-and-settings-getter.md
@@ -1,0 +1,21 @@
+---
+'eslint-plugin-browser-security': patch
+'eslint-plugin-secure-coding': patch
+---
+
+fix: two more false positives, found by rescanning after the last batch shipped.
+
+`require-csp-headers` matched the method name `render` on any receiver.
+`nunjucksEnv.render(template, data)` returns a string; only `res.render(view)`
+emits a response. On ministryofjustice/hmpps-arns-assessment-platform-ui that
+was 31 reports — every Nunjucks component module and every component test — in
+a repository that already sets a nonce-based CSP in middleware. Gated on the
+receiver, and the rule now takes `skipTestFiles`, which covered 29 of the 31.
+Down to 3.
+
+`no-missing-authentication` treated `app.get('port')` as a route. Express
+overloads the name: one argument reads a setting, two or more registers a
+route. `app.listen(app.get('port'), …)` was reported as an unauthenticated
+endpoint. A route always has a handler after its path, so the arity test is
+exact — and the `app.route(path).get(handler)` chained form, where the path
+comes from the previous call, keeps reporting.

--- a/apps/docs/content/docs/security/plugin-browser-security/rules/require-csp-headers.mdx
+++ b/apps/docs/content/docs/security/plugin-browser-security/rules/require-csp-headers.mdx
@@ -20,7 +20,7 @@ import { FalseNegativeCTA, WhenNotToUse, RuleBadges } from "@/components/RuleCom
 | --------------- | ----------------------------------------------- |
 | **Severity**    | Medium (XSS Mitigation)                         |
 | **Auto-Fix**    | ❌ No (requires policy definition)              |
-| **Category**   | Security |
+| **Category**    | Security                                        |
 | **ESLint MCP**  | ✅ Optimized for ESLint MCP integration         |
 | **Best For**    | Web servers serving HTML content                |
 | **Suggestions** | ✅ Advice on using Helmet for standard policies |
@@ -85,9 +85,34 @@ flowchart TD
 | 🚀 **Exfiltration** | Stealing data to external sites | Use `connect-src` to restrict outgoing requests |
 | 🤝 **Trust**        | Site used for phishing          | Use `frame-ancestors` to prevent clickjacking   |
 
-## Configuration
+## Options
 
-This rule has no configuration options in the current version.
+| Option              | Type       | Default                        | Description                                                                                                                                                           |
+| ------------------- | ---------- | ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `responseReceivers` | `string[]` | `['res', 'response', 'reply']` | Identifiers that name a response object, so `<name>.render(view)` emits a response rather than returning a string. Anything unlisted is treated as a template engine. |
+
+`<name>.render(view)` is only a response emission when `<name>` is a response
+object. `nunjucksEnv.render(template, data)` returns a string, and so do
+mustache, ejs, handlebars and ReactDOMServer — none of them can set an HTTP
+header, so demanding a CSP at those call sites is a finding nobody can action.
+
+Setting this **replaces** the default list rather than extending it, so a
+codebase whose handlers name the response something else lists every name it
+uses:
+
+```json
+{
+  "rules": {
+    "browser-security/require-csp-headers": [
+      "error",
+      { "responseReceivers": ["res", "response", "reply", "httpRes"] }
+    ]
+  }
+}
+```
+
+The rule also skips test files: rendering a template to assert on its markup is
+not a route serving a document.
 
 ## Examples
 
@@ -108,7 +133,7 @@ app.get('/home', (req, res) => {
 ### ✅ Correct
 
 ```javascript
-res.send({ data: 'json' })
+res.send({ data: 'json' });
 ```
 
 <WhenNotToUse />

--- a/packages/eslint-plugin-browser-security/docs/rules/require-csp-headers.md
+++ b/packages/eslint-plugin-browser-security/docs/rules/require-csp-headers.md
@@ -1,6 +1,6 @@
 ---
 title: require-csp-headers
-description: "CWE: [CWE-1021](https://cwe.mitre.org/data/definitions/1021.html)"
+description: 'CWE: [CWE-1021](https://cwe.mitre.org/data/definitions/1021.html)'
 tags: ['security', 'browser']
 category: security
 severity: medium
@@ -12,8 +12,8 @@ autofix: false
 > **CWE:** [CWE-1021: Improper Restriction of Rendered-UI Layers or Frames](https://cwe.mitre.org/data/definitions/1021.html)  
 > **OWASP Mobile:** [OWASP Mobile Top 10 M8: Security Misconfiguration](https://owasp.org/www-project-mobile-top-10/)
 
-
 <!-- @rule-summary -->
+
 CWE: [CWE-1021](https://cwe.mitre.org/data/definitions/1021.html)
 <!-- @/rule-summary -->
 
@@ -25,7 +25,7 @@ ESLint Rule: require-csp-headers. This rule is part of [`eslint-plugin-browser-s
 | --------------- | ----------------------------------------------- |
 | **Severity**    | Medium (XSS Mitigation)                         |
 | **Auto-Fix**    | ❌ No (requires policy definition)              |
-| **Category**   | Security |
+| **Category**    | Security                                        |
 | **ESLint MCP**  | ✅ Optimized for ESLint MCP integration         |
 | **Best For**    | Web servers serving HTML content                |
 | **Suggestions** | ✅ Advice on using Helmet for standard policies |
@@ -88,9 +88,34 @@ flowchart TD
 | 🚀 **Exfiltration** | Stealing data to external sites | Use `connect-src` to restrict outgoing requests |
 | 🤝 **Trust**        | Site used for phishing          | Use `frame-ancestors` to prevent clickjacking   |
 
-## Configuration
+## Options
 
-This rule has no configuration options in the current version.
+| Option              | Type       | Default                        | Description                                                                                                                                                           |
+| ------------------- | ---------- | ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `responseReceivers` | `string[]` | `['res', 'response', 'reply']` | Identifiers that name a response object, so `<name>.render(view)` emits a response rather than returning a string. Anything unlisted is treated as a template engine. |
+
+`<name>.render(view)` is only a response emission when `<name>` is a response
+object. `nunjucksEnv.render(template, data)` returns a string, and so do
+mustache, ejs, handlebars and ReactDOMServer — none of them can set an HTTP
+header, so demanding a CSP at those call sites is a finding nobody can action.
+
+Setting this **replaces** the default list rather than extending it, so a
+codebase whose handlers name the response something else lists every name it
+uses:
+
+```json
+{
+  "rules": {
+    "browser-security/require-csp-headers": [
+      "error",
+      { "responseReceivers": ["res", "response", "reply", "httpRes"] }
+    ]
+  }
+}
+```
+
+The rule also skips test files: rendering a template to assert on its markup is
+not a route serving a document.
 
 ## Examples
 
@@ -111,7 +136,7 @@ app.get('/home', (req, res) => {
 ### ✅ Correct
 
 ```javascript
-res.send({ data: 'json' })
+res.send({ data: 'json' });
 ```
 
 ## Known False Negatives

--- a/packages/eslint-plugin-browser-security/src/rules/require-csp-headers/a-template-engine-is-not-a-response.test.ts
+++ b/packages/eslint-plugin-browser-security/src/rules/require-csp-headers/a-template-engine-is-not-a-response.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * `nunjucksEnv.render(…)` returns a string. `res.render(…)` sends a response.
+ *
+ * Hand-verification run 2026-08-24 against
+ * ministryofjustice/hmpps-arns-assessment-platform-ui. The rule matched the
+ * METHOD NAME alone, so every Nunjucks component module and every component
+ * test drew a finding: 31 reports, the single largest block in that scan, on a
+ * repository that already sets a nonce-based CSP in `setUpWebSecurity.ts`.
+ *
+ * Twenty-nine of the 31 were in `*.test.ts` — a test that renders a template
+ * to assert on its markup is not a route serving a document — so the rule also
+ * takes `skipTestFiles`.
+ *
+ * Asking a template helper to set an HTTP header is asking for something it
+ * cannot do, which is the shape of a finding nobody can action.
+ */
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import parser from '@typescript-eslint/parser';
+import { requireCspHeaders } from './index';
+
+const ruleTester = new RuleTester({
+  languageOptions: { parser, ecmaVersion: 2022, sourceType: 'module' },
+});
+
+ruleTester.run(
+  'require-csp-headers — a template engine is not a response',
+  requireCspHeaders,
+  {
+    valid: [
+      // The corpus shape: an environment render that returns markup.
+      `function createRenderer(templatePath) {
+         return (props, nunjucksEnv) => nunjucksEnv.render(templatePath, { params: props });
+       }`,
+      // The other engines with the same method name.
+      `const html = mustache.render(template, view);`,
+      `const out = ejs.render(str, data);`,
+      `const markup = ReactDOMServer.render(element);`,
+      // Configuring the list REPLACES the default, so the built-in names stop
+      // matching — which is what makes the option able to narrow as well as
+      // widen.
+      {
+        code: `function handler(res) { res.render('index'); }`,
+        options: [{ responseReceivers: ['httpRes'] }],
+      },
+    ],
+    invalid: [
+      // The real thing still reports — a response object rendering a view.
+      {
+        code: `app.get('/', (req, res) => { res.render('index'); });`,
+        errors: 1,
+      },
+      // Fastify names it `reply`, and `this.res` / `ctx.res` are the same
+      // object one member deep.
+      {
+        code: `app.get('/', (req, reply) => { reply.render('index'); });`,
+        errors: 1,
+      },
+      { code: `function handler(ctx) { ctx.res.render('index'); }`, errors: 1 },
+      // A house convention that names it something else configures the list
+      // rather than losing the finding.
+      {
+        code: `function handler(httpRes) { httpRes.render('index'); }`,
+        options: [{ responseReceivers: ['httpRes'] }],
+        errors: 1,
+      },
+    ],
+  },
+);

--- a/packages/eslint-plugin-browser-security/src/rules/require-csp-headers/a-template-engine-is-not-a-response.test.ts
+++ b/packages/eslint-plugin-browser-security/src/rules/require-csp-headers/a-template-engine-is-not-a-response.test.ts
@@ -37,6 +37,17 @@ ruleTester.run(
       `function createRenderer(templatePath) {
          return (props, nunjucksEnv) => nunjucksEnv.render(templatePath, { params: props });
        }`,
+      // An alias resolves to what it was declared as, and the declaration
+      // outranks the name. Review's case: spelling a renderer `res` must not
+      // make it a response.
+      `const res = nunjucksEnv;
+       const html = res.render('index');`,
+      // skipTestFiles, isolated from receiver filtering: a real response
+      // object, in a file named like a test.
+      {
+        code: `app.get('/', (req, res) => { res.render('index'); });`,
+        filename: 'component.test.ts',
+      },
       // The other engines with the same method name.
       `const html = mustache.render(template, view);`,
       `const out = ejs.render(str, data);`,

--- a/packages/eslint-plugin-browser-security/src/rules/require-csp-headers/index.ts
+++ b/packages/eslint-plugin-browser-security/src/rules/require-csp-headers/index.ts
@@ -48,6 +48,7 @@ import {
   MessageIcons,
 } from '@interlace/eslint-devkit';
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
+import { AST_NODE_TYPES } from '@interlace/eslint-devkit';
 import { resolveInitializer } from '../../utils/resolve-binding';
 
 /**
@@ -521,6 +522,26 @@ export const requireCspHeaders = createRule<RuleOptions, MessageIds>({
       // only for a MemberExpression callee. A runtime guard here would be
       // unreachable, and an unreachable guard reads as a check that runs.
       const callee = node.callee as TSESTree.MemberExpression;
+
+      // EVIDENCE FIRST. If the receiver resolves to something declared in this
+      // file, believe the declaration over the name — `const res =
+      // nunjucksEnv; res.render('index')` renders a string however it is
+      // spelled. Only when the identifier resolves to nothing local does the
+      // name decide, which is the case that matters: `(req, res) => …` binds
+      // `res` as a PARAMETER, and a parameter has no initialiser to inspect.
+      if (callee.object.type === AST_NODE_TYPES.Identifier) {
+        const initializer = resolveInitializer(
+          callee.object,
+          context.sourceCode,
+        );
+        if (initializer !== undefined) {
+          // Resolved. A response object is produced by a framework, never
+          // declared as a local alias of something else, so anything with a
+          // visible initialiser here is a renderer being given a short name.
+          return false;
+        }
+      }
+
       let object: TSESTree.Node = callee.object;
       // `this.res.render(…)` / `ctx.res.render(…)` — take the last segment.
       if (object.type === 'MemberExpression' && !object.computed) {

--- a/packages/eslint-plugin-browser-security/src/rules/require-csp-headers/index.ts
+++ b/packages/eslint-plugin-browser-security/src/rules/require-csp-headers/index.ts
@@ -42,7 +42,11 @@
  * Those are complementary defects on the same line, not duplicates.
  */
 
-import { createRule, formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
+import {
+  createRule,
+  formatLLMMessage,
+  MessageIcons,
+} from '@interlace/eslint-devkit';
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
 import { resolveInitializer } from '../../utils/resolve-binding';
 
@@ -134,11 +138,14 @@ function staticString(
   }
   if (node.type === 'Identifier') {
     const init = resolveInitializer(node, sourceCode);
-    return init === undefined ? null : staticString(init, sourceCode, depth + 1);
+    return init === undefined
+      ? null
+      : staticString(init, sourceCode, depth + 1);
   }
   if (node.type === 'MemberExpression' && node.computed) {
     const index = node.property;
-    if (index.type !== 'Literal' || typeof index.value !== 'number') return null;
+    if (index.type !== 'Literal' || typeof index.value !== 'number')
+      return null;
     const array = foldToArray(node.object, sourceCode, depth + 1);
     const element = array?.elements[index.value];
     return element == null
@@ -169,7 +176,8 @@ function foldToArray(
   // A nested table — `PAGES[0][1]`, one row per locale.
   if (node.type === 'MemberExpression' && node.computed) {
     const index = node.property;
-    if (index.type !== 'Literal' || typeof index.value !== 'number') return null;
+    if (index.type !== 'Literal' || typeof index.value !== 'number')
+      return null;
     const outer = foldToArray(node.object, sourceCode, depth + 1);
     const element = outer?.elements[index.value];
     return element == null ? null : foldToArray(element, sourceCode, depth + 1);
@@ -328,19 +336,36 @@ function namesDocumentFile(
 
   return candidates.some((candidate) => {
     const dot = candidate.lastIndexOf('.');
-    return dot !== -1 && DOCUMENT_EXTENSIONS.has(candidate.slice(dot).toLowerCase());
+    return (
+      dot !== -1 && DOCUMENT_EXTENSIONS.has(candidate.slice(dot).toLowerCase())
+    );
   });
 }
 
 type MessageIds = 'violationDetected';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type, @typescript-eslint/no-empty-interface -- Rule has no configurable options
-export interface Options {}
+export interface Options {
+  /**
+   * Identifiers that name a response object, so `<name>.render(view)` emits a
+   * response rather than returning a string.
+   *
+   * Default: `['res', 'response', 'reply']`. A house convention that calls it
+   * something else — `httpRes`, `koaResponse` — adds it here rather than
+   * losing the finding. Matched case-insensitively, as a whole identifier, and
+   * one member deep so `this.res` and `ctx.res` resolve.
+   */
+  responseReceivers?: string[];
+}
 
 type RuleOptions = [Options?];
 
 export const requireCspHeaders = createRule<RuleOptions, MessageIds>({
   name: 'require-csp-headers',
+  // A test that renders a template to assert on its markup is not a route
+  // that serves a document. Twenty-nine of the findings on
+  // hmpps-arns-assessment-platform-ui were in `*.test.ts`.
+  skipTestFiles: true,
   meta: {
     type: 'problem',
     docs: {
@@ -358,12 +383,38 @@ export const requireCspHeaders = createRule<RuleOptions, MessageIds>({
         severity: 'MEDIUM',
         fix: 'Use helmet.contentSecurityPolicy() or set CSP header manually',
         documentationLink: 'https://cwe.mitre.org/data/definitions/1021.html',
-      })
+      }),
     },
-    schema: [],
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          responseReceivers: {
+            type: 'array',
+            items: { type: 'string' },
+            default: ['res', 'response', 'reply'],
+            description:
+              'Identifiers that name a response object, so `<name>.render(view)` emits a response rather than returning a string. Anything unlisted is treated as a template engine.',
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
   },
-  defaultOptions: [],
-  create(context) {
+  // The default list lives HERE and nowhere else. As a module const it was a
+  // baked-in vocabulary the rule-audit ratchet reports (and rightly: a word
+  // list no option can reach); as a `??` fallback beside a named default it
+  // was an unreachable branch. One home, reachable and overridable.
+  defaultOptions: [{ responseReceivers: ['res', 'response', 'reply'] }],
+  create(context, [options]) {
+    // `defaultOptions` supplies this and ESLint merges before `create` runs,
+    // so there is nothing to fall back to.
+    const responseReceivers = new Set(
+      (options as Required<Options>).responseReceivers.map((name) =>
+        name.toLowerCase(),
+      ),
+    );
+
     function report(node: TSESTree.Node) {
       context.report({ node, messageId: 'violationDetected' });
     }
@@ -413,11 +464,26 @@ export const requireCspHeaders = createRule<RuleOptions, MessageIds>({
 
         if (FILE_METHODS.has(method)) {
           const target = node.arguments[0];
-          if (target === undefined || !namesDocumentFile(target, context.sourceCode)) {
+          if (
+            target === undefined ||
+            !namesDocumentFile(target, context.sourceCode)
+          ) {
             return;
           }
         } else {
           if (!EMIT_METHODS.has(method)) return;
+
+          // WHOSE `render` is this? `res.render(view)` emits a response.
+          // `nunjucksEnv.render(template, data)` RETURNS A STRING, and so do
+          // marked, mustache, handlebars, ejs and ReactDOMServer.
+          //
+          // Matching the method name alone made the rule report 31 times on
+          // ministryofjustice/hmpps-arns-assessment-platform-ui — every
+          // Nunjucks component module and every component TEST — in a
+          // repository that sets a nonce-based CSP in middleware. Asking a
+          // template helper to set HTTP headers is asking for something it
+          // cannot do.
+          if (method === 'render' && !receiverLooksLikeResponse(node)) return;
 
           // `render` always emits a document — the markup lives in a template
           // file this rule will never see. The body methods need proof that
@@ -439,6 +505,33 @@ export const requireCspHeaders = createRule<RuleOptions, MessageIds>({
     };
 
     /** The method this member call invokes, resolving a computed key. */
+    /**
+     * Names an Express-style response object carries in the wild.
+     *
+     * A name test, which this file otherwise avoids — but the alternative is
+     * type information the rule does not have, and the receiver of `.render`
+     * is the only thing that distinguishes emitting a response from building
+     * a string. Kept deliberately tight: `res`, `response`, and the `this.res`
+     * / `ctx.res` forms. Anything else is assumed to be a template engine,
+     * which is the safe direction — a missed `myResponse.render()` is one
+     * finding, while matching every `.render` is thirty-one.
+     */
+    function receiverLooksLikeResponse(node: TSESTree.CallExpression): boolean {
+      // Reached only after `calleeMethodOf` returned a name, which it does
+      // only for a MemberExpression callee. A runtime guard here would be
+      // unreachable, and an unreachable guard reads as a check that runs.
+      const callee = node.callee as TSESTree.MemberExpression;
+      let object: TSESTree.Node = callee.object;
+      // `this.res.render(…)` / `ctx.res.render(…)` — take the last segment.
+      if (object.type === 'MemberExpression' && !object.computed) {
+        object = object.property;
+      }
+      return (
+        object.type === 'Identifier' &&
+        responseReceivers.has(object.name.toLowerCase())
+      );
+    }
+
     function calleeMethodOf(node: TSESTree.CallExpression): string | null {
       if (node.callee.type !== 'MemberExpression') return null;
       const property = node.callee.property;

--- a/packages/eslint-plugin-secure-coding/src/rules/no-missing-authentication/index.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/no-missing-authentication/index.ts
@@ -720,15 +720,18 @@ export const noMissingAuthentication = createRule<RuleOptions, MessageIds>({
 
             // In `app.route('/admin').get(handler)` the path lives on the
             // `route()` call and this call's arguments are ALL handlers.
-            const pathArgument = chainedPath ?? node.arguments[0];
+            // Always present by this point: either `chainedPath` came from a
+            // preceding `route(path)`, or the arity check above established
+            // that this call has a path and a handler. The `'unknown'`
+            // fallback it used to carry was reachable only from `app.get()`
+            // with no arguments, which no longer gets this far.
+            const pathArgument = (chainedPath ??
+              node.arguments[0]) as TSESTree.Node;
 
-            // Extract route path if available
-            let routePath = 'unknown';
-            if (pathArgument !== undefined && pathArgument.type === 'Literal') {
-              routePath = String(pathArgument.value);
-            } else if (pathArgument !== undefined) {
-              routePath = sourceCode.getText(pathArgument);
-            }
+            const routePath =
+              pathArgument.type === 'Literal'
+                ? String(pathArgument.value)
+                : sourceCode.getText(pathArgument);
 
             const text = sourceCode.getText(node);
             // These were `console.log('DEBUG MSG: ...')` in shipped code. Any consumer who

--- a/packages/eslint-plugin-secure-coding/src/rules/no-missing-authentication/index.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/no-missing-authentication/index.ts
@@ -8,12 +8,15 @@
  * ESLint Rule: no-missing-authentication
  * Detects missing authentication checks in route handlers
  * CWE-287: Improper Authentication
- * 
+ *
  * @see https://cwe.mitre.org/data/definitions/287.html
  * @see https://owasp.org/www-community/vulnerabilities/Improper_Authentication
  */
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
-import { AST_NODE_TYPES, formatLLMMessage, MessageIcons,
+import {
+  AST_NODE_TYPES,
+  formatLLMMessage,
+  MessageIcons,
   compileUserPattern,
   compileUserPatterns,
   matchesAnyUserPattern,
@@ -26,19 +29,19 @@ type MessageIds = 'missingAuthentication';
 export interface Options {
   /** Allow missing authentication in test files. Default: false */
   allowInTests?: boolean;
-  
+
   /**
    * Override which filenames `allowInTests` applies to, as a regex string.
    * Unset, the shared structural predicate (`isTestFilePath`) decides.
    */
   testFilePattern?: string | null;
-  
+
   /** Authentication middleware patterns to recognize. Default: ['authenticate', 'auth', 'requireAuth', 'isAuthenticated'] */
   authMiddlewarePatterns?: string[];
-  
+
   /** Route handler patterns to check. Default: ['get', 'post', 'put', 'delete', 'patch', 'all'] */
   routeHandlerPatterns?: string[];
-  
+
   /**
    * Route paths that need no authentication. REPLACES the built-in list, and
    * supplying it also widens matching to the whole registration text.
@@ -74,7 +77,6 @@ const DEFAULT_AUTH_MIDDLEWARE_PATTERNS = [
   'jwt',
   'session',
 ];
-
 
 /**
  * Routes that are public *by definition*. Requiring authentication on a login or
@@ -173,7 +175,15 @@ const ROUTER_NAME_WORDS = [
  * an unauthenticated HTTP router. A house framework belongs in
  * `routerNameWords`, which is the supported knob.
  */
-const ROUTER_FACTORY_NAMES = new Set(['express', 'Router', 'fastify', 'polka', 'restify', 'connect', 'Koa']);
+const ROUTER_FACTORY_NAMES = new Set([
+  'express',
+  'Router',
+  'fastify',
+  'polka',
+  'restify',
+  'connect',
+  'Koa',
+]);
 
 /**
  * Members whose call returns an application, router or server.
@@ -187,7 +197,13 @@ const ROUTER_FACTORY_NAMES = new Set(['express', 'Router', 'fastify', 'polka', '
  * invisible to the rule, or add a member and have an unrelated builder's result
  * reported as an unauthenticated route.
  */
-const ROUTER_FACTORY_MEMBERS = new Set(['Router', 'router', 'Server', 'server', 'createServer']);
+const ROUTER_FACTORY_MEMBERS = new Set([
+  'Router',
+  'router',
+  'Server',
+  'server',
+  'createServer',
+]);
 
 /**
  * Express's `app.route(path).get(handler).post(handler)` chaining, straight out
@@ -205,7 +221,10 @@ function routeChainBase(node: TSESTree.Node): TSESTree.CallExpression | null {
     current.callee.type === AST_NODE_TYPES.MemberExpression
   ) {
     const property = current.callee.property;
-    if (property.type === AST_NODE_TYPES.Identifier && property.name === 'route') {
+    if (
+      property.type === AST_NODE_TYPES.Identifier &&
+      property.name === 'route'
+    ) {
       return current;
     }
     current = current.callee.object;
@@ -233,7 +252,10 @@ function isDefinitelyNotRouter(init: TSESTree.Node): boolean {
 
 /** `express()`, `express.Router()`, `new Koa()`, `Hapi.server()` — resolvable evidence. */
 function isRouterFactory(node: TSESTree.Node): boolean {
-  if (node.type !== AST_NODE_TYPES.CallExpression && node.type !== AST_NODE_TYPES.NewExpression) {
+  if (
+    node.type !== AST_NODE_TYPES.CallExpression &&
+    node.type !== AST_NODE_TYPES.NewExpression
+  ) {
     return false;
   }
 
@@ -260,7 +282,9 @@ function referencedName(node: TSESTree.Node): string | null {
     node.property.type === AST_NODE_TYPES.Identifier
   ) {
     const objectPart =
-      node.object.type === AST_NODE_TYPES.Identifier ? `${node.object.name}.` : '';
+      node.object.type === AST_NODE_TYPES.Identifier
+        ? `${node.object.name}.`
+        : '';
     return `${objectPart}${node.property.name}`;
   }
   return null;
@@ -276,7 +300,10 @@ function referencedName(node: TSESTree.Node): string | null {
  * ordinary domain nouns — a CMS author, a conference talk — that silenced the
  * rule on genuinely unauthenticated routes.
  */
-function isAuthMiddlewareArg(arg: TSESTree.Node, authPatterns: string[]): boolean {
+function isAuthMiddlewareArg(
+  arg: TSESTree.Node,
+  authPatterns: string[],
+): boolean {
   const target = arg.type === AST_NODE_TYPES.CallExpression ? arg.callee : arg;
   const name = referencedName(target);
   return name !== null && nameHasAnyWord(name, authPatterns);
@@ -287,17 +314,19 @@ function isAuthMiddlewareArg(arg: TSESTree.Node, authPatterns: string[]): boolea
  */
 function isInsideAuthMiddleware(
   node: TSESTree.Node,
-  authPatterns: string[]
+  authPatterns: string[],
 ): boolean {
   let current: TSESTree.Node | null = node;
-  
+
   while (current) {
     // Check if current is an argument to a CallExpression
     if (current.parent && current.parent.type === 'CallExpression') {
       const callExpr = current.parent as TSESTree.CallExpression;
-      
+
       // Verify that current is actually an argument of this call
-      const isArgument = callExpr.arguments.some((arg: TSESTree.CallExpressionArgument) => arg === current);
+      const isArgument = callExpr.arguments.some(
+        (arg: TSESTree.CallExpressionArgument) => arg === current,
+      );
       if (!isArgument) {
         // Not an argument (e.g. `current` is the callee of this call, as in
         // an IIFE) - continue traversing upward. `current.parent` is
@@ -306,9 +335,9 @@ function isInsideAuthMiddleware(
         current = current.parent as TSESTree.Node;
         continue;
       }
-      
+
       const callee = callExpr.callee;
-      
+
       // Check if it's an authentication middleware call
       if (callee.type === 'Identifier') {
         if (nameHasAnyWord(callee.name, authPatterns)) {
@@ -317,7 +346,10 @@ function isInsideAuthMiddleware(
       }
 
       // Check if it's a member expression like app.use(auth())
-      if (callee.type === 'MemberExpression' && callee.property.type === 'Identifier') {
+      if (
+        callee.type === 'MemberExpression' &&
+        callee.property.type === 'Identifier'
+      ) {
         const propertyName = callee.property.name.toLowerCase();
         if (propertyName === 'use' || propertyName === 'all') {
           // Check if any argument is an auth middleware
@@ -329,7 +361,7 @@ function isInsideAuthMiddleware(
         }
       }
     }
-    
+
     // Traverse up the AST
     if ('parent' in current && current.parent) {
       current = current.parent as TSESTree.Node;
@@ -337,7 +369,7 @@ function isInsideAuthMiddleware(
       break;
     }
   }
-  
+
   return false;
 }
 
@@ -372,10 +404,9 @@ export const noMissingAuthentication = createRule<RuleOptions, MessageIds>({
         cwe: 'CWE-287',
         description: 'Route handler missing authentication check: {{route}}',
         severity: 'CRITICAL',
-        fix: 'Add authentication middleware: app.{{method}}(\'{{path}}\', authenticate(), handler)',
+        fix: "Add authentication middleware: app.{{method}}('{{path}}', authenticate(), handler)",
         documentationLink: 'https://cwe.mitre.org/data/definitions/287.html',
       }),
-
     },
     schema: [
       {
@@ -416,7 +447,8 @@ export const noMissingAuthentication = createRule<RuleOptions, MessageIds>({
             type: 'array',
             items: { type: 'string' },
             default: [],
-            description: 'Extra router-object name words, on top of `routerNameWords`.',
+            description:
+              'Extra router-object name words, on top of `routerNameWords`.',
           },
           testFilePattern: {
             // `null` IS the default, and saying so in the schema is the point.
@@ -454,7 +486,7 @@ export const noMissingAuthentication = createRule<RuleOptions, MessageIds>({
   ],
   create(
     context: TSESLint.RuleContext<MessageIds, RuleOptions>,
-    [options = {}]
+    [options = {}],
   ) {
     const {
       allowInTests = false,
@@ -514,7 +546,9 @@ export const noMissingAuthentication = createRule<RuleOptions, MessageIds>({
      */
     function looksLikeRouter(object: TSESTree.Identifier): boolean {
       const scope = sourceCode.getScope(object);
-      const reference = scope.references.find((ref) => ref.identifier === object);
+      const reference = scope.references.find(
+        (ref) => ref.identifier === object,
+      );
       const resolved = reference?.resolved;
 
       for (const def of resolved?.defs ?? []) {
@@ -535,31 +569,41 @@ export const noMissingAuthentication = createRule<RuleOptions, MessageIds>({
     /**
      * Find variable declaration for an identifier
      */
-    function findVariableDeclaration(identifier: TSESTree.Identifier): TSESTree.VariableDeclarator | null {
+    function findVariableDeclaration(
+      identifier: TSESTree.Identifier,
+    ): TSESTree.VariableDeclarator | null {
       const varName = identifier.name;
       let current: TSESTree.Node | null = identifier;
-      
+
       while (current) {
         // Search in current scope
-        if (current.type === 'Program' || 
-            current.type === 'FunctionDeclaration' || 
-            current.type === 'FunctionExpression' || 
-            current.type === 'ArrowFunctionExpression') {
-          const scopeBody = current.type === 'Program' 
-            ? current.body 
-            : (current.body.type === 'BlockStatement' ? current.body.body : []);
-          
+        if (
+          current.type === 'Program' ||
+          current.type === 'FunctionDeclaration' ||
+          current.type === 'FunctionExpression' ||
+          current.type === 'ArrowFunctionExpression'
+        ) {
+          const scopeBody =
+            current.type === 'Program'
+              ? current.body
+              : current.body.type === 'BlockStatement'
+                ? current.body.body
+                : [];
+
           for (const stmt of scopeBody) {
             if (stmt.type === 'VariableDeclaration') {
               for (const declarator of stmt.declarations) {
-                if (declarator.id.type === 'Identifier' && declarator.id.name === varName) {
+                if (
+                  declarator.id.type === 'Identifier' &&
+                  declarator.id.name === varName
+                ) {
                   return declarator;
                 }
               }
             }
           }
         }
-        
+
         // Traverse up
         if ('parent' in current && current.parent) {
           current = current.parent as TSESTree.Node;
@@ -567,24 +611,32 @@ export const noMissingAuthentication = createRule<RuleOptions, MessageIds>({
           break;
         }
       }
-      
+
       return null;
     }
 
     /**
      * Check if an identifier was assigned from an auth middleware call
      */
-    function isIdentifierFromAuthMiddleware(identifier: TSESTree.Identifier): boolean {
+    function isIdentifierFromAuthMiddleware(
+      identifier: TSESTree.Identifier,
+    ): boolean {
       const declarator = findVariableDeclaration(identifier);
       if (!declarator || !declarator.init) {
         return false;
       }
-      
+
       // Check if init is a CallExpression to auth middleware
-      if (declarator.init.type === 'CallExpression' && declarator.init.callee.type === 'Identifier') {
-        return nameHasAnyWord(declarator.init.callee.name, authMiddlewarePatterns);
+      if (
+        declarator.init.type === 'CallExpression' &&
+        declarator.init.callee.type === 'Identifier'
+      ) {
+        return nameHasAnyWord(
+          declarator.init.callee.name,
+          authMiddlewarePatterns,
+        );
       }
-      
+
       return false;
     }
 
@@ -600,7 +652,7 @@ export const noMissingAuthentication = createRule<RuleOptions, MessageIds>({
       if (node.callee.type === 'MemberExpression') {
         const property = node.callee.property;
         const object = node.callee.object;
-        
+
         // Only check if the object looks like an Express app/router: either an
         // identifier like `app` / `router`, or the `app.route(path)` call that
         // Express's own chaining API puts there.
@@ -612,7 +664,10 @@ export const noMissingAuthentication = createRule<RuleOptions, MessageIds>({
           }
         } else {
           const base = routeChainBase(object);
-          const baseObject = base?.callee.type === 'MemberExpression' ? base.callee.object : undefined;
+          const baseObject =
+            base?.callee.type === 'MemberExpression'
+              ? base.callee.object
+              : undefined;
           if (
             !base ||
             baseObject?.type !== AST_NODE_TYPES.Identifier ||
@@ -625,7 +680,7 @@ export const noMissingAuthentication = createRule<RuleOptions, MessageIds>({
 
         if (property.type === 'Identifier') {
           const methodName = property.name.toLowerCase();
-          
+
           if (routeHandlerPatterns.includes(methodName)) {
             // `app.use(middleware)` with no path mounts GLOBAL middleware — it is not a
             // route handler, so "missing authentication" is meaningless there. Flagging it
@@ -633,6 +688,25 @@ export const noMissingAuthentication = createRule<RuleOptions, MessageIds>({
             // `app.use(rateLimit(...))`, `app.use(express.json())`), the single largest
             // false-positive source in the plugin. Only a PATH-MOUNTED `use` —
             // `app.use('/api', handler)` — addresses a route and can be missing auth.
+            // `app.get('port')` READS A SETTING. Express overloads the same
+            // name: one argument is `app.set`'s getter, two or more registers
+            // a route. Treating the getter as a route made
+            // ministryofjustice/hmpps-arns-assessment-platform-ui report on
+            // `app.listen(app.get('port'), …)` and on the log line beside it —
+            // a port number judged as an unauthenticated endpoint.
+            //
+            // A route always has a handler after the path, so the arity test
+            // is exact rather than a heuristic. `use` has its own rule below;
+            // `all`/`post`/`put`/`patch`/`delete` are not overloaded this way,
+            // but a one-argument call to any of them registers nothing either.
+            if (
+              methodName !== 'use' &&
+              chainedPath === undefined &&
+              node.arguments.length < 2
+            ) {
+              return;
+            }
+
             if (methodName === 'use') {
               const first = node.arguments[0];
               const mountsAPath =
@@ -663,7 +737,10 @@ export const noMissingAuthentication = createRule<RuleOptions, MessageIds>({
             if (matchesIgnorePattern(routePath, ignorePatterns)) {
               return;
             }
-            if (scansWholeCallText && matchesIgnorePattern(text, ignorePatterns)) {
+            if (
+              scansWholeCallText &&
+              matchesIgnorePattern(text, ignorePatterns)
+            ) {
               return;
             }
 
@@ -690,7 +767,10 @@ export const noMissingAuthentication = createRule<RuleOptions, MessageIds>({
               }
 
               // Check if argument is an identifier assigned from auth middleware
-              if (arg.type === 'Identifier' && isIdentifierFromAuthMiddleware(arg)) {
+              if (
+                arg.type === 'Identifier' &&
+                isIdentifierFromAuthMiddleware(arg)
+              ) {
                 hasAuth = true;
                 break;
               }
@@ -699,8 +779,10 @@ export const noMissingAuthentication = createRule<RuleOptions, MessageIds>({
             // Check if the handler function itself is inside an auth middleware context
             if (!hasAuth && node.arguments.length > 0) {
               const lastArg = node.arguments[node.arguments.length - 1];
-              if (lastArg.type === 'ArrowFunctionExpression' || 
-                  lastArg.type === 'FunctionExpression') {
+              if (
+                lastArg.type === 'ArrowFunctionExpression' ||
+                lastArg.type === 'FunctionExpression'
+              ) {
                 // Check if the handler is inside an auth middleware call
                 if (isInsideAuthMiddleware(lastArg, authMiddlewarePatterns)) {
                   hasAuth = true;
@@ -729,4 +811,3 @@ export const noMissingAuthentication = createRule<RuleOptions, MessageIds>({
     };
   },
 });
-

--- a/packages/eslint-plugin-secure-coding/src/rules/no-missing-authentication/no-missing-authentication.test.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/no-missing-authentication/no-missing-authentication.test.ts
@@ -29,77 +29,94 @@ const ruleTester = new RuleTester({
 
 describe('no-missing-authentication', () => {
   describe('Valid Code', () => {
-    ruleTester.run('valid - routes with authentication', noMissingAuthentication, {
-      valid: [
-        {
-          code: 'app.get("/api/users", authenticate(), (req, res) => {});',
-        },
-        {
-          code: 'app.post("/api/users", auth, (req, res) => {});',
-        },
-        {
-          code: 'app.put("/api/users", requireAuth, isAuthenticated, (req, res) => {});',
-        },
-        {
-          code: 'router.get("/api/users", verifyToken(), (req, res) => {});',
-        },
-        {
-          code: 'app.use("/api", authenticate());',
-        },
-        // Test files (when allowInTests is true)
-        {
-          code: 'app.get("/api/users", (req, res) => {});',
-          filename: 'test.spec.ts',
-          options: [{ allowInTests: true }],
-        },
-        // Ignored patterns
-        {
-          code: 'app.get("/api/users", (req, res) => {});',
-          options: [{ ignorePatterns: ['/api/users'] }],
-        },
-      ],
-      invalid: [],
-    });
+    ruleTester.run(
+      'valid - routes with authentication',
+      noMissingAuthentication,
+      {
+        valid: [
+          // `app.get('port')` reads a setting; Express overloads the name. And
+          // `app.get()` with no arguments registers nothing at all. Neither is
+          // an endpoint, so neither can be missing authentication. Both used to
+          // report — `app.listen(app.get('port'), …)` was a finding on
+          // ministryofjustice/hmpps-arns-assessment-platform-ui.
+          `const port = app.get('port');`,
+          `app.listen(app.get('port'), () => logger.info('up'));`,
+          'app.get();',
+
+          {
+            code: 'app.get("/api/users", authenticate(), (req, res) => {});',
+          },
+          {
+            code: 'app.post("/api/users", auth, (req, res) => {});',
+          },
+          {
+            code: 'app.put("/api/users", requireAuth, isAuthenticated, (req, res) => {});',
+          },
+          {
+            code: 'router.get("/api/users", verifyToken(), (req, res) => {});',
+          },
+          {
+            code: 'app.use("/api", authenticate());',
+          },
+          // Test files (when allowInTests is true)
+          {
+            code: 'app.get("/api/users", (req, res) => {});',
+            filename: 'test.spec.ts',
+            options: [{ allowInTests: true }],
+          },
+          // Ignored patterns
+          {
+            code: 'app.get("/api/users", (req, res) => {});',
+            options: [{ ignorePatterns: ['/api/users'] }],
+          },
+        ],
+        invalid: [],
+      },
+    );
   });
 
   describe('Invalid Code - Missing Authentication', () => {
-    ruleTester.run('invalid - routes without authentication', noMissingAuthentication, {
-      valid: [],
-      invalid: [
-        {
-          code: 'app.get("/api/users", (req, res) => {});',
-          errors: [
-            {
-              messageId: 'missingAuthentication',
-            },
-          ],
-        },
-        {
-          code: 'app.post("/api/users", (req, res) => {});',
-          errors: [
-            {
-              messageId: 'missingAuthentication',
-            },
-          ],
-        },
-        {
-          code: 'router.put("/api/users/:id", (req, res) => {});',
-          errors: [
-            {
-              messageId: 'missingAuthentication',
-            },
-          ],
-        },
-        {
-          code: 'app.delete("/api/users/:id", (req, res) => {});',
-          errors: [
-            {
-              messageId: 'missingAuthentication',
-            },
-          ],
-        },
-      ],
-    });
+    ruleTester.run(
+      'invalid - routes without authentication',
+      noMissingAuthentication,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: 'app.get("/api/users", (req, res) => {});',
+            errors: [
+              {
+                messageId: 'missingAuthentication',
+              },
+            ],
+          },
+          {
+            code: 'app.post("/api/users", (req, res) => {});',
+            errors: [
+              {
+                messageId: 'missingAuthentication',
+              },
+            ],
+          },
+          {
+            code: 'router.put("/api/users/:id", (req, res) => {});',
+            errors: [
+              {
+                messageId: 'missingAuthentication',
+              },
+            ],
+          },
+          {
+            code: 'app.delete("/api/users/:id", (req, res) => {});',
+            errors: [
+              {
+                messageId: 'missingAuthentication',
+              },
+            ],
+          },
+        ],
+      },
+    );
   });
 
   describe('Options', () => {
@@ -125,15 +142,19 @@ describe('no-missing-authentication', () => {
       ],
     });
 
-    ruleTester.run('options - authMiddlewarePatterns', noMissingAuthentication, {
-      valid: [
-        {
-          code: 'app.get("/api/users", myCustomAuth(), (req, res) => {});',
-          options: [{ authMiddlewarePatterns: ['myCustomAuth'] }],
-        },
-      ],
-      invalid: [],
-    });
+    ruleTester.run(
+      'options - authMiddlewarePatterns',
+      noMissingAuthentication,
+      {
+        valid: [
+          {
+            code: 'app.get("/api/users", myCustomAuth(), (req, res) => {});',
+            options: [{ authMiddlewarePatterns: ['myCustomAuth'] }],
+          },
+        ],
+        invalid: [],
+      },
+    );
 
     ruleTester.run('options - routeHandlerPatterns', noMissingAuthentication, {
       valid: [
@@ -175,29 +196,37 @@ describe('no-missing-authentication', () => {
       ],
     });
 
-    ruleTester.run('coverage - invalid regex in ignorePatterns', noMissingAuthentication, {
-      valid: [],
-      invalid: [
-        {
-          code: 'app.get("/api/users", (req, res) => {});',
-          options: [{ ignorePatterns: ['['] }], // Invalid regex - should not match
-          errors: [
-            {
-              messageId: 'missingAuthentication',
-            },
-          ],
-        },
-      ],
-    });
+    ruleTester.run(
+      'coverage - invalid regex in ignorePatterns',
+      noMissingAuthentication,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: 'app.get("/api/users", (req, res) => {});',
+            options: [{ ignorePatterns: ['['] }], // Invalid regex - should not match
+            errors: [
+              {
+                messageId: 'missingAuthentication',
+              },
+            ],
+          },
+        ],
+      },
+    );
 
-    ruleTester.run('coverage - Identifier auth middleware', noMissingAuthentication, {
-      valid: [
-        {
-          code: 'const handler = (req, res) => {}; app.get("/api/users", authenticate(), handler);',
-        },
-      ],
-      invalid: [],
-    });
+    ruleTester.run(
+      'coverage - Identifier auth middleware',
+      noMissingAuthentication,
+      {
+        valid: [
+          {
+            code: 'const handler = (req, res) => {}; app.get("/api/users", authenticate(), handler);',
+          },
+        ],
+        invalid: [],
+      },
+    );
 
     ruleTester.run('coverage - app.all with auth', noMissingAuthentication, {
       valid: [
@@ -208,99 +237,111 @@ describe('no-missing-authentication', () => {
       invalid: [],
     });
 
-    ruleTester.run('coverage - CallExpression auth middleware', noMissingAuthentication, {
-      valid: [
-        {
-          code: 'app.get("/api/users", authenticate(), (req, res) => {});',
-        },
-      ],
-      invalid: [],
-    });
+    ruleTester.run(
+      'coverage - CallExpression auth middleware',
+      noMissingAuthentication,
+      {
+        valid: [
+          {
+            code: 'app.get("/api/users", authenticate(), (req, res) => {});',
+          },
+        ],
+        invalid: [],
+      },
+    );
 
-    ruleTester.run('coverage - handler inside auth context', noMissingAuthentication, {
-      valid: [],
-      invalid: [
-        {
-          code: 'const handler = (req, res) => {}; app.use("/api", authenticate()); app.get("/api/users", handler);',
-          errors: [
-            {
-              messageId: 'missingAuthentication',
-            },
-          ],
-        },
-      ],
-    });
+    ruleTester.run(
+      'coverage - handler inside auth context',
+      noMissingAuthentication,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: 'const handler = (req, res) => {}; app.use("/api", authenticate()); app.get("/api/users", handler);',
+            errors: [
+              {
+                messageId: 'missingAuthentication',
+              },
+            ],
+          },
+        ],
+      },
+    );
 
-    ruleTester.run('coverage - route path extraction', noMissingAuthentication, {
-      valid: [],
-      invalid: [
-        {
-          code: 'app.get("/api/users", (req, res) => {});',
-          errors: [
-            {
-              messageId: 'missingAuthentication',
-            },
-          ],
-        },
-        {
-          code: 'const path = "/api/users"; app.get(path, (req, res) => {});',
-          errors: [
-            {
-              messageId: 'missingAuthentication',
-            },
-          ],
-        },
-      ],
-    });
+    ruleTester.run(
+      'coverage - route path extraction',
+      noMissingAuthentication,
+      {
+        valid: [],
+        invalid: [
+          {
+            code: 'app.get("/api/users", (req, res) => {});',
+            errors: [
+              {
+                messageId: 'missingAuthentication',
+              },
+            ],
+          },
+          {
+            code: 'const path = "/api/users"; app.get(path, (req, res) => {});',
+            errors: [
+              {
+                messageId: 'missingAuthentication',
+              },
+            ],
+          },
+        ],
+      },
+    );
 
-    ruleTester.run('coverage - computed property and no-argument route calls', noMissingAuthentication, {
-      valid: [
-        // Computed member access (`app["get"]`) - `property.type` is not
-        // `Identifier`, so the methodName/routeHandlerPatterns check is
-        // skipped entirely.
-        {
-          code: 'app["get"]("/api/users", authenticate(), (req, res) => {});',
-        },
-      ],
-      invalid: [
-        // Route handler call with zero arguments - `node.arguments.length >
-        // 0` is false for both the Literal and the fallback text-based
-        // route-path extraction, so `routePath` stays "unknown" and no
-        // auth argument can be present.
-        {
-          code: 'app.get();',
-          errors: [
-            {
-              messageId: 'missingAuthentication',
-            },
-          ],
-        },
-      ],
-    });
+    ruleTester.run(
+      'coverage - computed property and no-argument route calls',
+      noMissingAuthentication,
+      {
+        valid: [
+          // Computed member access (`app["get"]`) - `property.type` is not
+          // `Identifier`, so the methodName/routeHandlerPatterns check is
+          // skipped entirely.
+          {
+            code: 'app["get"]("/api/users", authenticate(), (req, res) => {});',
+          },
+        ],
+        invalid: [
+          // Route handler call with zero arguments - `node.arguments.length >
+          // 0` is false for both the Literal and the fallback text-based
+          // route-path extraction, so `routePath` stays "unknown" and no
+          // auth argument can be present.
+        ],
+      },
+    );
 
-    ruleTester.run('coverage - identifier callee that is not an auth middleware', noMissingAuthentication, {
-      valid: [],
-      invalid: [
-        // The handler is wrapped by a plain function call whose callee name
-        // ("wrapHandler") does not match any auth pattern, so
-        // isInsideAuthMiddleware's Identifier-callee branch evaluates to
-        // false and falls through without matching the MemberExpression
-        // branch either (the callee here is a bare Identifier, not a
-        // MemberExpression) - the route must still be reported as missing.
-        {
-          code: `
+    ruleTester.run(
+      'coverage - identifier callee that is not an auth middleware',
+      noMissingAuthentication,
+      {
+        valid: [],
+        invalid: [
+          // The handler is wrapped by a plain function call whose callee name
+          // ("wrapHandler") does not match any auth pattern, so
+          // isInsideAuthMiddleware's Identifier-callee branch evaluates to
+          // false and falls through without matching the MemberExpression
+          // branch either (the callee here is a bare Identifier, not a
+          // MemberExpression) - the route must still be reported as missing.
+          {
+            code: `
             wrapHandler(() => {
               app.get("/wrapped/unprotected", (req, res) => {});
             });
           `,
-          errors: [
-            {
-              messageId: 'missingAuthentication',
-            },
-          ],
-        },
-      ],
-    });
+            errors: [
+              {
+                messageId: 'missingAuthentication',
+              },
+            ],
+          },
+        ],
+      },
+    );
 
     ruleTester.run('coverage - continue break logic', noMissingAuthentication, {
       valid: [
@@ -311,87 +352,99 @@ describe('no-missing-authentication', () => {
       invalid: [],
     });
 
-    ruleTester.run('coverage - Identifier auth variable', noMissingAuthentication, {
-      valid: [
-        {
-          code: 'const auth = authenticate(); app.get("/api/users", auth, (req, res) => {});',
-        },
-      ],
-      invalid: [],
-    });
+    ruleTester.run(
+      'coverage - Identifier auth variable',
+      noMissingAuthentication,
+      {
+        valid: [
+          {
+            code: 'const auth = authenticate(); app.get("/api/users", auth, (req, res) => {});',
+          },
+        ],
+        invalid: [],
+      },
+    );
 
-    ruleTester.run('coverage - nested authentication contexts', noMissingAuthentication, {
-      valid: [
-        // Route inside app.use(auth)
-        {
-          code: `
+    ruleTester.run(
+      'coverage - nested authentication contexts',
+      noMissingAuthentication,
+      {
+        valid: [
+          // Route inside app.use(auth)
+          {
+            code: `
             app.use(authenticate(), () => {
               app.get("/nested/protected", (req, res) => {});
             });
           `,
-        },
-        // Route inside authentication wrapper function
-        {
-          code: `
+          },
+          // Route inside authentication wrapper function
+          {
+            code: `
             withAuth(() => {
               app.get("/wrapped/protected", (req, res) => {});
             });
           `,
-          options: [{ authMiddlewarePatterns: ['withAuth'] }],
-        },
-        // Route inside app.all(auth)
-        {
-          code: `
+            options: [{ authMiddlewarePatterns: ['withAuth'] }],
+          },
+          // Route inside app.all(auth)
+          {
+            code: `
             app.all("/api/*", requireAuth(), () => {
               app.post("/api/data", (req, res) => {});
             });
           `,
-        },
-        // Route nested inside an IIFE argument (`(() => {...})()`) — while
-        // walking up from the inner handler, `current` becomes the callee of
-        // the IIFE's invocation (not one of its arguments, since it takes
-        // none), exercising the "not an argument, keep walking up" branch of
-        // isInsideAuthMiddleware before reaching the outer app.use(auth()).
-        {
-          code: `
+          },
+          // Route nested inside an IIFE argument (`(() => {...})()`) — while
+          // walking up from the inner handler, `current` becomes the callee of
+          // the IIFE's invocation (not one of its arguments, since it takes
+          // none), exercising the "not an argument, keep walking up" branch of
+          // isInsideAuthMiddleware before reaching the outer app.use(auth()).
+          {
+            code: `
             app.use(authenticate(), (() => {
               app.get("/nested/iife-protected", (req, res) => {});
             })());
           `,
-        },
-      ],
-      invalid: [
-        // Nested but not in auth.
-        // Previously expected TWO errors: one for the `app.use(...)` itself and one for the
-        // nested `app.get`. The first was wrong — `app.use(middleware, fn)` with no path
-        // registers global middleware and cannot be "a route handler missing
-        // authentication". Only the nested unprotected GET is the defect.
-        {
-          code: `
+          },
+        ],
+        invalid: [
+          // Nested but not in auth.
+          // Previously expected TWO errors: one for the `app.use(...)` itself and one for the
+          // nested `app.get`. The first was wrong — `app.use(middleware, fn)` with no path
+          // registers global middleware and cannot be "a route handler missing
+          // authentication". Only the nested unprotected GET is the defect.
+          {
+            code: `
             app.use(someMiddleware(), () => {
               app.get("/nested/unprotected", (req, res) => {});
             });
           `,
-          errors: [{ messageId: 'missingAuthentication' }],
-        },
-      ],
-    });
+            errors: [{ messageId: 'missingAuthentication' }],
+          },
+        ],
+      },
+    );
 
-    ruleTester.run('coverage - regex ignore patterns', noMissingAuthentication, {
-      valid: [
-        {
-          code: 'app.get("/api/public/health", (req, res) => {});',
-          options: [{ ignorePatterns: ['^/api/public/.*'] }],
-        },
-      ],
-      invalid: [
-        {
-          code: 'app.get("/api/private/data", (req, res) => {});',
-          options: [{ ignorePatterns: ['^/api/public/.*'] }],
-          errors: [{ messageId: 'missingAuthentication' }],
-        },
-      ],
-    });
+    ruleTester.run(
+      'coverage - regex ignore patterns',
+      noMissingAuthentication,
+      {
+        valid: [
+          {
+            code: 'app.get("/api/public/health", (req, res) => {});',
+            options: [{ ignorePatterns: ['^/api/public/.*'] }],
+          },
+        ],
+        invalid: [
+          {
+            code: 'app.get("/api/private/data", (req, res) => {});',
+            options: [{ ignorePatterns: ['^/api/public/.*'] }],
+            errors: [{ messageId: 'missingAuthentication' }],
+          },
+        ],
+      },
+    );
 
     ruleTester.run('coverage - scope traversal', noMissingAuthentication, {
       valid: [
@@ -422,92 +475,111 @@ describe('no-missing-authentication', () => {
       invalid: [],
     });
 
-    ruleTester.run('coverage - concise-body arrow function ancestor scope', noMissingAuthentication, {
-      valid: [],
-      invalid: [
-        // `setup`'s body is a CallExpression, not a BlockStatement, so while
-        // findVariableDeclaration walks up through the enclosing arrow
-        // function it must take the ternary's false branch (treat the scope
-        // body as empty) instead of scanning `current.body.body`.
-        {
-          code: 'const setup = () => app.get("/api/users", someVar, (req, res) => {});',
-          errors: [
-            {
-              messageId: 'missingAuthentication',
-            },
-          ],
-        },
-      ],
-    });
+    ruleTester.run(
+      'coverage - concise-body arrow function ancestor scope',
+      noMissingAuthentication,
+      {
+        valid: [],
+        invalid: [
+          // `setup`'s body is a CallExpression, not a BlockStatement, so while
+          // findVariableDeclaration walks up through the enclosing arrow
+          // function it must take the ternary's false branch (treat the scope
+          // body as empty) instead of scanning `current.body.body`.
+          {
+            code: 'const setup = () => app.get("/api/users", someVar, (req, res) => {});',
+            errors: [
+              {
+                messageId: 'missingAuthentication',
+              },
+            ],
+          },
+        ],
+      },
+    );
 
-    ruleTester.run('coverage - undeclared identifier argument', noMissingAuthentication, {
-      valid: [],
-      invalid: [
-        // `undeclaredMiddleware` has no VariableDeclarator anywhere in scope,
-        // so findVariableDeclaration must walk all the way up to Program,
-        // find nothing, and stop there (Program has no `.parent`).
-        {
-          code: 'app.get("/api/users", undeclaredMiddleware, (req, res) => {});',
-          errors: [
-            {
-              messageId: 'missingAuthentication',
-            },
-          ],
-        },
-      ],
-    });
+    ruleTester.run(
+      'coverage - undeclared identifier argument',
+      noMissingAuthentication,
+      {
+        valid: [],
+        invalid: [
+          // `undeclaredMiddleware` has no VariableDeclarator anywhere in scope,
+          // so findVariableDeclaration must walk all the way up to Program,
+          // find nothing, and stop there (Program has no `.parent`).
+          {
+            code: 'app.get("/api/users", undeclaredMiddleware, (req, res) => {});',
+            errors: [
+              {
+                messageId: 'missingAuthentication',
+              },
+            ],
+          },
+        ],
+      },
+    );
 
-    ruleTester.run('coverage - declared identifier without initializer', noMissingAuthentication, {
-      valid: [],
-      invalid: [
-        // `middleware` is declared but has no `init`, so
-        // isIdentifierFromAuthMiddleware must return false via the
-        // `!declarator.init` branch instead of inspecting a CallExpression.
-        // (The name itself must not textually contain any default auth
-        // pattern like "auth", or the earlier text-based check would catch
-        // it first.)
-        {
-          code: 'let middleware; app.get("/api/users", middleware, (req, res) => {});',
-          errors: [
-            {
-              messageId: 'missingAuthentication',
-            },
-          ],
-        },
-      ],
-    });
+    ruleTester.run(
+      'coverage - declared identifier without initializer',
+      noMissingAuthentication,
+      {
+        valid: [],
+        invalid: [
+          // `middleware` is declared but has no `init`, so
+          // isIdentifierFromAuthMiddleware must return false via the
+          // `!declarator.init` branch instead of inspecting a CallExpression.
+          // (The name itself must not textually contain any default auth
+          // pattern like "auth", or the earlier text-based check would catch
+          // it first.)
+          {
+            code: 'let middleware; app.get("/api/users", middleware, (req, res) => {});',
+            errors: [
+              {
+                messageId: 'missingAuthentication',
+              },
+            ],
+          },
+        ],
+      },
+    );
 
-    ruleTester.run('coverage - non-Identifier and non-router call objects', noMissingAuthentication, {
-      valid: [
-        // Member chain object (`db.users`) - not a plain Identifier, so it's
-        // skipped before the router-name check even runs.
-        {
-          code: 'db.users.get("/api/users", (req, res) => {});',
-        },
-        // Plain Identifier object, but the name doesn't look like a router
-        // (e.g. a prepared SQL statement) - skipped by the router-name check.
-        {
-          code: 'stmt.get("/api/users", (req, res) => {});',
-        },
-      ],
-      invalid: [],
-    });
+    ruleTester.run(
+      'coverage - non-Identifier and non-router call objects',
+      noMissingAuthentication,
+      {
+        valid: [
+          // Member chain object (`db.users`) - not a plain Identifier, so it's
+          // skipped before the router-name check even runs.
+          {
+            code: 'db.users.get("/api/users", (req, res) => {});',
+          },
+          // Plain Identifier object, but the name doesn't look like a router
+          // (e.g. a prepared SQL statement) - skipped by the router-name check.
+          {
+            code: 'stmt.get("/api/users", (req, res) => {});',
+          },
+        ],
+        invalid: [],
+      },
+    );
 
-    ruleTester.run('coverage - full-text ignore pattern match', noMissingAuthentication, {
-      valid: [
-        // The route path alone ("/api/users") does not match the ignore
-        // pattern, but the full call-expression text does (it matches on the
-        // handler body) - exercises the second, text-based ignore check.
-        {
-          code: 'app.get("/api/users", (req, res) => { legacySkipAuthHandler(); });',
-          options: [{ ignorePatterns: ['legacySkipAuthHandler'] }],
-        },
-      ],
-      invalid: [],
-    });
+    ruleTester.run(
+      'coverage - full-text ignore pattern match',
+      noMissingAuthentication,
+      {
+        valid: [
+          // The route path alone ("/api/users") does not match the ignore
+          // pattern, but the full call-expression text does (it matches on the
+          // handler body) - exercises the second, text-based ignore check.
+          {
+            code: 'app.get("/api/users", (req, res) => { legacySkipAuthHandler(); });',
+            options: [{ ignorePatterns: ['legacySkipAuthHandler'] }],
+          },
+        ],
+        invalid: [],
+      },
+    );
   });
 });
-
 
 /**
  * Regression locks — each FAILS on the pre-fix rule.
@@ -520,21 +592,25 @@ describe('no-missing-authentication', () => {
  * 2. The rule called `console.log('DEBUG MSG: ...')` whenever `ignorePatterns` matched.
  *    That shipped to npm, and stdout writes corrupt the JSON and SARIF formatters.
  */
-ruleTester.run('lock: path-less app.use() is not a route handler', noMissingAuthentication, {
-  valid: [
-    { code: 'app.use(helmet());' },
-    { code: 'app.use(rateLimit({ windowMs: 60000, max: 100 }));' },
-    { code: 'app.use(express.json());' },
-    { code: 'app.use((err, req, res, next) => { res.status(500).end(); });' },
-  ],
-  invalid: [
-    // A PATH-mounted use still addresses a route, so it is still checked.
-    {
-      code: 'app.use("/admin", (req, res) => {});',
-      errors: [{ messageId: 'missingAuthentication' }],
-    },
-  ],
-});
+ruleTester.run(
+  'lock: path-less app.use() is not a route handler',
+  noMissingAuthentication,
+  {
+    valid: [
+      { code: 'app.use(helmet());' },
+      { code: 'app.use(rateLimit({ windowMs: 60000, max: 100 }));' },
+      { code: 'app.use(express.json());' },
+      { code: 'app.use((err, req, res, next) => { res.status(500).end(); });' },
+    ],
+    invalid: [
+      // A PATH-mounted use still addresses a route, so it is still checked.
+      {
+        code: 'app.use("/admin", (req, res) => {});',
+        errors: [{ messageId: 'missingAuthentication' }],
+      },
+    ],
+  },
+);
 
 describe('lock: the rule never writes to stdout', () => {
   it('stays silent when ignorePatterns matches', async () => {
@@ -545,9 +621,18 @@ describe('lock: the rule never writes to stdout', () => {
     try {
       new Linter().verify('app.get("/health", (req, res) => res.send("ok"));', [
         {
-          plugins: { sc: { rules: { 'no-missing-authentication': noMissingAuthentication } } },
+          plugins: {
+            sc: {
+              rules: { 'no-missing-authentication': noMissingAuthentication },
+            },
+          },
           languageOptions: { ecmaVersion: 'latest' as const },
-          rules: { 'sc/no-missing-authentication': ['error', { ignorePatterns: ['health'] }] },
+          rules: {
+            'sc/no-missing-authentication': [
+              'error',
+              { ignorePatterns: ['health'] },
+            ],
+          },
         },
       ]);
     } finally {
@@ -569,33 +654,37 @@ describe('lock: the rule never writes to stdout', () => {
 describe('option: testFilePattern', () => {
   const ROUTE = 'app.get("/api/users", (req, res) => {});';
 
-  ruleTester.run('a custom pattern extends the exemption', noMissingAuthentication, {
-    valid: [
-      {
-        code: ROUTE,
-        filename: 'seeds/routes.ts',
-        options: [{ allowInTests: true, testFilePattern: 'seeds/' }],
-      },
-    ],
-    invalid: [
-      // Identical source and filename, `allowInTests` still on — only the
-      // pattern is gone, and the finding comes back.
-      {
-        code: ROUTE,
-        filename: 'seeds/routes.ts',
-        options: [{ allowInTests: true }],
-        errors: [{ messageId: 'missingAuthentication' }],
-      },
-      // The converse: a narrower pattern than the default withdraws the
-      // exemption from a file the default would have covered.
-      {
-        code: ROUTE,
-        filename: 'routes.spec.ts',
-        options: [{ allowInTests: true, testFilePattern: '\\.test\\.ts$' }],
-        errors: [{ messageId: 'missingAuthentication' }],
-      },
-    ],
-  });
+  ruleTester.run(
+    'a custom pattern extends the exemption',
+    noMissingAuthentication,
+    {
+      valid: [
+        {
+          code: ROUTE,
+          filename: 'seeds/routes.ts',
+          options: [{ allowInTests: true, testFilePattern: 'seeds/' }],
+        },
+      ],
+      invalid: [
+        // Identical source and filename, `allowInTests` still on — only the
+        // pattern is gone, and the finding comes back.
+        {
+          code: ROUTE,
+          filename: 'seeds/routes.ts',
+          options: [{ allowInTests: true }],
+          errors: [{ messageId: 'missingAuthentication' }],
+        },
+        // The converse: a narrower pattern than the default withdraws the
+        // exemption from a file the default would have covered.
+        {
+          code: ROUTE,
+          filename: 'routes.spec.ts',
+          options: [{ allowInTests: true, testFilePattern: '\\.test\\.ts$' }],
+          errors: [{ messageId: 'missingAuthentication' }],
+        },
+      ],
+    },
+  );
 });
 
 /**
@@ -620,134 +709,164 @@ describe('option: testFilePattern', () => {
  *    API, was skipped because the registration's object is a CallExpression.
  */
 describe('regression locks', () => {
-  ruleTester.run('lock: router identity comes from the binding, not a substring', noMissingAuthentication, {
-    valid: [
-      // app ⊂ wrapper / dataMapper / appointmentScheduler
-      { code: 'const wrapper = createCacheWrapper(); wrapper.get("k"); wrapper.delete("k");' },
-      { code: 'function f(appointmentScheduler) { return appointmentScheduler.get(1); }' },
-      // Resolved evidence outranks a genuine whole-word name match.
-      { code: 'const routeCache = new Map(); routeCache.get("/a"); routeCache.delete("/a");' },
-      { code: 'const serverStats = new Map(); serverStats.get("host");' },
-      { code: 'const dataMapper = { get: (id) => id }; dataMapper.get(1);' },
-    ],
-    invalid: [
-      // A router is a router whatever it is named, when the binding resolves.
-      {
-        code: 'const api = express.Router(); api.post("/admin/flags", (req, res) => {});',
-        errors: [{ messageId: 'missingAuthentication' }],
-      },
-      {
-        code: 'const gateway = express(); gateway.get("/admin/secrets", (req, res) => {});',
-        errors: [{ messageId: 'missingAuthentication' }],
-      },
-      {
-        code: 'const srv = new Koa(); srv.get("/admin/secrets", (req, res) => {});',
-        errors: [{ messageId: 'missingAuthentication' }],
-      },
-    ],
-  });
+  ruleTester.run(
+    'lock: router identity comes from the binding, not a substring',
+    noMissingAuthentication,
+    {
+      valid: [
+        // app ⊂ wrapper / dataMapper / appointmentScheduler
+        {
+          code: 'const wrapper = createCacheWrapper(); wrapper.get("k"); wrapper.delete("k");',
+        },
+        {
+          code: 'function f(appointmentScheduler) { return appointmentScheduler.get(1); }',
+        },
+        // Resolved evidence outranks a genuine whole-word name match.
+        {
+          code: 'const routeCache = new Map(); routeCache.get("/a"); routeCache.delete("/a");',
+        },
+        { code: 'const serverStats = new Map(); serverStats.get("host");' },
+        { code: 'const dataMapper = { get: (id) => id }; dataMapper.get(1);' },
+      ],
+      invalid: [
+        // A router is a router whatever it is named, when the binding resolves.
+        {
+          code: 'const api = express.Router(); api.post("/admin/flags", (req, res) => {});',
+          errors: [{ messageId: 'missingAuthentication' }],
+        },
+        {
+          code: 'const gateway = express(); gateway.get("/admin/secrets", (req, res) => {});',
+          errors: [{ messageId: 'missingAuthentication' }],
+        },
+        {
+          code: 'const srv = new Koa(); srv.get("/admin/secrets", (req, res) => {});',
+          errors: [{ messageId: 'missingAuthentication' }],
+        },
+      ],
+    },
+  );
 
-  ruleTester.run('lock: default public-route patterns match the PATH, not the handler body', noMissingAuthentication, {
-    valid: [
-      // A genuinely public path still matches, by path.
-      { code: 'app.post("/login", loginHandler);' },
-      { code: 'app.get("/healthz", (req, res) => {});' },
-    ],
-    invalid: [
-      // `res.status(500)` in the body must not exempt an admin route.
-      {
-        code: 'app.get("/admin/accounts", async (req, res) => { try { res.json(await listUsers()); } catch (e) { res.status(500).end(); } });',
-        errors: [{ messageId: 'missingAuthentication' }],
-      },
-      // Same for the other default path words appearing only in the body.
-      {
-        code: 'app.get("/admin/audit", (req, res) => { recordMetrics(); pingUpstream(); });',
-        errors: [{ messageId: 'missingAuthentication' }],
-      },
-    ],
-  });
+  ruleTester.run(
+    'lock: default public-route patterns match the PATH, not the handler body',
+    noMissingAuthentication,
+    {
+      valid: [
+        // A genuinely public path still matches, by path.
+        { code: 'app.post("/login", loginHandler);' },
+        { code: 'app.get("/healthz", (req, res) => {});' },
+      ],
+      invalid: [
+        // `res.status(500)` in the body must not exempt an admin route.
+        {
+          code: 'app.get("/admin/accounts", async (req, res) => { try { res.json(await listUsers()); } catch (e) { res.status(500).end(); } });',
+          errors: [{ messageId: 'missingAuthentication' }],
+        },
+        // Same for the other default path words appearing only in the body.
+        {
+          code: 'app.get("/admin/audit", (req, res) => { recordMetrics(); pingUpstream(); });',
+          errors: [{ messageId: 'missingAuthentication' }],
+        },
+      ],
+    },
+  );
 
-  ruleTester.run('lock: the handler is not its own authentication', noMissingAuthentication, {
-    valid: [
-      // Real middleware, in the middleware position.
-      { code: 'app.get("/api/reports", authenticate, getAuthorReport);' },
-      { code: 'const guard = requireAuth({}); app.get("/api/me", guard, getProfile);' },
-      { code: 'const guard = requireAuth({}); app.use("/api", guard);' },
-    ],
-    invalid: [
-      // auth ⊂ author — the handler's name is not a guard.
-      {
-        code: 'router.get("/api/reports/authors/:id", getAuthorReport);',
-        errors: [{ messageId: 'missingAuthentication' }],
-      },
-      // session ⊂ renderSessionRoster — a conference talk, not a login session.
-      {
-        code: 'router.get("/api/talks/:id/roster", renderSessionRoster);',
-        errors: [{ messageId: 'missingAuthentication' }],
-      },
-      // A guard-shaped local name is still not a guard in the handler slot.
-      {
-        code: 'router.get("/api/jwtTokens", listJwtTokens);',
-        errors: [{ messageId: 'missingAuthentication' }],
-      },
-    ],
-  });
+  ruleTester.run(
+    'lock: the handler is not its own authentication',
+    noMissingAuthentication,
+    {
+      valid: [
+        // Real middleware, in the middleware position.
+        { code: 'app.get("/api/reports", authenticate, getAuthorReport);' },
+        {
+          code: 'const guard = requireAuth({}); app.get("/api/me", guard, getProfile);',
+        },
+        { code: 'const guard = requireAuth({}); app.use("/api", guard);' },
+      ],
+      invalid: [
+        // auth ⊂ author — the handler's name is not a guard.
+        {
+          code: 'router.get("/api/reports/authors/:id", getAuthorReport);',
+          errors: [{ messageId: 'missingAuthentication' }],
+        },
+        // session ⊂ renderSessionRoster — a conference talk, not a login session.
+        {
+          code: 'router.get("/api/talks/:id/roster", renderSessionRoster);',
+          errors: [{ messageId: 'missingAuthentication' }],
+        },
+        // A guard-shaped local name is still not a guard in the handler slot.
+        {
+          code: 'router.get("/api/jwtTokens", listJwtTokens);',
+          errors: [{ messageId: 'missingAuthentication' }],
+        },
+      ],
+    },
+  );
 
-  ruleTester.run('lock: app.route(path).get(handler) chaining is a route registration', noMissingAuthentication, {
-    valid: [
-      { code: 'app.route("/api/me").get(authenticate, getProfile);' },
-      { code: 'app.route("/login").post(loginHandler);' },
-      // Not a router base — a query builder chain must stay untouched.
-      { code: 'db.route("/x").get(handler);' },
-    ],
-    invalid: [
-      {
-        code: 'app.route("/admin/tokens").get(listTokens);',
-        errors: [{ messageId: 'missingAuthentication' }],
-      },
-      // Deeper in the chain: the base is still the route() call.
-      {
-        code: 'app.route("/admin/tokens").get(listTokens).post(createToken);',
-        errors: [
-          { messageId: 'missingAuthentication' },
-          { messageId: 'missingAuthentication' },
-        ],
-      },
-    ],
-  });
+  ruleTester.run(
+    'lock: app.route(path).get(handler) chaining is a route registration',
+    noMissingAuthentication,
+    {
+      valid: [
+        { code: 'app.route("/api/me").get(authenticate, getProfile);' },
+        { code: 'app.route("/login").post(loginHandler);' },
+        // Not a router base — a query builder chain must stay untouched.
+        { code: 'db.route("/x").get(handler);' },
+      ],
+      invalid: [
+        {
+          code: 'app.route("/admin/tokens").get(listTokens);',
+          errors: [{ messageId: 'missingAuthentication' }],
+        },
+        // Deeper in the chain: the base is still the route() call.
+        {
+          code: 'app.route("/admin/tokens").get(listTokens).post(createToken);',
+          errors: [
+            { messageId: 'missingAuthentication' },
+            { messageId: 'missingAuthentication' },
+          ],
+        },
+      ],
+    },
+  );
 });
 
-ruleTester.run('coverage - router factory and middleware-name edge shapes', noMissingAuthentication, {
-  valid: [
-    // Middleware reached through a member chain whose OBJECT is itself a
-    // MemberExpression, so only the trailing property names the middleware.
-    { code: 'app.get("/api/x", middleware.chain.authenticate, handler);' },
-    // The same shape as a middleware FACTORY call, so the callee - not the
-    // argument - is the member chain whose object is not an Identifier.
-    { code: 'app.get("/api/y", middleware.chain.authenticate(), handler);' },
-    // An object literal argument names nothing at all.
-    { code: 'app.get("/api/z", authenticate, { name: "x" }, handler);' },
-    // Member-chain middleware whose object IS an identifier: the dotted name
-    // `passport.authenticate` is what the default patterns list.
-    { code: 'app.get("/api/orders", passport.authenticate("jwt"), listOrders);' },
-  ],
-  invalid: [
-    // `require("express")()` - the initialiser IS a CallExpression, but its
-    // callee is another call, so no factory name can be read off it. The
-    // fallback is the binding NAME, and `gw` carries no router word: this is
-    // a documented CJS false negative on the router side, kept here only to
-    // pin the branch.
-    {
-      code: 'const server = require("express")(); server.get("/admin/a", (req, res) => {});',
-      errors: [{ messageId: 'missingAuthentication' }],
-    },
-    // A declared identifier whose initialiser is not a call at all.
-    {
-      code: 'const guard = 42; app.get("/api/x", guard, (req, res) => {});',
-      errors: [{ messageId: 'missingAuthentication' }],
-    },
-  ],
-});
+ruleTester.run(
+  'coverage - router factory and middleware-name edge shapes',
+  noMissingAuthentication,
+  {
+    valid: [
+      // Middleware reached through a member chain whose OBJECT is itself a
+      // MemberExpression, so only the trailing property names the middleware.
+      { code: 'app.get("/api/x", middleware.chain.authenticate, handler);' },
+      // The same shape as a middleware FACTORY call, so the callee - not the
+      // argument - is the member chain whose object is not an Identifier.
+      { code: 'app.get("/api/y", middleware.chain.authenticate(), handler);' },
+      // An object literal argument names nothing at all.
+      { code: 'app.get("/api/z", authenticate, { name: "x" }, handler);' },
+      // Member-chain middleware whose object IS an identifier: the dotted name
+      // `passport.authenticate` is what the default patterns list.
+      {
+        code: 'app.get("/api/orders", passport.authenticate("jwt"), listOrders);',
+      },
+    ],
+    invalid: [
+      // `require("express")()` - the initialiser IS a CallExpression, but its
+      // callee is another call, so no factory name can be read off it. The
+      // fallback is the binding NAME, and `gw` carries no router word: this is
+      // a documented CJS false negative on the router side, kept here only to
+      // pin the branch.
+      {
+        code: 'const server = require("express")(); server.get("/admin/a", (req, res) => {});',
+        errors: [{ messageId: 'missingAuthentication' }],
+      },
+      // A declared identifier whose initialiser is not a call at all.
+      {
+        code: 'const guard = 42; app.get("/api/x", guard, (req, res) => {});',
+        errors: [{ messageId: 'missingAuthentication' }],
+      },
+    ],
+  },
+);
 
 /**
  * `routerNameWords` — the name-fallback vocabulary, made overridable.
@@ -760,62 +879,70 @@ ruleTester.run('coverage - router factory and middleware-name edge shapes', noMi
  * Every QUIET case below is paired with a positive control on the SAME snippet,
  * because silence on its own proves nothing.
  */
-ruleTester.run('routerNameWords and its additional variant', noMissingAuthentication, {
-  valid: [
-    {
-      // Positive control: the invalid case "DEFAULT: `app` is a router word".
-      name: 'routerNameWords REPLACES the built-ins: `app` is no longer a router',
-      code: 'app.get("/admin/accounts", (req, res) => { res.json(1); });',
-      options: [{ routerNameWords: ['gateway'] }],
-    },
-    {
-      name: 'DEFAULT: `gateway` is not a built-in router word',
-      code: 'gateway.get("/admin/accounts", (req, res) => { res.json(1); });',
-    },
-  ],
-  invalid: [
-    {
-      name: 'DEFAULT: `app` is a router word, with no options at all',
-      code: 'app.get("/admin/accounts", (req, res) => { res.json(1); });',
-      errors: [{ messageId: 'missingAuthentication' }],
-    },
-    {
-      name: 'routerNameWords REPLACES the built-ins: the replacement is a router',
-      code: 'gateway.get("/admin/accounts", (req, res) => { res.json(1); });',
-      options: [{ routerNameWords: ['gateway'] }],
-      errors: [{ messageId: 'missingAuthentication' }],
-    },
-    {
-      name: 'additionalRouterNameWords extends the built-ins',
-      code: 'gateway.get("/admin/accounts", (req, res) => { res.json(1); });',
-      options: [{ additionalRouterNameWords: ['gateway'] }],
-      errors: [{ messageId: 'missingAuthentication' }],
-    },
-  ],
-});
+ruleTester.run(
+  'routerNameWords and its additional variant',
+  noMissingAuthentication,
+  {
+    valid: [
+      {
+        // Positive control: the invalid case "DEFAULT: `app` is a router word".
+        name: 'routerNameWords REPLACES the built-ins: `app` is no longer a router',
+        code: 'app.get("/admin/accounts", (req, res) => { res.json(1); });',
+        options: [{ routerNameWords: ['gateway'] }],
+      },
+      {
+        name: 'DEFAULT: `gateway` is not a built-in router word',
+        code: 'gateway.get("/admin/accounts", (req, res) => { res.json(1); });',
+      },
+    ],
+    invalid: [
+      {
+        name: 'DEFAULT: `app` is a router word, with no options at all',
+        code: 'app.get("/admin/accounts", (req, res) => { res.json(1); });',
+        errors: [{ messageId: 'missingAuthentication' }],
+      },
+      {
+        name: 'routerNameWords REPLACES the built-ins: the replacement is a router',
+        code: 'gateway.get("/admin/accounts", (req, res) => { res.json(1); });',
+        options: [{ routerNameWords: ['gateway'] }],
+        errors: [{ messageId: 'missingAuthentication' }],
+      },
+      {
+        name: 'additionalRouterNameWords extends the built-ins',
+        code: 'gateway.get("/admin/accounts", (req, res) => { res.json(1); });',
+        options: [{ additionalRouterNameWords: ['gateway'] }],
+        errors: [{ messageId: 'missingAuthentication' }],
+      },
+    ],
+  },
+);
 
 /**
  * `ignorePatterns` REPLACES `DEFAULT_PUBLIC_ROUTE_PATTERNS`, and always did —
  * the schema said `default: []`, which was a lie the generated Options table
  * repeated. These pin the real default so it cannot drift back.
  */
-ruleTester.run('ignorePatterns default is the public-route list', noMissingAuthentication, {
-  valid: [
-    {
-      name: 'DEFAULT: /login is public by definition, with no options at all',
-      code: 'app.post("/login", (req, res) => { res.json(1); });',
-    },
-    {
-      name: 'DEFAULT: /healthz is public by definition, with no options at all',
-      code: 'app.get("/healthz", (req, res) => { res.json(1); });',
-    },
-  ],
-  invalid: [
-    {
-      name: 'a supplied ignorePatterns REPLACES the built-in list, so /login reports',
-      code: 'app.post("/login", (req, res) => { res.json(1); });',
-      options: [{ ignorePatterns: ['/webhooks/'] }],
-      errors: [{ messageId: 'missingAuthentication' }],
-    },
-  ],
-});
+ruleTester.run(
+  'ignorePatterns default is the public-route list',
+  noMissingAuthentication,
+  {
+    valid: [
+      {
+        name: 'DEFAULT: /login is public by definition, with no options at all',
+        code: 'app.post("/login", (req, res) => { res.json(1); });',
+      },
+      {
+        name: 'DEFAULT: /healthz is public by definition, with no options at all',
+        code: 'app.get("/healthz", (req, res) => { res.json(1); });',
+      },
+    ],
+    invalid: [
+      {
+        name: 'a supplied ignorePatterns REPLACES the built-in list, so /login reports',
+        code: 'app.post("/login", (req, res) => { res.json(1); });',
+        options: [{ ignorePatterns: ['/webhooks/'] }],
+        errors: [{ messageId: 'missingAuthentication' }],
+      },
+    ],
+  },
+);

--- a/packages/eslint-plugin-secure-coding/src/rules/no-missing-authentication/no-missing-authentication.test.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/no-missing-authentication/no-missing-authentication.test.ts
@@ -850,11 +850,12 @@ ruleTester.run(
       },
     ],
     invalid: [
-      // `require("express")()` - the initialiser IS a CallExpression, but its
+      // `require("express")()` — the initialiser IS a CallExpression, but its
       // callee is another call, so no factory name can be read off it. The
-      // fallback is the binding NAME, and `gw` carries no router word: this is
-      // a documented CJS false negative on the router side, kept here only to
-      // pin the branch.
+      // fallback is the binding NAME, and `server` IS a router word, so the
+      // case reports. That is what makes it an `invalid` case: it pins that
+      // the name fallback carries the CJS factory form, which the initialiser
+      // walk alone cannot.
       {
         code: 'const server = require("express")(); server.get("/admin/a", (req, res) => {});',
         errors: [{ messageId: 'missingAuthentication' }],


### PR DESCRIPTION
## Summary

Found by **rescanning the same targets after [#692](https://github.com/ofri-peretz/eslint/pull/692) shipped**, which is the point of rescanning. Two more rules deciding on a name.

### `browser-security/require-csp-headers` matched `render` on any receiver

```ts
function createRenderer(templatePath) {
  return (props, nunjucksEnv) => nunjucksEnv.render(templatePath, { params: props });
}
```

`nunjucksEnv.render(template, data)` **returns a string**. So do mustache, ejs, handlebars and ReactDOMServer. Only `res.render(view)` emits a response.

On `ministryofjustice/hmpps-arns-assessment-platform-ui` that was **31 reports** — every Nunjucks component module and every component test — in a repository that already sets a nonce-based CSP in `setUpWebSecurity.ts`. Asking a template helper to set an HTTP header is asking for something it cannot do, which is the shape of a finding nobody can action.

Gated on the receiver, and the rule now takes `skipTestFiles`: **29 of the 31 were in `*.test.ts`**, where rendering a template to assert on its markup is not a route serving a document.

**31 → 3.**

### `secure-coding/no-missing-authentication` treated `app.get('port')` as a route

```ts
const server = app.listen(app.get('port'), () => { … })
```

Express overloads the name: one argument reads a setting, two or more registers a route. A port number was being reported as an unauthenticated endpoint, as was the log line beside it.

A route always has a handler after its path, so the arity test is exact rather than a heuristic.

## Test plan

- [x] `eslint-plugin-browser-security` — 2,917 passed, coverage back to 100%.
- [x] `eslint-plugin-secure-coding` — 3,511 passed (the `redos-oracle` failures here are `recheck` missing from my local install, pre-existing and unrelated).
- [x] `rule-audit:gate --changed` — no regressions. It caught two things on the way and both were right: a baked-in word list with no option (`unconfigurable-vocabulary`) and then a schema option with no declared default.
- [x] **Both fixes verified against the file that produced them**, then the whole repository rescanned: MoJ went 105 → 75 findings across the two changes.
- [x] False-negative guards in the same diff: `res.render`, `reply.render` (Fastify) and `ctx.res.render` all still report; `app.route(path).get(handler)` still reports — its existing lock caught the first version of the arity fix, which did not exempt the chained form.

## Notes

The receiver list is an **option**, not a constant. The ratchet insisted and was right: a house convention that calls it `httpRes` should configure the list rather than lose the finding. The default lives in `defaultOptions` and the schema and nowhere else — as a module const it was an unreachable word list, and as a `??` fallback beside a named default it was an unreachable branch.

`no-missing-authentication` still reports 17 times on that repo, on the sign-in routes and health checks that must be public. That is a policy question rather than a bug, and a separate piece of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced false positives when detecting missing CSP headers in template-engine render calls.
  * Added support for configurable response receiver names and skipped test files during CSP checks.
  * Improved authentication detection by distinguishing route registration from settings access and other non-endpoint calls.
  * Preserved detection for chained routes and supported additional router configurations.

* **Tests**
  * Expanded coverage for template engines, response objects, authentication patterns, router behavior, and edge cases.

* **Chores**
  * Prepared patch releases for both ESLint plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->