### PR TITLE
fix(release): the Version PR never opened, so nothing could publish

### DIFF
--- a/.github/workflows/changesets-pr.yml
+++ b/.github/workflows/changesets-pr.yml
@@ -151,6 +151,16 @@ jobs:
           pr-title: 'chore(release): version packages'
           commit-message: 'chore(release): version packages'
           # No `publish:` — release.yml does that on merge.
+          #
+          # The token goes here as an INPUT, not as a GITHUB_TOKEN env var.
+          # v2.1.1 hard-errors when the env var is set and differs from this
+          # input — "The GITHUB_TOKEN environment variable is set and does not
+          # match the github-token input" — and the input defaults to the plain
+          # `github.token`, so passing a PAT via env produced exactly that
+          # mismatch. The job then failed on every push to main, no Version PR
+          # was opened, versions never bumped, and release.yml correctly found
+          # nothing to publish. Ten changesets were queued behind it.
+          github-token: ${{ secrets.RELEASE_BOT_PAT || secrets.AGENTS_REPO_PAT || secrets.GITHUB_TOKEN }}
         env:
           # The SAME token chain the approve step below uses, and for a sharper
           # reason: this is the push that decides whether the Version PR ever
@@ -172,7 +182,9 @@ jobs:
           # which re-triggers its workflows. Note that EVERY later merge to main
           # force-pushes this branch again and resets the checks to zero, so the
           # close/reopen has to be the last action before merging.
-          GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_PAT || secrets.AGENTS_REPO_PAT || secrets.GITHUB_TOKEN }}
+          # GITHUB_TOKEN was HERE and is deliberately gone — see `github-token`
+          # above. The token chain is unchanged; only where it is passed moved.
+          #
           # changesets/action runs `git commit` + `git push origin
           # HEAD:changeset-release/main` to open the Version PR. CI installs
           # lefthook git hooks (npm ci → prepare), and the pre-push `changelog`

--- a/scripts/__tests__/changesets-action-pin.test.ts
+++ b/scripts/__tests__/changesets-action-pin.test.ts
@@ -112,3 +112,45 @@ describe('changesets/action ↔ CLI pairing', () => {
     expect(dependabot).toContain('version-update:semver-major');
   });
 });
+
+describe('changesets/action token wiring', () => {
+  const wf = readFileSync(WORKFLOW, 'utf8');
+
+  /** The `- name: Open / refresh Version PR` step, up to the next step. */
+  function versionPrStep(): string {
+    const start = wf.indexOf('name: Open / refresh Version PR');
+    expect(start, 'the Version PR step was renamed or removed').toBeGreaterThan(
+      -1,
+    );
+    const rest = wf.slice(start);
+    const next = rest.indexOf('\n      - name:', 1);
+    return next === -1 ? rest : rest.slice(0, next);
+  }
+
+  /**
+   * v2.1.1 hard-errors when a GITHUB_TOKEN env var is set on this step and
+   * differs from the `github-token` input — and the input defaults to the plain
+   * `github.token`, so passing a PAT via env is exactly that mismatch.
+   *
+   * The blast radius is silent and total: the step fails on every push to main,
+   * no Version PR opens, versions never bump, and release.yml then correctly
+   * finds nothing to publish. On 2026-08-30 ten changesets were queued behind
+   * it while every workflow that anyone looked at was green.
+   */
+  it('passes the token as an input, never as a GITHUB_TOKEN env var', () => {
+    const step = versionPrStep();
+    expect(step, 'token must be passed as the github-token input').toMatch(
+      /github-token:\s*\$\{\{/,
+    );
+    expect(
+      /^\s+GITHUB_TOKEN:/m.test(step),
+      'GITHUB_TOKEN must NOT be set on this step — it conflicts with github-token',
+    ).toBe(false);
+  });
+
+  it('still disables lefthook for the bot push', () => {
+    // Unrelated to the token, but it lives in the same env block and removing
+    // the env var wholesale would silently take this with it.
+    expect(versionPrStep()).toMatch(/LEFTHOOK:\s*'0'/);
+  });
+});


### PR DESCRIPTION
## Summary

**New packages were not publishing automatically. The cause is upstream of `release.yml`, which was working correctly the whole time.**

`changesets/action@v2.1.1` hard-errors when a `GITHUB_TOKEN` env var is set on its step and differs from the `github-token` **input**:

> The GITHUB_TOKEN environment variable is set and does not match the "github-token" input.

The input defaults to the plain `github.token`, and we passed `RELEASE_BOT_PAT` via `env:` — exactly that mismatch.

### The chain

1. `Open / refresh Version PR` fails on **every** push to main
2. → no "Version Packages" PR is opened
3. → no `package.json` version ever bumps on main
4. → `release.yml`'s detect step compares local vs npm, finds every version equal, and correctly publishes nothing

**10 changesets are currently queued behind this**, while every workflow anyone looked at was green.

Worth stating: `release.yml` already handles a brand-new package correctly — `npm view` returns empty and it logs `🆕 first release`. That path was never broken.

## Fix

Move the token to the `github-token` input, drop the env var. Same token chain (`RELEASE_BOT_PAT || AGENTS_REPO_PAT || GITHUB_TOKEN`), different place. `LEFTHOOK: '0'` stays — unrelated, and it lives in the same env block that was edited.

## Lock

`changesets-action-pin.test.ts` gains: the Version PR step must pass `github-token` as an input, must **not** set `GITHUB_TOKEN`, and must keep `LEFTHOOK: '0'`.

This failure mode is silent by construction — "no Version PR" is indistinguishable from "nothing to release" — and per the file's own header this is the **second** time that has cost the repo unpublished work. A lock is the only thing that distinguishes them.

## Test plan

- [x] `changesets-action-pin.test.ts` — 6 tests pass
- [x] `npm run lint:workflows` — 37 files pass
- [ ] Verified after merge: the Version PR opens and picks up the 10 queued changesets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication handling for automated version pull requests.

* **Tests**
  * Added coverage to verify token configuration and prevent unintended environment-based authentication.
  * Confirmed existing hook-suppression behavior remains intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->