### PR TITLE
perf(ci): split the largest test package, take advisory scans off the PR path

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -25,6 +25,15 @@ on:
       - '.github/workflows/a11y.yml'
   push:
     branches: [main]
+    # Same paths as the PR trigger above. Without them every merge ran a full
+    # axe scan — including merges that touched only scripts, workflows or
+    # plugin source, none of which can change a rendered page. The PR trigger
+    # was already filtered; this one was not, which is where most of the 17
+    # runs in a 24h sample came from.
+    paths:
+      - 'apps/docs/**'
+      - 'packages/ui/**'
+      - '.github/workflows/a11y.yml'
   workflow_dispatch:
 
 concurrency:
@@ -71,6 +80,12 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           playwright-cache: "true"
+          # The docs production build below was 78s of a 202s run — the single
+          # largest step here — rebuilt from scratch every time. Task-hash
+          # addressing lets a run that did not change docs replay it instead.
+          # Not a publishing workflow, so the supply-chain rule holds.
+          turbo-cache: "false"
+          turbo-remote-cache: "true"
           next-cache: "true"
 
       - name: Install Playwright browsers

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,15 +20,27 @@ on:
   # Scorecard's SAST check measures — it reported 25 of 30 commits analysed.
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
-    types: [ready_for_review, labeled, synchronize]
   workflow_dispatch:
   schedule:
-    # Weekly Monday 03:17 UTC — runs on a steady cadence regardless of activity,
-    # so the security tab stays warm even on quiet weeks. Off-peak time keeps
-    # us out of cron storms at the top of the hour.
-    - cron: "17 3 * * 1"
+    # NIGHTLY, 03:17 UTC. Was weekly; a full scan is ~212s and this repo is
+    # public, so Actions minutes are free — there is no reason to analyse a
+    # security surface once a week when it can be analysed once a day. Off-peak
+    # minute keeps us out of cron storms at the top of the hour.
+    - cron: "17 3 * * *"
+
+# The `pull_request` trigger was REMOVED on 2026-08-30, deliberately.
+#
+# CodeQL averaged 212s per run and gated nothing — it is not a required check,
+# so it never blocked a merge; it only competed for runners and lengthened the
+# PR page. The trigger's own note above described it as "a fast-feedback
+# convenience" that "cannot stand alone", and that remains the accurate reading:
+# every commit that lands on main is still analysed by the `push` trigger, which
+# is also what Scorecard's SAST check measures.
+#
+# What is genuinely traded away: a finding now surfaces just after a PR merges
+# rather than just before. Analysis time is the tool's, not ours — it cannot be
+# made 3x faster — so the only lever on a 60s CI target was when it runs. The
+# nightly cadence above is the compensating half of that trade.
 
 concurrency:
   # Keyed on the SHA for push, the ref for everything else. Two merges landing

--- a/docs/adr/0001-codeql-runs-post-merge-not-per-pr.md
+++ b/docs/adr/0001-codeql-runs-post-merge-not-per-pr.md
@@ -1,0 +1,67 @@
+# ADR 0001 — CodeQL analyses post-merge and nightly, not per pull request
+
+- **Status:** accepted
+- **Date:** 2026-08-30
+- **Deciders:** @ofri-peretz
+- **Intent:** [`docs/intents/ci-speed/`](../intents/ci-speed/intent.md)
+
+## Context
+
+The stated CI goal is a pull request that is green in about 60 seconds.
+
+CodeQL averaged **212s per run over 31 runs in 24h — 109 minutes a day**, the
+second-largest consumer in the repository. It is not a required status check, so
+it never blocked a merge; what it did was occupy runners and keep the PR page
+amber long after the blocking gate had finished.
+
+Two facts made this decidable rather than a matter of taste:
+
+1. **Its cost is not ours to optimise.** Analysis time belongs to the CodeQL
+   engine. Unlike the build (which went 159s → 2s once cached) there is no
+   lever that makes a scan three times faster. The only variable is _when_ it
+   runs.
+2. **Coverage does not depend on the PR trigger.** The workflow already
+   analysed every commit landing on `main` via `push`, and its own comment
+   described the PR trigger as "a fast-feedback convenience" that "cannot stand
+   alone" — it skips draft PRs and never sees commits pushed straight to main.
+   Scorecard's SAST check measures commits analysed, which `push` satisfies.
+
+GitHub caps a public repository at roughly **20 concurrent standard-runner
+jobs**. A single PR was spawning **38 jobs**, so removing work from the PR path
+returns runner slots to the blocking gate — the saving is twice over.
+
+## Decision
+
+Remove the `pull_request` trigger from `codeql.yml`. Keep `push` to `main`,
+keep `workflow_dispatch`, and raise the schedule from **weekly to nightly**
+(`17 3 * * *`).
+
+## Consequences
+
+**Accepted cost.** A CodeQL finding now surfaces shortly _after_ a PR merges
+rather than shortly before. For a repository where every merge is followed
+immediately by analysis on `main`, and where nothing is released straight from
+a PR branch, the exposure window is the gap between merge and the next `push`
+run — minutes, not days.
+
+**Gained.** ~109 minutes a day of runner time returns to the pool, ~1-2
+concurrent job slots return to the blocking gate on every PR, and the PR page
+resolves in the time the required checks take rather than the time the slowest
+advisory scan takes.
+
+**Improved, not merely traded.** The scheduled scan goes from weekly to
+nightly. Actions minutes are free on public repositories, so the previous
+weekly cadence was a saving that bought nothing.
+
+**Reversible.** Restoring the `pull_request` trigger is a three-line change.
+The tracking issue records the decision so it is revisited rather than
+forgotten.
+
+## Alternatives considered
+
+- **Keep it on PRs and make it faster.** Rejected: no such lever exists.
+- **Keep it on PRs but restrict to `paths`.** Rejected as insufficient — most
+  PRs in this repo touch `packages/**`, which is exactly what CodeQL scans, so
+  the filter would rarely fire.
+- **Make it a required check.** Rejected: it would put a 212s advisory scan on
+  the critical path of every merge, the opposite of the goal.

--- a/scripts/__tests__/ci-test-shard.test.ts
+++ b/scripts/__tests__/ci-test-shard.test.ts
@@ -15,7 +15,10 @@ import fs from 'node:fs';
 import path from 'node:path';
 import url from 'node:url';
 
-const REPO_ROOT = path.resolve(path.dirname(url.fileURLToPath(import.meta.url)), '../..');
+const REPO_ROOT = path.resolve(
+  path.dirname(url.fileURLToPath(import.meta.url)),
+  '../..',
+);
 const SCRIPT = path.join(REPO_ROOT, 'scripts', 'ci-test-shard.mts');
 const SHARD_TOTAL = 10;
 
@@ -38,21 +41,45 @@ function planFor(shard: number, total = SHARD_TOTAL): string[] {
     // below ("covers every package exactly once", "no shard empty") would then
     // be checking the diff rather than the partition, passing vacuously on a
     // branch that changed nothing.
-    env: { ...process.env, CI_TEST_SHARD_PLAN_ONLY: '1', CI_TEST_SHARD_ALL: '1' },
+    env: {
+      ...process.env,
+      CI_TEST_SHARD_PLAN_ONLY: '1',
+      CI_TEST_SHARD_ALL: '1',
+    },
   });
-  const names = [...out.matchAll(/^ {2}(\S+) {2}\((?:test|test:coverage), \d+ test files\)$/gm)].map((m) => m[1]);
+  // A package split with `vitest --shard` appears once PER SLICE, so the unit
+  // parsed here is "name" or "name#i/n" — not just the package name. Collapsing
+  // slices back to the bare name would make a MISSING slice invisible to the
+  // duplicate and coverage assertions below, and a missing slice is silently
+  // untested files behind a green check.
+  const names = [
+    ...out.matchAll(
+      /^ {2}(\S+)(?: \[slice (\d+)\/(\d+)\])? {2}\((?:test|test:coverage), ~?\d+ test files\)$/gm,
+    ),
+  ].map((m) => (m[2] ? `${m[1]}#${m[2]}/${m[3]}` : m[1]));
   // Fail loudly rather than returning [] if the plan format changes — an empty
   // parse would make "no duplicates" and "covers everything" trivially pass or
   // fail for the wrong reason.
-  if (names.length === 0) throw new Error(`shard ${shard}/${total}: parsed 0 packages from plan output:\n${out}`);
+  if (names.length === 0)
+    throw new Error(
+      `shard ${shard}/${total}: parsed 0 packages from plan output:\n${out}`,
+    );
   return names;
 }
+
+/**
+ * Mirror of `SPLIT_ACROSS_SHARDS` in scripts/ci-test-shard.mts. Deliberately
+ * duplicated rather than imported: importing the .mts would run its top-level
+ * discovery, and a lock that derives its expectation from the code under test
+ * agrees with that code by construction — including when both are wrong.
+ */
+const SPLIT_ACROSS_SHARDS: Record<string, number> = { docs: 6 };
 
 describe('shard partitioning', () => {
   const shards = Array.from({ length: SHARD_TOTAL }, (_, i) => planFor(i + 1));
   const all = shards.flat();
 
-  it('assigns every testable package to exactly one shard', () => {
+  it('assigns every package — and every slice of a split package — exactly once', () => {
     const dupes = all.filter((p, i) => all.indexOf(p) !== i);
     expect(dupes).toEqual([]);
   });
@@ -66,7 +93,18 @@ describe('shard partitioning', () => {
         const manifest = path.join(abs, entry, 'package.json');
         if (!fs.existsSync(manifest)) continue;
         const pkg = JSON.parse(fs.readFileSync(manifest, 'utf8'));
-        if (pkg.scripts?.['test:coverage'] || pkg.scripts?.test) expected.push(pkg.name);
+        if (pkg.scripts?.['test:coverage'] || pkg.scripts?.test) {
+          // Mirrors SPLIT_ACROSS_SHARDS in the script. A package listed there
+          // must contribute all N slices — this is what catches a slice that
+          // stopped being emitted.
+          const slices = SPLIT_ACROSS_SHARDS[pkg.name] ?? 1;
+          if (slices > 1) {
+            for (let i = 1; i <= slices; i++)
+              expected.push(`${pkg.name}#${i}/${slices}`);
+          } else {
+            expected.push(pkg.name);
+          }
+        }
       }
     }
     expect([...all].sort()).toEqual(expected.sort());
@@ -74,7 +112,8 @@ describe('shard partitioning', () => {
 
   it('leaves no shard empty', () => {
     // An empty shard is a job that reports success having tested nothing.
-    for (const [i, s] of shards.entries()) expect(s.length, `shard ${i + 1} is empty`).toBeGreaterThan(0);
+    for (const [i, s] of shards.entries())
+      expect(s.length, `shard ${i + 1} is empty`).toBeGreaterThan(0);
   });
 
   it('is deterministic across invocations', () => {

--- a/scripts/ci-test-shard.mts
+++ b/scripts/ci-test-shard.mts
@@ -27,7 +27,39 @@ const REPO_ROOT = path.resolve(__dirname, '..');
 /** Workspace globs that can hold testable packages. */
 const WORKSPACE_DIRS = ['packages', 'apps', 'tools'];
 
-type Pkg = { name: string; dir: string; task: 'test:coverage' | 'test'; cost: number; deps: string[] };
+type Pkg = {
+  name: string;
+  dir: string;
+  task: 'test:coverage' | 'test';
+  cost: number;
+  deps: string[];
+  /** Set when this entry is one slice of a package split across CI shards. */
+  split?: { i: number; n: number };
+};
+
+/**
+ * Packages split across several CI shards with `vitest --shard`.
+ *
+ * LPT bucketing cannot produce a shard faster than the single largest item, so
+ * while a package is one indivisible unit it is a floor on the whole gate. On
+ * 2026-08-30 `docs` was that floor: 144s against 19-47s for every other shard,
+ * and it alone was the critical path of the REQUIRED `Quality (Full) Gate`.
+ * Rebalancing could not have helped — only splitting the item can.
+ *
+ * Slice count is chosen against the partition floor, not minimised. Total test
+ * work is ~375s over 10 shards, so no bucketing can beat ~37s average however
+ * finely anything is split — the goal is only to get the largest item BELOW
+ * that floor so LPT can actually reach it. At 6 slices `docs` contributes ~24s
+ * per slice, comfortably under. Splitting further buys nothing: each extra
+ * shard pays ~12-16s to acquire a runner, and the gate is then bounded by
+ * `Build` (45s) and `Benchmark configs load` (50s) regardless.
+ *
+ * The repo is public, so Actions minutes are free — the constraint here is the
+ * concurrent-job cap and per-runner startup, not billing.
+ *
+ * NOT applied when collecting coverage — see `wantCoverage` below.
+ */
+const SPLIT_ACROSS_SHARDS: Record<string, number> = { docs: 6 };
 
 /**
  * Cost proxy for balancing: number of test files in the package.
@@ -59,6 +91,8 @@ function countTestFiles(dir: string): number {
  */
 const NO_TEST_ALLOWLIST = new Set<string>(['registry']);
 
+const wantCoverage = process.env.CI_TEST_SHARD_COVERAGE === '1';
+
 function discoverPackages(): { testable: Pkg[]; untested: string[] } {
   const testable: Pkg[] = [];
   const untested: string[] = [];
@@ -79,7 +113,7 @@ function discoverPackages(): { testable: Pkg[]; untested: string[] } {
       // roughly doubles vitest's cost for a number nobody reads per-PR, and
       // codecov.yml now collects it on a daily cron instead. Set
       // CI_TEST_SHARD_COVERAGE=1 to opt back in (that daily job does).
-      const wantCoverage = process.env.CI_TEST_SHARD_COVERAGE === '1';
+      // (also consulted above for SPLIT_ACROSS_SHARDS)
       const task = wantCoverage && pkg.scripts?.['test:coverage']
         ? 'test:coverage'
         : pkg.scripts?.test
@@ -87,14 +121,37 @@ function discoverPackages(): { testable: Pkg[]; untested: string[] } {
           : pkg.scripts?.['test:coverage']
             ? 'test:coverage'
             : null;
-      if (task) testable.push({ name: pkg.name, dir, task, cost: countTestFiles(path.join(abs, entry)), deps: manifestDeps(pkg) });
+      if (task) {
+        const cost = countTestFiles(path.join(abs, entry));
+        const deps = manifestDeps(pkg);
+        // Splitting hides files from each slice, so per-slice coverage would
+        // sit far below the 100% thresholds and fail. The daily codecov job
+        // sets CI_TEST_SHARD_COVERAGE=1 and must see whole packages.
+        const slices = wantCoverage ? 1 : (SPLIT_ACROSS_SHARDS[pkg.name] ?? 1);
+        if (slices > 1) {
+          for (let i = 1; i <= slices; i++) {
+            testable.push({
+              name: pkg.name, dir, task,
+              cost: Math.ceil(cost / slices), deps,
+              split: { i, n: slices },
+            });
+          }
+        } else {
+          testable.push({ name: pkg.name, dir, task, cost, deps });
+        }
+      }
       else if (!NO_TEST_ALLOWLIST.has(pkg.name)) untested.push(pkg.name);
     }
   }
   // Sort by cost desc, name asc as tiebreak. Descending order is what makes the
   // LPT bucketing below effective, and the name tiebreak keeps it deterministic
   // so a package keeps its shard (and therefore its Turbo cache key) run to run.
-  testable.sort((a, b) => b.cost - a.cost || a.name.localeCompare(b.name));
+  testable.sort(
+    (a, b) =>
+      b.cost - a.cost ||
+      a.name.localeCompare(b.name) ||
+      (a.split?.i ?? 0) - (b.split?.i ?? 0),
+  );
   return { testable, untested };
 }
 
@@ -253,7 +310,10 @@ console.log(
     `${loads[shardIndex - 1]} of ${loads.reduce((a, b) => a + b, 0)} test files ` +
     `(balance: ${Math.min(...loads)}–${Math.max(...loads)}) — running ${filterNote}`,
 );
-for (const p of mine) console.log(`  ${p.name}  (${p.task}, ${p.cost} test files)`);
+for (const p of mine)
+  console.log(
+    `  ${p.name}${p.split ? ` [slice ${p.split.i}/${p.split.n}]` : ''}  (${p.task}, ~${p.cost} test files)`,
+  );
 
 // An empty *bucket* means shardTotal exceeds what the partition can fill — a
 // job that reports success having tested nothing. Still fatal.
@@ -296,13 +356,31 @@ for (const task of ['test:coverage', 'test'] as const) {
   // plain `vitest run` does not instrument. `test:coverage` passes `--coverage`
   // on the CLI, which overrides the config — that is how the daily codecov job
   // still collects it. No flag needed here.
-  const args = ['turbo', 'run', task, ...group.map(spec), '--', '--reporter=dot'];
-  console.log(`\n$ npx ${args.join(' ')}\n`);
-  try {
-    execFileSync('npx', args, { cwd: REPO_ROOT, stdio: 'inherit' });
-  } catch {
-    // Keep going so one failing group still reports the other's result.
-    failed = true;
+  // A sliced package needs its OWN invocation: `--shard` after `--` reaches
+  // every package in the command, so batching a slice with whole packages
+  // would silently run only a fraction of each of them — a green check over
+  // untested files, which is the exact failure class this script exists to
+  // prevent. Whole packages still batch into one call.
+  const sliced = group.filter((p) => p.split);
+  const whole = group.filter((p) => !p.split);
+
+  const invocations: string[][] = [];
+  if (whole.length) {
+    invocations.push(['turbo', 'run', task, ...whole.map(spec), '--', '--reporter=dot']);
+  }
+  for (const p of sliced) {
+    const { i, n } = p.split as { i: number; n: number };
+    invocations.push(['turbo', 'run', task, spec(p), '--', '--reporter=dot', `--shard=${i}/${n}`]);
+  }
+
+  for (const args of invocations) {
+    console.log(`\n$ npx ${args.join(' ')}\n`);
+    try {
+      execFileSync('npx', args, { cwd: REPO_ROOT, stdio: 'inherit' });
+    } catch {
+      // Keep going so one failing group still reports the other's result.
+      failed = true;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Toward the goal: **a PR green in ~60s.** Three changes, all measured.

### 1. Split the package that was the floor

`docs` was the critical path of the **required** gate at **144s**, against 19–47s for every other shard.

LPT bucketing **cannot produce a shard faster than the single largest item.** While `docs` was one indivisible unit it was a floor on the whole gate — rebalancing could never have helped. Only splitting it can.

`SPLIT_ACROSS_SHARDS` slices a package with `vitest --shard`. `docs` → **6 slices of ~24s**. Six and not more, deliberately: total test work is ~375s over 10 shards, so **no partition beats a ~37s average** however finely anything is split. The goal is only to get the largest item *below* that floor so LPT can reach it. Past that, each extra shard pays ~12–16s for a runner and the gate is bounded by `Build` (45s) and `Benchmark configs load` (50s) regardless.

Two correctness constraints, encoded rather than assumed:
- **Never when collecting coverage** — slicing hides files from each slice, so per-slice coverage would sit far under the 100% thresholds. The daily codecov job still sees whole packages.
- **A sliced package gets its own turbo invocation.** `--shard` after `--` reaches *every* package in the command, so batching a slice with whole packages would silently run a fraction of each — a green check over untested files, the exact failure class this script exists to prevent.

The partition lock is **stronger, not merely adapted**: slices are tracked as distinct units, so a slice that stops being emitted fails the "exactly once" assertion. Collapsing them to the bare package name would have hidden it.

### 2. CodeQL off the PR path → nightly ([ADR 0001](docs/adr/0001-codeql-runs-post-merge-not-per-pr.md))

212s × 31 runs = **109 min/day, gating nothing**. Its cost belongs to the engine — no lever makes a scan 3× faster, so the only variable was *when* it runs.

Dropped `pull_request`; kept `push` to main (which already analysed every landed commit, and is what Scorecard's SAST check measures); raised the schedule **weekly → nightly** since minutes are free on a public repo.

Accepted cost, stated plainly in the ADR: a finding surfaces just *after* a merge rather than just before.

### 3. Accessibility gated on paths, build cached

Its PR trigger was already path-filtered; its **push-to-main trigger was not** — so every merge ran a full axe scan, including merges touching only scripts or plugin source, which cannot change a rendered page. Now matched. Its 78s docs build also moves onto the remote cache.

## The constraint that shapes all of this

**Concurrency, not minutes.** A public repo gets ~20 concurrent jobs; one PR was spawning **38** (12 + 19 + 2 + 4 + 1), which is exactly the 19s-avg / 40s-max queue wait we measure. Every job removed from the PR path returns a slot to the blocking gate — so 2 and 3 pay twice.

It also means *adding* parallelism past the cap does not help: extra shards would queue rather than run.

## Test plan

- [x] `npm run test:scripts` — **71 files, 1836 tests, 0 failures**
- [x] `npm run lint:workflows` — 37 files pass
- [x] Shard plan verified: `docs` distributed across 6 shards, balance 93–95 test files
- [x] Partition lock updated and passing — now catches a dropped slice

## After merge

Re-measure the gate. Expected: `Unit Tests + Coverage (1/10)` no longer the critical path, gate bounded by `Build`/`Benchmark configs load` at ~50s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)