### PR TITLE
fix(ci): the merge-queue blocker was a regex, not CodeRabbit

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -16,10 +16,24 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  # `review` is a REQUIRED check. A merge queue waits for every required check
+  # to report on the `merge_group` event, so without this trigger the job never
+  # runs, the context never arrives, and every queued merge blocks forever with
+  # no error message. The job's own `if:` reads `github.event.pull_request`,
+  # which does not exist on `merge_group`, so it skips — and a skipped required
+  # check satisfies the queue. That is the intended behaviour, not an accident:
+  # the review already ran on the PR, and re-reviewing the queue's synthetic
+  # merge commit would spend the monthly credit to re-read an approved diff.
+  merge_group:
 
 concurrency:
   # One review per PR; cancel an in-flight review when a newer commit lands.
-  group: claude-review-${{ github.event.pull_request.number }}
+  #
+  # `pull_request.number` is null on `merge_group`, which would collapse every
+  # queue entry into one group named `claude-review-` and let them cancel each
+  # other — a cancelled required check blocks the queue. `github.ref` is the
+  # unique `gh-readonly-queue/...` branch, so entries stay independent.
+  group: claude-review-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/docs/intents/merge-latency/design.md
+++ b/docs/intents/merge-latency/design.md
@@ -126,6 +126,84 @@ named as blockers by a separate verdict test.
 
 **Step 1 is therefore not met, and step 3 must not be taken.** The queue is
 unblocked by exactly one decision, which is the user's to make: whether `review`
-stays a *required* context. Dropping it from branch protection (CodeRabbit still
+stays a _required_ context. Dropping it from branch protection (CodeRabbit still
 reviews every PR; it just stops being a merge gate) removes the only blocker,
 and the verdict test flips on its own once `REQUIRED_CHECKS` follows.
+
+---
+
+## Correction, 2026-09-02 — the blocker was not real
+
+The finding above is wrong on its central fact, and it stalled the intent for
+two days on a decision that never needed making.
+
+`review` is **not** CodeRabbit. It is the `review:` job in
+`.github/workflows/claude-code-review.yml`. Measured rather than inferred:
+
+```bash
+$ gh api repos/ofri-peretz/eslint/commits/<sha>/check-runs \
+    --jq '.check_runs[] | select(.name=="review") | .app.slug'
+github-actions
+
+$ gh api repos/ofri-peretz/eslint/commits/<sha>/status \
+    --jq '.statuses[].context'
+CodeRabbit
+```
+
+CodeRabbit is real, and it posts a **status context** named `CodeRabbit` —
+a different name, and one branch protection does not require. Two reviewers
+were collapsed into one because they both sound like "the review".
+
+### Why the lock agreed
+
+`workflowProviding()` searched for a job's `name:` value. The job is declared
+
+```yaml
+jobs:
+  review: # no `name:` — GitHub uses the job id as the check name
+```
+
+so the search found nothing, and "no workflow declares it" was read as
+positive evidence of an app. The lock's own header warns that a lock answering
+a narrower question than its name implies "converts _unverified_ into
+_verified_". It then did precisely that, one level down: it knew the
+classification was load-bearing, wrote a test to defend it, and that test
+carried the same blind spot as the belief it was defending. Absence of a match
+was never evidence of an app; it was evidence about one regex.
+
+`checksProvidedBy()` now resolves a job to its `name:` **or its job id**, which
+is what GitHub does. On that lookup the old classification fails immediately,
+with the remediation the lock already knew how to print.
+
+### What changes
+
+- `review` is reclassified `source: 'workflow'`.
+- `claude-code-review.yml` gains `merge_group:`. Its `if:` reads
+  `github.event.pull_request`, absent on that event, so the job **skips** — and
+  a skipped required check satisfies the queue. This is the wanted behaviour:
+  the review ran on the PR, and re-reviewing the queue's synthetic merge commit
+  would spend the monthly credit re-reading an approved diff.
+- Its `concurrency` group gains a `|| github.ref` fallback. `pull_request.number`
+  is null on `merge_group`, which would collapse every queue entry into one
+  group with `cancel-in-progress: true` and let entries cancel each other — a
+  cancelled required check blocks the queue. This was a real hazard the original
+  step-1 audit did not cover, because it only audited the two `quality*`
+  workflows.
+- The verdict test no longer asserts a hand-written blocker list. It resolves
+  every required check to its workflow and requires the trigger, so the answer
+  is derived from the required set rather than restated alongside it.
+
+**Step 1 is now met for all three required checks.** Steps 3–5 are unblocked,
+and no required check has to be dropped.
+
+### Still open — the trade-off this intent is really about
+
+A queue run executes **all** shards where a PR run executes only affected ones,
+so each individual run costs more. That is the velocity/async trade being made:
+one expensive, correct, asynchronous verification of the state that will
+actually land, in place of ~3.2 cheaper partial verifications of states that
+will not. Measured amplification on 2026-09-02 was **3.2 CI cycles per branch**
+(198 PR-event runs, 8 branches), down from the 7 recorded when this intent
+opened but still >1.
+
+Step 3 is a repository setting and is the user's call to make.

--- a/scripts/__tests__/merge-queue-readiness-lock.test.ts
+++ b/scripts/__tests__/merge-queue-readiness-lock.test.ts
@@ -45,25 +45,53 @@ const WORKFLOWS = join(ROOT, '.github', 'workflows');
 const REQUIRED_CHECKS = [
   { name: 'oxlint (fast pass)', source: 'workflow' },
   { name: 'Quality (Full) Gate', source: 'workflow' },
-  // CodeRabbit. Verified on PR #770: reported in 1m30s on a `pull_request`
-  // event from run 33337052342, which no workflow in `.github/workflows`
-  // declares.
-  { name: 'review', source: 'app' },
+  // Provided by the `review:` job in `claude-code-review.yml`, which declares
+  // no `name:` — so the check takes the job id. Recorded as CodeRabbit until
+  // 2026-09-02; the live check run's `app.slug` is `github-actions`. CodeRabbit
+  // posts a separate status context named `CodeRabbit`, and branch protection
+  // does not require it.
+  { name: 'review', source: 'workflow' },
 ] as const satisfies readonly { name: string; source: 'workflow' | 'app' }[];
 
 const WORKFLOW_CHECKS = REQUIRED_CHECKS.filter((c) => c.source === 'workflow');
 const APP_CHECKS = REQUIRED_CHECKS.filter((c) => c.source === 'app');
 
-/** The workflow file that declares a job whose `name:` is `check`. */
+/**
+ * Every check name a workflow file can post.
+ *
+ * A job's `name:` when it declares one — and **the job id when it does not**,
+ * which is what GitHub falls back to. Missing that fallback is what let
+ * `review` be recorded as an installed app for two days: the job is declared
+ * `review:` in `claude-code-review.yml` with no `name:`, so a scan for a
+ * `name:` value found nothing and "no workflow declares it" read as proof of
+ * an app. The live API disagreed the whole time — the check run's `app.slug`
+ * is `github-actions`, and CodeRabbit posts a separate *status context* named
+ * `CodeRabbit`, which branch protection does not require.
+ */
+function checksProvidedBy(src: string): string[] {
+  const jobsAt = src.search(/^jobs:/m);
+  if (jobsAt === -1) return [];
+  const body = src.slice(jobsAt);
+
+  const heads: { id: string; idx: number }[] = [];
+  const jobRe = /^ {2}([A-Za-z0-9_-]+):[ \t]*(?:#.*)?$/gm;
+  for (let m = jobRe.exec(body); m !== null; m = jobRe.exec(body))
+    heads.push({ id: m[1], idx: m.index });
+
+  return heads.map(({ id, idx }, i) => {
+    const segment = body.slice(idx, heads[i + 1]?.idx ?? body.length);
+    // A job-level `name:` sits at four spaces; step names carry a `- ` and are
+    // deeper, so they cannot be picked up here.
+    const declared = /^ {4}name:[ \t]*(.+?)[ \t]*$/m.exec(segment);
+    return declared ? declared[1].replace(/^['"]|['"]$/g, '') : id;
+  });
+}
+
+/** The workflow file that provides `check`, by job `name:` or by job id. */
 function workflowProviding(check: string): string | null {
   for (const file of readdirSync(WORKFLOWS).filter((f) => f.endsWith('.yml'))) {
     const src = readFileSync(join(WORKFLOWS, file), 'utf8');
-    // Job names are quoted or bare; match the `name:` value exactly.
-    const re = new RegExp(
-      `^\\s+name:\\s*['"]?${check.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}['"]?\\s*$`,
-      'm',
-    );
-    if (re.test(src)) return file;
+    if (checksProvidedBy(src).includes(check)) return file;
   }
   return null;
 }
@@ -125,13 +153,30 @@ describe('merge queue readiness', () => {
  * its name implies is worse than no lock: it converts "unverified" into
  * "verified".
  */
-describe('the merge queue is not safe to enable yet', () => {
-  it('names every app-provided required check as a blocker', () => {
-    // Not a TODO. This assertion is the record of WHY the queue is off, and it
-    // flips on its own the moment the blocking contexts are gone: drop `review`
-    // from branch protection and from REQUIRED_CHECKS, and this test starts
-    // reporting the queue as safe.
-    const blockers = APP_CHECKS.map((c) => c.name);
-    expect(blockers).toEqual(['review']);
+describe('the merge queue readiness verdict', () => {
+  it('has no app-provided required check left to block on', () => {
+    // Was `['review']` until 2026-09-02, on the belief that CodeRabbit posted
+    // it. The live check run says `app.slug: github-actions`, and the job is
+    // declared `review:` in claude-code-review.yml. The blocker was never real;
+    // the lookup that "proved" it only searched job `name:` fields, and that
+    // job has none. An app-provided required check IS a genuine blocker — this
+    // stays as the assertion that would catch a real one appearing.
+    expect(APP_CHECKS.map((c) => c.name)).toEqual([]);
+  });
+
+  it('every required check is provided by a workflow that triggers on merge_group', () => {
+    // The whole readiness question in one assertion, derived rather than
+    // declared: read the required set, resolve each to its workflow, require
+    // the trigger. Nothing here can be satisfied by an entry in a hand-written
+    // table.
+    const unready = REQUIRED_CHECKS.map(({ name }) => {
+      const file = workflowProviding(name);
+      if (file === null) return `${name}: no workflow provides it`;
+      if (!hasMergeGroupTrigger(file))
+        return `${name}: ${file} has no merge_group: trigger`;
+      return null;
+    }).filter((x): x is string => x !== null);
+
+    expect(unready).toEqual([]);
   });
 });


### PR DESCRIPTION
Unblocks [`docs/intents/merge-latency`](docs/intents/merge-latency/intent.md), stalled since 2026-08-30.

## The finding it corrects

That intent concluded `review` — one of three required checks — is posted by **CodeRabbit**, an installed app that cannot report on `merge_group`, so enabling the queue would hang every merge forever. The recorded way out was a decision about whether to drop a required check.

`review` is the `review:` job in `.github/workflows/claude-code-review.yml`. Measured, not inferred:

```
check-runs .name=="review"  ->  .app.slug == "github-actions"
statuses   .context         ->  "CodeRabbit"
```

CodeRabbit is real and posts under the context name `CodeRabbit` — which branch protection does **not** require. Two reviewers were collapsed into one because both sound like "the review".

## Why the lock agreed

`workflowProviding()` searched for a job's `name:` value. The job declares none, so GitHub uses the job id:

```yaml
jobs:
  review:            # no `name:` — the check takes the job id
```

No match was read as positive evidence of an app. The file's own header warns that a lock answering a narrower question than its name implies *"converts unverified into verified"* — it then did exactly that one level down, defending a load-bearing classification with a test that shared the classification's blind spot.

## Changes

- `checksProvidedBy()` resolves a job to its `name:` **or its job id**, matching GitHub.
- `review` reclassified `source: 'workflow'`.
- `claude-code-review.yml` gains `merge_group:`. Its `if:` reads `github.event.pull_request`, absent on that event, so the job **skips** — and a skipped required check satisfies the queue. That is wanted: the review already ran on the PR, and re-reviewing the queue's synthetic merge commit would spend the monthly credit re-reading an approved diff.
- Its `concurrency` group gains `|| github.ref`. `pull_request.number` is null on `merge_group`, which would collapse every queue entry into one group with `cancel-in-progress: true` and let entries cancel each other — a cancelled required check blocks the queue. **The original step-1 audit missed this** because it covered only the two `quality*` workflows.
- The verdict test no longer restates a hand-written blocker list; it resolves every required check to its workflow and requires the trigger.

## Test plan

- [x] `vitest run merge-queue-readiness-lock merge-procedure` — 20 passed.
- [x] **Sabotage-proven**: removing `merge_group:` from `claude-code-review.yml` fails 2 of 6 with `review: claude-code-review.yml has no merge_group: trigger`. Verified by `diff` (6827→6812 bytes) that the file genuinely changed.
- [x] Reclassification proven load-bearing: with the id-aware lookup and the old `source: 'app'`, the lock fails with its own remediation message naming `claude-code-review.yml`.
- [x] `lint-workflows.ts` — 44 workflow files pass conventions. `prettier --check` and `oxlint` clean.

## After merge

Step 1 of the merge-latency design is met for **all three** required checks; steps 3–5 are unblocked and no required check has to be dropped.

**Step 3 (enabling the queue) is a repository setting and is deliberately not taken here** — that is yours to make. Current amplification measured 2026-09-02: **3.2 CI cycles per branch** (198 PR-event runs across 8 branches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)