### PR TITLE
docs(ci): shard count assumes a runner budget we do not have

### DIFF
--- a/docs/intents/shard-count-from-measurement/design.md
+++ b/docs/intents/shard-count-from-measurement/design.md
@@ -1,0 +1,80 @@
+# Design — `shard-count-from-measurement`
+
+Intent: [`intent.md`](./intent.md). **Status:** draft.
+
+---
+
+## Requirements
+
+- **R1** The test matrix dispatches at most **4** shards, down from 10.
+- **R2** The shard total is stated in exactly one place per script. A shard job
+  that computes its slice with a different `M` than the matrix was built with
+  silently skips packages, and the gate reports success.
+- **R3** `SPLIT_ACROSS_SHARDS` slice counts stay ≥ the shard total for the one
+  package big enough to need slicing (`docs`), so the largest single unit
+  cannot exceed a shard's fair share. LPT cannot beat the largest item.
+- **R4** Coverage runs are untouched: `wantCoverage` still forces `slices = 1`.
+- **R5** `timeout-minutes` on the test job accounts for a cold shard now
+  carrying ~2.5× the packages it did at 10 shards.
+- **R6** The `test-scope` job's name reports the new total, not a stale literal.
+
+## Design
+
+One number changes; the work is making sure it is one number.
+
+1. `scripts/ci-test-shard.mts` — introduce `SHARD_TOTAL` as the single source
+   of truth, and have `--matrix` default to it. The workflow stops passing a
+   literal (R2).
+2. `.github/workflows/quality-full.yml` — `Unit Tests + Coverage (n/4)`, the
+   matrix step, and the `test-scope` name all read from the same place (R1, R6).
+3. `SPLIT_ACROSS_SHARDS: { docs: 6 }` stays. Six slices over four shards is
+   still a finer grain than four, and `docs` is the one package that dominates
+   a shard on its own (R3).
+4. Raise the test job's `timeout-minutes` in proportion (R5).
+
+Order matters: the script change lands first and is provable locally
+(`--matrix` output is a pure function of the tree), then the workflow follows.
+
+## Verification
+
+```bash
+npx vitest run scripts/__tests__/ci-shard-affected.test.ts \
+                scripts/__tests__/visible-test-scope-lock.test.ts
+```
+
+The lock that must exist and does not yet: **every package the discovery step
+finds is assigned to exactly one shard in `1..SHARD_TOTAL`**. Today nothing
+proves partition — a bug that dropped packages off the end of the range would
+shrink the matrix, every dispatched shard would pass, and the gate would be
+green having tested less. That test is the one that fails if R2 is violated,
+and it must be written against a fixed fixture tree rather than the live repo,
+so it does not go vacuous the day the package list changes.
+
+The success criteria in the intent are measured from the run itself, not from
+a test: re-run the `gh api .../jobs` command on the first wide PR after merge
+and compare the three numbers.
+
+## Rejected alternatives
+
+- **Drop to 1 shard.** Sums to ~43s of tests + ~20s overhead ≈ 63s in one job —
+  over target on its own, with no headroom for a cold cache, and it makes the
+  test step the critical path with nothing to overlap it.
+- **Keep 10 shards and shrink `setup`.** The 133s is `npm ci` plus toolchain;
+  even halving it leaves 10 × ~10s of tax to save 4s of work each. The tax is
+  per-job, so the fix is fewer jobs, not cheaper ones. (Worth doing anyway —
+  separate intent, it also speeds the jobs that remain.)
+- **Duration-weighted bin-packing instead of file counts.** Better balance
+  within a wave, but it does not reduce job count, which is what the queue
+  charges for. Revisit only after the count is right, and only with a results
+  database — the current cost proxy has no state to drift.
+- **Raise the concurrency ceiling.** Not ours to raise; the repo is public and
+  already on free unlimited minutes. Minutes were never the constraint —
+  simultaneous slots are.
+
+## Out of scope
+
+- The build matrix (`--matrix 4`) — already at four, already within budget.
+- `setup` cost reduction (its own intent, per the rejected alternative above).
+- The merge queue, which attacks run *amplification* across PRs rather than
+  latency within one. Blocked separately on
+  [`../merge-latency/design.md`](../merge-latency/design.md).

--- a/docs/intents/shard-count-from-measurement/intent.md
+++ b/docs/intents/shard-count-from-measurement/intent.md
@@ -1,0 +1,99 @@
+# Intent — `shard-count-from-measurement`
+
+**Status:** draft · **Opened:** `2026-08-30` · **Owner:** `@ofri-peretz`
+
+---
+
+## What is wanted
+
+The heavy gate finishes a wide-blast-radius PR in **under 60 seconds**, the same
+target the narrow case already meets. No check is removed, no coverage
+threshold is lowered, and no assertion stops running.
+
+## Why now
+
+Measured on run
+[33337052316](https://github.com/ofri-peretz/eslint/actions/runs/33337052316)
+(PR #770, all 10 test shards selected). Wall clock **261s**. Step-level timings
+across the ten shard jobs:
+
+| | total across 10 jobs |
+|---|---|
+| `./.github/actions/setup` | **133s** |
+| `actions/checkout` | **31s** |
+| **actual `Run shard N of 10`** | **43s** |
+
+Every test in the repository runs in **43 seconds**. Getting to them cost
+**164 seconds** of per-job overhead, paid ten times. Overhead:work is **3.8:1**.
+
+The wall clock is worse than either number, because the jobs did not run
+concurrently. All 18 jobs were *created* at `21:40:13`; they *started* between
+`21:40:33` and `21:43:39` — a **186-second** spread, in waves of about six:
+
+```
+21:40:33  Benchmark configs load        21:42:57  Unit Tests (1/10)
+21:40:35  Typecheck                     21:43:19  Unit Tests (9/10)
+21:41:03  Portability Audit             21:43:26  Unit Tests (4/10)
+21:41:11  Build (1/4)                   21:43:27  Unit Tests (10/10)
+21:41:20  Unit Tests (7/10)             21:43:28  Unit Tests (6/10)
+21:42:28  Unit Tests (8/10)             21:43:30  Build (3/4)
+21:42:39  Unit Tests (2/10)             21:43:32  Unit Tests (5/10)
+21:42:53  Script & Repo-Config Locks    21:43:34  Unit Tests (3/10)
+21:42:54  Build (4/4)
+21:42:56  Build (2/4)
+```
+
+Observed effective concurrency is **~6 jobs**, not the ~20 the earlier
+sharding work assumed. At six slots, 18 jobs is three serial waves. Roughly
+**80% of the 261s is queueing**, and the queue is fed by our own job count.
+
+This inverts the reasoning behind `--matrix 10`. That number was chosen when
+runners were assumed plentiful and the goal was to spread work thin. Under a
+six-slot ceiling, each additional shard adds a **~20s setup tax** and one more
+claim on the scarce resource, to remove ~4s of test work. Past about four
+shards we are paying to go slower.
+
+Reproduce:
+
+```bash
+gh api repos/ofri-peretz/eslint/actions/runs/<id>/jobs --paginate \
+  --jq '.jobs[] | "\(.started_at)  \(.completed_at)  \(.name)"' | sort
+```
+
+## Affected users and systems
+
+`.github/workflows/quality-full.yml` (test matrix, build matrix, the
+`test-scope` report), `scripts/ci-test-shard.mts` (`SPLIT_ACROSS_SHARDS`), and
+every contributor and agent waiting on the gate. Nothing published moves.
+
+## Constraints
+
+- **No check may be dropped or weakened.** This is a scheduling change only:
+  the same test files run, with the same assertions.
+- **Coverage stays whole-package.** `CI_TEST_SHARD_COVERAGE=1` (the daily
+  Codecov job) must keep seeing unsliced packages — slicing hides files from a
+  slice and the 100% thresholds fail.
+- **Cold-cache runs must not regress past the timeout.** Fewer shards means
+  more work per shard when turbo misses; `timeout-minutes` has to still hold.
+- The affected filter stays. Narrow PRs already finish in ~59s and must not
+  get slower.
+
+## Success criteria
+
+1. A PR whose diff selects **every** shard completes the `Quality (Full) Gate`
+   in **≤ 60s** wall clock, measured the same way as the baseline above.
+2. Total jobs dispatched by `quality-full.yml` on such a PR drops from 18 to
+   **≤ 12**, so the run fits in two waves at the observed ceiling.
+3. Sum of `Run shard N of M` step durations stays within noise of 43s — proof
+   the work was rescheduled, not removed.
+4. The narrow-PR case stays at or under its current ~59s.
+
+## Open questions
+
+- Is the ~6-slot ceiling a property of the account, or an artefact of the
+  other worktrees' PRs running concurrently at the time of measurement? The
+  baseline must be re-taken on a quiet repo before the shard count is treated
+  as tuned rather than guessed.
+- Cold-cache cost per shard is unmeasured. Every timing above is from a warm
+  turbo cache; the failing shard 4 on PR #769 had to build a package from
+  scratch, which is the case that sets `timeout-minutes`.


### PR DESCRIPTION
## Summary

Intent + design only — **no behaviour change**. Opening it because the measurement contradicts an assumption the current CI shape is built on, and that belongs in a reviewable artifact before anyone acts on it.

Measured on [run 33337052316](https://github.com/ofri-peretz/eslint/actions/runs/33337052316) (PR #770, all 10 test shards selected). Wall clock **261s**:

| across the 10 shard jobs | |
|---|---|
| `./.github/actions/setup` | **133s** |
| `actions/checkout` | **31s** |
| actual `Run shard N of 10` | **43s** |

**Every test in the repo runs in 43 seconds.** Reaching them cost 164s of per-job overhead, paid ten times — 3.8:1.

The wall clock is worse than either number because the jobs did not run concurrently. All 18 were *created* at `21:40:13` and *started* between `21:40:33` and `21:43:39`, in waves of about six. Observed effective concurrency is **~6 slots**, not the ~20 the original sharding work assumed — so **~80% of the 261s is queueing**, and the queue is fed by our own job count.

That inverts the reasoning behind `--matrix 10`. Under a six-slot ceiling, each extra shard adds a ~20s setup tax and one more claim on the scarce resource in order to remove ~4s of test work. Past about four shards we are paying to go slower.

## What this PR deliberately does NOT do

It does not change the shard count. The design's own open question is whether the ~6-slot ceiling belongs to the account or is an artefact of the several worktree PRs running concurrently during the measurement — **including mine**. Acting on a confounded number is the failure that CLAUDE.md's "measure before you design" rule exists to stop, so the number gets re-taken on a quiet repo first.

The design also names a lock that **does not exist yet**: nothing today proves every discovered package lands in exactly one shard in `1..M`. A partition bug would shrink the matrix, every dispatched shard would pass, and the gate would be green having tested less.

## Test plan

- [x] No code changed — two new files under `docs/intents/shard-count-from-measurement/`.
- [x] Every number cited is reproducible:
  ```
  gh api repos/ofri-peretz/eslint/actions/runs/33337052316/jobs --paginate \
    --jq '.jobs[] | "\(.started_at)  \(.completed_at)  \(.name)"' | sort
  ```

## After merge

Re-measure on a quiet repo, then implement (4 shards, a single-source `SHARD_TOTAL`, and the partition lock). Rejected alternatives are recorded in the design so they don't get re-proposed: 1 shard (~63s, over target on its own), cheaper `setup` (worth doing, but the tax is per-job so the fix is fewer jobs), duration-weighted packing (better balance, same job count — the queue charges for count), and raising the ceiling (not ours to raise; minutes were never the constraint, simultaneous slots are).

🤖 Generated with [Claude Code](https://claude.com/claude-code)