### PR TITLE
fix(scripts): lazy-rules probe survives an inherited FORCE_COLOR

### DIFF
--- a/scripts/__tests__/lazy-rules-artifact.test.ts
+++ b/scripts/__tests__/lazy-rules-artifact.test.ts
@@ -40,6 +40,32 @@ const built = (pkg: string): string | null => {
   return existsSync(entry) ? readFileSync(entry, 'utf8') : null;
 };
 
+/** Counts the rule modules a plugin pulls into require.cache on load. */
+const countProbe = (pkg: string): string => `
+  const path = ${JSON.stringify(entryFor(pkg))};
+  require(path);
+  process.stdout.write(String(
+    Object.keys(require.cache).filter((f) => f.includes('/dist/src/rules/')).length,
+  ));
+`;
+
+/**
+ * Runs a probe in a child node and returns its raw stdout.
+ *
+ * Both halves of this are load-bearing, and both defend the same failure.
+ * Node colourises `console.log(<number>)` when FORCE_COLOR is set — which
+ * modern terminals and some CI runners set globally — even with stdout piped,
+ * so the child emitted `\x1b[33m0\x1b[39m` and `Number()` gave NaN. The
+ * numeric locks below then failed for a reason that had nothing to do with
+ * the built artifact. `process.stdout.write` never colourises, and the pinned
+ * env stops an inherited FORCE_COLOR from reaching the child at all.
+ */
+const runProbe = (source: string): string =>
+  execFileSync(process.execPath, ['-e', source], {
+    encoding: 'utf8',
+    env: { ...process.env, FORCE_COLOR: '0', NO_COLOR: '1' },
+  }).trim();
+
 /**
  * How many rule modules a plugin pulls in purely by being `require`d.
  *
@@ -50,18 +76,8 @@ const built = (pkg: string): string | null => {
  * patterns unmatchable. The lock kept passing while testing nothing. What
  * actually matters is how many modules load, and that survives any formatting.
  */
-const rulesLoadedOnRequire = (pkg: string): number => {
-  const probe = `
-    const path = ${JSON.stringify(entryFor(pkg))};
-    require(path);
-    console.log(
-      Object.keys(require.cache).filter((f) => f.includes('/dist/src/rules/')).length,
-    );
-  `;
-  return Number(
-    execFileSync(process.execPath, ['-e', probe], { encoding: 'utf8' }).trim(),
-  );
-};
+const rulesLoadedOnRequire = (pkg: string): number =>
+  Number(runProbe(countProbe(pkg)));
 
 describe('lazy rule barrel (built artifact)', () => {
   it('loads no rule module when a fully-lazy plugin is required', () => {
@@ -92,7 +108,7 @@ describe('lazy rule barrel (built artifact)', () => {
       const afterEnumerate = ruleModules();
       const first = plugin.rules[names[0]];
       const again = plugin.rules[names[0]];
-      console.log(JSON.stringify({
+      process.stdout.write(JSON.stringify({
         total: names.length,
         afterLoad,
         afterEnumerate,
@@ -101,9 +117,7 @@ describe('lazy rule barrel (built artifact)', () => {
         stableIdentity: first === again,
       }));
     `;
-    const result = JSON.parse(
-      execFileSync(process.execPath, ['-e', probe], { encoding: 'utf8' }),
-    );
+    const result = JSON.parse(runProbe(probe));
 
     expect(result.total).toBeGreaterThan(10);
     expect(result.afterLoad).toBe(0);
@@ -111,5 +125,20 @@ describe('lazy rule barrel (built artifact)', () => {
     expect(result.afterAccess).toBe(1); // reading one rule loads exactly one
     expect(result.isRule).toBe(true);
     expect(result.stableIdentity).toBe(true);
+  });
+
+  it('reads a number back even when the environment forces colour', () => {
+    if (built(FULLY_LAZY) === null) return;
+    // Deliberately does NOT pass the FORCE_COLOR=0 guard from runProbe: this
+    // pins the other half of the fix, that the probe writes with
+    // `process.stdout.write` rather than `console.log`. On the unfixed probe
+    // the child emits ANSI codes here and this parses to NaN.
+    const raw = execFileSync(process.execPath, ['-e', countProbe(FULLY_LAZY)], {
+      encoding: 'utf8',
+      env: { ...process.env, FORCE_COLOR: '1' },
+    }).trim();
+
+    expect(raw).toMatch(/^\d+$/);
+    expect(Number.isNaN(Number(raw))).toBe(false);
   });
 });

--- a/scripts/__tests__/lazy-rules-artifact.test.ts
+++ b/scripts/__tests__/lazy-rules-artifact.test.ts
@@ -133,12 +133,19 @@ describe('lazy rule barrel (built artifact)', () => {
     // pins the other half of the fix, that the probe writes with
     // `process.stdout.write` rather than `console.log`. On the unfixed probe
     // the child emits ANSI codes here and this parses to NaN.
+    //
+    // NO_COLOR is DELETED rather than left to the spread. Current Node lets
+    // FORCE_COLOR win and warns that it ignored NO_COLOR, so an inherited
+    // NO_COLOR would only add stderr noise — but the precedence has not always
+    // run that way, and on a Node where NO_COLOR wins this case would go quiet
+    // and pass against the unfixed probe. Deleting the key means the child is
+    // forced to colourise on every version, so the guard cannot self-disable.
+    const { NO_COLOR: _inherited, ...envWithoutNoColor } = process.env;
     const raw = execFileSync(process.execPath, ['-e', countProbe(FULLY_LAZY)], {
       encoding: 'utf8',
-      env: { ...process.env, FORCE_COLOR: '1' },
+      env: { ...envWithoutNoColor, FORCE_COLOR: '1' },
     }).trim();
 
     expect(raw).toMatch(/^\d+$/);
-    expect(Number.isNaN(Number(raw))).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- `scripts/__tests__/lazy-rules-artifact.test.ts` parsed a child process's stdout with `Number()` while the child printed via `console.log(<number>)`. Node colourises that even when stdout is piped, so on any machine with `FORCE_COLOR=1` in the environment — common in modern terminals and some CI runners — the child emitted an ANSI-wrapped digit and the parse yielded `NaN`. Both numeric locks failed for a reason that had nothing to do with the built artifact.
- Fixed on both sides, because either alone leaves a hole: the probes now write with `process.stdout.write` (which never colourises), and a new `runProbe()` helper pins `FORCE_COLOR=0` / `NO_COLOR=1` in the child's env so an inherited value cannot reach it at all.
- Extracted `countProbe(pkg)` so the probe source is shared between the numeric locks and the new regression guard.

Nothing about the code under test changed — this is purely the measurement harness.

## Test plan

Both probed plugins were built first (`turbo run build --filter=eslint-plugin-node-security --filter=eslint-plugin-jwt-security`), so no case hits its `dist not built` early-return. The runs below are real measurements, not silent skips.

- [x] **Reproduced on the unfixed code.** `FORCE_COLOR=1 npx vitest run scripts/__tests__/lazy-rules-artifact.test.ts` → `2 failed | 1 passed`, with exactly the reported `expected NaN to be +0` and `expected NaN to be greater than 0`.
- [x] **Fixed.** Same command → `4 passed`. Also `4 passed` at `FORCE_COLOR=0`.
- [x] **The new guard is not vacuous.** `reads a number back even when the environment forces colour` runs the probe with `FORCE_COLOR=1` forced in the *child* env, deliberately bypassing the `runProbe` env pin, so it locks the `process.stdout.write` half specifically. Reverting only that half was confirmed to fail it: `expected '<ESC>[33m0<ESC>[39m' to match /^\d+$/`, with the other three still passing on the env pin.
- [x] `npx prettier --check` clean, `npx oxlint` clean, `typecheck:scripts` reports zero errors in this file (the pre-existing errors elsewhere in `scripts/` are untouched by this PR).
- [x] Full local pre-push gate green: `changelog`, `typecheck`, `build-and-test`.

## After merge

Nothing ships to production — this is a test-harness fix. The lock now measures the same thing regardless of the developer's terminal, so the file stops being a false red for anyone whose shell exports `FORCE_COLOR`.

Follow-up worth noting: this failure mode applies to any probe that parses a child's `console.log` output. `scripts/__tests__/lazy-rules-artifact.test.ts` was the only such site found in `scripts/`, but `runProbe` is the shape to copy if another is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)