### PR TITLE
fix(browser-security): lock the W3C namespace exemption in both http rules

### DIFF
--- a/.changeset/w3c-namespaces-are-identifiers.md
+++ b/.changeset/w3c-namespaces-are-identifiers.md
@@ -1,0 +1,16 @@
+---
+'eslint-plugin-browser-security': patch
+---
+
+fix: lock and document the W3C XML namespace exemption in `no-http-urls` and `detect-mixed-content`.
+
+The spec-frozen namespace identifiers — `http://www.w3.org/2000/svg`,
+`http://www.w3.org/1999/xhtml`, `http://www.w3.org/1999/xlink`,
+`http://www.w3.org/XML/1998/namespace`, `http://www.w3.org/2000/xmlns/` — are
+opaque strings compared byte-for-byte, never fetched, so neither CWE-319 nor
+mixed content applies. The 1.x line reported them (hit in the wild on SVG
+export code passing them to `createElementNS`); 2.x already exempts them via
+the namespace-authority host allowlist and the subresource-position predicate.
+This release pins every identifier in both shapes (bare literal and
+`createElementNS` argument) with regression locks in both rules, and names the
+exemption in both rule docs.

--- a/packages/eslint-plugin-browser-security/docs/rules/detect-mixed-content.md
+++ b/packages/eslint-plugin-browser-security/docs/rules/detect-mixed-content.md
@@ -32,7 +32,11 @@ Detects HTTP URLs in code that should use HTTPS, preventing mixed content vulner
 
 Mixed content occurs when HTTPS pages load resources over HTTP. This weakens the security of the entire page, as attackers can intercept or modify the insecure resources through man-in-the-middle attacks.
 
-This rule detects any string literal starting with `http://`.
+This rule detects `http://` strings written in a **subresource position** — `<img src>`, `<script src>`, `el.src = …`, `setAttribute('src', …)`, `importScripts(…)` and the like — which is the one shape a browser actually blocks as mixed content. Other hardcoded `http://` URLs are reported by `no-http-urls` instead, so each line draws exactly one finding.
+
+### Built-in exemption: XML namespace identifiers
+
+XML namespace URIs — `http://www.w3.org/2000/svg`, `http://www.w3.org/1999/xhtml`, `http://www.w3.org/1999/xlink`, `http://www.w3.org/XML/1998/namespace`, `http://www.w3.org/2000/xmlns/` — are never reported, whether written as a bare constant, an `xmlns` attribute, or a `createElementNS` / `setAttributeNS` argument. They are opaque identifiers compared byte-for-byte; nothing is ever fetched from them, so no mixed-content load exists, and rewriting one to `https://` breaks the document.
 
 ## Examples
 

--- a/packages/eslint-plugin-browser-security/docs/rules/detect-mixed-content.md
+++ b/packages/eslint-plugin-browser-security/docs/rules/detect-mixed-content.md
@@ -32,7 +32,7 @@ Detects HTTP URLs in code that should use HTTPS, preventing mixed content vulner
 
 Mixed content occurs when HTTPS pages load resources over HTTP. This weakens the security of the entire page, as attackers can intercept or modify the insecure resources through man-in-the-middle attacks.
 
-This rule detects `http://` strings written in a **subresource position** — `<img src>`, `<script src>`, `el.src = …`, `setAttribute('src', …)`, `importScripts(…)` and the like — which is the one shape a browser actually blocks as mixed content. Other hardcoded `http://` URLs are reported by `no-http-urls` instead, so each line draws exactly one finding.
+This rule detects `http://` strings written in a **subresource position** — `<img src>`, `<script src>`, `el.src = …`, `setAttribute('src', …)`, `importScripts(…)` and the like — which is the one shape a browser actually blocks as mixed content. Other hardcoded `http://` URLs are handled by the rule family: the URL argument of a `fetch`/`axios` call by `require-https-only`, everything else by `no-http-urls` — so each line draws exactly one finding.
 
 ### Built-in exemption: XML namespace identifiers
 

--- a/packages/eslint-plugin-browser-security/docs/rules/no-http-urls.md
+++ b/packages/eslint-plugin-browser-security/docs/rules/no-http-urls.md
@@ -89,6 +89,26 @@ flowchart TD
 | 🚀 **Injection**     | Attackers inject malicious scripts | Enforce HSTS and secure protocol selection |
 | 🔒 **Compliance**    | GDPR/App Store security violations | Ensure all endpoints are served over HTTPS |
 
+## Built-in Exemptions
+
+### XML namespace identifiers
+
+XML namespace URIs are opaque identifiers compared byte-for-byte, never fetched — `http://` is their spec-frozen spelling, and rewriting one to `https://` breaks the document. The rule exempts them before `allowedHosts` is consulted, on two independent signals:
+
+- **A registered namespace authority host** (exact hostname match, not substring): `www.w3.org`, `schemas.xmlsoap.org`, `purl.org`, `ns.adobe.com`, and other hosts that exist to mint identifiers. This covers all the well-known W3C namespaces — `http://www.w3.org/2000/svg`, `http://www.w3.org/1999/xhtml`, `http://www.w3.org/1999/xlink`, `http://www.w3.org/XML/1998/namespace`, `http://www.w3.org/2000/xmlns/` — whether written as a bare constant or passed to `createElementNS` / `setAttributeNS`.
+- **An `xmlns` / `xmlns:*` attribute or property position**, whatever the host — the XML spec's own declaration syntax makes the value an identifier by position.
+
+A URL merely *containing* `w3.org` in its path is still a real endpoint and still reports.
+
+```javascript
+// ✅ Exempt — identifiers, nothing is ever fetched from them
+const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+img.setAttributeNS('http://www.w3.org/1999/xlink', 'href', url);
+
+// ❌ Still reported — a real host whose PATH mentions w3.org
+const lib = 'http://cdn.example-corp.com/w3.org/lib.js';
+```
+
 ## Configuration
 
 This rule has no configuration options in the current version.

--- a/packages/eslint-plugin-browser-security/src/rules/detect-mixed-content/detect-mixed-content.test.ts
+++ b/packages/eslint-plugin-browser-security/src/rules/detect-mixed-content/detect-mixed-content.test.ts
@@ -235,6 +235,49 @@ jsxRuleTester.run('detect-mixed-content (jsx)', detectMixedContent, {
   ],
 });
 
+/**
+ * Regression lock — the spec-frozen W3C namespace identifiers.
+ *
+ * Hit in the wild on 2026-08-26 (ofri-peretz/blog PR #203): SVG export code
+ * and its test passed these strings to `createElementNS`, and the 1.x line of
+ * this plugin reported them as mixed content. Nothing is ever fetched from a
+ * namespace identifier, so CWE-311 cannot apply; under the subresource-position
+ * predicate they are structurally out of reach, and this suite pins each exact
+ * string in both shapes real code writes so a predicate change cannot quietly
+ * reclaim them.
+ */
+const W3C_NAMESPACE_IDENTIFIERS = [
+  'http://www.w3.org/2000/svg',
+  'http://www.w3.org/1999/xhtml',
+  'http://www.w3.org/1999/xlink',
+  'http://www.w3.org/XML/1998/namespace',
+  'http://www.w3.org/2000/xmlns/',
+];
+
+ruleTester.run('lock: W3C namespace identifiers are never mixed content', detectMixedContent, {
+  valid: [
+    // Each as a bare literal…
+    ...W3C_NAMESPACE_IDENTIFIERS.map((ns) => ({ code: `const NS = '${ns}';` })),
+    // …and as the createElementNS argument, the shape from the blog hit.
+    ...W3C_NAMESPACE_IDENTIFIERS.map((ns) => ({
+      code: `document.createElementNS('${ns}', 'svg');`,
+    })),
+    // The namespaced attribute setter takes the identifier first.
+    { code: "img.setAttributeNS('http://www.w3.org/1999/xlink', 'href', url);" },
+    // A namespaceURI comparison is how code branches on document type.
+    { code: "if (svg.namespaceURI === 'http://www.w3.org/2000/svg') { serialize(svg); }" },
+  ],
+  invalid: [
+    // POSITIVE CONTROL — a genuine http:// subresource load still reports, so
+    // the valid cases above are quiet for the right reason and not because the
+    // suite lost its sink.
+    {
+      code: "el.src = 'http://cdn.acmecorp.io/analytics.js';",
+      errors: [{ messageId: 'violationDetected' }],
+    },
+  ],
+});
+
 /*
  * ── REGRESSION: `<link>` needs its `rel` read ────────────────────────────────
  *

--- a/packages/eslint-plugin-browser-security/src/rules/no-http-urls/no-http-urls.test.ts
+++ b/packages/eslint-plugin-browser-security/src/rules/no-http-urls/no-http-urls.test.ts
@@ -296,6 +296,49 @@ ruleTester.run('no-http-urls (URL parsing base)', noHttpUrls, {
 });
 
 /**
+ * Regression lock — the spec-frozen W3C namespace identifiers.
+ *
+ * Hit in the wild on 2026-08-26 (ofri-peretz/blog PR #203, `svg-export.ts`):
+ * SVG export code passes these strings to `createElementNS`, and the 1.x line
+ * of this plugin reported every one. They are identifiers compared
+ * byte-for-byte — `http://` is their frozen spelling, nothing is ever fetched
+ * from them, and rewriting one to `https://` breaks the document. The host
+ * allowlist exempts them BEFORE `allowedHosts` is consulted; this suite pins
+ * each exact string in both shapes real code writes.
+ */
+const W3C_NAMESPACE_IDENTIFIERS = [
+  'http://www.w3.org/2000/svg',
+  'http://www.w3.org/1999/xhtml',
+  'http://www.w3.org/1999/xlink',
+  'http://www.w3.org/XML/1998/namespace',
+  'http://www.w3.org/2000/xmlns/',
+];
+
+ruleTester.run('lock: W3C namespace identifiers are never endpoints', noHttpUrls, {
+  valid: [
+    // Each as a bare literal…
+    ...W3C_NAMESPACE_IDENTIFIERS.map((ns) => ({ code: `const NS = '${ns}';` })),
+    // …and as the createElementNS argument, the shape from the blog hit.
+    ...W3C_NAMESPACE_IDENTIFIERS.map((ns) => ({
+      code: `document.createElementNS('${ns}', 'svg');`,
+    })),
+    // The namespaced attribute setter takes the identifier first.
+    { code: "img.setAttributeNS('http://www.w3.org/1999/xlink', 'href', url);" },
+    // A namespaceURI comparison is how code branches on document type.
+    { code: "if (svg.namespaceURI === 'http://www.w3.org/2000/svg') { serialize(svg); }" },
+  ],
+  invalid: [
+    // POSITIVE CONTROL — a genuine http:// resource URL in the same statement
+    // shape still reports, so the valid cases above are quiet for the right
+    // reason and not because the suite lost its sink.
+    {
+      code: "const NS = 'http://cdn.acmecorp.io/asset.js';",
+      errors: [{ messageId: 'insecureHttpWithException' }],
+    },
+  ],
+});
+
+/**
  * Regression lock — RFC 2606 reserved domains.
  *
  * `example.com` exists precisely so that nothing treats it as a real endpoint, and it was the


### PR DESCRIPTION
## Summary

- **Root cause of the wild FPs first**: `ofri-peretz/blog` PR #203 hit `no-http-urls` + `detect-mixed-content` on W3C namespace identifiers because `apps/blog` pins `eslint-plugin-browser-security@^1.2.3`. The 2.x line already exempts every one of these shapes — `no-http-urls` via the `NAMESPACE_AUTHORITY_HOSTS` exact-hostname allowlist (applied before `allowedHosts`), `detect-mixed-content` structurally via the subresource-position predicate. Verified with `probe-rule.mts` including positive controls (genuine `http://` URLs still report). **No rule code changes needed** — the blog's fix is bumping to `^2.0.6` and dropping its inline disables.
- Added regression-lock suites to both rules pinning all five spec-frozen identifiers (`2000/svg`, `1999/xhtml`, `1999/xlink`, `XML/1998/namespace`, `2000/xmlns/`) as bare literals and as `createElementNS` arguments, plus `setAttributeNS` and `namespaceURI`-comparison shapes, each suite carrying its own positive control.
- Named the exemption in both rule docs, and replaced `detect-mixed-content`'s stale "detects any string literal starting with http://" predicate description with the actual subresource-position predicate.
- Changeset: patch.

## Test plan

- [x] Positive controls: both rules report on genuine `http://` URLs before probing namespace shapes (per CLAUDE.md probe protocol).
- [x] Mutation check on both new locks: removing `www.w3.org` from the host allowlist fails 13 `no-http-urls` tests; restoring the 1.x any-literal predicate fails the `detect-mixed-content` lock suite. Both reverted.
- [x] Full package suite: 62 files, 2952 tests pass; 100% coverage gate holds.
- [x] `npm run lint:name-inference` (314 rules, no new sites), `npm run changeset:lint`, oxlint — all green.
- [x] Corpus recall gate not re-run: zero reporting-path changes (diff is tests + docs + changeset only).

## After merge

Nothing changes at runtime — 2.0.7 ships identical behavior with the exemption locked and documented. Follow-up in the blog repo: bump `eslint-plugin-browser-security` to `^2.0.6+` in `apps/blog` and remove the eslint-disable in `svg-export.test.ts` (and optionally restore the literal namespace in `svg-export.ts`). A residual, out-of-scope FP is tracked separately: custom (non-authority-host) namespace URIs passed to `createElementNS` still report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented false positives for standard W3C XML namespace identifiers.
  - Preserved detection of genuine insecure HTTP resource URLs.
  - Clarified that mixed-content checks apply specifically to subresource URLs.

- **Documentation**
  - Documented built-in exemptions for recognized XML namespace identifiers and namespace attributes.
  - Clarified how general HTTP URL detection and mixed-content detection differ.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->