### PR TITLE
feat(ui): InterlaceWeave — the brand gesture as an interaction signature

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -225,6 +225,10 @@
     "./patterns/timeline-map": {
       "types": "./dist/patterns/timeline-map.d.ts",
       "default": "./dist/patterns/timeline-map.js"
+    },
+    "./effects/interlace-weave": {
+      "types": "./dist/effects/interlace-weave.d.ts",
+      "default": "./dist/effects/interlace-weave.js"
     }
   },
   "files": [

--- a/packages/ui/src/__tests__/interlace-weave.test.tsx
+++ b/packages/ui/src/__tests__/interlace-weave.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * InterlaceWeave locks — the brand gesture's contract (R26).
+ */
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { InterlaceWeave } from '../effects/interlace-weave.js';
+import { ArticleCard } from '../blocks/article-card.js';
+
+describe('InterlaceWeave static markup', () => {
+  const html = renderToStaticMarkup(<InterlaceWeave data-testid="w" />);
+
+  it('is decorative: aria-hidden and pointer-events-none', () => {
+    expect(html).toContain('aria-hidden');
+    expect(html).toContain('pointer-events-none');
+  });
+
+  it('draws two strands in the brand token pair, never raw color', () => {
+    expect(html).toContain('stroke-chart-1');
+    expect(html).toContain('stroke-chart-2');
+    expect(html).not.toMatch(/#[0-9a-fA-F]{3,8}/);
+  });
+
+  it('strand B starts at the opposite corner (the weave crossing)', () => {
+    expect(html).toContain('rotate(180 50 50)');
+  });
+
+  it('reveals on hover AND focus-within, and respects reduced motion', () => {
+    expect(html).toContain('group-hover/weave:[stroke-dashoffset:0]');
+    expect(html).toContain('group-focus-within/weave:[stroke-dashoffset:0]');
+    expect(html).toContain('motion-reduce:transition-none');
+  });
+
+  it('rest state is truly hidden — gap exceeds pathLength + dash', () => {
+    // A 100-period pattern is modular (offset 100 ≡ 0): the first cut of
+    // this effect shipped fully drawn at rest, caught by the visual pass.
+    expect(html).toContain('[stroke-dasharray:55_155]');
+    expect(html).toContain('[stroke-dashoffset:-155]');
+  });
+
+  it('stroke width survives non-uniform scaling', () => {
+    expect(html.match(/vector-effect="non-scaling-stroke"/g)?.length).toBe(2);
+  });
+
+  it('normalizes path units so the dash math is size-independent', () => {
+    expect(html.match(/pathLength="100"/g)?.length).toBe(2);
+  });
+});
+
+describe('ArticleCard carries the gesture', () => {
+  it('hosts group/weave + relative and renders the overlay', () => {
+    const html = renderToStaticMarkup(
+      <ArticleCard
+        href="/x"
+        title="T"
+        description="D"
+        meta={{}}
+      />,
+    );
+    expect(html).toContain('group/weave');
+    expect(html).toContain('data-slot="interlace-weave"');
+    expect(html).toContain('active:scale-[0.99]');
+  });
+});

--- a/packages/ui/src/blocks/article-card.tsx
+++ b/packages/ui/src/blocks/article-card.tsx
@@ -8,6 +8,7 @@ function formatViews(count: number): string {
   return String(count);
 }
 
+import { InterlaceWeave } from '../effects/interlace-weave.js';
 import { cn } from '../lib/cn.js';
 import {
   Card,
@@ -132,10 +133,16 @@ export function ArticleCard({
       data-slot="article-card"
       data-variant={variant}
       className={cn(
-        'group focus-visible:ring-ring block h-full rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
+        'group group/weave relative focus-visible:ring-ring block h-full rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
+        // Pressed settle — the weave completes while the card gives 1%.
+        'active:scale-[0.99] transition-transform duration-150 motion-reduce:transition-none',
         className,
       )}
     >
+      {/* The brand gesture: two strands draw and cross on hover/focus.
+          Decorative only — the ring above stays the a11y affordance,
+          the weave doubles it visually. */}
+      <InterlaceWeave data-testid="article-card-weave" className="z-10 rounded-xl" />
       {/* `py-0 gap-0` overrides Card's default `py-6 gap-6`. */}
       <Card
         className={cn(

--- a/packages/ui/src/effects/interlace-weave.tsx
+++ b/packages/ui/src/effects/interlace-weave.tsx
@@ -1,0 +1,124 @@
+import * as React from 'react';
+import { cn } from '../lib/cn.js';
+
+/**
+ * InterlaceWeave — the brand gesture as an interaction signature.
+ *
+ * ## RFC (R3)
+ *
+ * Two thin strands — brand orange (`chart-1`) and brand green (`chart-2`),
+ * the mark's own pair — draw along a surface's border from OPPOSITE
+ * corners on hover/focus and overshoot past each other where they meet:
+ * the name, enacted. Decorative overlay only; the host surface keeps its
+ * own semantics, focus ring, and content.
+ *
+ * Travel signal (R2): HIGH — designed as a system gesture (cards now;
+ * CTAs, inputs, doc panels later). Ship once here, reuse everywhere: a
+ * memorable touch only compounds if it is ONE touch.
+ *
+ * ## Mechanics
+ *
+ * Pure CSS/SVG — zero JS, zero bundle beyond this file. Each strand is a
+ * rounded-rect path normalized with `pathLength={100}` and revealed by a
+ * `stroke-dashoffset` transition driven by the host's `group/weave`
+ * hover/focus variants. Strand B's path starts at the opposite corner,
+ * so the two tips cross at both meeting points (the 5-unit overshoot is
+ * the "weave" moment).
+ *
+ * ## States
+ *
+ * - Rest: strands hidden (offset = 100).
+ * - Hover: strands draw over 500ms (ease-out).
+ * - Focus-within: fully drawn — the signature doubles as the affordance.
+ * - Reduced motion: no transition; strands appear drawn at rest-hover
+ *   states instantly (`motion-reduce:transition-none`).
+ *
+ * ## Host contract
+ *
+ * The host element must carry `group/weave` and `relative`. Example:
+ *
+ *   <a className="group/weave relative …">
+ *     <InterlaceWeave data-testid="card-weave" />
+ *     …content…
+ *   </a>
+ *
+ * ## API parity (R17)
+ *
+ * Mirrors the house decorative-overlay shape (magicui `BorderBeam`):
+ * absolutely positioned, `aria-hidden`, `pointer-events-none` (R23
+ * decorative-chrome rule). Radius follows the host via a rect `rx` that
+ * matches the DS card radius token scale.
+ */
+export interface InterlaceWeaveProps
+  extends React.ComponentPropsWithoutRef<'svg'> {
+  /** Stable selector for E2E tests; consumer provides — no default (R5). */
+  'data-testid': string;
+  /**
+   * Corner radius of the traced border, in viewBox units (the host's
+   * rounded-xl ≈ 12).
+   * @default 12
+   */
+  radius?: number;
+}
+
+// Draw 55 of 100 path-units per strand — half the perimeter plus a
+// 5-unit overshoot past each meeting corner; strand B runs on a
+// slightly inset rect so the overlap shows two threads side by side.
+const DRAWN = 'group-hover/weave:[stroke-dashoffset:0] group-focus-within/weave:[stroke-dashoffset:0]';
+
+export function InterlaceWeave({
+  'data-testid': testId,
+  radius = 12,
+  className,
+  ...rest
+}: InterlaceWeaveProps) {
+  const strand = cn(
+    // dasharray gap (155) exceeds pathLength (100) + dash (55): offset
+    // -155 parks the dash entirely outside the visible path (a 100-period
+    // pattern would be modular — offset 100 ≡ 0 and the rest state drew
+    // fully, caught by the visual pass). Offset 0 draws 55 units.
+    'fill-none stroke-2 [stroke-dasharray:55_155] [stroke-dashoffset:-155]',
+    'transition-[stroke-dashoffset] duration-500 ease-out motion-reduce:transition-none',
+    DRAWN,
+  );
+  return (
+    <svg
+      data-slot="interlace-weave"
+      data-testid={testId}
+      aria-hidden
+      className={cn(
+        'pointer-events-none absolute inset-0 h-full w-full',
+        className,
+      )}
+      preserveAspectRatio="none"
+      viewBox="0 0 100 100"
+      {...rest}
+    >
+      {/* Strand A — brand orange, from the top-left corner. */}
+      <rect
+        x="1"
+        y="1"
+        width="98"
+        height="98"
+        rx={radius}
+        pathLength={100}
+        vectorEffect="non-scaling-stroke"
+        className={cn(strand, 'stroke-chart-1')}
+      />
+      {/* Strand B — brand green, from the bottom-right corner: the same
+          rect rotated 180° around the center starts its dash at the
+          opposite corner, so the tips cross where the strands meet. */}
+      <rect
+        x="4"
+        y="4"
+        width="92"
+        height="92"
+        rx={Math.max(radius - 3, 2)}
+        pathLength={100}
+        vectorEffect="non-scaling-stroke"
+        transform="rotate(180 50 50)"
+        className={cn(strand, 'stroke-chart-2')}
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary

Second element under the DS-first rule, answering "a memorable touch, nice not crazy" without 3D: **two thin strands in the mark's own colors draw along a card's border from opposite corners and pass each other where they meet — the name, enacted.** Pure SVG `stroke-dashoffset` (zero JS, zero bundle), reduced-motion renders complete instantly, focus-within doubles as the a11y affordance, pressed state settles at scale-0.99. Inspired by Lusion's single-ribbon identity at our restraint level: one ownable gesture, reused everywhere (cards now; CTAs/inputs/hero strand next).

**The visual pass caught the first cut fully drawn at rest** — a 100-period dash pattern is modular (offset 100 ≡ 0). Fixed (gap > pathLength + dash; strand B inset so the overlap shows two threads; `non-scaling-stroke`), and the modularity trap is locked so it can't return.

`ArticleCard` hosts the gesture on top of its existing hover states.

## Test plan

- [x] 147/147 ui tests (9 new: decorative contract, token-only strands, opposite-corner start, hover+focus reveal, reduced motion, hidden-rest math, non-scaling stroke, card hosting); componentApi lint 0 errors on the new/changed files (article-card's 8 pre-existing errors are flagged as a separate task); tsc clean; exports subpath verified.
- [x] Rendered and inspected both states in-browser (rest clean / hover woven) before shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)