### PR TITLE
fix(ci): comparison refresh builds before it probes; failed tag push fails the backfill

### DIFF
--- a/.github/workflows/comparison-refresh.yml
+++ b/.github/workflows/comparison-refresh.yml
@@ -61,6 +61,16 @@ jobs:
       - name: ISO 25010 crosswalk
         run: npm run ilb:iso25010-report
 
+      # The probe regenerates RULE_CASES.json when it is absent, and that ledger
+      # loads every plugin's rules from dist/. A fresh checkout has no dist/,
+      # so without this step the probe dies on
+      # `Cannot find module '@interlace/eslint-devkit/dist/src/index.js'`
+      # (run 33717558041) and the reporter files #803 against a workflow whose
+      # five real refreshes all succeeded. Locked by
+      # scripts/__tests__/comparison-refresh-prerequisites.lock.test.ts.
+      - name: Build the plugin graph (the probe loads rules from dist/)
+        run: npx turbo run build --output-logs=errors-only
+
       # Repo-local and offline: it renames every binding in the suite and re-runs
       # the tests, which is minutes rather than the seconds the artifacts above
       # take. It belongs on a schedule for exactly that reason —

--- a/scripts/__tests__/comparison-refresh-prerequisites.lock.test.ts
+++ b/scripts/__tests__/comparison-refresh-prerequisites.lock.test.ts
@@ -57,3 +57,40 @@ describe('name-dependence-probe handles missing RULE_CASES.json', () => {
     ).toMatch(/['"]rule-cases['"]/);
   });
 });
+
+/**
+ * Second prerequisite, found once the first was fixed: the regenerated ledger
+ * loads every plugin's rules from dist/, and a fresh CI checkout has no dist/.
+ * Run 33717558041 died in the probe on
+ * `Cannot find module '@interlace/eslint-devkit/dist/src/index.js'` after all
+ * five real refresh steps had succeeded — the same false alarm as #803, one
+ * layer down.
+ *
+ * Sabotage proof: delete the build step, or move it below the probe, and
+ * "must build the plugin graph before the probe" fails.
+ */
+describe('comparison-refresh.yml builds before it probes', () => {
+  const WORKFLOW = readFileSync(
+    resolve(ROOT, '.github/workflows/comparison-refresh.yml'),
+    'utf-8',
+  );
+
+  it('must build the plugin graph before the name-dependence probe', () => {
+    const build = WORKFLOW.indexOf('npx turbo run build');
+    const probe = WORKFLOW.indexOf('scripts/name-dependence-probe.mts');
+    expect(
+      build,
+      'comparison-refresh.yml must run `npx turbo run build` — the probe ' +
+        'regenerates RULE_CASES.json from every plugin\'s dist/, which a ' +
+        'fresh checkout does not have.',
+    ).toBeGreaterThan(-1);
+    expect(
+      probe,
+      'comparison-refresh.yml must still run scripts/name-dependence-probe.mts',
+    ).toBeGreaterThan(-1);
+    expect(
+      build,
+      'the build step must come BEFORE the Name-dependence probe step',
+    ).toBeLessThan(probe);
+  });
+});

--- a/scripts/__tests__/reconcile-tags-push.lock.test.ts
+++ b/scripts/__tests__/reconcile-tags-push.lock.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Lock: reconcile-tags.ts --backfill-missing fails when a tag push fails.
+ *
+ * On 2026-09-03 `release-hygiene.yml` (action=backfill-missing, run
+ * 33717605865) logged `+ eslint-devkit@1.17.0 → 3d101b8` and exited green.
+ * The tag never reached origin: the push was `shOk(...)`, which swallows the
+ * exit code, and the job's checkout carries no push credentials. The next
+ * `report` run still counted one missing tag, so the remedy the tracking
+ * issue (#743) prescribed could not close the issue it was prescribed for.
+ *
+ * Sabotage proof:
+ *   - Revert the push to a bare `shOk('git', ['push', ...])` → "must check
+ *     the result of every tag push" fails.
+ *   - Drop the `process.exit(1)` → "must exit non-zero when any push failed"
+ *     fails.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const ROOT = resolve(__dirname, '..', '..');
+const SOURCE = readFileSync(resolve(ROOT, 'scripts/reconcile-tags.ts'), 'utf-8');
+const BACKFILL_BLOCK = SOURCE.slice(SOURCE.indexOf('if (BACKFILL)'), SOURCE.indexOf('if (CLEANUP)'));
+
+describe('reconcile-tags backfill reports a failed push', () => {
+  it('has a BACKFILL block to lock', () => {
+    expect(BACKFILL_BLOCK.length).toBeGreaterThan(0);
+  });
+
+  it('must check the result of every tag push', () => {
+    expect(
+      BACKFILL_BLOCK,
+      'The backfill must test the return value of the `git push origin <tag>` ' +
+        'call (e.g. `if (!shOk(\'git\', [\'push\', ...]))`). A bare shOk swallows ' +
+        'the exit code, and a tag that only exists locally reads as backfilled.',
+    ).toMatch(/if \(!shOk\('git', \['push'/);
+    expect(BACKFILL_BLOCK).not.toMatch(/^\s*shOk\('git', \['push'/m);
+  });
+
+  it('must exit non-zero when any push failed', () => {
+    expect(
+      BACKFILL_BLOCK,
+      'After the loop the backfill must `process.exit(1)` when any push ' +
+        'failed, so the workflow goes red instead of reporting a fix that ' +
+        'did not land.',
+    ).toMatch(/process\.exit\(1\)/);
+  });
+});

--- a/scripts/reconcile-tags.ts
+++ b/scripts/reconcile-tags.ts
@@ -247,6 +247,11 @@ if (JSON_OUT) {
 }
 
 if (BACKFILL) {
+  // A push that fails must fail the run. On 2026-09-03 the workflow reported
+  // `+ eslint-devkit@1.17.0 → 3d101b8` and exited green while the tag never
+  // reached origin (the job's checkout has no push credentials), so the
+  // "missing" finding it was dispatched to fix survived its own fix.
+  const pushFailures: string[] = [];
   for (const f of findings) {
     for (const ver of f.missing) {
       const tag = `${f.short}@${ver}`;
@@ -262,8 +267,15 @@ if (BACKFILL) {
         sh('git', ['tag', '-a', tag, '-m', `Backfill release ${tag}`, targetSha]);
         log(`  + ${tag} → ${targetSha.slice(0, 7)}`);
       }
-      shOk('git', ['push', 'origin', tag]);
+      if (!shOk('git', ['push', 'origin', tag])) {
+        pushFailures.push(tag);
+        log(`  ✗ ${tag}: push to origin failed — the tag exists locally only.`);
+      }
     }
+  }
+  if (pushFailures.length > 0) {
+    log(`Backfill incomplete: ${pushFailures.length} tag(s) not pushed: ${pushFailures.join(', ')}`);
+    process.exit(1);
   }
 }
 


### PR DESCRIPTION
## Summary

- `comparison-refresh.yml` runs `npx turbo run build` before the name-dependence probe. The probe regenerates `RULE_CASES.json` from every plugin's `dist/`, which a fresh checkout does not have; run 33717558041 died on a missing devkit dist after all five real refreshes had succeeded, and the reporter filed #803.
- `scripts/reconcile-tags.ts --backfill-missing` now checks every `git push origin <tag>` and exits 1 if any failed. Run 33717605865 logged the tag as created and exited green while origin never received it, so the remedy for #743 could not close #743.

## Test plan

- [x] `npx vitest run scripts/__tests__/comparison-refresh-prerequisites.lock.test.ts scripts/__tests__/reconcile-tags-push.lock.test.ts` — 6 passed.
- [x] Sabotage: with the workflow edit stashed, the new "must build the plugin graph before the name-dependence probe" assertion fails; with the script edit stashed, both new reconcile-tags assertions fail.
- [x] `npm run lint:workflows` — 44 workflow files pass.

## After merge

Dispatch `comparison-refresh.yml` and close #803 when it is green. The next `release-hygiene` backfill will go red instead of green if a tag push is refused, which is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)