### PR TITLE
feat(ui): brand doctrine — strand tokens + BRAND_PHILOSOPHY.md

### DIFF
--- a/BRAND_PHILOSOPHY.md
+++ b/BRAND_PHILOSOPHY.md
@@ -112,9 +112,12 @@ pure SVG/CSS — no WebGL) are themselves brand material.
 ## 5. Enforcement
 
 - **Scope.** The doctrine governs the website(s) and the DS — there the
-  mandate is to be creative within the gate. Article **cover images are
-  exempt**: they stay as they are, by decision (cheap to maintain wins —
-  maintenance is the enemy of innovation, including our own).
+  mandate is to be creative within the gate. **Articles are exempt**:
+  they live on other platforms too (Dev.to and beyond), their covers and
+  format are a working cross-platform system, and the article queue is
+  performing. We do not replace what is working for us — by decision
+  (maintenance is the enemy of innovation, including our own; so is
+  redesigning a system that's winning).
 - **DS-first.** Every brand element is built in `packages/ui` at full
   quality (R1–R26, locked tests, reduced-motion, SSR-honesty), then
   downloaded by apps. App-local authoring needs a written reason.

--- a/BRAND_PHILOSOPHY.md
+++ b/BRAND_PHILOSOPHY.md
@@ -1,0 +1,128 @@
+# BRAND_PHILOSOPHY.md — one thread, every scale
+
+> The visual and verbal identity contract for everything Interlace ships —
+> the DS (`packages/ui`), the docs site, the blog, the storybook. Paired
+> with DOCS_PHILOSOPHY.md the way COLOR pairs with TYPOGRAPHY: this file
+> says who we are; the token files say how that renders.
+
+---
+
+## 1. What stands behind Interlace
+
+Interlace builds tools that let you move at **scale**, at **velocity**, and
+do your thing **peacefully**.
+
+The brand names its enemies, not its features:
+
+| We drive toward | The enemy we remove |
+| --- | --- |
+| **Innovation** | Maintenance — maintenance is the enemy of innovation |
+| **Velocity** | Tech debt — debt is the enemy of velocity |
+| **Scale** | Engineering bottlenecks — bottlenecks are the enemy of scale |
+
+These are mottos — the direction we drive, phrased as intent. They are
+never rendered as measured claims ("0 maintenance guaranteed"); data
+honesty outranks copy. *Peacefully* is the emotional promise and the word
+we own: quiet tooling, educational messages, no noise. Everyone in this
+ecosystem sells speed; nobody sells peace.
+
+The thread metaphor carries the values too: maintenance, debt, and
+bottlenecks are **snags in the weave**. Interlace removes snags.
+
+## 2. The line
+
+**One thread, every scale.**
+
+Interlace means weaving. The entire visual identity is one gesture — a
+strand being drawn — expressed at four scales:
+
+| Scale | Element | The thread as… |
+| --- | --- | --- |
+| micro | `DecodeText` | text resolving |
+| component | `InterlaceWeave` | a boundary being drawn |
+| section | `HeroStrand` *(planned)* | a journey through the page |
+| page | `TimelineMap` | data laid flat in lanes |
+
+Nothing else animates. The motion vocabulary is exactly **two verbs**:
+
+- **draw** — `stroke-dashoffset` strand reveals
+- **decode** — glyph-noise resolving into text
+
+Both cap at **600ms**, both go silent under `prefers-reduced-motion`, and
+both are SSR-honest: static markup always carries the final state, so
+crawlers, reader mode, and JS-off visitors never see a half-drawn brand.
+
+## 3. Palette law — depth, not breadth
+
+One hue: the mark's burnt orange (oklch hue 41 — `#7d350c` light /
+`#fbb99a` dark, AAA both modes). Taking the brand "to the next level"
+never means adding hues; it means going deeper into this one.
+
+**The strand pair** (`--interlace-strand-a` / `--interlace-strand-b` in
+`packages/ui/styles/interlace-theme.css`):
+
+- `strand-a` — the mark's hue 41, the thread itself.
+- `strand-b` — the temperature complement, a cool steel blue (hue 230).
+  It exists so the crossing is legible: warm passing cool.
+- `strand-b` appears **only** inside woven gestures, and woven gestures
+  use **only** the strand pair. It is not a chart color, not an accent,
+  not available for decoration.
+- The pair replaced `chart-2` (emerald, hue 162) in the weave — that was
+  the *success* status hue used decoratively, which COLOR philosophy
+  forbids. Status colors carry status, nothing else.
+
+**Chrome is a gallery.** Surfaces stay warm-achromatic (paper white /
+near-black, warm-tinted neutrals). Brand color appears only where meaning
+crosses: primary CTAs, active states, woven gestures. Color budget per
+view: one accent + one counter-strand. If a screen needs a third color to
+work, the layout is wrong, not the palette.
+
+**Type carries the scale contrast.** Monospace micro-labels (DecodeText's
+native habitat) against oversized grotesk display; numbered eyebrows
+(`01 — Detection`) for series and sections.
+
+## 4. Inspired, never a mix
+
+References contribute **structural laws**, never signature looks. Each law
+is refracted through the thread metaphor before it ships:
+
+| Reference | Law we keep | Signature we reject |
+| --- | --- | --- |
+| Lusion | one gesture, every scale | WebGL cinematics, their ribbon |
+| Raycast | one accent, type-forward restraint | glassy dark glow, pill nav |
+| In Pieces | constraint generates the world; craft-as-story | shards, pastel fields, grunge type |
+| Cuberto | chrome as gallery; numbered indices | gooey cursor, marquee, cool grays |
+
+**The ownership gate** — every new visual element must pass all four
+before it ships:
+
+1. It expresses the thread in one of our two verbs (draw / decode).
+2. It uses only our palette (hue 41 + strand-b + warm neutrals).
+3. It descends from at most **one** reference law. Needs two references
+   to explain → it's a mix → cut it.
+4. A screenshot of it alone reads as Interlace — never as the site that
+   inspired it.
+
+What makes the brand its own thing is anchored where no reference can
+follow: the thread **is our name** made visible; burnt orange on warm
+paper is unoccupied territory in the linter ecosystem; terminal-decode is
+native to a lint brand; and the receipts (SSR-honest, AAA both modes,
+pure SVG/CSS — no WebGL) are themselves brand material.
+
+## 5. Enforcement
+
+- **Scope.** The doctrine governs the website(s) and the DS — there the
+  mandate is to be creative within the gate. Article **cover images are
+  exempt**: they stay as they are, by decision (cheap to maintain wins —
+  maintenance is the enemy of innovation, including our own).
+- **DS-first.** Every brand element is built in `packages/ui` at full
+  quality (R1–R26, locked tests, reduced-motion, SSR-honesty), then
+  downloaded by apps. App-local authoring needs a written reason.
+- **Tokens only.** No raw color in component source; the strand pair
+  lives in `interlace-theme.css` and nowhere else.
+- **Locks.** The weave's test asserts `stroke-strand-a`/`-b` and rejects
+  `chart-2`; the map's test asserts `text-strand-a`. New brand elements
+  add equivalent locks in the same PR.
+- **Forbidden:** new decorative hues; status colors as decoration; motion
+  verbs beyond draw/decode; animation above 600ms; brand gestures that
+  skip the reduced-motion bail; copy that states a motto as a measurement.

--- a/packages/ui/src/__tests__/interlace-weave.test.tsx
+++ b/packages/ui/src/__tests__/interlace-weave.test.tsx
@@ -15,8 +15,11 @@ describe('InterlaceWeave static markup', () => {
   });
 
   it('draws two strands in the brand token pair, never raw color', () => {
-    expect(html).toContain('stroke-chart-1');
-    expect(html).toContain('stroke-chart-2');
+    expect(html).toContain('stroke-strand-a');
+    expect(html).toContain('stroke-strand-b');
+    // strand-b exists so the weave never strokes chart-2 (emerald = the
+    // success status hue; status colors are never decorative)
+    expect(html).not.toContain('chart-2');
     expect(html).not.toMatch(/#[0-9a-fA-F]{3,8}/);
   });
 

--- a/packages/ui/src/__tests__/timeline-map.test.tsx
+++ b/packages/ui/src/__tests__/timeline-map.test.tsx
@@ -83,8 +83,8 @@ describe('static markup (SSR honesty)', () => {
     expect(html).toContain('Hover a dot.');
   });
 
-  it('marks use the chart-1 token, never raw color', () => {
-    expect(html).toContain('text-chart-1');
+  it('marks use the strand-a token, never raw color', () => {
+    expect(html).toContain('text-strand-a');
     expect(html).not.toMatch(/#[0-9a-fA-F]{3,8}/);
   });
 

--- a/packages/ui/src/effects/interlace-weave.tsx
+++ b/packages/ui/src/effects/interlace-weave.tsx
@@ -6,7 +6,7 @@ import { cn } from '../lib/cn.js';
  *
  * ## RFC (R3)
  *
- * Two thin strands — brand orange (`chart-1`) and brand green (`chart-2`),
+ * Two thin strands — brand orange (`strand-a`) and its cool complement (`strand-b`),
  * the mark's own pair — draw along a surface's border from OPPOSITE
  * corners on hover/focus and overshoot past each other where they meet:
  * the name, enacted. Decorative overlay only; the host surface keeps its
@@ -103,7 +103,7 @@ export function InterlaceWeave({
         rx={radius}
         pathLength={100}
         vectorEffect="non-scaling-stroke"
-        className={cn(strand, 'stroke-chart-1')}
+        className={cn(strand, 'stroke-strand-a')}
       />
       {/* Strand B — brand green, from the bottom-right corner: the same
           rect rotated 180° around the center starts its dash at the
@@ -117,7 +117,7 @@ export function InterlaceWeave({
         pathLength={100}
         vectorEffect="non-scaling-stroke"
         transform="rotate(180 50 50)"
-        className={cn(strand, 'stroke-chart-2')}
+        className={cn(strand, 'stroke-strand-b')}
       />
     </svg>
   );

--- a/packages/ui/src/patterns/timeline-map.tsx
+++ b/packages/ui/src/patterns/timeline-map.tsx
@@ -51,7 +51,7 @@ import { cn } from '../lib/cn.js';
  *
  * x = date (left → right), row = category, dot diameter = optional
  * `weight` (0..1 → 10–16px; the Detail strip must spell the value out —
- * size is never the only carrier). Marks are single-hue `chart-1` (R19
+ * size is never the only carrier). Marks are single-hue `strand-a` (R19
  * token): identity is carried spatially by labeled lanes, so no
  * multi-hue palette is needed and none is offered.
  *
@@ -385,7 +385,7 @@ function TimelineMapFilter({ className, ...rest }: TimelineMapFilterProps) {
           className={cn(
             'rounded-full border px-2.5 py-0.5 text-xs font-medium transition-colors',
             active.has(name)
-              ? 'border-chart-1/50 bg-chart-1/10 text-foreground'
+              ? 'border-strand-a/50 bg-strand-a/10 text-foreground'
               : 'border-border text-muted-foreground hover:text-foreground',
           )}
         >
@@ -524,7 +524,7 @@ function TimelineMapChart({ className, ...rest }: TimelineMapChartProps) {
                   />
                 ))}
               </g>
-              <g className="text-chart-1">
+              <g className="text-strand-a">
                 {lane.dots.filter((d) => visible(d.item)).map((d) => (
                   <LinkComponent
                     key={d.item.id}

--- a/packages/ui/styles/interlace-theme.css
+++ b/packages/ui/styles/interlace-theme.css
@@ -72,6 +72,18 @@
   --interlace-secondary: #f5f3f0;
   --interlace-secondary-foreground: #1f1a15;
 
+  /* Strands — the woven brand gesture (BRAND_PHILOSOPHY.md).
+   *
+   * strand-a is the mark's burnt orange (oklch hue 41, same profile as
+   * chart-1). strand-b is its temperature complement, a cool steel blue
+   * (hue 230) — NOT chart-2's emerald (hue 162), which is the success
+   * status hue; status colors are never decorative. These two are the
+   * only colors permitted in woven gestures (InterlaceWeave, HeroStrand,
+   * TimelineMap marks), and woven gestures are the only place strand-b
+   * may appear. Decorative strokes: ≥3:1 on background in both modes. */
+  --interlace-strand-a: oklch(0.55 0.16 41);
+  --interlace-strand-b: oklch(0.55 0.12 230);
+
   /* Destructive (Tailwind red-800 — text-destructive on white ≈ 8.0:1, AAA) */
   --interlace-destructive: #991b1b;
   --interlace-destructive-foreground: #ffffff;
@@ -128,6 +140,10 @@
   --interlace-secondary: #201c17;
   --interlace-secondary-foreground: #f0ede9;
 
+  /* Strands — lighter tints of the same pair (chart dark profile) */
+  --interlace-strand-a: oklch(0.78 0.14 41);
+  --interlace-strand-b: oklch(0.78 0.1 230);
+
   /* Destructive (red-300 — text-destructive on near-black ≈ 9:1, AAA) */
   --interlace-destructive: #fca5a5;
   --interlace-destructive-foreground: #0a0a0a;
@@ -168,6 +184,8 @@
   --ring: var(--interlace-ring);
   --destructive: var(--interlace-destructive);
   --destructive-foreground: var(--interlace-destructive-foreground);
+  --strand-a: var(--interlace-strand-a);
+  --strand-b: var(--interlace-strand-b);
 
   /* Override fumadocs-prefixed tokens for AA contrast.
    *
@@ -209,4 +227,6 @@
   --color-ring: var(--ring);
   --color-destructive: var(--destructive);
   --color-destructive-foreground: var(--destructive-foreground);
+  --color-strand-a: var(--strand-a);
+  --color-strand-b: var(--strand-b);
 }


### PR DESCRIPTION
## Summary

- **BRAND_PHILOSOPHY.md** (repo root, beside DOCS_PHILOSOPHY.md): the accepted brand line — *"One thread, every scale."* Values layer in the user's words (move at scale, at velocity, peacefully; maintenance/debt/bottlenecks as the named enemies), the thread gesture at four scales, exactly two motion verbs (draw / decode, ≤600ms, reduced-motion silent), gallery chrome, palette law (one hue, depth not breadth), the inspiration→law table (Lusion / Raycast / In Pieces / Cuberto) with the ownership gate that keeps the brand its own thing, and scope (site + DS creative mandate; article covers exempt by decision).
- **Strand tokens**: `--interlace-strand-a` (the mark's oklch hue 41) + `--interlace-strand-b` (cool steel blue, hue 230) in `interlace-theme.css`, light + dark, bound and registered as Tailwind theme keys (`stroke-strand-a`, `text-strand-a`, …).
- **Fixes a real collision**: InterlaceWeave stroked `chart-2` (emerald, hue 162) — the *success* status hue used decoratively, which COLOR philosophy forbids. Weave now strokes `strand-a` × `strand-b` (warm passing cool — more legible crossing, semantically clean).
- **TimelineMap** rewired `chart-1` → `strand-a` (identical value, zero visual change; doctrine coherence).
- **Locks updated in the same PR**: weave test asserts `stroke-strand-a`/`-b` and rejects `chart-2` outright; map test asserts `text-strand-a`.

Note: strand tokens live in the brand layer (`interlace-theme.css`), not the bridge (`theme.css`) — consumers must import all three style files per the contract at the top of that file. No current consumer renders the kit yet (consumption pass is next), so nothing can regress visually here.

## Test plan

- [x] `packages/ui` vitest: 152/152 pass (includes the updated strand locks)
- [x] `tsc -b tsconfig.lib.json`: clean
- [x] `eslint` on all changed source/test files: 0 errors
- [x] Lock check: reverting the weave rewire fails `interlace-weave.test.tsx` (asserts strand classes present AND chart-2 absent)

## After merge

Doctrine is canon for all future visual work. Next in the queue: HeroStrand (section-scale ribbon), SectionIndex eyebrow, Storybook stories, then the blog/docs consumption pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)