### PR TITLE
fix(ci): unblock three silent health crons, define how docs quality is measured

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -21,6 +21,7 @@ concurrency:
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 jobs:
   gate:
@@ -118,3 +119,25 @@ jobs:
         run: |
           echo "❌ Link check failed. See report for details."
           exit 1
+
+      # On a PR the failure is visible: the job goes red and the step above comments
+      # the report. On the weekly cron nobody is looking, so a broken link would sit
+      # in a red run until someone happened to open the Actions tab. One issue,
+      # reopened and commented rather than a new one per week.
+      - name: 🚨 Open an issue on a scheduled failure
+        if: failure() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          TITLE="Link integrity check failed"
+          EXISTING=$(gh issue list --state open --search "$TITLE in:title" \
+            --json number --jq '.[0].number // empty')
+          BODY=$(printf '%s\n\n[Run](%s) — the full report is the `link-report` artifact.\n' \
+            "The weekly link check found broken or insecure links in the docs content." "$RUN_URL")
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "$BODY"
+          else
+            gh issue create --title "$TITLE" --body "$BODY"
+          fi

--- a/.github/workflows/integration-health.yml
+++ b/.github/workflows/integration-health.yml
@@ -88,7 +88,14 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: 🚨 Open an issue on failure
-        if: steps.probe.outcome == 'failure' && inputs.create-issue != false
+        # `inputs.*` is empty on a `schedule` run, and GitHub coerces '' to false, so
+        # `inputs.create-issue != false` evaluated FALSE on every cron — the issue was
+        # filed only on a manual dispatch, i.e. only when someone was already watching.
+        # The probe went red on 2026-08-24 and again on 2026-08-29 and opened nothing.
+        # Schedule always files; the toggle applies to manual runs, where it belongs.
+        if: >-
+          steps.probe.outcome == 'failure' &&
+          (github.event_name != 'workflow_dispatch' || inputs.create-issue)
         env:
           GH_TOKEN: ${{ github.token }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/peer-health.yml
+++ b/.github/workflows/peer-health.yml
@@ -25,6 +25,7 @@ jobs:
     permissions:
       contents: write        # commit the snapshot
       pull-requests: write   # open/update the snapshot PR
+      issues: write          # open/comment the failure issue
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -55,7 +56,7 @@ jobs:
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add benchmark-results/peer-health.json benchmark-results/peer-health.md
-            git commit -m "chore(bench): refresh peer-health snapshot
+            git commit -m "chore(benchmarks): refresh peer-health snapshot
 
             Automated weekly refresh of the peer-plugin health metrics
             named in distribution/ECOSYSTEM_LANDSCAPE.md. Source data
@@ -63,4 +64,26 @@ jobs:
             git push
           else
             echo "No peer-health changes detected."
+          fi
+
+      # A scheduled refresher that fails notifies nobody by default. This one failed
+      # every run for months — the commit step used a scope commitlint rejected — and
+      # the snapshot it exists to refresh silently stopped moving. One issue, reopened
+      # and commented rather than a new one per run, same shape as integration-health.
+      - name: 🚨 Open an issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          TITLE="peer-health snapshot refresh is failing"
+          EXISTING=$(gh issue list --state open --search "$TITLE in:title" \
+            --json number --jq '.[0].number // empty')
+          BODY=$(printf '%s\n\n[Run](%s)\n' \
+            "The weekly peer-health refresher failed, so `benchmark-results/peer-health.{json,md}` is now stale. Those numbers back `distribution/ECOSYSTEM_LANDSCAPE.md`." "$RUN_URL")
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "$BODY"
+          else
+            gh issue create --title "$TITLE" --body "$BODY"
           fi

--- a/.github/workflows/resource-profile.yml
+++ b/.github/workflows/resource-profile.yml
@@ -40,6 +40,7 @@ jobs:
     permissions:
       contents: write        # commit the profile snapshot
       pull-requests: write   # open/update the snapshot PR
+      issues: write          # open/comment the failure issue
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -65,7 +66,7 @@ jobs:
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add benchmark-results/resource-profile.json benchmark-results/resource-profile.md
-            git commit -m "chore(bench): refresh resource profile (peak RSS + cold start)
+            git commit -m "chore(benchmarks): refresh resource profile (peak RSS + cold start)
 
             Automated monthly refresh of the peak-RSS / cold-start
             measurements named in distribution/EVALUATION_METRICS.md
@@ -85,3 +86,25 @@ jobs:
             benchmark-results/resource-profile.json
             benchmark-results/resource-profile.md
           retention-days: 90
+
+      # A scheduled refresher that fails notifies nobody by default. This one failed
+      # every run for months — the commit step used a scope commitlint rejected — and
+      # the snapshot it exists to refresh silently stopped moving. One issue, reopened
+      # and commented rather than a new one per run, same shape as integration-health.
+      - name: 🚨 Open an issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          TITLE="resource-profile refresh is failing"
+          EXISTING=$(gh issue list --state open --search "$TITLE in:title" \
+            --json number --jq '.[0].number // empty')
+          BODY=$(printf '%s\n\n[Run](%s)\n' \
+            "The monthly resource-profile refresher failed, so `benchmark-results/resource-profile.{json,md}` (peak RSS + cold start) is now stale." "$RUN_URL")
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "$BODY"
+          else
+            gh issue create --title "$TITLE" --body "$BODY"
+          fi

--- a/.github/workflows/weekly-benchmark.yml
+++ b/.github/workflows/weekly-benchmark.yml
@@ -382,7 +382,7 @@ jobs:
           # Body built via heredoc into a file: an inline multi-line -m
           # would dedent out of this YAML block scalar and break parsing.
           {
-            echo "chore(bench): weekly benchmark refresh $(date -u +%Y-%m-%d)"
+            echo "chore(benchmarks): weekly benchmark refresh $(date -u +%Y-%m-%d)"
             echo
             echo "Automated run of ilb:headline + ilb:flagship against the"
             echo "shallow-cloned OOS corpus. Verified publishable by"
@@ -403,7 +403,7 @@ jobs:
           # an already-open PR simply updates in place.
           git push --force origin HEAD:bench/weekly-refresh
           if gh pr create --base main --head bench/weekly-refresh \
-               --title "chore(bench): weekly benchmark refresh $(date -u +%Y-%m-%d)" \
+               --title "chore(benchmarks): weekly benchmark refresh $(date -u +%Y-%m-%d)" \
                --body-file /tmp/bench-commit-msg.txt 2>/tmp/pr-err.txt; then
             echo "Opened the refresh PR."
           elif grep -qi "already exists" /tmp/pr-err.txt; then

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,15 +1,33 @@
-import { readdirSync, statSync } from 'node:fs';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
 /**
  * Commitlint config — conventional commits with scope validation.
  *
  * Valid scopes are:
- *   1. Any directory under packages/ (e.g. crypto, jwt, secure-coding).
- *   2. Any directory under apps/ or tools/.
+ *   1. Every npm workspace member, read from `package.json#workspaces`.
+ *   2. For packages, also the short form (`node-security` for
+ *      `eslint-plugin-node-security`).
  *   3. The special scopes below (ci, deps, release, docs, workspace).
  *
  * Scope is optional. When provided, it must be in this list.
+ *
+ * WHY THE WORKSPACE LIST AND NOT THREE HARDCODED DIRECTORIES
+ * ----------------------------------------------------------
+ * This used to scan `packages/`, `apps/` and `tools/` literally. `benchmarks` is a
+ * workspace member too — it is in `package.json#workspaces` and publishes as
+ * `@interlace/benchmarks` — but it is a bare directory, not a glob, so it was never
+ * scanned and `bench`/`benchmarks` was not a valid scope.
+ *
+ * Nothing caught that, because the only commits using it are made by robots. Three
+ * scheduled data refreshers commit `chore(bench): ...`, hit this rule, and exit 1:
+ * `peer-health.yml` had failed every weekly run since at least 2026-07-20 and
+ * `resource-profile.yml` every monthly run since at least 2026-06-01, so the
+ * snapshots they exist to refresh silently stopped moving for months. A red cron
+ * notifies nobody by default — see the issue-filing step added to both.
+ *
+ * Reading the workspace list means a new workspace member is a valid scope the day
+ * it is added, rather than the day someone remembers this file.
  */
 
 // Discover workspace folder names — replaces the old `npx nx show projects`
@@ -34,11 +52,20 @@ function shortScope(name) {
   return name.replace(/^eslint-plugin-/, '');
 }
 
-const workspaceScopes = [
-  ...listChildren('packages').flatMap((n) => [n, shortScope(n)]),
-  ...listChildren('apps'),
-  ...listChildren('tools'),
-];
+// Expand `package.json#workspaces`: a `dir/*` glob contributes its children, a bare
+// `dir` entry contributes itself.
+function workspaceMembers() {
+  const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
+  const patterns = Array.isArray(pkg.workspaces) ? pkg.workspaces : (pkg.workspaces?.packages ?? []);
+  const names = [];
+  for (const pattern of patterns) {
+    if (pattern.endsWith('/*')) names.push(...listChildren(pattern.slice(0, -2)));
+    else names.push(pattern.replace(/\/$/, '').split('/').pop());
+  }
+  return names;
+}
+
+const workspaceScopes = workspaceMembers().flatMap((n) => [n, shortScope(n)]);
 
 const specialScopes = [
   'ci',         // CI/CD workflows

--- a/docs/DOCS_QUALITY.md
+++ b/docs/DOCS_QUALITY.md
@@ -1,0 +1,149 @@
+# How we measure documentation quality
+
+Companion to [DOCS_PHILOSOPHY.md](../DOCS_PHILOSOPHY.md), which says what the docs
+should *be*. This says how we know whether they are, and what happens when they are
+not.
+
+_Last reviewed: 2026-08-30._
+
+---
+
+## The one principle
+
+**A claim about the docs is worth exactly as much as the check that holds it.**
+
+Everything below names a check, not an intention. Where there is no check, the row
+says so — an honest gap is useful, an unmeasured aspiration is not.
+
+Two corollaries, both learned the hard way in this repo:
+
+1. **A check nobody runs is not a check.** `tools/scripts/check-readme-structure.ts`
+   encoded the entire README standard and was wired into no npm script, no workflow
+   and no hook. While it sat unrun, all thirty plugin READMEs drifted onto a
+   pre-migration brand asset.
+2. **A red check nobody sees is not a check either.** `peer-health.yml` failed every
+   weekly run from 2026-07-20 to 2026-08-24 and `resource-profile.yml` every monthly
+   run from 2026-06-01, so two published data snapshots silently stopped moving.
+   `integration-health.yml` found a real production defect on 2026-08-24 and opened
+   nothing, because its issue-filing step was conditioned on a `workflow_dispatch`
+   input that is empty on a cron.
+
+So a check has to satisfy three things, and the table columns are exactly these:
+it **exists**, it **runs unattended**, and a failure **reaches a human**.
+
+**Measured today: 17 scheduled workflows, 6 with no failure channel at all** —
+`codecov`, `cve-latency`, `eslint-version-matrix`, `oxlint-parity`, `quality-full`,
+`weekly-corpus-scan`. A red run there is visible only to someone who opens the
+Actions tab. Eight file an issue, one opens a PR, and CodeQL and Scorecard report to
+the Security tab, which is a channel.
+
+---
+
+## Where a check belongs
+
+| The check… | goes in | because |
+| :--- | :--- | :--- |
+| reads only files in the repo | **PR gate** (vitest / a workflow step) | it is deterministic and fast, and the PR that breaks it is the cheapest place to fix it |
+| touches the network — a live URL, npm, the docs site | **scheduled cron that files an issue** | an upstream 404 is not the PR author's fault and must never wedge a merge |
+| needs a build or a benchmark run | **`ready_for_review` gate** (`quality-full.yml`) | too slow for every push, too important to skip before merge |
+
+This is why link checking is *not* a blocking PR gate. Twitter rotates image URLs
+faster than our cache TTL; a peer's README moves. Those are real findings that need
+a human, not a red merge button.
+
+> **`npm run quality` is a local convenience command, not a gate.** No workflow
+> invokes it. Adding a check there and nowhere else means it runs when someone
+> remembers to type it. Add checks to `scripts/__tests__/` (which
+> `npm run test:scripts` runs in `quality.yml`) or to a workflow step.
+
+---
+
+## The four things that rot
+
+### 1. Links
+
+| Metric | Target | Held by | Cadence |
+| :--- | :--- | :--- | :--- |
+| External links in MDX that resolve 2xx | 100% | `apps/docs/scripts/check-links.ts` → `check-links.yml` | weekly (Fri), files an issue + on `ready_for_review` |
+| Internal markdown links that resolve | 100% | `npm run check-links` (`scripts/check-markdown-links.ts`) | manual — **gap** |
+| Docs links carry the UTM contract | 100% | `check-utm-links.ts` | manual — **gap** |
+| README docs slug resolves to a real page | 100% | `plugin-name-metadata-drift.lock.test.ts` | PR |
+| Renamed docs slugs redirect, never 404 | every rename | `next.config.mjs` redirects + `remote-markdown-slug-lock.test.ts` | PR |
+| Live production surface behaves | 100% | `integration-health.yml` | weekly (Sat), files an issue |
+
+> **Two different link checkers, confusingly named.** `npm run check-links` runs
+> `scripts/check-markdown-links.ts` over *internal* markdown links and is manual-only.
+> `check-links.yml` runs `apps/docs/scripts/check-links.ts` over *external* HTTP links
+> in MDX and is the scheduled one. Renaming them is a follow-up.
+
+### 2. Names
+
+Every identifier a plugin has, and what holds it, is enumerated in
+[`.agent/link-and-name-map.md`](../.agent/link-and-name-map.md) — generated, so it
+cannot drift from the sources it describes.
+
+| Metric | Target | Held by | Cadence |
+| :--- | :--- | :--- | :--- |
+| Rule-id prefix == package suffix, and the preset registers it | 100% | `plugin-prefix-identity.lock.test.ts` | PR |
+| Every name in a machine-read surface resolves to a real package | 100% | `plugin-name-metadata-drift.lock.test.ts` | PR |
+| Docs registry ↔ `packages/` agree exactly | exact | same lock | PR |
+| The name map matches its sources | exact | `link-and-name-map.lock.test.ts` | PR |
+| README structure + brand marks | 100% of 31 | `readme-structure-gate.lock.test.ts` | PR |
+| Rule docs name their own plugin prefix | 100% | `documentation-standards.test.ts` | PR |
+
+### 3. Data
+
+The numbers we publish — benchmark results, peer health, download counts, coverage.
+**This is the weakest column**, and the failures above all landed here.
+
+| Metric | Target | Held by | Cadence |
+| :--- | :--- | :--- | :--- |
+| Benchmark snapshots refreshed | weekly | `weekly-benchmark.yml` | weekly (Mon) |
+| Peer-health snapshot refreshed | weekly | `peer-health.yml` | weekly — **was silently failing 6+ weeks** |
+| Resource profile refreshed | monthly | `resource-profile.yml` | monthly — **was silently failing 3+ months** |
+| Published claims match measured values | 100% | `npm run audit:claims` | manual — **gap** |
+| Audit snapshots not stale | age-bounded | `check-audit-freshness.ts` | manual — **gap** |
+| Coverage reported per package | 30/30 | `codecov.yml` components | PR — **19/30, gap** |
+
+**Every refresher must file an issue when it fails.** A snapshot that stops moving
+looks identical to a snapshot that has not changed. `peer-health`, `resource-profile`
+and `check-links` now do; `integration-health` already had the step but guarded it on
+a `workflow_dispatch` input that is empty on a cron, so it never fired unattended.
+
+### 4. Content
+
+| Metric | Target | Held by | Cadence |
+| :--- | :--- | :--- | :--- |
+| Every exported rule has a doc page | 100% | `rule-docs-sync-drift.test.ts` | PR |
+| Rule MDX matches its `.md` source | exact | `sync-rules-docs.ts --check` | PR |
+| Documented options exist in the schema, and vice versa | 100% | `documented-options-exist.test.ts` | PR |
+| Docs pages render without a11y violations | 0 serious | Playwright a11y suite | PR |
+| Core Web Vitals | budget in `lighthouse.yml` | Lighthouse CI | weekly (Wed) |
+| Articles reviewed before publish | 5 reviewers ≥9.0 | the `ofri-next-article` skill | per article |
+
+---
+
+## Reading this as a scorecard
+
+Count the rows. Today: **8 gaps** — four checks that exist but run only when typed
+(`check-links`, `check:utm-links`, `audit:claims`, `check:audit-freshness`), eleven of
+thirty plugins with no codecov component (19/30), six scheduled workflows with no
+failure channel (6/17), and the two data refreshers that have to prove a green run before their column can be
+trusted again.
+
+The number to move is **gaps → 0**, not "docs feel good". When a row moves from
+manual to a cadence, this file changes in the same PR.
+
+---
+
+## Adding a check
+
+1. Decide the tier from the table above — repo-only, network, or build-heavy.
+2. Repo-only: put a `*.lock.test.ts` in `scripts/__tests__/`. It runs in CI via
+   `npm run test:scripts`.
+3. Network: a workflow with a `schedule:` **and** an issue-filing step guarded by
+   `if: failure()` — not by a `workflow_dispatch` input, which is empty on a cron.
+4. **Prove the check fails on the unfixed state.** A lock that passes against a
+   broken tree is worse than none; see
+   [CLAUDE.md](../CLAUDE.md) — "Regressions are the issue. Lock everything you fix."
+5. Add the row here.


### PR DESCRIPTION
Answers "how do we ensure our links, naming and data stay up to date" by first measuring it — and the measurement found three refreshers that had been dead for months.

## What was broken

`commitlint.config.mjs` derived valid scopes by scanning `packages/`, `apps/` and `tools/` **literally**. `benchmarks` is a workspace member too — it is in `package.json#workspaces` and publishes as `@interlace/benchmarks` — but it is a bare directory rather than a glob, so it was never scanned and `bench` was not a valid scope.

Three workflows commit `chore(bench): …`, hit the rule, and exit 1:

| Workflow | Failing since | Consequence |
| :--- | :--- | :--- |
| `peer-health.yml` | ≥ 2026-07-20, **every weekly run** | `benchmark-results/peer-health.{json,md}` — which backs `distribution/ECOSYSTEM_LANDSCAPE.md` — frozen for six weeks |
| `resource-profile.yml` | ≥ 2026-06-01, **every monthly run** | peak RSS + cold-start numbers frozen for three months |
| `weekly-benchmark.yml` | same scope in its PR title | — |

Nobody noticed because **a red cron notifies nobody by default**. The work succeeded every time; only the commit was rejected, so the snapshot silently stopped moving. A snapshot that stops moving is indistinguishable from one that has not changed.

Scopes now come from `package.json#workspaces`, so a new workspace member is a valid scope the day it is added rather than the day someone remembers this file. The three workflows use `benchmarks`; no alias invented.

## The feedback loop was wired backwards

`integration-health.yml` already had an issue-filing step — guarded by `inputs.create-issue != false`. `inputs.*` is empty on a `schedule` run and GitHub coerces `''` to false, so the guard evaluated **FALSE on every cron**. The issue was filed only on a manual dispatch: only when someone was already watching.

It went red on 2026-08-24 and again on 2026-08-29 and opened nothing.

### ⚠️ That probe is right, and it found a live production defect

> `NEXT_PUBLIC_POSTHOG_KEY` is marked **Sensitive** in Vercel for `serverless.interlace.tools`, so the build inlined the literal string `[SENSITIVE]` instead of the key. The same var feeds `posthog-js`, so **that site is sending no analytics at all**, and its CSP report-uri is dead.

Fixing it needs Vercel access (different repo, not something I can do here): remove the var and re-add it with `--no-sensitive`.

`peer-health`, `resource-profile` and `check-links` now file an issue on failure too — one issue, reopened and commented, the shape `integration-health` already used.

## docs/DOCS_QUALITY.md

What "good documentation" means here, as **rows with a metric, a target, the check that holds it, and a cadence** — never an intention. Four sections: links, names, data, content.

It states the tiering rule that was implicit:

| The check… | goes in | because |
| :--- | :--- | :--- |
| reads only repo files | PR gate (vitest) | deterministic; the PR that breaks it is the cheapest place to fix it |
| touches the network | cron that files an issue | an upstream 404 is not the PR author's fault and must never wedge a merge |
| needs a build or benchmark | `ready_for_review` | too slow per-push, too important to skip before merge |

And one thing worth knowing on its own: **`npm run quality` is a local convenience command that no workflow invokes.** A check added only there runs when someone remembers to type it. Checks belong in `scripts/__tests__/` (run by `test:scripts` in `quality.yml`) or in a workflow step.

### Measured, not asserted — 8 gaps today

- 4 checks that exist but run only when typed: `check-links`, `check:utm-links`, `audit:claims`, `check:audit-freshness`
- **19 of 30** plugins have a codecov component (the other 11 render a badge that resolves to `unknown` — same finding as #749)
- **6 of 17** scheduled workflows have no failure channel at all: `codecov`, `cve-latency`, `eslint-version-matrix`, `oxlint-parity`, `quality-full`, `weekly-corpus-scan`
- the two revived refreshers have to prove a green run before their column can be trusted

The number to move is **gaps → 0**.

## Test plan

- [x] `turbo run build` + `turbo run test --filter=...[origin/main]` + `oxlint:shims:verify` — exit 0.
- [x] `npm run lint:workflows` — 35 workflow files pass conventions.
- [x] `npm run lint:md` — 0 issues in 1095 files.
- [x] `vitest run scripts/__tests__` — 1654 passed / 61 files.
- [x] Commitlint config exercised directly: `benchmarks` now resolves, `bench` correctly does not, and the 74-scope list still contains `workspace`, `docs`, `ui` and every package short form.
- [x] All four health workflows parsed with `yaml` to confirm the issue-filing step is present and its `if:` guard fires on `schedule`.

## After merge

Watch the next scheduled runs actually go green — Fri (`check-links`), Sat (`integration-health`), Sun (`peer-health`), 1st of month (`resource-profile`). `integration-health` will stay red and now file an issue until the Vercel env var is fixed; that is the correct behaviour, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
