### PR TITLE
chore(secure-coding): lock the npm-slug template out of no-xpath-injection

### DIFF
--- a/packages/eslint-plugin-secure-coding/src/rules/no-xpath-injection/no-xpath-injection.test.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/no-xpath-injection/no-xpath-injection.test.ts
@@ -90,6 +90,25 @@ describe('no-xpath-injection', () => {
         // `sourceCode.getText(node)`.
         `function f(req) { const s = render.text() + req.query.q; use(s); }`,
         `function f(req) { const s = base /* //user[@id] */ + req.query.q; use(s); }`,
+        // A regex literal inside an interpolation is not string content either.
+        // `.replace(/\//g, "-")` prints as `/\//g`, whose `//` read as the
+        // descendant axis when the gate regexed printed source — the blog's npm
+        // slug builder reported dangerousXpathExpression on v3.2.0, in a file
+        // with no XPath sink and no XPath package anywhere.
+        {
+          code: `const packageSeries = [...byPlugin.entries()].map(([id, daily]) => {
+  const name = live.get(id) ?? String(id);
+  return {
+    id: \`npm:\${name.replace(/^@/, "").replace(/\\//g, "-")}\`,
+  };
+});`,
+        },
+        // Same snippet with the constant-pattern sweep re-enabled: the static
+        // text is only "npm:", so even the aggressive mode has no XPath to see.
+        {
+          options: [{ reportDangerousConstructs: true }],
+          code: `const slug = \`npm:\${name.replace(/^@/, "").replace(/\\//g, "-")}\`; use(slug);`,
+        },
         // A non-string literal contributes no text.
         `function f(req) { const s = '/total: ' + 42 + req.query.n; use(s); }`,
         // Safe XPath literals


### PR DESCRIPTION
## Summary

- An external consumer (the blog, running eslint-plugin-secure-coding **3.2.0**) got a false CWE-643 `dangerousXpathExpression` at error severity on plain npm-slug construction: `` `npm:${name.replace(/^@/, "").replace(/\//g, "-")}` ``. The 3.2.0 template gate regexed **printed source**, where the regex literal `/\//g` carries the `//` that reads as the XPath descendant axis. Nothing in the file is XPath — no sink, no XPath package.
- HEAD (5.1.4) is already quiet on this shape: the template path reads only the static quasis via `literalTextOf`, and the constant-pattern sweep sits behind `reportDangerousConstructs` (off by default). So no rule change — this PR adds the missing **lock**: two valid cases in `no-xpath-injection.test.ts`, the exact consumer snippet with default options and the slug template with `reportDangerousConstructs: true`.
- Probe protocol followed: positive controls first (concatenation path reports `xpathInjection`, template path reports `unsafeXpathConcatenation` on genuinely tainted XPath), then the repro — QUIET on HEAD, reproduced firing on the consumer's installed 3.2.0.

## Test plan

- [x] Non-vacuous lock verified by mutation: reverting the TemplateLiteral handler to `sourceCode.getText(node)` + an unconditional `//` sweep makes **both** new valid cases fail; restoring HEAD makes them pass.
- [x] `vitest run src/rules/no-xpath-injection` — 153/153 pass.
- [x] Full `eslint-plugin-secure-coding` suite — all tests pass, coverage 100% statements/branches/functions/lines (with the `recheck` oracle installed, matching CI).
- [x] Pre-commit gate (oxlint, scope-audit, rule-audit, shim-drift, tests-affected 22/22) green.

## After merge

Nothing ships to consumers (test-only change; no changeset needed per `changeset:coverage`). The consumer-side fix is upgrading the blog from 3.2.0 to ^5.1.4, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved XPath injection analysis to correctly handle regular expressions inside template interpolations.
  * Prevented valid regular expression patterns from being incorrectly flagged as XPath content, including when enhanced detection is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->