### PR TITLE
feat(ci): three silent crons start reporting, and the shape gets a ratchet

### DIFF
--- a/.github/cron-alerting-debt.json
+++ b/.github/cron-alerting-debt.json
@@ -1,0 +1,31 @@
+{
+  "note": "Scheduled-workflow jobs that can fail with nobody reporting it. This is a RATCHET: entries may be removed, never added. See docs/intents/cron-failure-delivery/.",
+  "recorded": "2026-09-01",
+  "uncovered": {
+    "check-links.yml": [
+      "gate"
+    ],
+    "codeql.yml": [
+      "gate"
+    ],
+    "lighthouse.yml": [
+      "lighthouse"
+    ],
+    "metrics-freshness.yml": [
+      "check"
+    ],
+    "npm-token-health.yml": [
+      "check-npm-token"
+    ],
+    "quality-full.yml": [
+      "bench-configs",
+      "test-scope"
+    ],
+    "release-drift.yml": [
+      "drift"
+    ],
+    "release-hygiene.yml": [
+      "reconcile"
+    ]
+  }
+}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -364,3 +364,32 @@ jobs:
                 body,
               });
             }
+
+  # Aggregate failure reporting.
+  #
+  # Reporting from inside the working jobs does not survive the shapes those
+  # jobs actually fail in: a `fail-fast` matrix cancels its siblings (and
+  # `failure()` is false in a cancelled job), and a report living in one job
+  # says nothing when a different job is the one that breaks. This job depends
+  # on all of them and runs with `if: always()`, so it sees the whole run.
+  report:
+    name: 🚨 Report a scheduled failure
+    needs: [gate, ilb-formatter, ilb-corpus-truth, ilb-preset-budget, audit-meta, typecheck-scripts, ilb-wild]
+    if: >-
+      always() && github.event_name == 'schedule' &&
+      contains(needs.*.result, 'failure')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/report-failure
+        with:
+          title: "Scheduled benchmark is failing"
+          body: >-
+            The weekly benchmark run did not complete, so the numbers behind the published comparison are not being refreshed. Until this is fixed the figures on the docs site are older than they appear.
+          token: ${{ github.token }}

--- a/.github/workflows/eslint-version-matrix.yml
+++ b/.github/workflows/eslint-version-matrix.yml
@@ -147,3 +147,32 @@ jobs:
           title: 'ESLint version matrix is failing'
           body: 'The scheduled ESLint version matrix failed. Support for one of the declared ESLint majors may be broken, or the matrix itself is.'
           token: ${{ github.token }}
+
+  # Aggregate failure reporting.
+  #
+  # Reporting from inside the working jobs does not survive the shapes those
+  # jobs actually fail in: a `fail-fast` matrix cancels its siblings (and
+  # `failure()` is false in a cancelled job), and a report living in one job
+  # says nothing when a different job is the one that breaks. This job depends
+  # on all of them and runs with `if: always()`, so it sees the whole run.
+  report:
+    name: 🚨 Report a scheduled failure
+    needs: [matrix]
+    if: >-
+      always() && github.event_name == 'schedule' &&
+      contains(needs.*.result, 'failure')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/report-failure
+        with:
+          title: "ESLint version matrix is failing"
+          body: >-
+            At least one ESLint major stopped passing. This matrix is the only check that the plugins work across ESLint 8, 9 and 10, so a break here is a compatibility claim we can no longer make.
+          token: ${{ github.token }}

--- a/.github/workflows/oxlint-parity.yml
+++ b/.github/workflows/oxlint-parity.yml
@@ -219,3 +219,32 @@ jobs:
           title: 'Oxlint parity check is failing'
           body: 'The scheduled oxlint parity run failed, so the ESLint/oxlint parity claim in our docs is unverified.'
           token: ${{ github.token }}
+
+  # Aggregate failure reporting.
+  #
+  # Reporting from inside the working jobs does not survive the shapes those
+  # jobs actually fail in: a `fail-fast` matrix cancels its siblings (and
+  # `failure()` is false in a cancelled job), and a report living in one job
+  # says nothing when a different job is the one that breaks. This job depends
+  # on all of them and runs with `if: always()`, so it sees the whole run.
+  report:
+    name: 🚨 Report a scheduled failure
+    needs: [gate, static-audit, runtime-and-parity, deep-parity]
+    if: >-
+      always() && github.event_name == 'schedule' &&
+      contains(needs.*.result, 'failure')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/report-failure
+        with:
+          title: "Oxlint parity check is failing"
+          body: >-
+            The oxlint parity run did not complete. Engine portability is the differentiator this repo claims, and parity drift is invisible until someone runs it.
+          token: ${{ github.token }}

--- a/scripts/__tests__/cron-alerting-shape.lock.test.ts
+++ b/scripts/__tests__/cron-alerting-shape.lock.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Every scheduled workflow can actually reach a human when it fails.
+ *
+ * On 2026-09-01, 7 of 15 scheduled workflows were failing and only 3 had filed
+ * an issue. The other four were not missing alerting — three of them declared
+ * it — they were failing in shapes their alerting could not see:
+ *
+ *   benchmark              7 jobs, no reporting anywhere
+ *   eslint-version-matrix  report inside a `fail-fast: true` matrix, where a
+ *                          cancelled sibling makes `failure()` false
+ *   oxlint-parity          report only in `deep-parity`; `runtime-and-parity`
+ *                          was the job that broke
+ *   integration-health     `if:` read `inputs.*`, which is empty on schedule
+ *
+ * A scan asking "does this file mention report-failure" passes three of those
+ * four. That is worse than no check, because it reads as coverage. So this
+ * asserts the job GRAPH instead: whatever can fail must be reachable by
+ * something that reports.
+ *
+ * See docs/intents/cron-failure-delivery/.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+import { parse } from 'yaml';
+
+const ROOT = resolve(__dirname, '..', '..');
+const WORKFLOWS = resolve(ROOT, '.github/workflows');
+const debt = (
+  JSON.parse(
+    readFileSync(resolve(ROOT, '.github/cron-alerting-debt.json'), 'utf8'),
+  ) as { uncovered: Record<string, string[]> }
+).uncovered;
+
+type Step = Record<string, unknown>;
+type Job = { steps?: Step[]; needs?: string | string[]; if?: string };
+
+const reports = (j: Job) =>
+  (j.steps ?? []).some(
+    (s) =>
+      (typeof s.uses === 'string' && s.uses.includes('report-failure')) ||
+      (typeof s.name === 'string' && s.name.includes('🚨')),
+  );
+
+const needsOf = (j: Job) =>
+  Array.isArray(j.needs) ? j.needs : j.needs ? [j.needs] : [];
+
+/** Does this condition still evaluate when an upstream job failed? */
+const survivesFailure = (cond: string) =>
+  /always\(\)|failure\(\)|needs\.\*\.result/.test(cond);
+
+describe('a scheduled workflow can reach a human when it fails', () => {
+  const files = readdirSync(WORKFLOWS).filter((f) => f.endsWith('.yml'));
+
+  it.each(files)('%s', (file) => {
+    const raw = readFileSync(join(WORKFLOWS, file), 'utf8');
+    const doc = parse(raw) as { on?: unknown; true?: unknown; jobs?: Record<string, Job> };
+    const triggers = (doc.on ?? doc.true) as Record<string, unknown> | undefined;
+    if (!triggers || !Array.isArray(triggers.schedule)) return;
+
+    const jobs = doc.jobs ?? {};
+
+    // An explicit, reviewable opt-out. Silence should be a decision with a
+    // reason attached, not something achieved by leaving a step out.
+    if (/#\s*alerting:\s*none/i.test(raw)) return;
+
+    const reporters = Object.entries(jobs).filter(([, j]) => reports(j));
+
+    // A RATCHET, not a clean bill of health.
+    //
+    // Nine jobs across eight workflows are uncovered today, recorded in
+    // `.github/cron-alerting-debt.json`. Several are single-job crons that
+    // file *finding* issues (their purpose) but have no *failure* reporter —
+    // a distinction worth keeping, and one that needs a judgement per
+    // workflow rather than a blanket edit. Paying that down is tracked in
+    // docs/intents/cron-failure-delivery.
+    //
+    // What this refuses is GROWTH: a new scheduled job that nobody reports.
+    // Asserting zero today would mean either a red suite or deleting the
+    // finding, and both end with the debt invisible again.
+    const allowed = new Set(debt[file] ?? []);
+
+    const uncovered = Object.entries(jobs)
+      .filter(([, job]) => !reports(job))
+      .filter(
+        ([id]) =>
+          !reporters.some(
+            ([, r]) =>
+              needsOf(r).includes(id) && survivesFailure(String(r.if ?? '')),
+          ),
+      )
+      .map(([id]) => id);
+
+    const added = uncovered.filter((id) => !allowed.has(id));
+    expect(
+      added,
+      `${file}: job(s) ${added.join(', ')} can fail with nobody reporting it. ` +
+        `A reporter must list the job in \`needs\` and run on failure ` +
+        `(always() / failure() / contains(needs.*.result, 'failure')) — a ` +
+        `reporter inside another job, or one that omits this job, does not ` +
+        `see it. If the silence is deliberate, say so with ` +
+        `"# alerting: none — <reason>".`,
+    ).toEqual([]);
+
+    // Debt that is paid must be removed from the baseline, or the ratchet
+    // quietly stops ratcheting.
+    const stale = [...allowed].filter((id) => !uncovered.includes(id));
+    expect(
+      stale,
+      `${file}: ${stale.join(', ')} are listed in cron-alerting-debt.json but ` +
+        `are now covered. Remove them so the baseline keeps meaning what it says.`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Build stage of [`docs/intents/cron-failure-delivery`](docs/intents/cron-failure-delivery/intent.md).

## Summary

Seven scheduled workflows are failing right now. Three file an issue, three were **silent**, and one (`integration-health`) is already fixed and waiting for its next run. The silent three fail in shapes their alerting could not see:

| workflow | why it stayed quiet |
|---|---|
| `benchmark` | 7 jobs, no reporting anywhere |
| `eslint-version-matrix` | report inside a `fail-fast: true` matrix — a cancelled sibling makes `failure()` false |
| `oxlint-parity` | report only in `deep-parity`; `runtime-and-parity` is the job that broke |

Each gets an aggregate `report` job that `needs` every working job and runs on `always() && contains(needs.*.result, 'failure')`, so it sees the whole run rather than the job it happens to live in.

## The lock asserts the job graph, not the file text

A scan for *"does this file mention report-failure"* passes three of those four — worse than no check, because it reads as coverage.

Running the graph version surfaced **nine more uncovered jobs across eight workflows** that no failure had exposed yet. Several are single-job crons that file *finding* issues (their purpose) but have no *failure* reporter — a distinction my earlier survey missed by grepping loosely for `issues: write`.

## Why those nine are a ratchet, not a fix

Recorded in `.github/cron-alerting-debt.json`. Each needs a judgement about whether its silence is a defect or a decision, and making that call blind across eight workflows would be guessing.

Asserting zero today would mean either a red suite or a deleted finding — both end with the debt invisible again, which is the failure this intent exists to remove. The ratchet refuses **growth**, and requires paid-down entries to be removed so it can't quietly stop ratcheting.

## Test plan

- [x] `cron-alerting-shape.lock.test.ts` — 43 workflows pass
- [x] Sabotage-proven **both directions**: removing the new `oxlint-parity` reporter fails with its three now-uncovered jobs named; marking already-covered work as debt fails too
- [x] `lint:workflows` — 43 files pass conventions

The repo's own workflow linter caught that my three new `report` jobs had no `timeout-minutes`. Fixed rather than excused — that check exists because runaway jobs drain quota.

## Deferred

The live canary from the design. #802 and #803 were filed by crons today, so the channel demonstrably works — the *shape* was the failing half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)