### PR TITLE
chore(docs): sync generated data

### DIFF
--- a/apps/docs/src/data/changelog.json
+++ b/apps/docs/src/data/changelog.json
@@ -5,6 +5,161 @@
   "oldestYear": 2024,
   "releases": [
     {
+      "package": "eslint-plugin-prisma-security",
+      "short": "eslint-plugin-prisma-security",
+      "version": "0.3.5",
+      "date": "2026-09-01T06:53:31Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "Refresh the README npm serves for these plugins. npm renders the README from the last publish, so all seven still advertise `eslint-plugin-pg` and `eslint-plugin-jwt` — names retired in #414 and since deprecated on npm. A reader who followed one installed the frozen pre-rename package instead of the maintained one. The repo has been correct since the rename; only a publish moves what npmjs.com shows.",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.18.1`",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-knex-security",
+      "short": "eslint-plugin-knex-security",
+      "version": "0.4.5",
+      "date": "2026-09-01T06:53:29Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "Refresh the README npm serves for these plugins. npm renders the README from the last publish, so all seven still advertise `eslint-plugin-pg` and `eslint-plugin-jwt` — names retired in #414 and since deprecated on npm. A reader who followed one installed the frozen pre-rename package instead of the maintained one. The repo has been correct since the rename; only a publish moves what npmjs.com shows.",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.18.1`",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-mysql-security",
+      "short": "eslint-plugin-mysql-security",
+      "version": "0.3.5",
+      "date": "2026-09-01T06:53:29Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "Refresh the README npm serves for these plugins. npm renders the README from the last publish, so all seven still advertise `eslint-plugin-pg` and `eslint-plugin-jwt` — names retired in #414 and since deprecated on npm. A reader who followed one installed the frozen pre-rename package instead of the maintained one. The repo has been correct since the rename; only a publish moves what npmjs.com shows.",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.18.1`",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "@interlace/eslint-devkit",
+      "short": "eslint-devkit",
+      "version": "1.18.1",
+      "date": "2026-09-01T06:53:27Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "Cross-link the full plugin ecosystem from the devkit README. It is published to npm and was the one released package whose README pointed at none of the thirty plugins it exists to build — it linked the root README instead of listing them.",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-drizzle-security",
+      "short": "eslint-plugin-drizzle-security",
+      "version": "0.3.5",
+      "date": "2026-09-01T06:53:26Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "Refresh the README npm serves for these plugins. npm renders the README from the last publish, so all seven still advertise `eslint-plugin-pg` and `eslint-plugin-jwt` — names retired in #414 and since deprecated on npm. A reader who followed one installed the frozen pre-rename package instead of the maintained one. The repo has been correct since the rename; only a publish moves what npmjs.com shows.",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.18.1`",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-sqlite-security",
+      "short": "eslint-plugin-sqlite-security",
+      "version": "0.1.8",
+      "date": "2026-09-01T06:53:22Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "Refresh the README npm serves for these plugins. npm renders the README from the last publish, so all seven still advertise `eslint-plugin-pg` and `eslint-plugin-jwt` — names retired in #414 and since deprecated on npm. A reader who followed one installed the frozen pre-rename package instead of the maintained one. The repo has been correct since the rename; only a publish moves what npmjs.com shows.",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.18.1`",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-typeorm-security",
+      "short": "eslint-plugin-typeorm-security",
+      "version": "0.3.5",
+      "date": "2026-09-01T06:53:04Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "Refresh the README npm serves for these plugins. npm renders the README from the last publish, so all seven still advertise `eslint-plugin-pg` and `eslint-plugin-jwt` — names retired in #414 and since deprecated on npm. A reader who followed one installed the frozen pre-rename package instead of the maintained one. The repo has been correct since the rename; only a publish moves what npmjs.com shows.",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.18.1`",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-sequelize-security",
+      "short": "eslint-plugin-sequelize-security",
+      "version": "0.3.5",
+      "date": "2026-09-01T06:53:03Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "Refresh the README npm serves for these plugins. npm renders the README from the last publish, so all seven still advertise `eslint-plugin-pg` and `eslint-plugin-jwt` — names retired in #414 and since deprecated on npm. A reader who followed one installed the frozen pre-rename package instead of the maintained one. The repo has been correct since the rename; only a publish moves what npmjs.com shows.",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.18.1`",
+          "pr": null
+        }
+      ]
+    },
+    {
       "package": "eslint-plugin-vercel-ai-security",
       "short": "eslint-plugin-vercel-ai-security",
       "version": "2.1.0",
@@ -13617,21 +13772,6 @@
     {
       "package": "@interlace/eslint-devkit",
       "short": "eslint-devkit",
-      "version": "1.18.1",
-      "date": null,
-      "isApp": false,
-      "isPrivate": false,
-      "entries": [
-        {
-          "kind": "fix",
-          "title": "Cross-link the full plugin ecosystem from the devkit README. It is published to npm and was the one released package whose README pointed at none of the thirty plugins it exists to build — it linked the root README instead of listing them.",
-          "pr": null
-        }
-      ]
-    },
-    {
-      "package": "@interlace/eslint-devkit",
-      "short": "eslint-devkit",
       "version": "1.17.0",
       "date": null,
       "isApp": false,
@@ -13696,26 +13836,6 @@
           "kind": "feature",
           "title": "`RemoteMarkdown` accepts `tags`, forwarded to the underlying fetch as `next.tags`.",
           "pr": 628
-        }
-      ]
-    },
-    {
-      "package": "eslint-plugin-drizzle-security",
-      "short": "eslint-plugin-drizzle-security",
-      "version": "0.3.5",
-      "date": null,
-      "isApp": false,
-      "isPrivate": false,
-      "entries": [
-        {
-          "kind": "fix",
-          "title": "Refresh the README npm serves for these plugins. npm renders the README from the last publish, so all seven still advertise `eslint-plugin-pg` and `eslint-plugin-jwt` — names retired in #414 and since deprecated on npm. A reader who followed one installed the frozen pre-rename package instead of the maintained one. The repo has been correct since the rename; only a publish moves what npmjs.com shows.",
-          "pr": null
-        },
-        {
-          "kind": "deps",
-          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.18.1`",
-          "pr": null
         }
       ]
     },
@@ -13835,46 +13955,6 @@
         {
           "kind": "other",
           "title": "Ofri Peretz",
-          "pr": null
-        }
-      ]
-    },
-    {
-      "package": "eslint-plugin-knex-security",
-      "short": "eslint-plugin-knex-security",
-      "version": "0.4.5",
-      "date": null,
-      "isApp": false,
-      "isPrivate": false,
-      "entries": [
-        {
-          "kind": "fix",
-          "title": "Refresh the README npm serves for these plugins. npm renders the README from the last publish, so all seven still advertise `eslint-plugin-pg` and `eslint-plugin-jwt` — names retired in #414 and since deprecated on npm. A reader who followed one installed the frozen pre-rename package instead of the maintained one. The repo has been correct since the rename; only a publish moves what npmjs.com shows.",
-          "pr": null
-        },
-        {
-          "kind": "deps",
-          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.18.1`",
-          "pr": null
-        }
-      ]
-    },
-    {
-      "package": "eslint-plugin-mysql-security",
-      "short": "eslint-plugin-mysql-security",
-      "version": "0.3.5",
-      "date": null,
-      "isApp": false,
-      "isPrivate": false,
-      "entries": [
-        {
-          "kind": "fix",
-          "title": "Refresh the README npm serves for these plugins. npm renders the README from the last publish, so all seven still advertise `eslint-plugin-pg` and `eslint-plugin-jwt` — names retired in #414 and since deprecated on npm. A reader who followed one installed the frozen pre-rename package instead of the maintained one. The repo has been correct since the rename; only a publish moves what npmjs.com shows.",
-          "pr": null
-        },
-        {
-          "kind": "deps",
-          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.18.1`",
           "pr": null
         }
       ]
@@ -14000,86 +14080,6 @@
         {
           "kind": "other",
           "title": "Ofri Peretz",
-          "pr": null
-        }
-      ]
-    },
-    {
-      "package": "eslint-plugin-prisma-security",
-      "short": "eslint-plugin-prisma-security",
-      "version": "0.3.5",
-      "date": null,
-      "isApp": false,
-      "isPrivate": false,
-      "entries": [
-        {
-          "kind": "fix",
-          "title": "Refresh the README npm serves for these plugins. npm renders the README from the last publish, so all seven still advertise `eslint-plugin-pg` and `eslint-plugin-jwt` — names retired in #414 and since deprecated on npm. A reader who followed one installed the frozen pre-rename package instead of the maintained one. The repo has been correct since the rename; only a publish moves what npmjs.com shows.",
-          "pr": null
-        },
-        {
-          "kind": "deps",
-          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.18.1`",
-          "pr": null
-        }
-      ]
-    },
-    {
-      "package": "eslint-plugin-sequelize-security",
-      "short": "eslint-plugin-sequelize-security",
-      "version": "0.3.5",
-      "date": null,
-      "isApp": false,
-      "isPrivate": false,
-      "entries": [
-        {
-          "kind": "fix",
-          "title": "Refresh the README npm serves for these plugins. npm renders the README from the last publish, so all seven still advertise `eslint-plugin-pg` and `eslint-plugin-jwt` — names retired in #414 and since deprecated on npm. A reader who followed one installed the frozen pre-rename package instead of the maintained one. The repo has been correct since the rename; only a publish moves what npmjs.com shows.",
-          "pr": null
-        },
-        {
-          "kind": "deps",
-          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.18.1`",
-          "pr": null
-        }
-      ]
-    },
-    {
-      "package": "eslint-plugin-sqlite-security",
-      "short": "eslint-plugin-sqlite-security",
-      "version": "0.1.8",
-      "date": null,
-      "isApp": false,
-      "isPrivate": false,
-      "entries": [
-        {
-          "kind": "fix",
-          "title": "Refresh the README npm serves for these plugins. npm renders the README from the last publish, so all seven still advertise `eslint-plugin-pg` and `eslint-plugin-jwt` — names retired in #414 and since deprecated on npm. A reader who followed one installed the frozen pre-rename package instead of the maintained one. The repo has been correct since the rename; only a publish moves what npmjs.com shows.",
-          "pr": null
-        },
-        {
-          "kind": "deps",
-          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.18.1`",
-          "pr": null
-        }
-      ]
-    },
-    {
-      "package": "eslint-plugin-typeorm-security",
-      "short": "eslint-plugin-typeorm-security",
-      "version": "0.3.5",
-      "date": null,
-      "isApp": false,
-      "isPrivate": false,
-      "entries": [
-        {
-          "kind": "fix",
-          "title": "Refresh the README npm serves for these plugins. npm renders the README from the last publish, so all seven still advertise `eslint-plugin-pg` and `eslint-plugin-jwt` — names retired in #414 and since deprecated on npm. A reader who followed one installed the frozen pre-rename package instead of the maintained one. The repo has been correct since the rename; only a publish moves what npmjs.com shows.",
-          "pr": null
-        },
-        {
-          "kind": "deps",
-          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.18.1`",
           "pr": null
         }
       ]


### PR DESCRIPTION
Regenerated apps/docs/src/data/ (trigger: push). Opened by the Docs Data Sync workflow; contents come entirely from the apps/docs/scripts/sync-* scripts, so review the diff rather than hand-editing.