### PR TITLE
fix(release): changeset:version regenerates the link-and-name map

### DIFF
--- a/.changeset/version-regenerates-name-map.md
+++ b/.changeset/version-regenerates-name-map.md
@@ -1,0 +1,17 @@
+---
+---
+
+fix(release): `changeset:version` now regenerates the link-and-name map
+
+A version bump changes package versions, and `.agent/link-and-name-map.md`
+records them. It was not regenerated with the rest, so it went stale on the
+**Version PR itself** — the one PR that has to be mergeable for anything to
+publish — and `link-and-name-map.lock` failed there every release.
+
+The failure is quiet in the worst way: it does not break a package, it blocks
+the release, and it surfaces as an unrelated-looking lint failure on a bot PR
+that nobody reads closely. It needed a hand-written commit each time to clear.
+
+Added to the same chain that already regenerates the lockfile, the in-source
+version constants and the CHANGELOGs. A lock asserts all four, so dropping any
+one of them fails a test instead of a release.

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "changeset:status": "env -u GIT_DIR changeset status --since=origin/main",
     "changeset:coverage": "tsx scripts/check-changeset-coverage.ts",
     "changeset:lint": "tsx scripts/lint-changesets.ts",
-    "changeset:version": "changeset version && tsx scripts/normalize-changelogs.ts && tsx scripts/sync-source-versions.ts && npm install --package-lock-only",
+    "changeset:version": "changeset version && tsx scripts/normalize-changelogs.ts && tsx scripts/sync-source-versions.ts && npm install --package-lock-only && tsx scripts/map-links-and-names.ts",
     "changeset:pre:enter": "changeset pre enter",
     "changeset:pre:exit": "changeset pre exit",
     "changeset:snapshot": "changeset version --snapshot canary && tsx scripts/normalize-changelogs.ts",

--- a/scripts/__tests__/version-regenerates-generated-files.test.ts
+++ b/scripts/__tests__/version-regenerates-generated-files.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Lock: `changeset:version` regenerates everything a version bump invalidates.
+ *
+ * A bump changes package versions, and several checked-in artifacts record
+ * them. Whatever is not regenerated in the same command goes stale on the
+ * **Version PR itself** — the one PR that must be mergeable for anything to
+ * publish. `.agent/link-and-name-map.md` did exactly that: `link-and-name-map`
+ * failed on the release PR, and it needed a hand-written commit every release
+ * to clear it.
+ *
+ * The failure mode is quiet in the worst way. It does not break a package; it
+ * blocks the release and looks like an unrelated lint failure on a bot PR that
+ * nobody reads closely.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const ROOT = resolve(__dirname, '..', '..');
+
+/** Each entry: a generator, and the artifact that goes stale without it. */
+const REGENERATED = [
+  { script: 'npm install --package-lock-only', artifact: 'package-lock.json' },
+  {
+    script: 'scripts/sync-source-versions.ts',
+    artifact: 'in-source version constants',
+  },
+  { script: 'scripts/normalize-changelogs.ts', artifact: 'package CHANGELOGs' },
+  {
+    script: 'scripts/map-links-and-names.ts',
+    artifact: '.agent/link-and-name-map.md',
+  },
+];
+
+describe('changeset:version', () => {
+  const version = (
+    JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf-8')) as {
+      scripts: Record<string, string>;
+    }
+  ).scripts['changeset:version'];
+
+  it('exists', () => {
+    expect(version, 'changeset:version script is missing').toBeDefined();
+  });
+
+  it.each(REGENERATED)('regenerates $artifact', ({ script, artifact }) => {
+    expect(
+      version.includes(script),
+      `changeset:version does not run ${script}, so ${artifact} goes stale on ` +
+        'the Version PR and blocks the release until someone commits it by hand.',
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## The release PR was failing its own lint

A version bump changes package versions, and `.agent/link-and-name-map.md` records them. It was not regenerated alongside the lockfile, the in-source version constants and the CHANGELOGs — so it went stale on the **Version PR itself**, the one PR that has to be mergeable for anything to publish:

```
AssertionError: ❌ .agent/link-and-name-map.md is out of date —
run `npm run map:names` and commit the result.
```

I just cleared it by hand on [#767](https://github.com/ofri-peretz/eslint/pull/767) (diff: five version numbers, nothing else). Without this, that hand-written commit is needed **every release**.

## Why it hid

It does not break a package. It blocks the release, and it surfaces as an unrelated-looking lint failure on a bot-generated PR that nobody reads closely — the same shape as the changesets-action drift in [#757](https://github.com/ofri-peretz/eslint/pull/757), where a broken release path looked like ordinary CI noise.

## The change

One entry appended to the chain that already exists:

```
changeset version
  && normalize-changelogs.ts
  && sync-source-versions.ts
  && npm install --package-lock-only
  && map-links-and-names.ts        ← added
```

`scripts/__tests__/version-regenerates-generated-files.test.ts` asserts **all four**, each with the artifact it keeps fresh, so the next thing added to the release chain is covered by the same rule rather than rediscovered on a red release PR.

## Test plan

- [x] `vitest scripts/__tests__/version-regenerates-generated-files.test.ts` — 5 pass.
- [x] **Verified by sabotage**: removing the map step fails the lock; restoring passes.
- [x] Ran `map-links-and-names.ts` on the Version PR branch — regenerated cleanly, lock passes, diff is version numbers only.
- [x] `lint-changesets`, prettier, markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)