### PR TITLE
fix(ui): preflight height:auto is photographic-media only, never svg

### DIFF
--- a/packages/ui/styles/preflight.css
+++ b/packages/ui/styles/preflight.css
@@ -126,9 +126,17 @@ button {
 
 /* ─────────────────────────────────────────────────────────────────
  * 4. Image + media defaults
- *    Responsive by default (max-width: 100%). aspect-ratio preserved via
- *    height: auto. vertical-align: middle prevents the descender gap
- *    under inline images.
+ *    Responsive by default (max-width: 100%). vertical-align: middle
+ *    prevents the descender gap under inline images.
+ *
+ *    `height: auto` applies to PHOTOGRAPHIC media only (img/picture/
+ *    video) — matching Tailwind's own preflight, which deliberately
+ *    excludes svg + canvas. A blanket `svg { height: auto }` defeats
+ *    `h-full` on drawn surfaces: with a viewBox the element snaps to
+ *    its intrinsic ratio, and without one it falls to the 300×150
+ *    replaced-element default — InterlaceWeave's overlay covering only
+ *    the top band of production article cards is how this was found.
+ *    (Same fix as the canonical DS preflight in the interlace repo.)
  * ──────────────────────────────────────────────────────────────── */
 img,
 picture,
@@ -137,8 +145,13 @@ canvas,
 svg {
   display: block;
   max-width: 100%;
-  height: auto;
   vertical-align: middle;
+}
+
+img,
+picture,
+video {
+  height: auto;
 }
 
 /* ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Post-#726 production verification measured the weave overlay at **597×150 inside a 597×420 card** on https://eslint.interlace.tools/articles: the rest state is correctly blank now (offset +55 ✓), but the blanket `img, picture, video, canvas, svg { height: auto }` preflight defeats `h-full` on the viewBox-less svg, which falls to the 300×150 replaced-element default — a hover would draw the weave around only the card's top band.
- `height: auto` now applies to photographic media only (img/picture/video), exactly matching Tailwind's own preflight split and the canonical DS fix already merged in the interlace repo (interlace#56).

## Test plan

- [x] `packages/ui` vitest 152/152
- [x] Root cause measured live on production before the fix; the identical change in the interlace repo passed its full 1290-test suite + storybook a11y sweep
- [x] CSS-only diff; no component source touched

## After merge

Auto-deploy ships docs; verify the /articles card overlay measures the full host height and hover draws around the whole card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)