### PR TITLE
chore(scripts): a triage verdict must say how much of it was looked at

### DIFF
--- a/.agent/triage-sampling-debt.json
+++ b/.agent/triage-sampling-debt.json
@@ -1,0 +1,15 @@
+[
+  "conventions/no-commented-code",
+  "maintainability/cognitive-complexity",
+  "maintainability/identical-functions",
+  "maintainability/max-parameters",
+  "modernization/prefer-at",
+  "modernization/prefer-event-target",
+  "modernization/prefer-template-literal",
+  "modularity/ddd-value-object-immutability",
+  "react-a11y/prefer-tag-over-role",
+  "react-features/hooks-exhaustive-deps",
+  "react-features/jsx-key",
+  "react-features/no-unknown-property",
+  "reliability/no-missing-null-checks"
+]

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -128,6 +128,11 @@ jobs:
       # each one. #659 added twelve credential spellings and three reached the
       # PR with no test — removing them from the rule left the suite green.
       - run: npm run lint:detection-list-coverage
+      # And the same question one layer out, on the LEDGER rather than the
+      # rule: a triage verdict above a handful of findings has to say how
+      # much of it was actually looked at. no-cycle carried "the DETECTION
+      # is right" until the first sample read 66.7% wrong (#702, #705).
+      - run: npm run lint:triage-sampling
       # The FULL rule-audit ratchet. The pre-commit hook runs a scoped version
       # that only sees rules whose own files changed; a shared-util edit can
       # move a rule's findings without touching it, so this run — every rule,

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "scripts": {
     "prepare": "[ -d .git ] && lefthook install || true",
     "ci:local": "lefthook run pre-push --all-files --force",
+    "lint:triage-sampling": "tsx scripts/lint-triage-sampling.ts",
     "lint:taxonomy": "tsx scripts/lint-plugin-taxonomy.ts",
     "rule-ledger": "tsx scripts/build-rule-ledger.ts",
     "rule-audit:gate": "tsx scripts/rule-audit-gate.ts",

--- a/scripts/__tests__/triage-sampling.test.ts
+++ b/scripts/__tests__/triage-sampling.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Unit lock for the triage-sampling gate.
+ *
+ * The exemption is the part worth pinning. A rule with a handful of findings
+ * gets a CENSUS — the note lists every one — and that is stronger than any
+ * sample, so demanding an `n=` there would be noise that trains people to
+ * ignore the gate. 30 of the ledger's 46 verdict-bearing entries are that
+ * shape. If the ceiling ever silently drops to 0, this gate becomes a nag.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  CENSUS_CEILING,
+  assertsVerdict,
+  citesSample,
+  findingCount,
+  unsupportedVerdicts,
+} from '../lint-triage-sampling';
+
+describe('citesSample', () => {
+  it('accepts the forms the ledger actually uses', () => {
+    for (const s of ['n=24 across 4 repos', 'stratified across repos', 'sampled 10 findings', 'a census of all 3'])
+      expect(citesSample(s)).toBe(true);
+  });
+
+  it('rejects a bare assertion', () => {
+    expect(citesSample('Correct — real circular imports. The DETECTION is right.')).toBe(false);
+  });
+});
+
+describe('assertsVerdict', () => {
+  it('catches the phrasings that carried the two real failures', () => {
+    // Both of these stood in the ledger and both fell to the first sample.
+    expect(assertsVerdict('Correct — real circular imports. The DETECTION is right.')).toBe(true);
+    expect(assertsVerdict('all 4 are TRUE POSITIVES')).toBe(true);
+  });
+
+  it('leaves alone a note that admits it has not decided', () => {
+    // Honest about its own limits — nagging it would punish the good behaviour.
+    expect(assertsVerdict('UNADJUDICATED. The budget is the first measurement, not a verdict.')).toBe(false);
+  });
+
+  it('leaves alone a note that only reports a number', () => {
+    expect(assertsVerdict('1421. Ratcheted down from 1635 after the generated-file opt-out.')).toBe(false);
+  });
+});
+
+describe('findingCount', () => {
+  it('reads both budget shapes', () => {
+    expect(findingCount(1337)).toBe(1337);
+    expect(findingCount({ max: 42 })).toBe(42);
+    expect(findingCount(undefined)).toBe(0);
+  });
+});
+
+describe('unsupportedVerdicts', () => {
+  const VERDICT = 'Correct — these are real.';
+
+  it('flags a verdict on a high-volume rule with no stated basis', () => {
+    expect(unsupportedVerdicts({ 'a/b': 200 }, { 'a/b': VERDICT })).toEqual([
+      { rule: 'a/b', findings: 200 },
+    ]);
+  });
+
+  it('exempts a low-volume rule, where the note can list every finding', () => {
+    expect(unsupportedVerdicts({ 'a/b': CENSUS_CEILING }, { 'a/b': VERDICT })).toEqual([]);
+  });
+
+  it('accepts a high-volume verdict that states its basis', () => {
+    expect(
+      unsupportedVerdicts({ 'a/b': 200 }, { 'a/b': `${VERDICT} Stratified n=24 across 4 repos.` }),
+    ).toEqual([]);
+  });
+
+  it('orders by findings, so the biggest unsupported claim reads first', () => {
+    const out = unsupportedVerdicts(
+      { 'a/b': 50, 'c/d': 500 },
+      { 'a/b': VERDICT, 'c/d': VERDICT },
+    );
+    expect(out.map((u) => u.rule)).toEqual(['c/d', 'a/b']);
+  });
+});

--- a/scripts/lint-triage-sampling.ts
+++ b/scripts/lint-triage-sampling.ts
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * A triage verdict on a high-volume rule must say how much of it was looked at.
+ *
+ * The triage ledger in `.agent/corpus-findings-budget.json` is the record people
+ * read INSTEAD of re-deriving an analysis. That is its value and its hazard: an
+ * unsupported verdict there does not read as a guess, it reads as settled.
+ *
+ * Twice now a verdict in it has failed under the first sample anyone took:
+ *
+ *   - `no-cycle` said "correct — real circular imports … the DETECTION is
+ *     right". A stratified n=24 came back 66.7% type-only — imports TypeScript
+ *     erases before emit, where the hazard the rule's own message claims cannot
+ *     occur (#702, fixed in #705).
+ *   - `no-extraneous-dependencies` sat at UNADJUDICATED while describing a bug
+ *     that had already shipped fixed in 2.4.0 (#693).
+ *
+ * Neither was caught by a test, because neither is code.
+ *
+ * ## The bar, and why it is not "cite a sample for everything"
+ *
+ * A rule with a handful of findings gets a CENSUS: the note enumerates every
+ * one, which is stronger evidence than any sample. 30 of the ledger's 46
+ * verdict-bearing entries are that shape and are exempt by construction.
+ *
+ * Above `CENSUS_CEILING` findings, enumeration stops being plausible and the
+ * note has to state its own basis: an explicit `n=`, the word `stratified`, or
+ * `sampled`. BENCHMARK-CRITERIA §A2 already sets the protocol — ≥20 findings,
+ * stratified across repos, each labelled with a one-line reason. This gate does
+ * not re-litigate that; it only refuses a verdict that is silent about it.
+ *
+ * ## Ratchet
+ *
+ * `.agent/triage-sampling-debt.json` records what is unsupported today. A new
+ * unsupported verdict fails, and so does a debt entry that has since been
+ * supported — a ledger nobody prunes stops describing the repo, the same
+ * bidirectional shape `lint:severity-consistency` uses.
+ *
+ *   npm run lint:triage-sampling
+ *   npm run lint:triage-sampling -- --update
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const ROOT = path.resolve(__dirname, '..');
+const BUDGET = path.join(ROOT, '.agent', 'corpus-findings-budget.json');
+const DEBT_FILE = path.join(ROOT, '.agent', 'triage-sampling-debt.json');
+
+/** At or below this many findings, a note can plausibly enumerate them all. */
+export const CENSUS_CEILING = 10;
+
+/** Does the note state the basis of its verdict? */
+export const citesSample = (note: string): boolean =>
+  /\bn\s*=\s*\d+|\bstratified\b|\bsampled?\b|\bcensus\b/i.test(note);
+
+/**
+ * Does the note actually assert something about correctness?
+ *
+ * A note that only reports a number, or that says outright it has not been
+ * adjudicated, is honest about its own limits and is not what this gate is for.
+ */
+export const assertsVerdict = (note: string): boolean => {
+  if (/\bUNADJUDICATED\b|\bnot (yet )?adjudicated\b|\bunmeasured\b/i.test(note)) return false;
+  return /\bcorrect\b|\btrue positives?\b|\bnot (an? )?(FP|false positive)|\bDETECTION is right\b|\blegitimate\b|\breal\b/i.test(
+    note,
+  );
+};
+
+export const findingCount = (budget: unknown): number =>
+  typeof budget === 'number' ? budget : ((budget as { max?: number })?.max ?? 0);
+
+export interface Unsupported {
+  rule: string;
+  findings: number;
+}
+
+export function unsupportedVerdicts(
+  budgets: Record<string, unknown>,
+  triage: Record<string, string>,
+): Unsupported[] {
+  const out: Unsupported[] = [];
+  for (const [rule, note] of Object.entries(triage)) {
+    const findings = findingCount(budgets[rule]);
+    if (findings <= CENSUS_CEILING) continue;
+    if (!assertsVerdict(note)) continue;
+    if (citesSample(note)) continue;
+    out.push({ rule, findings });
+  }
+  return out.sort((a, b) => b.findings - a.findings);
+}
+
+function main(): void {
+  const update = process.argv.includes('--update');
+  const { budgets = {}, triage = {} } = JSON.parse(fs.readFileSync(BUDGET, 'utf8'));
+  const current = unsupportedVerdicts(budgets, triage);
+  const currentRules = current.map((u) => u.rule).sort();
+
+  if (update) {
+    fs.mkdirSync(path.dirname(DEBT_FILE), { recursive: true });
+    fs.writeFileSync(DEBT_FILE, `${JSON.stringify(currentRules, null, 2)}\n`);
+    console.log(`Recorded ${currentRules.length} unsupported verdict(s).`);
+    return;
+  }
+
+  const debt: string[] = fs.existsSync(DEBT_FILE)
+    ? JSON.parse(fs.readFileSync(DEBT_FILE, 'utf8'))
+    : [];
+  const known = new Set(debt);
+  const added = current.filter((u) => !known.has(u.rule));
+  const fixed = debt.filter((r) => !currentRules.includes(r));
+
+  console.log(
+    `${Object.keys(triage).length} triage entries, ${current.length} asserting a verdict above ` +
+      `${CENSUS_CEILING} findings without stating a sample.`,
+  );
+
+  if (added.length) {
+    console.error(`\n✗ ${added.length} verdict(s) with nothing behind them:\n`);
+    for (const u of added) console.error(`    ${u.rule} — ${u.findings} findings`);
+    console.error(
+      '\n  State the basis in the note: an explicit n=, "stratified", or a census.\n' +
+        '  BENCHMARK-CRITERIA §A2 sets the protocol — >=20, stratified across repos,\n' +
+        '  each labelled with a one-line reason. Saying "correct" is not a measurement:\n' +
+        '  no-cycle carried "the DETECTION is right" until a sample read 66.7% wrong.\n',
+    );
+  }
+  if (fixed.length) {
+    console.error(`\n✗ ${fixed.length} debt entry/entries now state a basis — prune the ledger:\n`);
+    for (const r of fixed) console.error(`    ${r}`);
+    console.error('\n  Run: npm run lint:triage-sampling -- --update\n');
+  }
+  if (added.length || fixed.length) process.exit(1);
+  console.log('✅ No unsupported triage verdicts.');
+}
+
+if (require.main === module) main();


### PR DESCRIPTION
## Why

The triage ledger in `.agent/corpus-findings-budget.json` is the record people read **instead of** re-deriving an analysis. That is its value and its hazard: an unsupported verdict there does not read as a guess, it reads as settled.

Twice this week one failed under the first sample anyone took:

- **`no-cycle`** said *"correct — real circular imports … the DETECTION is right"*. A stratified n=24 came back **66.7% type-only** — imports TypeScript erases before emit, where the hazard the rule's own message claims cannot occur. ([#702](https://github.com/ofri-peretz/eslint/pull/702), fixed in [#705](https://github.com/ofri-peretz/eslint/pull/705))
- **`no-extraneous-dependencies`** sat at `UNADJUDICATED` while describing a bug that had already shipped fixed in 2.4.0. ([#693](https://github.com/ofri-peretz/eslint/pull/693))

Neither was caught by a test, because neither is code.

## The exemption is the interesting half

A rule with a handful of findings gets a **census** — the note enumerates every one — and that is stronger evidence than any sample. **30 of the ledger's 46 verdict-bearing entries are that shape.** A gate demanding `n=` everywhere would be 30 nags that train people to ignore it.

Above 10 findings enumeration stops being plausible, and the note has to state its basis: an explicit `n=`, `stratified`, or a census. `BENCHMARK-CRITERIA` §A2 already sets the protocol; this gate does not re-litigate it, it only refuses a verdict that is silent about it.

It also leaves alone a note that says `UNADJUDICATED`, or that only reports a number. **Punishing a note for admitting its limits would select for false confidence** — the exact failure being gated.

## Scope

**13** entries recorded as debt — the honest count after separating census from claim, not the 47 a naive scan reports:

| findings | rule |
|---:|---|
| 258 | `maintainability/identical-functions` |
| 227 | `maintainability/cognitive-complexity` |
| 185 | `modernization/prefer-template-literal` |
| 139 | `reliability/no-missing-null-checks` |
| … | 9 more |

Ratcheted both ways: a new unsupported verdict fails, and so does a debt entry that has since gained a basis.

**This does not adjudicate the 13. It stops the fourteenth from being silent.**

## Test plan

- [x] 10 unit tests, including that `UNADJUDICATED` and number-only notes are left alone, and that the census ceiling holds.
- [x] Control 1 — a new unsupported verdict on a 999-finding rule fails and names it.
- [x] Control 2 — appending "Stratified n=24" to a debt entry fails with "prune the ledger".
- [x] `lint:workflows` — 35 files pass conventions.

Runs beside `lint:taxonomy`, `lint:name-inference` and `lint:detection-list-coverage`: the same question at four altitudes — the rule's name, its metadata, its detection table, and now the ledger's claim about it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)