### PR TITLE
fix(scripts): corpus scan retries registry propagation, and nothing else

### DIFF
--- a/.changeset/corpus-scan-registry-retry.md
+++ b/.changeset/corpus-scan-registry-retry.md
@@ -1,0 +1,23 @@
+---
+---
+
+fix(scripts): the corpus scan retries registry propagation, and nothing else
+
+`Scan pinned corpus` installs the plugin versions a release just published. For
+the minute or two before the registry serves them everywhere, that install 404s
+— so one green release turns every open PR red at once. It happened five times
+in a single evening; every pinned dependency resolved by hand minutes later.
+
+The cost is not the red run. It is the habit: a required check that cries wolf
+gets re-run reflexively, and the day it fails for a real reason — a corpus
+regression, a genuinely missing version — nobody reads it.
+
+Three attempts, ten seconds apart, and **only for a resolution failure**:
+`E404`, `ETARGET`, `No matching version found`, `is not in this registry`. A
+dependency conflict, a bad lockfile, ENOSPC or a permissions error fails on the
+first attempt exactly as before. A blanket retry would have been the wolf-crying
+this exists to prevent.
+
+Locked on both halves — that the transient cases retry, and that five real
+failures do not. Verified by sabotage: widening the predicate to `return true`
+fails five assertions, removing the attempt cap fails one.

--- a/scripts/__tests__/corpus-scan-modes.test.ts
+++ b/scripts/__tests__/corpus-scan-modes.test.ts
@@ -58,8 +58,17 @@ describe('corpus-scan modes', () => {
     // cannot identify the code — npm would serve the previous build from cache
     // and the run would silently measure something else. This exact bug cost a
     // day: no-magic-numbers read 1,635 against a fresh 1,421.
-    expect(SOURCE).toMatch(/local \? `\$\{plugin\}:local:\$\{distHash\(plugin\)\}`/);
-    expect(SOURCE).toContain('`${plugin}@${publishedVersion(plugin)}`');
+    //
+    // Matched whitespace-insensitively. The first version of this assertion
+    // pinned the ternary's single-line layout, so it broke the moment an
+    // unrelated edit made the file long enough for prettier to wrap it across
+    // three lines — a lock failing on formatting says nothing about the
+    // behaviour it names, and trains people to reformat until it passes.
+    const collapsed = SOURCE.replace(/\s+/g, ' ');
+    expect(collapsed).toContain(
+      'local ? `${plugin}:local:${distHash(plugin)}`',
+    );
+    expect(collapsed).toContain('`${plugin}@${publishedVersion(plugin)}`');
   });
 
   it('installs the devkit FROM THE WORKING TREE in local mode', () => {
@@ -85,7 +94,9 @@ describe('corpus-scan modes', () => {
     // Hashing only the plugins left a devkit-only change stamped as unchanged,
     // so the rig kept its stale copy. Adding an export made it loud; changing
     // an existing one is silent.
-    expect(SOURCE).toContain("`eslint-devkit:local:${distHash('eslint-devkit')}`");
+    expect(SOURCE).toContain(
+      "`eslint-devkit:local:${distHash('eslint-devkit')}`",
+    );
   });
 
   it('gives the rig a private npm cache and drops it on rebuild', () => {
@@ -106,15 +117,21 @@ describe('corpus-scan modes', () => {
     expect(SOURCE).toContain("'--install-targets'");
     expect(SOURCE).toContain("'--ignore-scripts'");
     // Off by default: it costs minutes and gigabytes and the gate runs per PR.
-    expect(SOURCE).toMatch(/installTargets = process\.argv\.includes\('--install-targets'\)/);
+    expect(SOURCE).toMatch(
+      /installTargets = process\.argv\.includes\('--install-targets'\)/,
+    );
   });
 
   it('stops excluding the dependency-dependent rules once targets are installed', () => {
     // Without an install, `no-unresolved` answers a question about the clone.
     // With one, it answers a question about the rule — measured on
     // auth0/express-openid-connect, 86 findings went to 0.
-    expect(SOURCE).toContain('function unmeasurableRules(targetsInstalled: boolean)');
-    expect(SOURCE).toMatch(/targetsInstalled \? new Set<string>\(\) : DEPENDENCY_DEPENDENT_RULES/);
+    expect(SOURCE).toContain(
+      'function unmeasurableRules(targetsInstalled: boolean)',
+    );
+    expect(SOURCE).toMatch(
+      /targetsInstalled \? new Set<string>\(\) : DEPENDENCY_DEPENDENT_RULES/,
+    );
     expect(SOURCE).toContain("'import-next/no-unresolved'");
   });
 
@@ -136,9 +153,10 @@ describe('corpus-scan modes', () => {
     // before and after an install. It was excluded by association with
     // `no-unresolved` and 3,147 findings were invisible to this gate for no
     // reason. An exclusion needs the same evidence as a budget.
-    const excluded = /DEPENDENCY_DEPENDENT_RULES: ReadonlySet<string> = new Set\(\[([\s\S]*?)\]\)/.exec(
-      SOURCE,
-    );
+    const excluded =
+      /DEPENDENCY_DEPENDENT_RULES: ReadonlySet<string> = new Set\(\[([\s\S]*?)\]\)/.exec(
+        SOURCE,
+      );
     expect(excluded).not.toBeNull();
     expect(excluded?.[1]).not.toContain('no-extraneous-dependencies');
   });
@@ -147,6 +165,8 @@ describe('corpus-scan modes', () => {
     // Several targets are pnpm or yarn workspaces whose tree npm cannot always
     // reproduce. The run still has something true to say about every rule that
     // does not depend on it.
-    expect(SOURCE).toMatch(/failed to install; its dependency-dependent findings/);
+    expect(SOURCE).toMatch(
+      /failed to install; its dependency-dependent findings/,
+    );
   });
 });

--- a/scripts/__tests__/corpus-scan-registry-retry.test.ts
+++ b/scripts/__tests__/corpus-scan-registry-retry.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Lock: the rig install retries registry propagation, and nothing else.
+ *
+ * `Scan pinned corpus` installs the plugin versions a release just published.
+ * For the minute or two before the registry serves them everywhere, that
+ * install 404s — so one green release turns every open PR red at once. Seen
+ * five times in a single evening, each time resolving by hand minutes later.
+ *
+ * The danger in the fix is wider than the bug. A blanket retry would also
+ * paper over a dependency conflict, a bad lockfile or a disk-full — and a
+ * required check that retries its way to green is worse than one that fails,
+ * because "just re-run it" becomes the reflex and the day it means something
+ * nobody reads it.
+ *
+ * So this asserts BOTH halves: propagation lag is recognised, and everything
+ * else is not.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const SOURCE = readFileSync(
+  resolve(__dirname, '..', 'corpus-scan.ts'),
+  'utf-8',
+);
+
+/** Rebuilt from source so the test cannot drift from the shipped predicate. */
+function looksLikePropagationLag(output: string): boolean {
+  const body =
+    /function looksLikePropagationLag\([^)]*\)[^{]*\{([\s\S]*?)\n\}/.exec(
+      SOURCE,
+    );
+  if (!body)
+    throw new Error('looksLikePropagationLag not found in corpus-scan.ts');
+  // eslint-disable-next-line no-new-func -- reading the real predicate, not a copy
+  return new Function('output', body[1])(output) as boolean;
+}
+
+describe('registry propagation retry', () => {
+  it('only the rig install is retried', () => {
+    // Retrying every `sh` would retry git clones and eslint runs too.
+    expect(SOURCE).toContain('shWithRegistryRetry(');
+    expect((SOURCE.match(/shWithRegistryRetry\(\s*'npm'/g) ?? []).length).toBe(
+      1,
+    );
+  });
+
+  it('gives up rather than retrying forever', () => {
+    expect(SOURCE).toMatch(/REGISTRY_PROPAGATION_RETRIES\s*=\s*[1-9]/);
+    expect(SOURCE).toMatch(/attempt >= REGISTRY_PROPAGATION_RETRIES/);
+  });
+
+  it.each([
+    [
+      'E404 npm ERR! 404 Not Found - GET https://registry.npmjs.org/eslint-plugin-x',
+    ],
+    ['npm ERR! notarget No matching version found for eslint-plugin-x@2.0.7'],
+    ['npm ERR! code ETARGET'],
+    ['eslint-plugin-x is not in this registry'],
+  ])('retries transient resolution failure: %s', (output) => {
+    expect(looksLikePropagationLag(output)).toBe(true);
+  });
+
+  it.each([
+    ['npm ERR! ERESOLVE unable to resolve dependency tree'],
+    ['npm ERR! code ENOSPC', 'disk full'],
+    ['npm ERR! Cannot read properties of undefined', 'a broken lockfile'],
+    ['npm ERR! EACCES: permission denied'],
+    ['3 rule(s) over budget', 'a real corpus regression'],
+  ])('does NOT retry %s', (output) => {
+    expect(looksLikePropagationLag(output)).toBe(false);
+  });
+});

--- a/scripts/corpus-scan.ts
+++ b/scripts/corpus-scan.ts
@@ -51,7 +51,13 @@
  */
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { existsSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import path from 'node:path';
 import { SCAN_IGNORES } from './lib/corpus-scan-ignores.ts';
 import { ensurePrivateDir, resolveCacheHome } from './lib/private-cache-dir.ts';
@@ -99,13 +105,28 @@ const PLUGINS = [
 // Advancing a pin is now a deliberate commit that shows up in review, which is
 // the same standard `--update` already applies to the budget itself.
 const TARGETS: ReadonlyArray<{ repo: string; ref: string }> = [
-  { repo: 'okta/okta-auth-js', ref: '17efe6a87db904c7bf8de9abb8e5961580f6a30c' },
-  { repo: 'auth0/express-openid-connect', ref: '94a08dd6c214a5a427a70110898e0e2099e5daab' },
+  {
+    repo: 'okta/okta-auth-js',
+    ref: '17efe6a87db904c7bf8de9abb8e5961580f6a30c',
+  },
+  {
+    repo: 'auth0/express-openid-connect',
+    ref: '94a08dd6c214a5a427a70110898e0e2099e5daab',
+  },
   { repo: 'stripe/stripe-js', ref: '16f79edb92e1e74c8da01c975cf85520b8f14c5b' },
-  { repo: 'twilio/twilio-node', ref: 'c8a4c27de84ec3838726da878cb9ca04a438ec59' },
+  {
+    repo: 'twilio/twilio-node',
+    ref: 'c8a4c27de84ec3838726da878cb9ca04a438ec59',
+  },
   { repo: 'redis/ioredis', ref: 'c0cd66cad8bc3d6fb02e2021f32ae2a88506ee97' },
-  { repo: 'paypal/paypal-checkout-components', ref: '861ab38f819840054eaed903bfc1ce32eb9b535f' },
-  { repo: 'okta/okta-signin-widget', ref: '0fec2f240ae83e5303c2e5e822989e7f82a3eaec' },
+  {
+    repo: 'paypal/paypal-checkout-components',
+    ref: '861ab38f819840054eaed903bfc1ce32eb9b535f',
+  },
+  {
+    repo: 'okta/okta-signin-widget',
+    ref: '0fec2f240ae83e5303c2e5e822989e7f82a3eaec',
+  },
   { repo: 'Shopify/cli', ref: 'cdcb458232c1482f13ae502b72112afb827f9135' },
 ];
 
@@ -190,12 +211,16 @@ function unmeasurableRules(targetsInstalled: boolean): ReadonlySet<string> {
 // change fixes — so they are gone rather than left as a second way to pin.
 
 function lockedVersion(name: string): string {
-  const lock = JSON.parse(readFileSync(path.join(ROOT, 'package-lock.json'), 'utf-8')) as {
+  const lock = JSON.parse(
+    readFileSync(path.join(ROOT, 'package-lock.json'), 'utf-8'),
+  ) as {
     packages: Record<string, { version?: string } | undefined>;
   };
   const version = lock.packages[`node_modules/${name}`]?.version;
   if (!version) {
-    throw new Error(`no resolved version for ${name} in package-lock.json — cannot pin the scan rig`);
+    throw new Error(
+      `no resolved version for ${name} in package-lock.json — cannot pin the scan rig`,
+    );
   }
   return version;
 }
@@ -313,6 +338,74 @@ interface Budget {
   triage?: Record<string, string>;
 }
 
+/**
+ * npm registry propagation is not instant, and this scan installs the versions
+ * a release *just published*.
+ *
+ * Every open PR runs `Scan pinned corpus`, and it resolves the published plugin
+ * versions from the lockfile. Publish six packages and, for the minute or two
+ * before the registry serves them everywhere, that install 404s — so a green
+ * release turns the whole PR queue red at once. Observed five times in one
+ * evening; every pinned dependency resolved by hand minutes later.
+ *
+ * The cost of no retry is not the red run, it is the habit: a required check
+ * that cries wolf gets re-run reflexively, and the day it fails for a real
+ * reason — a corpus regression, a genuinely missing version — nobody reads it.
+ *
+ * Deliberately narrow. Only a *resolution* failure is retried, because that is
+ * the one with a known transient cause. A dependency conflict, a bad lockfile
+ * or an ENOSPC fails on the first attempt exactly as before; retrying those
+ * would be the wolf-crying this exists to prevent.
+ */
+const REGISTRY_PROPAGATION_RETRIES = 3;
+const REGISTRY_RETRY_DELAY_MS = 10_000;
+
+/** Does this npm failure look like "published, not visible yet"? */
+function looksLikePropagationLag(output: string): boolean {
+  return (
+    /\bE404\b/.test(output) ||
+    /No matching version found for/i.test(output) ||
+    /is not in this registry/i.test(output) ||
+    /ETARGET/.test(output)
+  );
+}
+
+/** `sh`, retried only while npm says it cannot yet see a version. */
+function shWithRegistryRetry(
+  cmd: string,
+  args: string[],
+  cwd?: string,
+): string {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return sh(cmd, args, cwd);
+    } catch (error) {
+      const err = error as {
+        stdout?: string;
+        stderr?: string;
+        message?: string;
+      };
+      const output = `${err.stdout ?? ''}${err.stderr ?? ''}${err.message ?? ''}`;
+      if (
+        attempt >= REGISTRY_PROPAGATION_RETRIES ||
+        !looksLikePropagationLag(output)
+      ) {
+        throw error;
+      }
+      log(
+        `  npm could not resolve a pinned version (attempt ${attempt}/${REGISTRY_PROPAGATION_RETRIES}). ` +
+          `A release may still be propagating; retrying in ${REGISTRY_RETRY_DELAY_MS / 1000}s.`,
+      );
+      Atomics.wait(
+        new Int32Array(new SharedArrayBuffer(4)),
+        0,
+        0,
+        REGISTRY_RETRY_DELAY_MS,
+      );
+    }
+  }
+}
+
 function sh(cmd: string, args: string[], cwd?: string): string {
   return execFileSync(cmd, args, {
     cwd,
@@ -390,7 +483,11 @@ function scanTarget(dir: string, configPath: string): Map<string, number> {
   }
 
   for (const file of JSON.parse(raw) as Array<{
-    messages: Array<{ ruleId: string | null; message: string; fatal?: boolean }>;
+    messages: Array<{
+      ruleId: string | null;
+      message: string;
+      fatal?: boolean;
+    }>;
   }>) {
     for (const message of file.messages) {
       if (!message.ruleId || message.fatal) continue;
@@ -478,7 +575,10 @@ function main(): number {
   // the runtime. The plugins are taken from this checkout, so the scan
   // measures the code in the PR rather than the last published release.
   ensurePrivateDir(RIG, CACHE_HOME);
-  writeFileSync(path.join(RIG, 'package.json'), JSON.stringify({ name: 'rig', private: true }));
+  writeFileSync(
+    path.join(RIG, 'package.json'),
+    JSON.stringify({ name: 'rig', private: true }),
+  );
   // Wipe the rig when the set of versions under test changes.
   //
   // The rig installs the PUBLISHED plugins, so what it measures is what users
@@ -507,7 +607,9 @@ function main(): number {
   // the previous one while reporting a number against the new code.
   const fingerprint = [
     ...PLUGINS.map((plugin) =>
-      local ? `${plugin}:local:${distHash(plugin)}` : `${plugin}@${publishedVersion(plugin)}`,
+      local
+        ? `${plugin}:local:${distHash(plugin)}`
+        : `${plugin}@${publishedVersion(plugin)}`,
     ),
     ...(local ? [`eslint-devkit:local:${distHash('eslint-devkit')}`] : []),
   ].join('\n');
@@ -531,13 +633,12 @@ function main(): number {
     rmSync(NPM_CACHE, { recursive: true, force: true });
   }
 
-
   log(
     local
       ? 'Installing scan rig — LOCAL WORKING TREE (not shipped behaviour)…'
       : 'Installing scan rig — published plugin versions…',
   );
-  sh(
+  shWithRegistryRetry(
     'npm',
     [
       'install',
@@ -589,7 +690,9 @@ function main(): number {
       // to the measurement.
       `oxc-resolver@${lockedVersion('oxc-resolver')}`,
       ...PLUGINS.map((p) =>
-        local ? `${p}@file:${path.join(ROOT, 'packages', p)}` : `${p}@${publishedVersion(p)}`,
+        local
+          ? `${p}@file:${path.join(ROOT, 'packages', p)}`
+          : `${p}@${publishedVersion(p)}`,
       ),
       // The devkit, from the working tree, in LOCAL mode only.
       //
@@ -666,8 +769,24 @@ function main(): number {
         // scratch-space lock test asserts every directory here goes via it.
         ensurePrivateDir(dir, CACHE_HOME);
         sh('git', ['-C', dir, 'init', '--quiet']);
-        sh('git', ['-C', dir, 'remote', 'add', 'origin', `https://github.com/${repo}.git`]);
-        sh('git', ['-C', dir, 'fetch', '--depth', '1', '--quiet', 'origin', ref]);
+        sh('git', [
+          '-C',
+          dir,
+          'remote',
+          'add',
+          'origin',
+          `https://github.com/${repo}.git`,
+        ]);
+        sh('git', [
+          '-C',
+          dir,
+          'fetch',
+          '--depth',
+          '1',
+          '--quiet',
+          'origin',
+          ref,
+        ]);
         sh('git', ['-C', dir, 'checkout', '--quiet', 'FETCH_HEAD']);
       }
       if (installTargets) installTargetDependencies(dir, repo);
@@ -685,12 +804,16 @@ function main(): number {
   // headline — the most dangerous possible output, because zero findings is
   // also what a perfect result looks like. Refuse to report at all instead.
   if (scanned === 0) {
-    console.error('::error::every target failed to scan — no findings were measured');
+    console.error(
+      '::error::every target failed to scan — no findings were measured',
+    );
     for (const f of failed) console.error(`  ${f}`);
     return 3;
   }
   if (failed.length > 0) {
-    console.error(`::warning::${failed.length} of ${TARGETS.length} targets failed to scan`);
+    console.error(
+      `::warning::${failed.length} of ${TARGETS.length} targets failed to scan`,
+    );
     for (const f of failed) console.error(`  ${f}`);
   }
 
@@ -719,7 +842,9 @@ function main(): number {
     return 2;
   }
 
-  const budget: Budget = JSON.parse(readFileSync(BUDGET_FILE, 'utf-8')) as Budget;
+  const budget: Budget = JSON.parse(
+    readFileSync(BUDGET_FILE, 'utf-8'),
+  ) as Budget;
 
   // A PARTIAL scan must never rewrite the budget. Running `--update` while the
   // rig was busy once reduced 27 entries to 4: the targets that failed simply
@@ -752,7 +877,9 @@ function main(): number {
       ...(budget.triage ? { triage: budget.triage } : {}),
     };
     writeFileSync(BUDGET_FILE, `${JSON.stringify(next, null, 2)}\n`);
-    log(`Wrote ${Object.keys(next.budgets).length} budgets to ${path.relative(ROOT, BUDGET_FILE)}`);
+    log(
+      `Wrote ${Object.keys(next.budgets).length} budgets to ${path.relative(ROOT, BUDGET_FILE)}`,
+    );
     return 0;
   }
 


### PR DESCRIPTION
## One release turns the whole PR queue red

`Scan pinned corpus` installs the plugin versions a release **just published**. For the minute or two before the registry serves them everywhere, that install 404s:

```
Error: Command failed: npm install --cache … eslint-plugin-secure-coding@5.1.3 …
```

Every open PR runs that check, so a single green release fails all of them at once. It happened **five times in one evening** — #717, #712, #721, #723, and again on #739 tonight. Each time I cleared it by re-running, and each time every pinned dependency resolved by hand minutes later.

## The cost is the habit, not the red run

A required check that cries wolf gets re-run reflexively. The day `Scan pinned corpus` fails for a real reason — a corpus regression, a genuinely missing version — the muscle memory is already "just re-run it," and nobody reads it.

## Why this is narrow on purpose

The dangerous fix here is wider than the bug. A blanket retry would also paper over a dependency conflict, a bad lockfile, or a disk-full — turning a check that cries wolf into one that retries its way to green, which is strictly worse.

So it retries **only a resolution failure**: `E404`, `ETARGET`, `No matching version found`, `is not in this registry`. Three attempts, ten seconds apart, then it fails. Everything else fails on the first attempt exactly as before. Only the rig install is wrapped — git clones and eslint runs are untouched.

## Test plan

- [x] `vitest scripts/__tests__/corpus-scan-registry-retry.test.ts` — **11 pass**, asserting both halves: four transient shapes retry, and five real failures (`ERESOLVE`, `ENOSPC`, a broken lockfile, `EACCES`, *"3 rule(s) over budget"*) do not.
- [x] The test rebuilds the predicate **from the shipped source**, so it cannot drift into testing a copy of itself.
- [x] **Verified by sabotage**: widening the predicate to `return true` fails 5 assertions; removing the attempt cap fails 1; restored passes 11.
- [x] Typecheck, prettier, markdownlint, `lint-changesets` clean.

One note on method: my first attempt at the second sabotage *passed*, and it would have been easy to take that as proof. Prettier had wrapped the guard across three lines so my replacement never matched — I had tested nothing. Re-done against the real formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)