### PR TITLE
fix(scripts): record the finding the widened name-inference gate made visible

### DIFF
--- a/docs/rule-ledger/baseline.json
+++ b/docs/rule-ledger/baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-26",
+  "generated": "2026-08-30",
   "rules": {
     "secure-coding/detect-non-literal-regexp": [
       "duplicate-coverage",
@@ -33,6 +33,7 @@
     ],
     "secure-coding/no-hardcoded-credentials": [
       "duplicate-coverage",
+      "nominal-inference-suppress",
       "unguarded-recursion"
     ],
     "secure-coding/no-hardcoded-session-tokens": [


### PR DESCRIPTION
## Main is red; this is the fix

`rule-audit:gate` fails on `main` after [#755](https://github.com/ofri-peretz/eslint/pull/755):

```
⛔ rule-audit ratchet: 1 regression(s)
   secure-coding/no-hardcoded-credentials — gained: nominal-inference-suppress
```

The finding is real but the **behaviour is not new**. Widening `SUBSTRING_METHODS` to include `startsWith`/`endsWith` made the audit able to *see* that `no-hardcoded-credentials` suppresses on keys ending in `name`/`label`/`placeholder`. The suppression predates both changes — it was simply invisible to the check.

Re-recorded the baseline. The diff is one line: that rule gains `nominal-inference-suppress`. That is the honest record — the rule has that shape, and now the ledger says so rather than the gate pretending otherwise.

## My mistake, stated plainly

I merged #755 while `Plugin Taxonomy` was failing. I read the check status and ran the merge **in the same command**, so the failure was already merged by the time the output reached me. Checking first and *then* deciding is the entire point of those being two steps, and I collapsed them.

Main was red for the time it took to notice, reproduce, and open this.

## Test plan

- [x] Reproduced locally on `origin/main`: `rule-audit:gate` fails with exactly that regression.
- [x] `rule-audit-gate --update` → `Baseline recorded: 121 rules, 135 findings`.
- [x] Re-ran the gate: `121 rule(s) checked, no regressions`.
- [x] Baseline diff reviewed line by line — one finding added, plus the generated date. Nothing else moved.

## Follow-up worth doing separately

`no-hardcoded-credentials` suppressing on a key ending in `name` is real debt, not just a ledger entry: **a credential assigned to a key ending in "name" is still a credential.** It is registered in `lint-name-inference` and now in the audit baseline; fixing the suppression itself is its own change with its own recall implications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)