### PR TITLE
feat(ci): mint the Turborepo cache token from OIDC, not a stored secret

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -283,6 +283,28 @@ runs:
     #
     # Exactly one of these runs. Both at once would leave the shim's local
     # TURBO_API pointing at localhost while credentials say Vercel.
+    # Mint a short-lived Turborepo token from the job's GitHub OIDC identity and
+    # export it as TURBO_TOKEN for the steps below. Unlike a PAT this is
+    # team-scoped rather than person-scoped, grants Remote Cache and nothing
+    # else, and expires — so there is no long-lived secret in this repo to leak
+    # or rotate.
+    #
+    # `continue-on-error` is load-bearing, not defensive habit. This step fails
+    # whenever the exchange cannot happen — no OIDC policy configured on the
+    # Vercel team yet, or a fork PR, where GitHub issues no writable id-token at
+    # all. Both are ordinary states, not defects, and both must fall through to
+    # the Actions-backed cache below rather than fail a PR. Without it, adding
+    # this step turns every fork PR red.
+    #
+    # Guarded on TURBO_TEAM because the exchange needs the team slug, and the
+    # workflow supplies it from `vars.TURBO_TEAM`. Unset -> skip -> fallback.
+    - name: Exchange the GitHub OIDC token for a Turborepo cache token
+      if: inputs.turbo-remote-cache == 'true' && env.TURBO_TEAM != '' && env.TURBO_TOKEN == ''
+      continue-on-error: true
+      uses: vercel/setup-turborepo-remote-cache-action@49d7b1b46ba4c9251e1977986bfe18336feabc8f # v1.1.0
+      with:
+        team: ${{ env.TURBO_TEAM }}
+
     - name: Turborepo remote cache (GitHub Actions backend — no token)
       if: inputs.turbo-remote-cache == 'true' && env.TURBO_TOKEN == ''
       uses: rharkor/caching-for-turbo@2238fae6eb9a9936f92356f54cb3660200d105e7 # v2.5.1

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -50,6 +50,12 @@ env:
 
 permissions:
   contents: read
+  # For the Turborepo Remote Cache OIDC exchange in ./.github/actions/setup.
+  # The minted token grants Remote Cache access on the Vercel team and nothing
+  # else. Deliberately NOT added to release.yml or supply-chain-attestation.yml
+  # — `infra-metrics-lock` asserts those never enable the remote cache at all,
+  # because a cache write is a path into what we publish.
+  id-token: write
 
 jobs:
   gate:

--- a/.github/workflows/quality-full.yml
+++ b/.github/workflows/quality-full.yml
@@ -51,6 +51,12 @@ concurrency:
 
 permissions:
   contents: read
+  # For the Turborepo Remote Cache OIDC exchange in ./.github/actions/setup.
+  # The minted token grants Remote Cache access on the Vercel team and nothing
+  # else. Deliberately NOT added to release.yml or supply-chain-attestation.yml
+  # — `infra-metrics-lock` asserts those never enable the remote cache at all,
+  # because a cache write is a path into what we publish.
+  id-token: write
 
 env:
   # No `--filter=...[origin/main]`. It made both Build and Unit Tests report a

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -47,6 +47,12 @@ concurrency:
 
 permissions:
   contents: read
+  # For the Turborepo Remote Cache OIDC exchange in ./.github/actions/setup.
+  # The minted token grants Remote Cache access on the Vercel team and nothing
+  # else. Deliberately NOT added to release.yml or supply-chain-attestation.yml
+  # — `infra-metrics-lock` asserts those never enable the remote cache at all,
+  # because a cache write is a path into what we publish.
+  id-token: write
 
 env:
   TURBO_TELEMETRY_DISABLED: '1'

--- a/scripts/__tests__/cache-budget-lock.test.ts
+++ b/scripts/__tests__/cache-budget-lock.test.ts
@@ -85,6 +85,56 @@ describe('exactly one Turborepo remote-cache backend can be active', () => {
   });
 });
 
+describe('the OIDC exchange degrades instead of failing', () => {
+  const step = SETUP.slice(
+    SETUP.indexOf('Exchange the GitHub OIDC token'),
+    SETUP.indexOf('Turborepo remote cache (GitHub Actions backend'),
+  );
+
+  it('is present', () => {
+    expect(step.length).toBeGreaterThan(0);
+  });
+
+  it('carries continue-on-error', () => {
+    // The single most important line here. The exchange fails in two ORDINARY
+    // states — no OIDC policy on the Vercel team yet, and any fork PR, where
+    // GitHub issues no writable id-token. Without this, wiring OIDC turns every
+    // fork PR red, and a repo that accepts outside contributions cannot take
+    // that. Neither state is a defect; both must fall through to the
+    // Actions-backed cache.
+    expect(step).toMatch(/continue-on-error:\s*true/);
+  });
+
+  it('runs before the backend it feeds', () => {
+    // It exports TURBO_TOKEN, and the two backend steps below branch on it.
+    // Ordered after them, the guards read an empty value and the Vercel path is
+    // permanently unreachable while everything stays green.
+    expect(SETUP.indexOf('Exchange the GitHub OIDC token')).toBeLessThan(
+      SETUP.indexOf('Turborepo remote cache (GitHub Actions backend'),
+    );
+  });
+
+  it('pins the third-party action by SHA', () => {
+    // Same rule as every other third-party action here: a moving tag is the
+    // whole attack, and this one mints a credential.
+    expect(step).toMatch(
+      /uses:\s*vercel\/setup-turborepo-remote-cache-action@[a-f0-9]{40}/,
+    );
+  });
+
+  it('every workflow that opts in can actually mint a token', () => {
+    // `id-token: write` is what makes the exchange possible. Missing it, the
+    // step fails, continue-on-error swallows it, and the repo silently runs on
+    // the fallback forever — configured, green, and doing nothing.
+    for (const file of TURBO_WORKFLOWS) {
+      const src = readFileSync(join(ROOT, '.github/workflows', file), 'utf8');
+      expect(src, `${file} needs id-token: write`).toMatch(
+        /^\s*id-token:\s*write/m,
+      );
+    }
+  });
+});
+
 describe('the credentials reach the jobs that would use them', () => {
   it.each(TURBO_WORKFLOWS)(
     '%s passes TURBO_TOKEN and TURBO_TEAM through to the setup action',


### PR DESCRIPTION
Replaces the planned `TURBO_TOKEN` secret from #828 with an OIDC exchange.

The job proves its identity with GitHub's `id-token` and receives a short-lived Turborepo access token that is **scoped to the Vercel team, grants Remote Cache and nothing else, and expires**. No long-lived credential in this repo to leak or rotate, and none tied to a person.

## How it fits the existing fallback

The exchange exports `TURBO_TOKEN`, and the two backend steps from #828 already branch on it — so nothing about that design changes:

| state | backend |
|---|---|
| exchange succeeds | Vercel (off the 10 GB Actions budget, shared across branches) |
| exchange skipped or fails | `rharkor/caching-for-turbo` (Actions-backed) |

## `continue-on-error` is the load-bearing line

The exchange fails in two **ordinary** states, neither of which is a defect:

- no OIDC policy configured on the Vercel team (today, and until someone creates one)
- **any fork PR** — GitHub issues no writable `id-token` there at all

Both must fall through to the Actions-backed cache. Without `continue-on-error`, wiring OIDC turns **every fork PR red**, which a repo taking outside contributions cannot accept.

## Permissions

`id-token: write` on `quality`, `quality-full`, `a11y` only — the three that opt into the remote cache. Deliberately **not** `release.yml` or `supply-chain-attestation.yml`: `infra-metrics-lock` already asserts those never enable the remote cache, because a cache write is a path into what we publish.

## Test plan

- [x] 17 passed in `cache-budget-lock`; 49 across it + `infra-metrics-lock` + `merge-queue-readiness-lock`.
- [x] **Four new assertions, each sabotage-proven to fail alone**: `continue-on-error` present · action pinned by SHA · exchange ordered *before* the backends it feeds · every opted-in workflow can actually mint a token.
- [x] `lint:workflows` 44/44 · `oxlint` clean · every `.yml` under `.github/` parses.

That last assertion guards the silent failure this design invites: without `id-token: write` the exchange fails, `continue-on-error` swallows it, and the repo runs the fallback forever while every check stays green.

## Activation — two things, both yours

1. **Vercel dashboard** → Settings → Build and Deployment → *OIDC Policies for CLI Access* → Add a **Turborepo CLI policy**, selecting this GitHub account and repo.
2. **Set the team slug** (a variable, not a secret — so GitHub doesn't censor it in logs):

```bash
gh -R ofri-peretz/eslint variable set TURBO_TEAM --body "your-team-slug"
```

The slug is the part after `vercel.com/` in your team URL. Until both exist, `TURBO_TEAM` is empty, the exchange is skipped, and behaviour is exactly as it is today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)