### PR TITLE
fix(ci): bound the Remote Cache request rate before it chokes the quota

### DIFF
--- a/scripts/__tests__/cache-budget-lock.test.ts
+++ b/scripts/__tests__/cache-budget-lock.test.ts
@@ -85,6 +85,52 @@ describe('exactly one Turborepo remote-cache backend can be active', () => {
   });
 });
 
+describe('the Vercel Remote Cache request budget', () => {
+  /**
+   * Vercel's fair-use cap is on REQUEST RATE, not storage — artifacts expire
+   * after 7 days on their own, so there is no size to manage.
+   *
+   *   Hobby   100 requests / minute
+   *   Pro   10000 requests / minute
+   *
+   * Every job that opts in starts its turbo run at roughly the same moment, and
+   * turbo issues at least one lookup per task plus an upload on a miss.
+   * Measured 2026-09-02: `turbo run build --dry` = 37 tasks, `turbo run test
+   * --dry` = 57, across 7 opted-in jobs.
+   *
+   *   7 x 37  = 259 .. 518 requests   (build-shaped)
+   *   7 x 57  = 399 .. 798 requests   (test-shaped)
+   *
+   * all inside the opening minute. That is 2.6x - 8x over the Hobby cap and
+   * about 5-8% of Pro. A merge-queue run is worse by construction: it executes
+   * ALL shards where a PR run executes only affected ones.
+   *
+   * So the count of opted-in jobs is a quota decision, not a convenience. This
+   * bound makes growing it a deliberate act with the arithmetic in front of
+   * you, rather than a line added to one more workflow.
+   */
+  const BUDGETED_JOBS = 7;
+
+  it('no more jobs opt in than the budget allows', () => {
+    const dir = join(ROOT, '.github/workflows');
+    const optedIn = readdirSync(dir)
+      .filter((f) => f.endsWith('.yml'))
+      .map((f) => readFileSync(join(dir, f), 'utf8'))
+      .reduce(
+        (n, src) =>
+          n + (src.match(/turbo-remote-cache:\s*['"]true['"]/g) ?? []).length,
+        0,
+      );
+
+    expect(
+      optedIn,
+      `${optedIn} jobs enable the remote cache; budget is ${BUDGETED_JOBS}. ` +
+        'Each adds ~37-57 requests to the same opening minute. Raise the ' +
+        'budget deliberately, and check the plan cap before you do.',
+    ).toBeLessThanOrEqual(BUDGETED_JOBS);
+  });
+});
+
 describe('the OIDC exchange degrades instead of failing', () => {
   const step = SETUP.slice(
     SETUP.indexOf('Exchange the GitHub OIDC token'),


### PR DESCRIPTION
Audit of what our Vercel activity will actually consume once #830's OIDC exchange is live.

## The cap is request RATE, not storage

Artifacts expire after 7 days on their own, so there is no size to manage. The fair-use limit is:

| Plan | Requests / minute |
|---|---:|
| Hobby | **100** |
| Pro | 10,000 |

## What we would send

Every opted-in job starts its turbo run at roughly the same moment, and turbo issues at least one lookup per task plus an upload on a miss. Measured 2026-09-02:

- `turbo run build --dry` → **37 tasks**
- `turbo run test --dry` → **57 tasks**
- **7 jobs** opt in (5 in `quality-full`, 1 `quality`, 1 `a11y`)

| shape | requests in the opening minute |
|---|---|
| build | 259 – 518 |
| test | 399 – 798 |

**2.6× to 8× over the Hobby cap.** About 5–8% of Pro. A merge-queue run is worse by construction — it runs *all* shards where a PR run runs only affected ones.

## What this adds

A bound on the opted-in job count, with the arithmetic recorded next to it. The count is a quota decision, not a convenience, and nothing captured that — an eighth job is one line in one workflow, and its cost is invisible at the point you'd add it.

Proven: opting an eighth job in fails with `8 jobs enable the remote cache; budget is 7`.

## Test plan

- [x] `cache-budget-lock` 18 passed; sabotage-proven (8th job → 1 failure, exact message).
- [x] `prettier --check`, `oxlint`, `lint:workflows` (44/44) clean.

## What I could not check

I have no read access to Vercel-side usage — no CLI on this machine and the token is a repo secret I can't (and shouldn't) read. So **I cannot tell you which plan the account is on**, and that single fact decides whether the numbers above are fine or 8× over. Worth confirming before completing the OIDC activation in #830.

Separately, for context on overall Vercel load: `deploy-docs.yml` ran **308 times in 30 days** (~10.3 production Next.js builds/day), all `workflow_dispatch` from `auto-deploy.yml`, against 422 merges — so turbo-affected filtering is working at 0.73 deploys/merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)