### PR TITLE
ci(workspace): name the affected-filter's decision instead of hiding it

### DIFF
--- a/.github/workflows/quality-full.yml
+++ b/.github/workflows/quality-full.yml
@@ -77,6 +77,7 @@ jobs:
       run: ${{ steps.decide.outputs.run }}
       shards: ${{ steps.matrix.outputs.shards }}
       any: ${{ steps.matrix.outputs.any }}
+      shard_count: ${{ steps.matrix.outputs.count }}
       heavy: ${{ steps.matrix.outputs.heavy }}
       build_shards: ${{ steps.build_matrix.outputs.build_shards }}
       build_any: ${{ steps.build_matrix.outputs.build_any }}
@@ -211,6 +212,56 @@ jobs:
             echo "run=false" >> "$GITHUB_OUTPUT"
             echo "::notice::No benchmark config, package source/manifest or size-metric input touched — skipping the config-load + size-metrics job."
           fi
+
+  # A skipped job leaves NO row in the PR's checks list. That makes an
+  # affected-filtered matrix that legitimately selected nothing look identical
+  # to a matrix step that broke: in both cases the "Unit Tests + Coverage"
+  # checks are simply absent, and the aggregate gate is green either way. The
+  # absence was read as a regression by a reviewer ("how come we run no unit
+  # tests now") — correct behaviour is not the same as visible behaviour.
+  #
+  # This job always runs and puts the decision in the checks list BY NAME, so
+  # the PR page states which of the two happened without anyone opening a log.
+  # It does no work: no checkout, no install, one echo. ~5s of a runner buys
+  # the difference between "verified nothing was affected" and "verified
+  # nothing".
+  test-scope:
+    name: "${{ needs.gate.outputs.any == 'true' && format('Unit tests — {0} of 10 shards affected', needs.gate.outputs.shard_count) || 'Unit tests SKIPPED — no package sources changed' }}"
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Report what the gate selected
+        env:
+          ANY: ${{ needs.gate.outputs.any }}
+          COUNT: ${{ needs.gate.outputs.shard_count }}
+          BUILD_ANY: ${{ needs.gate.outputs.build_any }}
+          HEAVY: ${{ needs.gate.outputs.heavy }}
+          BASE: ${{ github.event.pull_request.base.sha || 'origin/main' }}
+        run: |
+          set -euo pipefail
+          if [ "$ANY" = "true" ]; then
+            headline="Unit tests ran: ${COUNT} of 10 shards held affected packages."
+          else
+            headline="Unit tests skipped: no package source changed vs the base commit, so no shard had anything to run."
+          fi
+          {
+            echo "# ${headline}"
+            echo ""
+            echo "| Gate output | Value | Meaning |"
+            echo "|---|---|---|"
+            echo "| \`any\` | ${ANY} | whether any test shard was dispatched |"
+            echo "| \`shard_count\` | ${COUNT} | shards holding at least one affected package |"
+            echo "| \`build_any\` | ${BUILD_ANY} | whether any build shard was dispatched |"
+            echo "| \`heavy\` | ${HEAVY} | whether Typecheck / Portability were dispatched |"
+            echo ""
+            echo "Affected packages are computed against \`${BASE}\` by"
+            echo "\`scripts/ci-test-shard.mts --matrix 10\`. \`scripts/__tests__\` is outside every"
+            echo "workspace and runs unconditionally in **Script & Repo-Config Locks**, so a"
+            echo "skip here never means *nothing* was verified."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::notice::${headline}"
 
   # `scripts/` is not an npm workspace (`workspaces` is apps/*, packages/*,
   # tools/*, benchmarks), so turbo has no task for it and `turbo run test` never

--- a/scripts/__tests__/visible-test-scope-lock.test.ts
+++ b/scripts/__tests__/visible-test-scope-lock.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Lock: the affected-filter's decision must be VISIBLE on the PR.
+ *
+ * `quality-full.yml` dispatches only the test shards that hold an affected
+ * package. When a diff touches no package source the matrix is empty, every
+ * `Unit Tests + Coverage (n/10)` job's `if` evaluates false, and GitHub renders
+ * **no rows at all** for them. That is correct behaviour and it is
+ * indistinguishable, from the PR page, from the matrix step having broken —
+ * the failure mode this workflow's own guards exist to prevent. It was read as
+ * a regression in review ("how come we run no unit tests now").
+ *
+ * The `test-scope` job closes that gap by always running and naming the
+ * decision. Two things keep it honest, and this file pins both:
+ *
+ *   1. `scripts/ci-test-shard.mts` must emit `count` — the job name
+ *      interpolates it, and a missing output renders as an empty string.
+ *   2. The job must stay unconditional (beyond the workflow's own gate) and
+ *      must keep BOTH branches in its name, since a name that only ever says
+ *      "ran" is exactly as blind as no job.
+ *
+ * Run from the repo root:
+ *   npx vitest run scripts/__tests__/visible-test-scope-lock.test.ts
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const WORKFLOW = join(ROOT, '.github', 'workflows', 'quality-full.yml');
+const SHARD_SCRIPT = join(ROOT, 'scripts', 'ci-test-shard.mts');
+
+const workflow = readFileSync(WORKFLOW, 'utf8');
+
+/** The `test-scope:` block, up to the next job at the same indentation. */
+function jobBlock(name: string): string {
+  const start = workflow.indexOf(`\n  ${name}:\n`);
+  expect(start, `no \`${name}:\` job in quality-full.yml`).toBeGreaterThan(-1);
+  const rest = workflow.slice(start + 1);
+  const next = rest.slice(1).search(/\n {2}[a-z][a-z0-9-]*:\n/);
+  return next === -1 ? rest : rest.slice(0, next + 1);
+}
+
+describe('the test-scope job keeps the affected-filter decision visible', () => {
+  const block = jobBlock('test-scope');
+
+  it('runs whenever the workflow itself runs — never conditioned on `any`', () => {
+    const ifLine = /^\s+if:\s*(.+)$/m.exec(block)?.[1] ?? '';
+    expect(ifLine).toBe("needs.gate.outputs.run == 'true'");
+    // The whole point: gating this job on `any` would delete the very row that
+    // reports `any` was false.
+    expect(ifLine).not.toContain('any');
+  });
+
+  it('names both outcomes, so the check line states which one happened', () => {
+    const nameLine = /^\s+name:\s*(.+)$/m.exec(block)?.[1] ?? '';
+    expect(nameLine).toContain('needs.gate.outputs.any');
+    expect(nameLine).toMatch(/SKIPPED/);
+    expect(nameLine).toContain('needs.gate.outputs.shard_count');
+  });
+
+  it('reads shard_count from the gate, which reads it from the matrix step', () => {
+    expect(jobBlock('gate')).toContain(
+      'shard_count: ${{ steps.matrix.outputs.count }}',
+    );
+  });
+});
+
+describe('ci-test-shard.mts feeds it', () => {
+  it('emits a `count` output alongside `any`', () => {
+    const src = readFileSync(SHARD_SCRIPT, 'utf8');
+    // Pinned as one template literal: `any` and `count` are written by the same
+    // appendFileSync, so they cannot drift apart.
+    expect(src).toContain('count=${shardNumbers.length}');
+    expect(src).toContain('any=${shardNumbers.length > 0}');
+  });
+});

--- a/scripts/ci-test-shard.mts
+++ b/scripts/ci-test-shard.mts
@@ -181,7 +181,11 @@ function emitMatrix(shardNumbers: number[], heavy = true): void {
   if (process.env.GITHUB_OUTPUT) {
     fs.appendFileSync(
       process.env.GITHUB_OUTPUT,
-      `shards=${json}\nany=${shardNumbers.length > 0}\nheavy=${heavy}\n`,
+      // `count` exists purely so the workflow can NAME the decision. A skipped
+      // job leaves no row in the PR's checks list, so "0 shards affected" and
+      // "the matrix step broke" look identical from outside — see the
+      // `test-scope` job in quality-full.yml.
+      `shards=${json}\nany=${shardNumbers.length > 0}\ncount=${shardNumbers.length}\nheavy=${heavy}\n`,
     );
   }
 }


### PR DESCRIPTION
## Summary

- A skipped job leaves **no row** in the PR's checks list. When the affected filter legitimately selects nothing, the `Unit Tests + Coverage (n/10)` checks are simply absent — indistinguishable from a broken matrix step, with the aggregate gate green either way. That absence was read as a regression in review ("how come we run no unit tests now").
- Adds a `test-scope` job that always runs and names the decision in the checks list:
  - `Unit tests — 3 of 10 shards affected`
  - `Unit tests SKIPPED — no package sources changed`
- The job does no work: no checkout, no install, one echo, ~5s of a runner. Its step summary prints the four gate outputs behind the decision, plus the reminder that `scripts/__tests__` runs unconditionally in **Script & Repo-Config Locks**, so a skip never means *nothing* was verified.
- `scripts/ci-test-shard.mts` emits a `count` output beside `any` (same `appendFileSync`, so the two cannot drift) because the job name interpolates it and a missing output would render as an empty string.

## Test plan

- [x] `npm run test:scripts` — 73 files, 1859 tests, all pass.
- [x] Lock added: `scripts/__tests__/visible-test-scope-lock.test.ts` — the job must exist, must **not** be conditioned on `any` (gating it on `any` would delete the very row that reports `any` was false), must name both outcomes, and the script must keep emitting `count`.
- [x] Sabotage-proven: with both files reverted to `origin/main` the lock fails with ``no `test-scope:` job in quality-full.yml``; restored, it passes.
- [x] Matrix output proven both ways — `CI_TEST_SHARD_ALL=1` → `any=true count=10`; base=HEAD → `any=false count=0`.
- [x] Job's shell extracted from the YAML: `bash -n` clean, dry-run rendered the skipped-path summary correctly.

## After merge

This PR changes no package source, so its own run should show the **SKIPPED** name — which is the demonstration. The job name is dynamic and therefore cannot itself be a required check; it is informational. Required checks are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)