### PR TITLE
fix(workspace): two published READMEs still told readers to install retired names

### DIFF
--- a/.changeset/retired-names-in-readmes.md
+++ b/.changeset/retired-names-in-readmes.md
@@ -1,0 +1,9 @@
+---
+'eslint-plugin-secure-coding': patch
+'eslint-plugin-sequelize-security': patch
+---
+
+Stop pointing readers at retired package names. `secure-coding`'s "extend your
+coverage" block linked `eslint-plugin-jwt` and `sequelize-security`'s prose named
+`eslint-plugin-pg` — both deprecated on npm since #414, and following either
+installs the frozen pre-rename build rather than the maintained one.

--- a/packages/eslint-plugin-secure-coding/README.md
+++ b/packages/eslint-plugin-secure-coding/README.md
@@ -73,7 +73,7 @@ export default [
 
 > **Using `recommended` already?** Extend your coverage with domain-specific plugins:
 > [`eslint-plugin-node-security`](https://www.npmjs.com/package/eslint-plugin-node-security) (crypto, eval, buffer) ·
-> [`eslint-plugin-jwt`](https://www.npmjs.com/package/eslint-plugin-jwt) (JWT auth) ·
+> [`eslint-plugin-jwt-security`](https://www.npmjs.com/package/eslint-plugin-jwt-security) (JWT auth) ·
 > [`eslint-plugin-express-security`](https://www.npmjs.com/package/eslint-plugin-express-security) (Express middleware)
 
 ---

--- a/packages/eslint-plugin-sequelize-security/README.md
+++ b/packages/eslint-plugin-sequelize-security/README.md
@@ -29,7 +29,7 @@ This plugin provides Security rules for the Sequelize ORM (SQL injection prevent
 
 ## Why Sequelize-specific?
 
-An ORM is not a defence against SQL injection — it narrows the surface to the raw escapes, and those are still string-built. Sequelize has two: `sequelize.query()` and `Sequelize.literal()`. OWASP Juice Shop's two flagship injections are both the former, and neither was reported by any recommended preset in this ecosystem until this plugin existed — the only implementation of the detection shipped inside `eslint-plugin-pg`, which no Sequelize user installs.
+An ORM is not a defence against SQL injection — it narrows the surface to the raw escapes, and those are still string-built. Sequelize has two: `sequelize.query()` and `Sequelize.literal()`. OWASP Juice Shop's two flagship injections are both the former, and neither was reported by any recommended preset in this ecosystem until this plugin existed — the only implementation of the detection shipped inside `eslint-plugin-postgresql-security`, which no Sequelize user installs.
 
 Being Sequelize-specific is what makes the rule precise. It knows the safe conventions to stay quiet on (`replacements`, `bind`), and it knows `literal()` is a SQL sink rather than an ordinary helper — so it catches `ORDER BY` injection that a generic string-concatenation linter has no reason to flag. It also tracks variable taint across statements, so `const sql = "SELECT..." + id; sequelize.query(sql)` reports even with the concatenation on a separate line.
 

--- a/scripts/__tests__/no-retired-names-in-published-readmes.lock.test.ts
+++ b/scripts/__tests__/no-retired-names-in-published-readmes.lock.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2026 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Workspace lock — a published README never tells a reader to install a retired name.
+ *
+ * #414 renamed `eslint-plugin-pg` → `eslint-plugin-postgresql-security` and
+ * `eslint-plugin-jwt` → `eslint-plugin-jwt-security`. The generated ecosystem table
+ * moved with it, because a generator owns it. Two hand-written lines did not:
+ * `secure-coding`'s "extend your coverage" block still linked
+ * `npmjs.com/package/eslint-plugin-jwt`, and `sequelize-security`'s prose still named
+ * `eslint-plugin-pg`.
+ *
+ * Nothing caught them. `map:names:check` compares registry identifiers,
+ * `lint:name-inference` reads rule ids, `check-links` only asks whether a URL
+ * resolves — and these resolve fine, to a deprecated package. Prose that no generator
+ * owns had no gate at all, and a deprecated package is the worst kind of live link:
+ * following `eslint-plugin-pg` installs the frozen pre-rename build, the name-matching
+ * version whose false positives the evidence gating exists to remove.
+ *
+ * Scope is deliberately the published READMEs. Audits, exposure logs and AGENTS.md
+ * name the old packages correctly — they are recording history, and a lock that
+ * cannot tell an instruction from a record would force them to lie.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const REPO_ROOT = resolve(__dirname, '../..');
+const PACKAGES_DIR = join(REPO_ROOT, 'packages');
+const ALIAS_LOCK = join(REPO_ROOT, 'benchmarks/__tests__/plugin-prefix-identity.lock.test.ts');
+
+/**
+ * Retired prefixes, parsed from the lock that already owns them, so this file cannot
+ * disagree with it. A future rename updates one map and both checks follow.
+ */
+function retiredNames(): string[] {
+  const src = readFileSync(ALIAS_LOCK, 'utf-8');
+  const block = src.match(/DEPRECATED_ALIASES[^=]*=\s*\{([\s\S]*?)\}/)?.[1];
+  if (!block) throw new Error(`Could not parse DEPRECATED_ALIASES from ${ALIAS_LOCK}`);
+  return [...block.matchAll(/:\s*'([a-z0-9-]+)'/g)].map((m) => `eslint-plugin-${m[1]}`);
+}
+
+/** Published packages only — a private package ships no README to npm. */
+function publishedReadmes(): { dir: string; text: string }[] {
+  return readdirSync(PACKAGES_DIR, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .flatMap((e) => {
+      const manifest = join(PACKAGES_DIR, e.name, 'package.json');
+      const readme = join(PACKAGES_DIR, e.name, 'README.md');
+      if (!existsSync(manifest) || !existsSync(readme)) return [];
+      if (JSON.parse(readFileSync(manifest, 'utf-8')).private) return [];
+      return [{ dir: e.name, text: readFileSync(readme, 'utf-8') }];
+    })
+    .sort((a, b) => a.dir.localeCompare(b.dir));
+}
+
+const RETIRED = retiredNames();
+const READMES = publishedReadmes();
+
+describe('no retired package names in published READMEs', () => {
+  it('knows which names are retired', () => {
+    // Guards the guard: an empty list would make every assertion below vacuous.
+    expect(RETIRED.length).toBeGreaterThan(0);
+    expect(RETIRED).toContain('eslint-plugin-jwt');
+  });
+
+  it('found the READMEs it is meant to be checking', () => {
+    expect(READMES.length).toBeGreaterThan(20);
+  });
+
+  it.each(READMES.map((r) => [r.dir, r] as const))('%s names no retired package', (dir, readme) => {
+    for (const name of RETIRED) {
+      // Not followed by `-`, so `eslint-plugin-jwt-security` is not a match for
+      // `eslint-plugin-jwt`. That substring is exactly why a manual grep missed these.
+      const re = new RegExp(`${name}(?![a-z0-9-])`, 'g');
+      const hits = [...readme.text.matchAll(re)].map((m) => {
+        const line = readme.text.slice(0, m.index).split('\n').length;
+        return `${dir}/README.md:${line}`;
+      });
+      expect(
+        hits,
+        `${dir}/README.md points a reader at \`${name}\`, which is deprecated on npm. ` +
+          'Following it installs the frozen pre-rename build. Use the current name.',
+      ).toEqual([]);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`secure-coding`'s hand-written "extend your coverage" block linked `npmjs.com/package/eslint-plugin-jwt`; `sequelize-security`'s prose named `eslint-plugin-pg`. Both were retired by #414 and are deprecated on npm.

The generated ecosystem table moved with the rename because a generator owns it. These two lines are prose, which nothing owned:

- `map:names:check` compares registry identifiers
- `lint:name-inference` reads rule ids
- `check-links` only asks whether a URL resolves — **and these resolve perfectly well**, to a deprecated package

That's the worst kind of live link. Following `eslint-plugin-pg` installs the frozen pre-rename build — the name-matching version whose false positives the evidence gating exists to remove.

**How they were found.** By auditing what npm actually serves rather than what the repo contains: `npm view <pkg> readme` across all 31 published packages. 21 were stale purely from never being republished after the rename, and releasing fixed those. This one was stale *in the source*, which is why it survived the release and showed up in the re-audit as the last holdout.

**New lock** reads `DEPRECATED_ALIASES` from `plugin-prefix-identity.lock.test.ts`, which already owns that map, so a future rename updates one place and both checks follow. Scope is deliberately the published READMEs — audits, exposure logs and `AGENTS.md` name the old packages *correctly*, because they record history, and a gate that cannot tell an instruction from a record would force them to lie.

## Test plan

- [x] **Fails on the shipped state.** With both fixes reverted, the lock fails naming `eslint-plugin-secure-coding/README.md:76` and `eslint-plugin-sequelize-security/README.md:32`.
- [x] Passes with the fixes (33 tests).
- [x] Word-boundary verified: `eslint-plugin-jwt-security` is not a match for `eslint-plugin-jwt` — that substring is exactly why a manual grep missed these.
- [x] Two guard-the-guard assertions: the retired list is non-empty, and the README set is non-trivial, so neither can go vacuously green.

## After merge

A patch release for both packages refreshes what npmjs.com shows. Re-audit went 21 stale → 1 → 0 once this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)