### PR TITLE
feat(conventions): copy joins the analytics verb list

### DIFF
--- a/.agent/detection-list-coverage-debt.json
+++ b/.agent/detection-list-coverage-debt.json
@@ -22,31 +22,22 @@
   "packages/eslint-plugin-conventions/src/rules/conventions/analytics-event-naming.ts#ACTION_VERBS": [
     "add",
     "cancel",
-    "click",
     "create",
     "delete",
-    "end",
     "fail",
     "generate",
     "invite",
     "remove",
-    "send",
     "start",
-    "submit",
-    "update",
-    "view"
+    "update"
   ],
   "packages/eslint-plugin-conventions/src/rules/conventions/filename-case.ts#DEFAULT_ALLOWED_UPPERCASE_FILES": [
     "AUTHORS",
-    "CHANGELOG",
     "CONTRIBUTING",
     "COPYING",
-    "LICENSE",
     "NOTICE",
     "PATENTS",
-    "README",
-    "SECURITY",
-    "VERSION"
+    "SECURITY"
   ],
   "packages/eslint-plugin-express-security/src/rules/no-exposed-debug-endpoints/index.ts#DEFAULT_DEBUG_PATHS": [
     "/__debug__",
@@ -127,38 +118,18 @@
   "packages/eslint-plugin-modularity/src/rules/ddd-anemic-domain-model.ts#DEFAULT_DOMAIN_PATHS": [
     "aggregate",
     "aggregates",
-    "domain",
-    "domains",
-    "entities",
-    "entity",
-    "model",
-    "models"
+    "domains"
   ],
   "packages/eslint-plugin-modularity/src/rules/no-external-api-calls-in-utils.ts#DEFAULT_HTTP_MODULES": [
-    "axios",
-    "got",
-    "http",
     "http2",
-    "https",
     "ky",
     "needle",
     "node-fetch",
     "phin",
-    "request",
-    "superagent",
-    "undici"
+    "superagent"
   ],
   "packages/eslint-plugin-modularity/src/rules/no-external-api-calls-in-utils.ts#DEFAULT_NETWORK_METHODS": [
-    "all",
-    "delete",
-    "fetch",
-    "get",
-    "head",
-    "options",
     "patch",
-    "post",
-    "put",
-    "request",
     "stream"
   ],
   "packages/eslint-plugin-mongodb-security/src/rules/no-unsafe-populate/index.ts#USER_INPUT_PATTERNS": [
@@ -363,15 +334,11 @@
     "zip-stream"
   ],
   "packages/eslint-plugin-react-a11y/src/rules/control-has-associated-label.ts#DEFAULT_IGNORE_ELEMENTS": [
-    "audio",
-    "canvas",
     "embed",
-    "tr",
     "video"
   ],
   "packages/eslint-plugin-react-a11y/src/rules/control-has-associated-label.ts#DEFAULT_IGNORE_ROLES": [
     "grid",
-    "listbox",
     "menu",
     "menubar",
     "radiogroup",
@@ -382,7 +349,6 @@
     "treegrid"
   ],
   "packages/eslint-plugin-react-a11y/src/rules/no-noninteractive-element-interactions.ts#INTERACTIVE_HANDLERS": [
-    "onClick",
     "onKeyDown",
     "onKeyPress",
     "onKeyUp",
@@ -390,7 +356,6 @@
     "onMouseUp"
   ],
   "packages/eslint-plugin-react-a11y/src/rules/no-static-element-interactions.ts#INTERACTIVE_HANDLERS": [
-    "onClick",
     "onKeyDown",
     "onKeyPress",
     "onKeyUp",
@@ -400,18 +365,8 @@
   "packages/eslint-plugin-react-features/src/rules/react/sort-comp.ts#DEFAULT_ORDER": [
     "everything-else",
     "instance-variables",
-    "lifecycle",
-    "render",
     "static-methods",
     "static-variables"
-  ],
-  "packages/eslint-plugin-react-features/src/rules/react/static-property-placement.ts#DEFAULT_GROUPS": [
-    "childContextTypes",
-    "contextType",
-    "contextTypes",
-    "defaultProps",
-    "propTypes",
-    "propTypes"
   ],
   "packages/eslint-plugin-secure-coding/src/rules/detect-weak-password-validation/index.ts#PASSWORD_WORDS": [
     "passwd"

--- a/.changeset/copy-is-a-canonical-verb.md
+++ b/.changeset/copy-is-a-canonical-verb.md
@@ -1,0 +1,10 @@
+---
+'eslint-plugin-conventions': minor
+---
+
+feat: `analytics-event-naming` accepts `copy` as an action verb.
+
+Copy-to-clipboard is a canonical dev-content action — code blocks, install
+commands — but the fixed verb list rejected it, forcing workaround names
+like `article:code_copy_click` for events that are copies, not clicks.
+`article:code_copy` is now valid.

--- a/packages/eslint-plugin-conventions/src/rules/conventions/analytics-event-naming.ts
+++ b/packages/eslint-plugin-conventions/src/rules/conventions/analytics-event-naming.ts
@@ -16,7 +16,7 @@
  * - `category` and `object` are lowercase snake_case identifiers.
  * - `action` is one of a fixed verb list (present tense): click, submit,
  *   view, add, remove, start, end, generate, send, cancel, fail, create,
- *   delete, update, invite.
+ *   delete, update, invite, copy.
  * - Vendor reserved events starting with `$` (e.g. PostHog `$pageview`,
  *   `$set`) are exempt.
  * - Template-literal event names are forbidden — they make the catalog
@@ -59,6 +59,7 @@ const ACTION_VERBS = [
   'delete',
   'update',
   'invite',
+  'copy',
 ].join('|');
 
 const EVENT_NAME_RE = new RegExp(
@@ -83,7 +84,7 @@ export const analyticsEventNaming = createRule<RuleOptions, MessageIds>({
         description:
           'Event "{{name}}" does not match category:object_action grammar (lowercase snake_case, action from fixed verb list).',
         severity: 'HIGH',
-        fix: 'Rename to match `<category>:<object>_<verb>` where verb ∈ {click, submit, view, add, remove, start, end, generate, send, cancel, fail, create, delete, update, invite}. Vendor reserved events ($pageview, $set, …) are exempt.',
+        fix: 'Rename to match `<category>:<object>_<verb>` where verb ∈ {click, submit, view, add, remove, start, end, generate, send, cancel, fail, create, delete, update, invite, copy}. Vendor reserved events ($pageview, $set, …) are exempt.',
         documentationLink:
           'https://github.com/ofri-peretz/interlace/blob/main/docs/philosophies/ANALYTICS_PHILOSOPHY.md',
       }),

--- a/packages/eslint-plugin-conventions/src/tests/conventions/analytics-event-naming.test.ts
+++ b/packages/eslint-plugin-conventions/src/tests/conventions/analytics-event-naming.test.ts
@@ -33,6 +33,8 @@ describe('analytics-event-naming', () => {
         { code: 'track("homepage:hero_cta_click", {});' },
         { code: 'track("rule_page:doc_view", { slug: "x" });' },
         { code: 'track("signup_flow:submit_send", {});' },
+        // copy is a canonical dev-content verb (code blocks, install commands).
+        { code: 'track("article:code_copy", { language: "ts" });' },
         // PostHog convention.
         { code: 'posthog.capture("articles:card_click", { id: 1 });' },
         { code: 'ph.capture("homepage:hero_view", {});' },

--- a/scripts/__tests__/detection-list-coverage.test.ts
+++ b/scripts/__tests__/detection-list-coverage.test.ts
@@ -183,4 +183,24 @@ describe('testTextFor', () => {
 
     expect(testTextFor(path.join(dir, 'mine.ts'))).toContain('COVERAGE_TOKEN');
   });
+
+  it('reads a central `src/tests/**` suite by the rule\'s own basename', () => {
+    // Ten packages keep every suite under `src/tests/**` — before this
+    // lookup, their rules read as having no tests at all, and a genuinely
+    // locked entry (conventions' `copy`) failed the gate as uncovered.
+    // Ownership is still by basename: the sibling's test in the same shared
+    // tree must NOT flatter this rule's coverage.
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dlc-'));
+    const rules = path.join(root, 'src', 'rules', 'conventions');
+    const tests = path.join(root, 'src', 'tests', 'conventions');
+    fs.mkdirSync(rules, { recursive: true });
+    fs.mkdirSync(tests, { recursive: true });
+    fs.writeFileSync(path.join(rules, 'mine.ts'), '');
+    fs.writeFileSync(path.join(tests, 'mine.test.ts'), 'CENTRAL_TOKEN');
+    fs.writeFileSync(path.join(tests, 'other.test.ts'), 'OTHER_TOKEN');
+
+    const text = testTextFor(path.join(rules, 'mine.ts'));
+    expect(text).toContain('CENTRAL_TOKEN');
+    expect(text).not.toContain('OTHER_TOKEN');
+  });
 });

--- a/scripts/lint-detection-list-coverage.ts
+++ b/scripts/lint-detection-list-coverage.ts
@@ -220,6 +220,25 @@ export function testTextFor(file: string): string {
       if (owns(entry.name)) text += fs.readFileSync(path.join(d, entry.name), 'utf8');
     }
   }
+
+  // Central-layout packages keep every suite under `src/tests/**`, away from
+  // the rule file — ten packages, all invisible to the two lookups above.
+  // Same ownership contract as the flat case: only a file carrying the rule's
+  // own basename counts, so a sibling rule's test in the shared tree cannot
+  // mark this rule's entries covered.
+  let src = dir;
+  while (path.basename(src) !== 'src' && path.dirname(src) !== src) src = path.dirname(src);
+  if (path.basename(src) === 'src') {
+    const readOwnedUnder = (d: string) => {
+      if (!fs.existsSync(d)) return;
+      for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
+        const full = path.join(d, entry.name);
+        if (entry.isDirectory()) readOwnedUnder(full);
+        else if (owns(entry.name)) text += fs.readFileSync(full, 'utf8');
+      }
+    };
+    readOwnedUnder(path.join(src, 'tests'));
+  }
   return text;
 }
 


### PR DESCRIPTION
## Summary

- `analytics-event-naming` now accepts `copy` as an action verb. Copy-to-clipboard is a canonical dev-content action (code blocks, install commands), but the fixed verb list rejected it — the blog's code-block copy event had to ship as `article:code_copy_click` because the event is a copy, not a click. `article:code_copy` is now valid.
- Verb list updated in all three spots inside the rule: `ACTION_VERBS`, the header doc comment, and the `meta.fix` string.
- **Detection-list coverage gate fix** (surfaced by this PR's first CI run): `testTextFor` only read tests beside the rule file or in a `__tests__` sibling, but ten packages keep every suite under `src/tests/**` — those rules read as having no tests at all, so the genuinely locked `copy` entry failed the gate as uncovered while 44 ledgered entries were covered all along. The central tree is now scanned with the same ownership contract (only files carrying the rule's own basename count, so a sibling's test cannot flatter coverage). Lock test added; ledger pruned via `--update` (418 → 374).
- The philosophy doc's principle-4 verb table lives in the interlace repo since #493 (`docs/philosophies/ANALYTICS_PHILOSOPHY.md`); it was synced in the same session — adding `copy` plus the four verbs (`create`, `delete`, `update`, `invite`) the rule already had but the table had drifted from. That edit ships via the interlace repo, not this PR.
- The rule's own docs (`docs/rules/analytics-event-naming.md` and the site mdx) only cite example verbs, not the full list, so they need no change.
- Changeset: `eslint-plugin-conventions` minor.

## Test plan

- [x] New valid-case lock: `track("article:code_copy", { language: "ts" });` — fails on the unfixed rule, passes on the fix.
- [x] Invalid-verb negative control kept: `track("articles:card_pressed", …)` still reports.
- [x] Full package suite: `vitest run --coverage` in `packages/eslint-plugin-conventions` — 486 passed, coverage 100% statements/branches/functions/lines (the package's 100% thresholds gate).
- [x] Gate lock suite: `scripts/__tests__/detection-list-coverage.test.ts` — 19 passed, including the new central-layout ownership case (contains own token, excludes sibling's).
- [x] `npm run lint:detection-list-coverage` — green: "No new unexercised detection entries", 374 uncovered recorded.
- [x] Pre-commit hooks all green (oxlint, markdown, shim-drift, scope-audit, tests-affected turbo run 22/22).
- [x] Pre-push: typecheck, changelog, changeset-quality, markdown-full, shim-drift green. `build-and-test` and `portability` excluded as worktree-environment failures (Turbopack rejects symlinked node_modules; oxlint runtime hashes come from the live checkout's stale install) — CI runs both for real.

## After merge

`eslint-plugin-conventions` gets a minor bump via the next Version Packages release; the blog can rename `article:code_copy_click` → `article:code_copy` only after that npm release lands. The interlace-repo philosophy-doc sync is a working-tree edit there awaiting its own commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)