### PR TITLE
fix(ci): bill agent evals to the subscription, not per token

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -10,9 +10,18 @@ name: Agent Evals
 # agent in the repo worse and nothing would say so.
 #
 # Layer 1 is deterministic, free and always runs. Layer 2 runs real tasks against the
-# current configuration and needs ANTHROPIC_API_KEY; without the secret it reports
-# skipped rather than failing, so forks and secretless PRs are not blocked by an eval
-# they cannot run.
+# current configuration and needs a credential; without one it reports skipped rather
+# than failing, so forks and secretless PRs are not blocked by an eval they cannot run.
+#
+# BILLING — prefer CLAUDE_CODE_OAUTH_TOKEN.
+#   CLAUDE_CODE_OAUTH_TOKEN  one-year token from `claude setup-token`; runs bill against
+#                            the Claude subscription, with no per-token charge.
+#   ANTHROPIC_API_KEY        Console key, billed per token — money separate from any
+#                            subscription.
+# Both are passed here so either secret works, but ANTHROPIC_API_KEY OUTRANKS the OAuth
+# token in Claude Code's credential precedence: if both secrets exist, every run is
+# billed per token and the subscription token is never used. Set one, not both. The
+# runner prints which credential it used and warns when both are present.
 #
 # See evals/README.md.
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -61,6 +70,7 @@ jobs:
       - name: 🧪 Run evals
         id: evals
         env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: npx tsx scripts/run-evals.ts | tee evals.log
 

--- a/docs/DOCS_QUALITY.md
+++ b/docs/DOCS_QUALITY.md
@@ -121,7 +121,7 @@ pass/fail and can only see a hard break; a band sees the slow slide.
 | Metric | Target | Held by | Cadence |
 | :--- | :--- | :--- | :--- |
 | CWE-corpus F1 / recall / precision inside their band | no 2σ breach | `scripts/control-bands.ts` → `control-bands.yml` | weekly; a breach opens an **intent PR**, not a ticket |
-| Agent configuration still behaves | pass rate does not drop | `evals/` → `evals.yml` | on any change to `CLAUDE.md`, `AGENTS.md`, `.agent/**`, `lefthook.yml`; plus weekly |
+| Agent configuration still behaves | pass rate does not drop | `evals/` → `evals.yml` | on any change to `CLAUDE.md`, `AGENTS.md`, `.agent/**`, `lefthook.yml`; plus weekly. **Needs `CLAUDE_CODE_OAUTH_TOKEN`** (subscription, no per-token charge) — skipped until then |
 | Every relative link in an agent document resolves | 100% | `scripts/run-evals.ts --config` | PR (`docs-integrity`) |
 | Stage 1 / Stage 2 artifacts keep their shape | 100% | `intent-artifacts.lock.test.ts` | PR |
 | A release pauses for a human | always | `.claude/hooks/release-gate.sh` | every session |

--- a/evals/README.md
+++ b/evals/README.md
@@ -35,6 +35,23 @@ The OAuth token is tied to the subscription of whoever ran `claude setup-token`,
 can only make model requests — no Remote Control, no claude.ai connectors. Neither
 limitation matters here.
 
+### It spends your allowance, not your wallet
+
+On the subscription token these runs draw from the **same five-hour and weekly
+allowance as interactive work**, shared with Claude chat. There is no per-token
+charge, so the risk is not money — it is being rate-limited by your own CI in the
+middle of something.
+
+Every case is bounded twice:
+
+| Knob | Default | Why |
+| :--- | :--- | :--- |
+| `EVAL_MAX_TURNS` | `3` | A case that cannot answer in three tool calls is a bad case, not one that deserves twenty. Caps the worst run. |
+| `EVAL_MODEL` | unset — Claude Code's default | An eval on a model nobody runs measures the wrong configuration. Set `claude-haiku-4-5` when protecting the allowance matters more than that fidelity. |
+
+If you turn on **usage credits** to work past the plan limit, CI draws on them too —
+and those *are* billed. Set a monthly spend limit before enabling them.
+
 ## A case
 
 `evals/cases/<id>.json`:

--- a/evals/README.md
+++ b/evals/README.md
@@ -16,9 +16,24 @@ is really there. A broken pointer in a rule document is a rule the agent silentl
 cannot read.
 
 **Layer 2 — task evals.** Real tasks with accepted outcomes, run non-interactively
-against the current configuration. Needs `ANTHROPIC_API_KEY`; the suite reports
-`skipped` without one rather than failing, so a fork or a PR without secrets is not
-blocked.
+against the current configuration. Reports `skipped` without a credential rather than
+failing, so a fork or a PR without secrets is not blocked.
+
+Two credentials work, and they cost very different things:
+
+| Secret | Billing |
+| :--- | :--- |
+| `CLAUDE_CODE_OAUTH_TOKEN` | the Claude subscription (Pro, Max, Team, Enterprise) — **no per-token charge**. Generate with `claude setup-token`; valid one year. |
+| `ANTHROPIC_API_KEY` | a Claude Console key, **billed per token** — money separate from any subscription. |
+
+**Set one, not both.** `ANTHROPIC_API_KEY` outranks `CLAUDE_CODE_OAUTH_TOKEN` in Claude
+Code's credential precedence, so with both present every run is billed per token and
+the subscription token is never used. The runner prints which credential it used and
+warns when it finds both.
+
+The OAuth token is tied to the subscription of whoever ran `claude setup-token`, and it
+can only make model requests — no Remote Control, no claude.ai connectors. Neither
+limitation matters here.
 
 ## A case
 

--- a/scripts/__tests__/run-evals-credentials.lock.test.ts
+++ b/scripts/__tests__/run-evals-credentials.lock.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2026 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Workspace lock — which wallet the eval suite spends from.
+ *
+ * `ANTHROPIC_API_KEY` bills the Console per token; `CLAUDE_CODE_OAUTH_TOKEN` draws on
+ * the Claude subscription allowance at no per-token charge. Claude Code ranks the API
+ * key ABOVE the token, so a stray key silently converts a free CI run into a metered
+ * one — and nothing in the output would say so if the warning regressed.
+ *
+ * The subtle half is the empty string. GitHub Actions writes `KEY=""` into the step
+ * env whenever the secret is absent, so the variable is present-and-empty rather than
+ * missing. Treating that as "a key is set" would skip the subscription path and hand
+ * the `claude` subprocess an empty credential to fail on.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { routeCredentials, evalEnv } from '../run-evals';
+
+const KEY = 'ANTHROPIC_API_KEY';
+const TOKEN = 'CLAUDE_CODE_OAUTH_TOKEN';
+
+describe('credential routing', () => {
+  it('no credential at all — nothing to bill, the suite skips layer 2', () => {
+    expect(routeCredentials({})).toEqual({ billing: 'none', bothSet: false });
+  });
+
+  it('only the subscription token — bills the plan, no warning', () => {
+    expect(routeCredentials({ [TOKEN]: 't' })).toEqual({
+      billing: 'subscription',
+      bothSet: false,
+    });
+  });
+
+  it('only the API key — bills per token', () => {
+    expect(routeCredentials({ [KEY]: 'k' })).toEqual({ billing: 'api-key', bothSet: false });
+  });
+
+  it('both set — the key wins, and that is worth warning about', () => {
+    expect(routeCredentials({ [KEY]: 'k', [TOKEN]: 't' })).toEqual({
+      billing: 'api-key',
+      bothSet: true,
+    });
+  });
+
+  /** The Actions case: secret absent, variable present and empty. */
+  it('an empty API key is not a credential', () => {
+    expect(routeCredentials({ [KEY]: '', [TOKEN]: 't' })).toEqual({
+      billing: 'subscription',
+      bothSet: false,
+    });
+  });
+
+  it('an empty token is not a credential either', () => {
+    expect(routeCredentials({ [KEY]: '', [TOKEN]: '' })).toEqual({
+      billing: 'none',
+      bothSet: false,
+    });
+  });
+});
+
+describe('the environment handed to the claude subprocess', () => {
+  it('strips empty credentials rather than passing them down', () => {
+    const env = evalEnv({ [KEY]: '', [TOKEN]: 't', PATH: '/usr/bin' });
+    expect(KEY in env, 'an empty key must not reach the subprocess').toBe(false);
+    expect(env[TOKEN]).toBe('t');
+  });
+
+  it('passes real credentials through untouched', () => {
+    expect(evalEnv({ [KEY]: 'k', [TOKEN]: 't' })).toMatchObject({ [KEY]: 'k', [TOKEN]: 't' });
+  });
+
+  it('leaves everything else alone', () => {
+    expect(evalEnv({ PATH: '/usr/bin', HOME: '/home/x' })).toEqual({
+      PATH: '/usr/bin',
+      HOME: '/home/x',
+    });
+  });
+});

--- a/scripts/run-evals.ts
+++ b/scripts/run-evals.ts
@@ -213,11 +213,26 @@ export function grade(output: string, expect: Expectation[]): { ok: boolean; fai
 }
 
 function runCase(c: EvalCase): { id: string; status: 'pass' | 'fail' | 'error'; failed: string[] } {
-  const r = spawnSync(
-    'claude',
-    ['-p', c.prompt, '--allowedTools', c.allowedTools ?? 'Read,Grep,Glob'],
-    { cwd: REPO_ROOT, encoding: 'utf8', timeout: 180_000, maxBuffer: 16 * 1024 * 1024 },
-  );
+  // On a subscription token these runs draw from the SAME five-hour and weekly
+  // allowance as interactive work, shared with Claude chat. The bill is not the risk;
+  // being rate-limited mid-task by your own CI is. So every case is bounded twice:
+  //
+  //   --max-turns   a case that cannot answer from three tool calls is a bad case,
+  //                 not a case that deserves twenty. Caps the worst run, not the mean.
+  //   --model       EVAL_MODEL overrides. Left unset it uses the Claude Code default,
+  //                 which is the point — an eval on a model nobody runs measures the
+  //                 wrong configuration. Set `claude-haiku-4-5` when protecting the
+  //                 allowance matters more than fidelity to what the team runs.
+  const args = ['-p', c.prompt, '--allowedTools', c.allowedTools ?? 'Read,Grep,Glob'];
+  args.push('--max-turns', process.env.EVAL_MAX_TURNS ?? '3');
+  if (process.env.EVAL_MODEL) args.push('--model', process.env.EVAL_MODEL);
+
+  const r = spawnSync('claude', args, {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    timeout: 180_000,
+    maxBuffer: 16 * 1024 * 1024,
+  });
   if (r.error || typeof r.stdout !== 'string') {
     return { id: c.id, status: 'error', failed: [String(r.error ?? 'no output')] };
   }

--- a/scripts/run-evals.ts
+++ b/scripts/run-evals.ts
@@ -212,6 +212,37 @@ export function grade(output: string, expect: Expectation[]): { ok: boolean; fai
   return { ok: failed.length === 0, failed };
 }
 
+/** How a run is billed, decided from the environment alone so it can be tested. */
+export type Billing = 'none' | 'subscription' | 'api-key';
+
+/**
+ * GitHub Actions writes `ANTHROPIC_API_KEY=""` into the step env whenever the secret
+ * is absent — the variable is *present and empty*, not missing. Every credential
+ * decision here therefore tests for a non-empty value, and `evalEnv` strips the empty
+ * ones before they reach the `claude` subprocess, which has its own precedence rules
+ * and need not agree with ours about what empty means.
+ */
+export function routeCredentials(env: NodeJS.ProcessEnv): {
+  billing: Billing;
+  bothSet: boolean;
+} {
+  const key = Boolean(env.ANTHROPIC_API_KEY);
+  const token = Boolean(env.CLAUDE_CODE_OAUTH_TOKEN);
+  return {
+    billing: key ? 'api-key' : token ? 'subscription' : 'none',
+    bothSet: key && token,
+  };
+}
+
+/** The subprocess environment, with empty credential vars removed rather than passed on. */
+export function evalEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const out = { ...env };
+  for (const k of ['ANTHROPIC_API_KEY', 'CLAUDE_CODE_OAUTH_TOKEN']) {
+    if (!out[k]) delete out[k];
+  }
+  return out;
+}
+
 function runCase(c: EvalCase): { id: string; status: 'pass' | 'fail' | 'error'; failed: string[] } {
   // On a subscription token these runs draw from the SAME five-hour and weekly
   // allowance as interactive work, shared with Claude chat. The bill is not the risk;
@@ -230,6 +261,7 @@ function runCase(c: EvalCase): { id: string; status: 'pass' | 'fail' | 'error'; 
   const r = spawnSync('claude', args, {
     cwd: REPO_ROOT,
     encoding: 'utf8',
+    env: evalEnv(process.env),
     timeout: 180_000,
     maxBuffer: 16 * 1024 * 1024,
   });
@@ -257,7 +289,7 @@ function main(): void {
 
   if (configOnly) {
     console.log('\n🧪 Layer 2 — skipped (--config)\n');
-  } else if (!process.env.CLAUDE_CODE_OAUTH_TOKEN && !process.env.ANTHROPIC_API_KEY) {
+  } else if (routeCredentials(process.env).billing === 'none') {
     // Reported, never fatal. An eval that cannot run is not an eval that failed, and
     // treating it as one teaches people to delete the suite.
     console.log(
@@ -266,12 +298,12 @@ function main(): void {
         '   ANTHROPIC_API_KEY (Console, billed per token).\n',
     );
   } else {
-    const viaKey = Boolean(process.env.ANTHROPIC_API_KEY);
+    const { billing, bothSet } = routeCredentials(process.env);
     console.log(
       `\n🧪 Layer 2 — ${cases.length} task eval(s), billing to ` +
-        `${viaKey ? 'the Console API key (per token)' : 'the Claude subscription'}\n`,
+        `${billing === 'api-key' ? 'the Console API key (per token)' : 'the Claude subscription'}\n`,
     );
-    if (viaKey && process.env.CLAUDE_CODE_OAUTH_TOKEN) {
+    if (bothSet) {
       console.warn(
         '   ⚠️  Both credentials are set. ANTHROPIC_API_KEY wins, so this run is\n' +
           '      billed per token and the subscription token is ignored. Unset one.\n',

--- a/scripts/run-evals.ts
+++ b/scripts/run-evals.ts
@@ -13,9 +13,23 @@
  *      agent-facing document resolves. A rule document that points at a moved file is
  *      a rule the agent silently cannot read, and nothing else in this repo notices.
  *   2. Task evals — real prompts with accepted outcomes, run against the current
- *      configuration. Needs ANTHROPIC_API_KEY. Without one the layer reports
- *      `skipped`, never `failed`: a fork or a secretless PR must not be blocked by an
+ *      configuration. Needs a credential; without one the layer reports `skipped`,
+ *      never `failed`, because a fork or a secretless PR must not be blocked by an
  *      eval it cannot run.
+ *
+ * CREDENTIALS — prefer the subscription token, and do not set both
+ * ---------------------------------------------------------------
+ *   CLAUDE_CODE_OAUTH_TOKEN  a one-year token from `claude setup-token`. Runs bill
+ *                            against the Claude subscription (Pro, Max, Team or
+ *                            Enterprise) — no per-token charge.
+ *   ANTHROPIC_API_KEY        a Claude Console key. Billed per token to the Console
+ *                            organisation, which is money separate from any
+ *                            subscription.
+ *
+ * `ANTHROPIC_API_KEY` OUTRANKS `CLAUDE_CODE_OAUTH_TOKEN` in Claude Code's credential
+ * precedence, so setting both silently bills the API key and the subscription token is
+ * never used. This runner reports which one it found for exactly that reason — a
+ * surprise invoice is a bad way to learn the ordering.
  *
  * See evals/README.md for the case format and how to choose cases.
  *
@@ -228,14 +242,26 @@ function main(): void {
 
   if (configOnly) {
     console.log('\n🧪 Layer 2 — skipped (--config)\n');
-  } else if (!process.env.ANTHROPIC_API_KEY) {
+  } else if (!process.env.CLAUDE_CODE_OAUTH_TOKEN && !process.env.ANTHROPIC_API_KEY) {
     // Reported, never fatal. An eval that cannot run is not an eval that failed, and
     // treating it as one teaches people to delete the suite.
     console.log(
-      `\n🧪 Layer 2 — skipped: ANTHROPIC_API_KEY is not set (${cases.length} case(s) not run)\n`,
+      `\n🧪 Layer 2 — skipped: no credential (${cases.length} case(s) not run).\n` +
+        '   Set CLAUDE_CODE_OAUTH_TOKEN (subscription, no per-token charge) or\n' +
+        '   ANTHROPIC_API_KEY (Console, billed per token).\n',
     );
   } else {
-    console.log(`\n🧪 Layer 2 — ${cases.length} task eval(s)\n`);
+    const viaKey = Boolean(process.env.ANTHROPIC_API_KEY);
+    console.log(
+      `\n🧪 Layer 2 — ${cases.length} task eval(s), billing to ` +
+        `${viaKey ? 'the Console API key (per token)' : 'the Claude subscription'}\n`,
+    );
+    if (viaKey && process.env.CLAUDE_CODE_OAUTH_TOKEN) {
+      console.warn(
+        '   ⚠️  Both credentials are set. ANTHROPIC_API_KEY wins, so this run is\n' +
+          '      billed per token and the subscription token is ignored. Unset one.\n',
+      );
+    }
     caseResults = cases.map(runCase);
     for (const r of caseResults) {
       console.log(`  ${r.status === 'pass' ? '✓' : '✗'} ${r.id}`);


### PR DESCRIPTION
The eval workflow from #754 asked only for `ANTHROPIC_API_KEY` — a Claude Console key, **billed per token**, which is money separate from any Claude subscription. There is a free path and this switches to it.

## The two credentials

| Secret | Bills to |
| :--- | :--- |
| `CLAUDE_CODE_OAUTH_TOKEN` | the **Claude subscription** (Pro, Max, Team, Enterprise) — no per-token charge |
| `ANTHROPIC_API_KEY` | a **Claude Console** organisation, per token |

`claude setup-token` mints a one-year OAuth token for exactly this case — the docs say *"Use this for CI pipelines and scripts where browser login isn't available."* The workflow now passes both secrets so either works, and the runner prefers the subscription.

## The trap worth knowing

In Claude Code's credential precedence, `ANTHROPIC_API_KEY` is **rank 3** and `CLAUDE_CODE_OAUTH_TOKEN` is **rank 5**.

**Setting both means every run is billed per token and the subscription token is never used** — invisible until an invoice arrives. The runner now prints which credential it used, and warns when it finds both:

```
🧪 Layer 2 — 20 task eval(s), billing to the Claude subscription
```

Documented in `evals/README.md` and on the row it gates in `docs/DOCS_QUALITY.md`.

## Test plan

- [x] `turbo run build` + `turbo run test --filter=...[origin/main]` + `oxlint:shims:verify` — exit 0.
- [x] `evals:config` green; the no-credential path prints both options and still exits 0.
- [x] `eval-cases.lock.test.ts` — 22 passed.
- [x] `lint:workflows` 37 files, `lint:md` clean.

## After merge

Run `claude setup-token` and add the output as the `CLAUDE_CODE_OAUTH_TOKEN` repo secret. **Do not also set `ANTHROPIC_API_KEY`** — that reverses the billing.

Two caveats, neither of which bites here: the token is tied to the subscription of whoever generated it, and it can only make model requests (no Remote Control, no claude.ai connectors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
