### PR TITLE
chore(docs): sync generated data

### DIFF
--- a/apps/docs/src/data/changelog.json
+++ b/apps/docs/src/data/changelog.json
@@ -1,9 +1,674 @@
 {
-  "releaseCount": 506,
+  "releaseCount": 527,
   "packageCount": 34,
-  "entryCount": 1664,
+  "entryCount": 1731,
   "oldestYear": 2024,
   "releases": [
+    {
+      "package": "eslint-plugin-vercel-ai-security",
+      "short": "eslint-plugin-vercel-ai-security",
+      "version": "2.1.0",
+      "date": "2026-09-01T06:31:52Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "feature",
+          "title": "**🐛 Fix** — a template literal is a string, in 82 rules that disagreed",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.18.0`",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-secure-coding",
+      "short": "eslint-plugin-secure-coding",
+      "version": "5.2.0",
+      "date": "2026-09-01T06:31:40Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "feature",
+          "title": "**🐛 Fix** — a template literal is a string, in 82 rules that disagreed",
+          "pr": null
+        },
+        {
+          "kind": "feature",
+          "title": "**✨ Feature** — `no-insecure-comparison` gains `reportLooseEquality`",
+          "pr": null
+        },
+        {
+          "kind": "feature",
+          "title": "**✨ Feature** — `no-hardcoded-session-tokens` gains `sessionWords`",
+          "pr": null
+        },
+        {
+          "kind": "feature",
+          "title": "`detect-weak-password-validation` takes `passwordWords`",
+          "pr": null
+        },
+        {
+          "kind": "feature",
+          "title": "**✨ Feature** — `no-unsafe-regex-construction` gains `requestRootNames`",
+          "pr": null
+        },
+        {
+          "kind": "feature",
+          "title": "**🐛 Fix** — `no-sql-injection` reads a request by SHAPE, not by the name `req`",
+          "pr": null
+        },
+        {
+          "kind": "feature",
+          "title": "**✨ Feature** — the names these rules look for are yours to state",
+          "pr": null
+        },
+        {
+          "kind": "fix",
+          "title": "**🐛 Fix** — `no-unsafe-regex-construction` reported on dynamic flags alone",
+          "pr": null
+        },
+        {
+          "kind": "fix",
+          "title": "`no-mutable-exports` resolves bindings instead of grepping the file text",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.18.0`",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-reliability",
+      "short": "eslint-plugin-reliability",
+      "version": "4.1.0",
+      "date": "2026-09-01T06:31:35Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "feature",
+          "title": "**🐛 Fix** — a template literal is a string, in 82 rules that disagreed",
+          "pr": null
+        },
+        {
+          "kind": "fix",
+          "title": "**🐛 Fix** — `no-unhandled-promise` silenced a promise passed as an argument",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.18.0`",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-react-features",
+      "short": "eslint-plugin-react-features",
+      "version": "1.6.0",
+      "date": "2026-09-01T06:31:29Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "feature",
+          "title": "**🐛 Fix** — a template literal is a string, in 82 rules that disagreed",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.18.0`",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-postgresql-security",
+      "short": "eslint-plugin-postgresql-security",
+      "version": "2.3.0",
+      "date": "2026-09-01T06:31:14Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "feature",
+          "title": "**🐛 Fix** — a template literal is a string, in 82 rules that disagreed",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.18.0`",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-react-a11y",
+      "short": "eslint-plugin-react-a11y",
+      "version": "2.5.0",
+      "date": "2026-09-01T06:31:12Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "feature",
+          "title": "**🐛 Fix** — a template literal is a string, in 82 rules that disagreed",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.18.0`",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-operability",
+      "short": "eslint-plugin-operability",
+      "version": "4.0.0",
+      "date": "2026-09-01T06:31:05Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "breaking",
+          "title": "**💥 Breaking** — `require-data-minimization` no longer guesses what your PII is",
+          "pr": null
+        },
+        {
+          "kind": "feature",
+          "title": "**✨ Feature** — `require-code-minification` gains `minificationKeys`",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.18.0`",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-node-security",
+      "short": "eslint-plugin-node-security",
+      "version": "5.3.0",
+      "date": "2026-09-01T06:30:01Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "feature",
+          "title": "**🐛 Fix** — a template literal is a string, in 82 rules that disagreed",
+          "pr": null
+        },
+        {
+          "kind": "feature",
+          "title": "**🐛 Fix** — `no-ssrf` reads a request by SHAPE, not by the name `req`",
+          "pr": null
+        },
+        {
+          "kind": "feature",
+          "title": "**🐛 Fix** — `no-ssrf` identifies an HTTP client by its module, not its variable name",
+          "pr": null
+        },
+        {
+          "kind": "feature",
+          "title": "**✨ Feature** — `no-zip-slip` gains `archiveEntryFields`",
+          "pr": null
+        },
+        {
+          "kind": "fix",
+          "title": "`no-unsafe-buffer-alloc` has fixtures for the `countNames` option",
+          "pr": null
+        },
+        {
+          "kind": "fix",
+          "title": "**🐛 Fix** — `require-secure-credential-storage` no longer reads configuration as a credential",
+          "pr": null
+        },
+        {
+          "kind": "fix",
+          "title": "`no-mutable-exports` resolves bindings instead of grepping the file text",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.18.0`",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-nestjs-security",
+      "short": "eslint-plugin-nestjs-security",
+      "version": "3.1.0",
+      "date": "2026-09-01T06:29:52Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "feature",
+          "title": "`no-permissive-cors` takes `environmentHintNames`",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.18.0`",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-mongodb-security",
+      "short": "eslint-plugin-mongodb-security",
+      "version": "9.1.0",
+      "date": "2026-09-01T06:29:40Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "feature",
+          "title": "**🐛 Fix** — a template literal is a string, in 82 rules that disagreed",
+          "pr": null
+        },
+        {
+          "kind": "feature",
+          "title": "**🐛 Fix** — `no-unsafe-query` was wrong in both directions",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.18.0`",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-modularity",
+      "short": "eslint-plugin-modularity",
+      "version": "2.5.0",
+      "date": "2026-09-01T06:28:37Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "feature",
+          "title": "**🐛 Fix** — a template literal is a string, in 82 rules that disagreed",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.18.0`",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-modernization",
+      "short": "eslint-plugin-modernization",
+      "version": "3.1.0",
+      "date": "2026-09-01T06:28:27Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "feature",
+          "title": "**🐛 Fix** — a template literal is a string, in 82 rules that disagreed",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.18.0`",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-mcp-sdk-security",
+      "short": "eslint-plugin-mcp-sdk-security",
+      "version": "0.4.0",
+      "date": "2026-09-01T06:28:15Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "feature",
+          "title": "**🐛 Fix** — a template literal is a string, in 82 rules that disagreed",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.18.0`",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-browser-security",
+      "short": "eslint-plugin-browser-security",
+      "version": "2.1.0",
+      "date": "2026-09-01T06:28:10Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "feature",
+          "title": "**🐛 Fix** — a template literal is a string, in 82 rules that disagreed",
+          "pr": null
+        },
+        {
+          "kind": "feature",
+          "title": "**✨ Feature** — `no-sensitive-indexeddb` gains `sensitiveTerms`",
+          "pr": null
+        },
+        {
+          "kind": "feature",
+          "title": "**✨ Feature** — `no-incomplete-url-sanitization` gains `urlNameWords`",
+          "pr": null
+        },
+        {
+          "kind": "fix",
+          "title": "**🐛 Fix** — `no-innerhtml` missed three receiver shapes",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.18.0`",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-jwt-security",
+      "short": "eslint-plugin-jwt-security",
+      "version": "3.1.0",
+      "date": "2026-09-01T06:28:01Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "feature",
+          "title": "**🐛 Fix** — a template literal is a string, in 82 rules that disagreed",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.18.0`",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-maintainability",
+      "short": "eslint-plugin-maintainability",
+      "version": "3.2.0",
+      "date": "2026-09-01T06:27:56Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "feature",
+          "title": "**🐛 Fix** — a template literal is a string, in 82 rules that disagreed",
+          "pr": null
+        },
+        {
+          "kind": "fix",
+          "title": "**🐛 Fix** — `no-unhandled-promise` silenced a promise passed as an argument",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.18.0`",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "@interlace/eslint-devkit",
+      "short": "eslint-devkit",
+      "version": "1.18.0",
+      "date": "2026-09-01T06:27:48Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "feature",
+          "title": "**✨ Feature** — `spellings`: the five ways a rule reads a name, in one place",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-import-next",
+      "short": "eslint-plugin-import-next",
+      "version": "2.7.0",
+      "date": "2026-09-01T06:27:42Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "feature",
+          "title": "**🐛 Fix** — a template literal is a string, in 82 rules that disagreed",
+          "pr": null
+        },
+        {
+          "kind": "fix",
+          "title": "`no-mutable-exports` resolves bindings instead of grepping the file text",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.18.0`",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-express-security",
+      "short": "eslint-plugin-express-security",
+      "version": "3.2.0",
+      "date": "2026-09-01T06:27:38Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "feature",
+          "title": "**🐛 Fix** — a template literal is a string, in 82 rules that disagreed",
+          "pr": null
+        },
+        {
+          "kind": "feature",
+          "title": "Express rules agree on what an app receiver is called, and let you say",
+          "pr": null
+        },
+        {
+          "kind": "feature",
+          "title": "**🐛 Fix** — `no-user-controlled-render-locals` reads a request by shape, not by name",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.18.0`",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-lambda-security",
+      "short": "eslint-plugin-lambda-security",
+      "version": "2.1.0",
+      "date": "2026-09-01T06:27:31Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "feature",
+          "title": "**🐛 Fix** — a template literal is a string, in 82 rules that disagreed",
+          "pr": null
+        },
+        {
+          "kind": "feature",
+          "title": "**✨ Feature** — `eventParamNames` / `contextParamNames`, because a handler's parameters are positional",
+          "pr": null
+        },
+        {
+          "kind": "feature",
+          "title": "`no-unvalidated-event-body` takes `validationMethodNames`",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.18.0`",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-conventions",
+      "short": "eslint-plugin-conventions",
+      "version": "5.2.0",
+      "date": "2026-09-01T06:27:28Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "feature",
+          "title": "**🐛 Fix** — a template literal is a string, in 82 rules that disagreed",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.18.0`",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-conventions",
+      "short": "eslint-plugin-conventions",
+      "version": "5.1.0",
+      "date": "2026-09-01T02:29:47Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "feature",
+          "title": "`analytics-event-naming` accepts `copy` as an action verb.",
+          "pr": null
+        },
+        {
+          "kind": "fix",
+          "title": "`prefer-dom-node-text-content` no longer gates on the variable's name",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.17.4`",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "@interlace/eslint-devkit",
+      "short": "eslint-devkit",
+      "version": "1.17.4",
+      "date": "2026-09-01T02:29:45Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "the default `createRule` no longer mints a docs URL that 404s",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-maintainability",
+      "short": "eslint-plugin-maintainability",
+      "version": "3.1.2",
+      "date": "2026-09-01T02:29:45Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "`max-parameters` no longer counts TypeScript's `this` parameter",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.17.4`",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-browser-security",
+      "short": "eslint-plugin-browser-security",
+      "version": "2.0.7",
+      "date": "2026-09-01T02:29:44Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "lock and document the W3C XML namespace exemption in `no-http-urls` and `detect-mixed-content`.",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.17.4`",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-modularity",
+      "short": "eslint-plugin-modularity",
+      "version": "2.4.0",
+      "date": "2026-09-01T02:29:44Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "`ddd-anemic-domain-model` matches DTO names by suffix, not substring",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.17.4`",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-react-features",
+      "short": "eslint-plugin-react-features",
+      "version": "1.5.0",
+      "date": "2026-09-01T02:29:43Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "`hooks-exhaustive-deps` decides stability by resolving the binding, not by its name",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.17.4`",
+          "pr": null
+        }
+      ]
+    },
     {
       "package": "eslint-plugin-secure-coding",
       "short": "eslint-plugin-secure-coding",
@@ -12952,21 +13617,6 @@
     {
       "package": "@interlace/eslint-devkit",
       "short": "eslint-devkit",
-      "version": "1.17.4",
-      "date": null,
-      "isApp": false,
-      "isPrivate": false,
-      "entries": [
-        {
-          "kind": "fix",
-          "title": "the default `createRule` no longer mints a docs URL that 404s",
-          "pr": null
-        }
-      ]
-    },
-    {
-      "package": "@interlace/eslint-devkit",
-      "short": "eslint-devkit",
       "version": "1.17.0",
       "date": null,
       "isApp": false,
@@ -13031,51 +13681,6 @@
           "kind": "feature",
           "title": "`RemoteMarkdown` accepts `tags`, forwarded to the underlying fetch as `next.tags`.",
           "pr": 628
-        }
-      ]
-    },
-    {
-      "package": "eslint-plugin-browser-security",
-      "short": "eslint-plugin-browser-security",
-      "version": "2.0.7",
-      "date": null,
-      "isApp": false,
-      "isPrivate": false,
-      "entries": [
-        {
-          "kind": "fix",
-          "title": "lock and document the W3C XML namespace exemption in `no-http-urls` and `detect-mixed-content`.",
-          "pr": null
-        },
-        {
-          "kind": "deps",
-          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.17.4`",
-          "pr": null
-        }
-      ]
-    },
-    {
-      "package": "eslint-plugin-conventions",
-      "short": "eslint-plugin-conventions",
-      "version": "5.1.0",
-      "date": null,
-      "isApp": false,
-      "isPrivate": false,
-      "entries": [
-        {
-          "kind": "feature",
-          "title": "`analytics-event-naming` accepts `copy` as an action verb.",
-          "pr": null
-        },
-        {
-          "kind": "fix",
-          "title": "`prefer-dom-node-text-content` no longer gates on the variable's name",
-          "pr": null
-        },
-        {
-          "kind": "deps",
-          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.17.4`",
-          "pr": null
         }
       ]
     },
@@ -13195,46 +13800,6 @@
         {
           "kind": "other",
           "title": "Ofri Peretz",
-          "pr": null
-        }
-      ]
-    },
-    {
-      "package": "eslint-plugin-maintainability",
-      "short": "eslint-plugin-maintainability",
-      "version": "3.1.2",
-      "date": null,
-      "isApp": false,
-      "isPrivate": false,
-      "entries": [
-        {
-          "kind": "fix",
-          "title": "`max-parameters` no longer counts TypeScript's `this` parameter",
-          "pr": null
-        },
-        {
-          "kind": "deps",
-          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.17.4`",
-          "pr": null
-        }
-      ]
-    },
-    {
-      "package": "eslint-plugin-modularity",
-      "short": "eslint-plugin-modularity",
-      "version": "2.4.0",
-      "date": null,
-      "isApp": false,
-      "isPrivate": false,
-      "entries": [
-        {
-          "kind": "fix",
-          "title": "`ddd-anemic-domain-model` matches DTO names by suffix, not substring",
-          "pr": null
-        },
-        {
-          "kind": "deps",
-          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.17.4`",
           "pr": null
         }
       ]
@@ -13360,26 +13925,6 @@
         {
           "kind": "other",
           "title": "Ofri Peretz",
-          "pr": null
-        }
-      ]
-    },
-    {
-      "package": "eslint-plugin-react-features",
-      "short": "eslint-plugin-react-features",
-      "version": "1.5.0",
-      "date": null,
-      "isApp": false,
-      "isPrivate": false,
-      "entries": [
-        {
-          "kind": "fix",
-          "title": "`hooks-exhaustive-deps` decides stability by resolving the binding, not by its name",
-          "pr": null
-        },
-        {
-          "kind": "deps",
-          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.17.4`",
           "pr": null
         }
       ]

--- a/apps/docs/src/data/plugin-stats.json
+++ b/apps/docs/src/data/plugin-stats.json
@@ -5,7 +5,7 @@
       "rules": 46,
       "description": "ESLint plugin for browser security — detects DOM XSS, postMessage abuse, tokens in localStorage, insecure cookies, clickjacking, mixed content, and CSP gaps",
       "category": "security",
-      "version": "2.0.7",
+      "version": "2.1.0",
       "published": true
     },
     {
@@ -13,7 +13,7 @@
       "rules": 42,
       "description": "ESLint plugin for Node.js security — detects command injection, path traversal, SSRF, zip slip, and weak crypto (MD5/SHA-1, ECB, static IV) in fs, child_process, vm, and crypto",
       "category": "security",
-      "version": "5.2.3",
+      "version": "5.3.0",
       "published": true
     },
     {
@@ -21,7 +21,7 @@
       "rules": 33,
       "description": "ESLint plugin for secure coding — detects LDAP, XPath, XXE, GraphQL and template injection, unsafe deserialization, ReDoS, missing authentication, and PII in logs",
       "category": "security",
-      "version": "5.1.4",
+      "version": "5.2.0",
       "published": true
     },
     {
@@ -29,7 +29,7 @@
       "rules": 19,
       "description": "ESLint plugin for Vercel AI SDK security — detects prompt injection, system-prompt leaks, hardcoded API keys, and unvalidated model output in generateText and streamText",
       "category": "security",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "published": true
     },
     {
@@ -37,7 +37,7 @@
       "rules": 16,
       "description": "ESLint plugin for MongoDB and Mongoose security — detects NoSQL operator injection, unsafe queries and regex, hardcoded connection strings, and missing TLS",
       "category": "security",
-      "version": "9.0.2",
+      "version": "9.1.0",
       "published": true
     },
     {
@@ -45,7 +45,7 @@
       "rules": 13,
       "description": "ESLint plugin for JWT security — detects algorithm confusion (CVE-2022-23540), alg:none, weak or hardcoded secrets, and decode-without-verify",
       "category": "security",
-      "version": "3.0.3",
+      "version": "3.1.0",
       "published": true
     },
     {
@@ -53,7 +53,7 @@
       "rules": 13,
       "description": "ESLint plugin for the pg PostgreSQL driver — detects SQL injection, unreleased clients, floating queries, unsafe search_path, and insecure SSL",
       "category": "security",
-      "version": "2.2.1",
+      "version": "2.3.0",
       "published": true
     },
     {
@@ -77,7 +77,7 @@
       "rules": 4,
       "description": "ESLint plugin for Model Context Protocol (MCP) SDK security — catches tools registered without an input schema, handlers reading arguments the schema never declared, model-visible descriptions built from dynamic text, and tool arguments reaching a shell",
       "category": "security",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "published": true
     },
     {
@@ -149,7 +149,7 @@
       "rules": 28,
       "description": "ESLint plugin for Express.js security — detects permissive CORS, missing CSRF protection, missing helmet headers, insecure cookies, and GraphQL introspection in production",
       "category": "framework",
-      "version": "3.1.3",
+      "version": "3.2.0",
       "published": true
     },
     {
@@ -157,7 +157,7 @@
       "rules": 14,
       "description": "ESLint plugin for AWS Lambda security — detects overly permissive IAM policies and CORS, unvalidated event bodies, secrets in env vars, and leaked error details",
       "category": "framework",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "published": true
     },
     {
@@ -165,7 +165,7 @@
       "rules": 10,
       "description": "ESLint plugin for NestJS security — detects missing auth guards, missing validation pipes, unthrottled routes, and exposed private fields",
       "category": "framework",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "published": true
     },
     {
@@ -173,7 +173,7 @@
       "rules": 55,
       "description": "ESLint plugin for imports and module boundaries — drop-in replacement for eslint-plugin-import, 3.1x faster end-to-end, zero-config migration",
       "category": "architecture",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "published": true
     },
     {
@@ -181,7 +181,7 @@
       "rules": 15,
       "description": "ESLint plugin for team code conventions — enforces filename case, magic-number bans, commented-out code, expiring TODOs, and deprecated-API usage",
       "category": "quality",
-      "version": "5.1.0",
+      "version": "5.2.0",
       "published": true
     },
     {
@@ -189,7 +189,7 @@
       "rules": 12,
       "description": "ESLint plugin for maintainable code — limits cognitive complexity, nesting depth, parameter counts, duplicate functions, and unhandled or silent errors",
       "category": "quality",
-      "version": "3.1.2",
+      "version": "3.2.0",
       "published": true
     },
     {
@@ -197,7 +197,7 @@
       "rules": 9,
       "description": "ESLint plugin for runtime reliability — enforces error handling, network timeouts, null checks, and safe type narrowing",
       "category": "quality",
-      "version": "4.0.2",
+      "version": "4.1.0",
       "published": true
     },
     {
@@ -205,7 +205,7 @@
       "rules": 6,
       "description": "ESLint plugin for module architecture — enforces DDD value objects and anemic-model checks, naming, REST conventions, and utility isolation",
       "category": "quality",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "published": true
     },
     {
@@ -213,7 +213,7 @@
       "rules": 6,
       "description": "ESLint plugin for production operability — bans debug code and console logging in production, verbose error messages, and process.exit calls",
       "category": "quality",
-      "version": "3.1.1",
+      "version": "4.0.0",
       "published": true
     },
     {
@@ -221,7 +221,7 @@
       "rules": 4,
       "description": "ESLint plugin for modernizing JavaScript — auto-fixes legacy patterns to ES2022+ (Array.at, template literals, EventTarget, Array.isArray)",
       "category": "quality",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "published": true
     },
     {
@@ -229,7 +229,7 @@
       "rules": 61,
       "description": "ESLint plugin for React — hooks, prop-types, JSX correctness, render performance, and class-to-hooks migration rules for modern React codebases",
       "category": "react",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "published": true
     },
     {
@@ -237,12 +237,12 @@
       "rules": 37,
       "description": "ESLint plugin for React accessibility — WCAG 2.1 rules for ARIA, alt text, keyboard interaction, and focus management, with auto-fixes",
       "category": "react",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "published": true
     }
   ],
   "totalRules": 477,
   "totalPlugins": 30,
   "allPluginsCount": 30,
-  "generatedAt": "2026-08-31"
+  "generatedAt": "2026-09-01"
 }


### PR DESCRIPTION
Regenerated apps/docs/src/data/ (trigger: push). Opened by the Docs Data Sync workflow; contents come entirely from the apps/docs/scripts/sync-* scripts, so review the diff rather than hand-editing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the September 1, 2026 release announcement for six updated ESLint plugins and related tooling.
  * Removed duplicate entries for the same releases from their previous locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->