### PR TITLE
ci(workspace): make the required checks merge-queue ready

### DIFF
--- a/.github/workflows/quality-full.yml
+++ b/.github/workflows/quality-full.yml
@@ -36,6 +36,12 @@ on:
     # still skips drafts unless they carry the `run-full-ci` label.
     types: [opened, reopened, ready_for_review, labeled, synchronize]
   workflow_dispatch:
+  # A merge queue builds `refs/heads/gh-readonly-queue/...` and waits for the
+  # REQUIRED checks to report on this event. Without this trigger the check
+  # never reports and every queued merge blocks forever with no error — a worse
+  # failure than the amplification the queue exists to fix. See
+  # docs/intents/merge-latency/design.md; this ships BEFORE the queue is enabled.
+  merge_group:
   schedule:
     - cron: '0 4 * * 0'
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -34,6 +34,12 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # A merge queue builds `refs/heads/gh-readonly-queue/...` and waits for the
+  # REQUIRED checks to report on this event. Without this trigger the check
+  # never reports and every queued merge blocks forever with no error — a worse
+  # failure than the amplification the queue exists to fix. See
+  # docs/intents/merge-latency/design.md; this ships BEFORE the queue is enabled.
+  merge_group:
 
 concurrency:
   group: quality-${{ github.ref }}

--- a/docs/intents/merge-latency/design.md
+++ b/docs/intents/merge-latency/design.md
@@ -1,0 +1,98 @@
+# Design — Merge queue, sequenced so a merge can never hang
+
+> Stage 2 artifact. One chosen approach, one rejected, and an ordering that is
+> itself the safety property.
+
+---
+
+## Chosen: GitHub merge queue
+
+The queue tests the **projected merge result** — your PR on top of everything
+ahead of it — once, in order, and merges it. A PR no longer has to be
+individually up to date at merge time, because the queue constructs and tests
+that state for it.
+
+This preserves the guarantee `strict: true` exists for (code is tested against
+the main it lands on) while removing the O(N x M) re-run cost of enforcing it
+per-PR. Amplification goes from ~7 runs per merged PR toward 1.
+
+It also removes the merge race entirely: there is no slot to win.
+
+## Rejected: drop `strict: true`
+
+Cuts runs immediately and reintroduces exactly the breakage the setting
+prevents — a PR green against a stale main, merged into a main it was never
+tested against. The queue gives the same run reduction _and_ keeps the
+guarantee, so this is strictly worse.
+
+## Rejected: prioritise some authors' PRs
+
+Reorders a queue without reducing any duration. Recorded in `intent.md`.
+
+## The failure mode that dictates the order
+
+A merge queue builds `refs/heads/gh-readonly-queue/main/...` and waits for the
+**required checks** to report on a `merge_group` event. If the workflows
+providing those checks do not trigger on `merge_group`, they never report, and
+**every merge blocks forever with no error message**. That is worse than the
+problem being solved.
+
+Neither required check listens for it today:
+
+| required check        | workflow           | `merge_group`? |
+| --------------------- | ------------------ | -------------- |
+| `oxlint (fast pass)`  | `quality.yml`      | **NO**         |
+| `Quality (Full) Gate` | `quality-full.yml` | **NO**         |
+
+So the triggers ship **first, in their own PR, and land on main**, and the queue
+is enabled only afterwards. Enabling both together risks wedging the repo.
+
+## What `merge_group` does to the existing conditionals
+
+Audited rather than assumed — most already behave correctly because they treat
+"not a pull_request" as "run everything":
+
+| logic                                                        | on `merge_group`               | verdict                                                                            |
+| ------------------------------------------------------------ | ------------------------------ | ---------------------------------------------------------------------------------- |
+| `gate.decide`: `EVENT_NAME != 'pull_request'` → `run=true`   | runs                           | correct                                                                            |
+| `CI_TEST_SHARD_ALL: event == 'pull_request' && '0' \|\| '1'` | `'1'` — all shards             | correct, and deliberately conservative: the queue run is the last gate before main |
+| `bench_configs`: `BASE_SHA` empty → `run=true`               | runs                           | correct                                                                            |
+| `concurrency: quality-full-${{ github.ref }}`                | ref is the unique queue branch | correct — queue entries cannot cancel each other                                   |
+| `CI_TEST_SHARD_BASE: ...base.sha \|\| 'origin/main'`         | falls back to `origin/main`    | unused when `SHARD_ALL=1`, but the fallback must stay valid                        |
+
+The cost note is honest: a queue run executes **all** shards where a PR run
+executes only affected ones. That is more expensive per run, and still a large
+net win against paying a partial run seven times.
+
+## Sequence
+
+| #   | Step                                                                               | Gate before proceeding                      |
+| --- | ---------------------------------------------------------------------------------- | ------------------------------------------- |
+| 1   | Add `merge_group:` to `quality.yml` and `quality-full.yml`; commit intent + design | Normal PR flow still green                  |
+| 2   | Land step 1 on main                                                                | Required checks confirmed passing from main |
+| 3   | Enable the merge queue on `main`                                                   | —                                           |
+| 4   | Route one real PR through the queue                                                | Check reports on `merge_group`; PR merges   |
+| 5   | Re-measure runs-per-merged-PR over 24h                                             | Compare against the 84/12 baseline          |
+
+Step 3 is a repository setting, not code, and is reversible in one click — the
+risk is concentrated entirely in step 1 being wrong, which step 4 catches on a
+single PR rather than repo-wide.
+
+## Rollback
+
+Disable the merge queue rule. PRs immediately revert to direct merge with
+`strict: true`. The `merge_group` triggers are inert without a queue — they cost
+nothing and can stay.
+
+## How we will know it worked
+
+Re-run the amplification measurement:
+
+```bash
+gh -R ofri-peretz/eslint run list --workflow=quality-full.yml --limit 100 \
+  --json headBranch,createdAt \
+  --jq '[.[]|select((now-(.createdAt|fromdate))<86400)]|length'
+```
+
+Baseline: **84 runs / ~12 merges in 24h**. Target: at or near one gate run per
+merged PR, with no check removed.

--- a/docs/intents/merge-latency/intent.md
+++ b/docs/intents/merge-latency/intent.md
@@ -1,0 +1,88 @@
+# Intent — Cut the merge bottleneck: one gate run per merged PR
+
+> Stage 1 artifact. Opened after `ci-speed` shipped: check DURATION is largely
+> solved, and the bottleneck moved to how many times we run those checks.
+
+**Status:** draft · **Opened:** 2026-08-30 · **Owner:** @ofri-peretz
+
+---
+
+## What is wanted
+
+**A ready PR merges without re-running the full gate N times.** The target is
+~1 full-gate run per merged PR, against ~7 today — with no check removed and no
+weakening of the "tested against latest main" guarantee.
+
+Scope is the merge protocol. Check duration is a separate, largely-solved intent
+(`docs/intents/ci-speed/`).
+
+## Why now
+
+`ci-speed` cut `quality.yml` from 194s to 37s and PR #758 does the same for the
+gate that actually blocks a merge. That work makes each run cheap. It does
+nothing about **how many runs a single PR costs**, and measurement says that is
+now the dominant cost.
+
+## Measured (24h window, 2026-08-30)
+
+`quality-full.yml` runs, grouped by branch:
+
+| runs             | branch                           |
+| ---------------- | -------------------------------- |
+| 17               | `main` (post-merge verification) |
+| **12**           | `feat/infra-metrics`             |
+| 10               | `feat/fp-precision-ratchet`      |
+| 7                | `feat/name-inference-regex-form` |
+| 6                | `feat/ai-native-sdlc`            |
+| 5                | `feat/link-name-map`             |
+| 3, 3, 3, 2, 2, 2 | six more branches                |
+
+**84 full-gate runs in 24 hours to merge roughly 12 PRs — ~7x amplification.**
+At 180-260s per run that is on the order of **4.7 hours of runner time per day**,
+the large majority of it re-executing code that did not change.
+
+## The mechanism
+
+Branch protection sets `strict: true` — a PR must be up to date with `main` at
+the moment it merges. `main` moves roughly every 10 minutes.
+
+The consequence is quadratic, not linear. Every push to `main` invalidates
+**every** open PR, and each one must re-sync and re-run the full gate to become
+mergeable again. With N open PRs and M pushes to main, the protocol costs
+**O(N x M)** gate runs, and only one PR can be "currently up to date" at a time.
+This session's own PR paid that 12 times, and lost the merge race four times
+while doing it.
+
+Nothing here is a slow check. It is a slow _protocol_.
+
+## Constraints
+
+1. **`strict` semantics must be preserved, not dropped.** The guarantee — code
+   is tested against the main it will actually land on — is the reason the
+   setting exists. Simply turning it off would cut runs and reintroduce the
+   class of breakage it prevents.
+2. **No check removed, no threshold lowered.**
+3. **A merge must never be able to hang forever.** The failure mode of the
+   obvious fix is worse than the problem: enable a merge queue while the
+   required checks do not report on `merge_group`, and every merge blocks
+   indefinitely with no error.
+4. **Actions minutes matter.** The fix should reduce total runs, not relocate
+   them.
+
+## Success criteria
+
+- Full-gate runs per merged PR at or near **1** (from ~7).
+- Total `quality-full.yml` runs per day **materially below 84** at comparable
+  merge volume.
+- Zero manual merge races: no human or agent re-syncing a branch to win a slot.
+- `strict`-equivalent safety retained — nothing merges without having been
+  tested against the main it lands on.
+
+## Non-goals
+
+- Reducing check duration further (that is `ci-speed`; the floor is now setup
+  cost, ~12-16s per job).
+- Prioritising any author's PRs over another's. Considered and rejected:
+  it reorders a queue without reducing any duration, and the PRs it would have
+  starved this session were themselves fixes landing on main — two of them
+  spawned by this very work.

--- a/scripts/__tests__/merge-queue-readiness-lock.test.ts
+++ b/scripts/__tests__/merge-queue-readiness-lock.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Lock: a required check must report inside the merge queue.
+ *
+ * A merge queue builds `refs/heads/gh-readonly-queue/main/...` and waits for
+ * the REQUIRED status checks to report on a `merge_group` event. A workflow
+ * that provides a required check but does not trigger on `merge_group` never
+ * reports, so every queued merge blocks **forever, with no error message** —
+ * strictly worse than the run amplification the queue exists to remove.
+ *
+ * The trigger is therefore a precondition of enabling the queue, and this test
+ * is what keeps it true afterwards: deleting `merge_group:` from either
+ * workflow would wedge merges repo-wide, and nothing else would catch it until
+ * the next merge silently hung.
+ *
+ * Run from the repo root:
+ *   npx vitest run scripts/__tests__/merge-queue-readiness-lock.test.ts
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const WORKFLOWS = join(ROOT, '.github', 'workflows');
+
+/**
+ * Required status checks on `main`, as configured in branch protection.
+ *
+ * Kept in sync by hand — GitHub's branch-protection API is not reachable from
+ * a unit test. If branch protection changes, this list changes with it; a
+ * required check missing here is a required check nobody verified is
+ * queue-ready. Verify with:
+ *   gh api repos/ofri-peretz/eslint/branches/main/protection/required_status_checks
+ */
+const REQUIRED_CHECKS = ['oxlint (fast pass)', 'Quality (Full) Gate'];
+
+/** The workflow file that declares a job whose `name:` is `check`. */
+function workflowProviding(check: string): string | null {
+  for (const file of readdirSync(WORKFLOWS).filter((f) => f.endsWith('.yml'))) {
+    const src = readFileSync(join(WORKFLOWS, file), 'utf8');
+    // Job names are quoted or bare; match the `name:` value exactly.
+    const re = new RegExp(
+      `^\\s+name:\\s*['"]?${check.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}['"]?\\s*$`,
+      'm',
+    );
+    if (re.test(src)) return file;
+  }
+  return null;
+}
+
+/** Does this workflow listen for the merge queue's event? */
+function hasMergeGroupTrigger(file: string): boolean {
+  const src = readFileSync(join(WORKFLOWS, file), 'utf8');
+  return /^\s{2}merge_group:/m.test(src);
+}
+
+describe('merge queue readiness', () => {
+  it.each(REQUIRED_CHECKS)(
+    'the workflow providing %s exists and triggers on merge_group',
+    (check) => {
+      const file = workflowProviding(check);
+      expect(
+        file,
+        `no workflow declares a job named "${check}"`,
+      ).not.toBeNull();
+      expect(
+        hasMergeGroupTrigger(file as string),
+        `${file} provides the required check "${check}" but has no \`merge_group:\` trigger — ` +
+          'every queued merge would block forever',
+      ).toBe(true);
+    },
+  );
+
+  // Guards the shape of the test itself: a typo in REQUIRED_CHECKS would make
+  // workflowProviding return null for everything, and `.each` over an empty
+  // list would pass vacuously.
+  it('is checking a non-empty set of required checks', () => {
+    expect(REQUIRED_CHECKS.length).toBeGreaterThan(0);
+    for (const c of REQUIRED_CHECKS)
+      expect(workflowProviding(c)).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

**Step 1 of [`docs/intents/merge-latency/`](docs/intents/merge-latency/intent.md). Triggers only — the merge queue is NOT enabled in this PR, and that ordering is the safety property.**

Check *duration* is largely solved (194s → 37s in `ci-speed`, and #758 does the gate that blocks merges). The bottleneck moved to **how many times we run those checks.**

### Measured, 24h window

| runs | branch |
|---|---|
| 17 | `main` |
| **12** | `feat/infra-metrics` |
| 10 | `feat/fp-precision-ratchet` |
| 7 | `feat/name-inference-regex-form` |
| 6, 5, 3, 3, 3, 2, 2, 2 | eight more |

**84 `quality-full.yml` runs to merge ~12 PRs — ~7× amplification**, on the order of **4.7 hours of runner time per day**. One branch paid it 12 times and still lost four merge races.

### The mechanism

`strict: true` + a main that moves every ~10 minutes. Every push to main invalidates **every** open PR, so with N open PRs and M pushes the protocol costs **O(N × M)** gate runs, and only one PR can be up to date at a time.

Nothing here is a slow check. It is a slow *protocol*.

## Why triggers ship alone, first

A merge queue waits for the **required** checks to report on a `merge_group` event. Neither workflow providing one listened for it:

| required check | workflow | before |
|---|---|---|
| `oxlint (fast pass)` | `quality.yml` | ❌ |
| `Quality (Full) Gate` | `quality-full.yml` | ❌ |

Enable the queue in that state and **every merge blocks forever, with no error** — strictly worse than the amplification it fixes. So triggers land on main first; the queue is enabled only after.

## Audited, not assumed

The existing conditionals mostly already do the right thing, because they treat "not a `pull_request`" as "run everything":

| logic | on `merge_group` | verdict |
|---|---|---|
| `gate.decide` — `EVENT_NAME != 'pull_request'` → `run=true` | runs | correct |
| `CI_TEST_SHARD_ALL` → `'1'` | all shards | correct; the queue run is the last gate before main |
| `bench_configs` — empty `BASE_SHA` → `run=true` | runs | correct |
| `concurrency: …-${{ github.ref }}` | unique queue ref | correct; entries can't cancel each other |

Honest cost note: a queue run executes **all** shards where a PR run executes only affected ones — more expensive per run, still a large net win versus paying a partial run seven times.

## Test plan

- [x] `npm run test:scripts` — **70 files, 1832 tests, 0 failures**
- [x] `npm run lint:workflows` — 37 files pass
- [x] **New lock proven non-vacuous**: deleting `merge_group:` fails with _"quality-full.yml provides the required check "Quality (Full) Gate" but has no `merge_group:` trigger — every queued merge would block forever"_
- [x] The lock resolves check → workflow by job name, and guards itself against passing vacuously on an empty list

## After merge

Enable the queue on `main`, route one real PR through it to confirm the check reports on `merge_group`, then re-measure runs-per-merged-PR against the 84/12 baseline. Rollback is one click — the triggers are inert without a queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)