### PR TITLE
refactor(browser-security): delete the #409 husks, not just silence them

### DIFF
--- a/packages/eslint-plugin-browser-security/src/rules/no-filereader-innerhtml/index.ts
+++ b/packages/eslint-plugin-browser-security/src/rules/no-filereader-innerhtml/index.ts
@@ -121,74 +121,6 @@ export const noFilereaderInnerhtml = createRule<RuleOptions, MessageIds>({
       return {};
     }
 
-    // Track FileReader onload handlers
-
-    /**
-     * Check if we're in a FileReader onload assignment
-     */
-    function isFileReaderOnloadAssignment(
-      node: TSESTree.AssignmentExpression,
-    ): { isHandler: boolean; eventParam: string | null } {
-      if (
-        node.left.type === AST_NODE_TYPES.MemberExpression &&
-        node.left.property.type === AST_NODE_TYPES.Identifier &&
-        (node.left.property.name === 'onload' ||
-          node.left.property.name === 'onloadend')
-      ) {
-        // No receiver-NAME heuristic here. It used to require the name to
-        // contain 'reader'/'fr'/'r', which is narrower than the resolver that
-        // now decides ownership: `const f = new FileReader()` failed the name
-        // check while the resolver still attributed the payload to filereader,
-        // so no-innerhtml skipped it and THIS rule never fired — the finding
-        // vanished. The gate below (payloadSource === 'filereader') resolves
-        // the binding by construction, which is the correct question.
-        const handler = node.right;
-        if (
-          handler.type === AST_NODE_TYPES.ArrowFunctionExpression ||
-          handler.type === AST_NODE_TYPES.FunctionExpression
-        ) {
-          const firstParam = handler.params[0];
-          if (firstParam && firstParam.type === AST_NODE_TYPES.Identifier) {
-            return { isHandler: true, eventParam: firstParam.name };
-          }
-        }
-      }
-      return { isHandler: false, eventParam: null };
-    }
-
-    /**
-     * Check if we're in a FileReader addEventListener('load')
-     */
-    function isFileReaderAddEventListener(node: TSESTree.CallExpression): {
-      isHandler: boolean;
-      eventParam: string | null;
-    } {
-      if (
-        node.callee.type === AST_NODE_TYPES.MemberExpression &&
-        node.callee.property.type === AST_NODE_TYPES.Identifier &&
-        node.callee.property.name === 'addEventListener' &&
-        node.arguments.length >= 2
-      ) {
-        const eventType = node.arguments[0];
-        if (
-          eventType.type === AST_NODE_TYPES.Literal &&
-          (eventType.value === 'load' || eventType.value === 'loadend')
-        ) {
-          const callback = node.arguments[1];
-          if (
-            callback.type === AST_NODE_TYPES.ArrowFunctionExpression ||
-            callback.type === AST_NODE_TYPES.FunctionExpression
-          ) {
-            const firstParam = callback.params[0];
-            if (firstParam && firstParam.type === AST_NODE_TYPES.Identifier) {
-              return { isHandler: true, eventParam: firstParam.name };
-            }
-          }
-        }
-      }
-      return { isHandler: false, eventParam: null };
-    }
-
     // Ownership gate: this rule reports only what the resolver attributes
     // to the filereader source. Everything it cannot identify belongs to the
     // generic sink rule, so no value is ever reported by both.
@@ -222,19 +154,7 @@ export const noFilereaderInnerhtml = createRule<RuleOptions, MessageIds>({
         }
       },
 
-      'AssignmentExpression:exit'(node: TSESTree.AssignmentExpression) {
-        const { isHandler } = isFileReaderOnloadAssignment(node);
-        // Husk from #409 ("one rule per finding"): that refactor removed the
-        // body and the `eventParam` it used, leaving the guard behind. Deleting
-        // it also orphans the predicate above, so it is a two-part removal —
-        // tracked separately rather than half-cut here.
-        // eslint-disable-next-line no-empty
-        if (isHandler) {
-        }
-      },
-
       CallExpression(node: TSESTree.CallExpression) {
-        // Check if entering addEventListener handler
 
         // Same here — the resolver is the sink condition, not the mutable flag.
 
@@ -258,17 +178,6 @@ export const noFilereaderInnerhtml = createRule<RuleOptions, MessageIds>({
               break;
             }
           }
-        }
-      },
-
-      'CallExpression:exit'(node: TSESTree.CallExpression) {
-        const { isHandler } = isFileReaderAddEventListener(node);
-        // Husk from #409 ("one rule per finding"): that refactor removed the
-        // body and the `eventParam` it used, leaving the guard behind. Deleting
-        // it also orphans the predicate above, so it is a two-part removal —
-        // tracked separately rather than half-cut here.
-        // eslint-disable-next-line no-empty
-        if (isHandler) {
         }
       },
     };

--- a/packages/eslint-plugin-browser-security/src/rules/no-websocket-innerhtml/index.ts
+++ b/packages/eslint-plugin-browser-security/src/rules/no-websocket-innerhtml/index.ts
@@ -88,67 +88,6 @@ export const noWebsocketInnerhtml = createRule<RuleOptions, MessageIds>({
       return {};
     }
 
-    // Track WebSocket onmessage handlers
-
-    /**
-     * Check if we're in a WebSocket onmessage assignment
-     */
-    function isWsOnmessageAssignment(node: TSESTree.AssignmentExpression): {
-      isHandler: boolean;
-      eventParam: string | null;
-    } {
-      if (
-        node.left.type === AST_NODE_TYPES.MemberExpression &&
-        node.left.property.type === AST_NODE_TYPES.Identifier &&
-        node.left.property.name === 'onmessage'
-      ) {
-        const handler = node.right;
-        if (
-          handler.type === AST_NODE_TYPES.ArrowFunctionExpression ||
-          handler.type === AST_NODE_TYPES.FunctionExpression
-        ) {
-          const firstParam = handler.params[0];
-          if (firstParam && firstParam.type === AST_NODE_TYPES.Identifier) {
-            return { isHandler: true, eventParam: firstParam.name };
-          }
-        }
-      }
-      return { isHandler: false, eventParam: null };
-    }
-
-    /**
-     * Check if we're in a WebSocket addEventListener('message')
-     */
-    function isWsAddEventListener(node: TSESTree.CallExpression): {
-      isHandler: boolean;
-      eventParam: string | null;
-    } {
-      if (
-        node.callee.type === AST_NODE_TYPES.MemberExpression &&
-        node.callee.property.type === AST_NODE_TYPES.Identifier &&
-        node.callee.property.name === 'addEventListener' &&
-        node.arguments.length >= 2
-      ) {
-        const eventType = node.arguments[0];
-        if (
-          eventType.type === AST_NODE_TYPES.Literal &&
-          eventType.value === 'message'
-        ) {
-          const callback = node.arguments[1];
-          if (
-            callback.type === AST_NODE_TYPES.ArrowFunctionExpression ||
-            callback.type === AST_NODE_TYPES.FunctionExpression
-          ) {
-            const firstParam = callback.params[0];
-            if (firstParam && firstParam.type === AST_NODE_TYPES.Identifier) {
-              return { isHandler: true, eventParam: firstParam.name };
-            }
-          }
-        }
-      }
-      return { isHandler: false, eventParam: null };
-    }
-
     // Ownership gate: this rule reports only what the resolver attributes
     // to the websocket source. Everything it cannot identify belongs to the
     // generic sink rule, so no value is ever reported by both.
@@ -156,7 +95,6 @@ export const noWebsocketInnerhtml = createRule<RuleOptions, MessageIds>({
 
     return {
       AssignmentExpression(node: TSESTree.AssignmentExpression) {
-        // Check if this is ws.onmessage = handler
 
         // Check for innerHTML/outerHTML assignment within handler
         // The resolver is the sole sink condition. A mutable in-handler
@@ -181,19 +119,7 @@ export const noWebsocketInnerhtml = createRule<RuleOptions, MessageIds>({
         }
       },
 
-      'AssignmentExpression:exit'(node: TSESTree.AssignmentExpression) {
-        const { isHandler } = isWsOnmessageAssignment(node);
-        // Husk from #409 ("one rule per finding"): that refactor removed the
-        // body and the `eventParam` it used, leaving the guard behind. Deleting
-        // it also orphans the predicate above, so it is a two-part removal —
-        // tracked separately rather than half-cut here.
-        // eslint-disable-next-line no-empty
-        if (isHandler) {
-        }
-      },
-
       CallExpression(node: TSESTree.CallExpression) {
-        // Check if this is ws.addEventListener('message', handler)
 
         // Check for dangerous method calls within handler
         // The resolver is the sole sink condition. A mutable in-handler
@@ -218,17 +144,6 @@ export const noWebsocketInnerhtml = createRule<RuleOptions, MessageIds>({
               break;
             }
           }
-        }
-      },
-
-      'CallExpression:exit'(node: TSESTree.CallExpression) {
-        const { isHandler } = isWsAddEventListener(node);
-        // Husk from #409 ("one rule per finding"): that refactor removed the
-        // body and the `eventParam` it used, leaving the guard behind. Deleting
-        // it also orphans the predicate above, so it is a two-part removal —
-        // tracked separately rather than half-cut here.
-        // eslint-disable-next-line no-empty
-        if (isHandler) {
         }
       },
     };

--- a/packages/eslint-plugin-browser-security/src/rules/no-worker-message-innerhtml/index.ts
+++ b/packages/eslint-plugin-browser-security/src/rules/no-worker-message-innerhtml/index.ts
@@ -82,76 +82,6 @@ export const noWorkerMessageInnerhtml = createRule<RuleOptions, MessageIds>({
       return {};
     }
 
-    // Track Worker message handlers
-
-    /**
-     * Check if we're in a Worker onmessage assignment
-     */
-    function isWorkerOnmessageAssignment(node: TSESTree.AssignmentExpression): {
-      isHandler: boolean;
-      eventParam: string | null;
-    } {
-      if (
-        node.left.type === AST_NODE_TYPES.MemberExpression &&
-        node.left.property.type === AST_NODE_TYPES.Identifier &&
-        node.left.property.name === 'onmessage'
-      ) {
-        // No receiver-NAME gate. `const button = new Worker('w.js')` is a
-        // Worker whatever it is called; the name check made ownership depend
-        // on spelling, and combined with no-innerhtml's skip that meant the
-        // finding was reported by nobody. The resolver below identifies the
-        // binding by construction.
-        {
-          const handler = node.right;
-          if (
-            handler.type === AST_NODE_TYPES.ArrowFunctionExpression ||
-            handler.type === AST_NODE_TYPES.FunctionExpression
-          ) {
-            const firstParam = handler.params[0];
-            if (firstParam && firstParam.type === AST_NODE_TYPES.Identifier) {
-              return { isHandler: true, eventParam: firstParam.name };
-            }
-          }
-        }
-      }
-      return { isHandler: false, eventParam: null };
-    }
-
-    /**
-     * Check if we're in a Worker addEventListener('message')
-     */
-    function isWorkerAddEventListener(node: TSESTree.CallExpression): {
-      isHandler: boolean;
-      eventParam: string | null;
-    } {
-      if (
-        node.callee.type === AST_NODE_TYPES.MemberExpression &&
-        node.callee.property.type === AST_NODE_TYPES.Identifier &&
-        node.callee.property.name === 'addEventListener' &&
-        node.arguments.length >= 2
-      ) {
-        // Check if it's a message event
-        const eventType = node.arguments[0];
-        if (
-          eventType.type === AST_NODE_TYPES.Literal &&
-          eventType.value === 'message'
-        ) {
-          // Identified by construction, not by spelling — see the note above.
-          const callback = node.arguments[1];
-          if (
-            callback.type === AST_NODE_TYPES.ArrowFunctionExpression ||
-            callback.type === AST_NODE_TYPES.FunctionExpression
-          ) {
-            const firstParam = callback.params[0];
-            if (firstParam && firstParam.type === AST_NODE_TYPES.Identifier) {
-              return { isHandler: true, eventParam: firstParam.name };
-            }
-          }
-        }
-      }
-      return { isHandler: false, eventParam: null };
-    }
-
     // Ownership gate: this rule reports only what the resolver attributes
     // to the worker source. Everything it cannot identify belongs to the
     // generic sink rule, so no value is ever reported by both.
@@ -181,17 +111,6 @@ export const noWorkerMessageInnerhtml = createRule<RuleOptions, MessageIds>({
         }
       },
 
-      'AssignmentExpression:exit'(node: TSESTree.AssignmentExpression) {
-        const { isHandler } = isWorkerOnmessageAssignment(node);
-        // Husk from #409 ("one rule per finding"): that refactor removed the
-        // body and the `eventParam` it used, leaving the guard behind. Deleting
-        // it also orphans the predicate above, so it is a two-part removal —
-        // tracked separately rather than half-cut here.
-        // eslint-disable-next-line no-empty
-        if (isHandler) {
-        }
-      },
-
       CallExpression(node: TSESTree.CallExpression) {
 
         // Check for dangerous method calls within handler
@@ -215,17 +134,6 @@ export const noWorkerMessageInnerhtml = createRule<RuleOptions, MessageIds>({
               break;
             }
           }
-        }
-      },
-
-      'CallExpression:exit'(node: TSESTree.CallExpression) {
-        const { isHandler } = isWorkerAddEventListener(node);
-        // Husk from #409 ("one rule per finding"): that refactor removed the
-        // body and the `eventParam` it used, leaving the guard behind. Deleting
-        // it also orphans the predicate above, so it is a two-part removal —
-        // tracked separately rather than half-cut here.
-        // eslint-disable-next-line no-empty
-        if (isHandler) {
         }
       },
     };


### PR DESCRIPTION
## Summary

Finishes the removal that [#769](https://github.com/ofri-peretz/eslint/pull/769) had to defer.

#769 added `--deny-warnings` to `npm run oxlint` and cleared the backlog, but six warnings could not be cleared there: the empty `if (isHandler) {}` guards in three browser-security rules needed a two-part removal that broke the parse when attempted inline. They shipped suppressed, with a stated reason and a tracking comment. This is that removal.

```ts
'AssignmentExpression:exit'(node: TSESTree.AssignmentExpression) {
  const { isHandler } = isXOnmessageAssignment(node);
  // Husk from #409 ("one rule per finding"): that refactor removed the
  // body and the `eventParam` it used, leaving the guard behind. ...
  // eslint-disable-next-line no-empty
  if (isHandler) {
  }
},
```

The guards are husks from [#409](https://github.com/ofri-peretz/eslint/pull/409) (*"one rule per finding, and check the source you claim"*), which took the body and the `eventParam` it destructured and left the guard standing. Dead, not unimplemented — confirmed via `git log -S`: `createPayloadResolver` has been the sole ownership gate since #409, and these predicates fed nothing but a discarded boolean.

**Both halves go together**, which is exactly what made it a two-parter. Deleting only the visitors strands the predicates and turns 6 warnings into 6 `no-unused-vars` **errors**:

1. the six `AssignmentExpression:exit` / `CallExpression:exit` visitors
2. the six predicates they were the only callers of — `isWorkerOnmessageAssignment`, `isWorkerAddEventListener`, `isWsOnmessageAssignment`, `isWsAddEventListener`, `isFileReaderOnloadAssignment`, `isFileReaderAddEventListener`

With the code gone, #769's scaffolding goes too: the four-line `// Husk from #409 ...` comment and the `// eslint-disable-next-line no-empty` above each guard. Also drops three one-line comments that narrated the deleted tracking (`// Check if this is ws.onmessage = handler` and friends) and described nothing.

Done as precise per-function edits rather than brace counting — `isFileReaderOnloadAssignment` has a multi-line signature that a naive cut splits, orphaning the body (the failure mode #769 hit). Each file re-read afterwards.

**Pure deletion — 268 lines removed, zero added.** No reporting path is touched: the `AssignmentExpression` / `CallExpression` visitors that call `context.report` are byte-identical.

## Test plan

- [x] `npm run oxlint` — **exit 0, zero findings**, now genuinely under `--deny-warnings`. Proven both directions: planting one empty block back makes it exit 1 with a `no-empty` finding; the clean tree exits 0. A quiet gate that was never proven able to go red proves nothing.
- [x] `npx turbo run test --filter=eslint-plugin-browser-security` — **62 files, 2952 tests passed**. Coverage held at **100%** statements / branches / functions / lines, so no rule's reported findings moved.
- [x] `npm run typecheck` (whole-graph tsgo) — exit 0.
- [x] Pre-commit gates: oxlint, scope-audit, rule-audit ratchet, shim-drift, stale-build-artifacts, tests-affected.
- [x] Pre-push battery: typecheck, build-and-test, portability, shim-drift, lockfile, changelog.

Verified in a fresh worktree branched from `origin/main` with a real `npm install` (no symlinked `node_modules`), so `@interlace/*` resolved to this branch's own packages rather than whichever branch another checkout sits on.

## Note on the history of this branch

This PR was first pushed from `b43128d39`, before #769 merged. At that base the suppression comments did not exist yet and `npm run oxlint` had no `--deny-warnings`, so the first revision removed the visitors and predicates only, and reported 9 leftover warnings elsewhere in the repo. #769 then landed on `main`, fixed those 9, added the gate, and suppressed these 6 — conflicting with all three files.

The branch was rebuilt from scratch on top of `a9c395f2c` rather than merge-resolved, so the diff stays a clean pure deletion against current `main`. The leftover-warning table in the original description is obsolete: #769 fixed every one of them, and this PR takes the repo to zero.

## After merge

Removes 268 lines of dead code from three published rules and the suppression #769 had to leave behind — `npm run oxlint --deny-warnings` is clean with no outstanding `no-empty` exemptions. No behavior change ships to consumers: detection logic is untouched and every fixture reports identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified security linting rules for FileReader, WebSocket, and Worker message data.
  * Preserved existing detection and reporting of unsafe HTML assignments and method calls.
  * Improved sink analysis by relying on direct payload attribution rather than handler tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->