### PR TITLE
fix(nestjs-security): type-aware cases get a timeout that survives the coverage run

### DIFF
--- a/packages/eslint-plugin-nestjs-security/src/type-aware-timeout.lock.test.ts
+++ b/packages/eslint-plugin-nestjs-security/src/type-aware-timeout.lock.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Lock: the type-aware suite runs its cases with a timeout that survives the
+ * coverage run.
+ *
+ * `type-aware.test.ts` builds a TypeScript program per run; the first case
+ * absorbs that cost. Under `codecov.yml` (turbo fan-out of every package's
+ * `test:coverage`, v8 instrumentation on) that case exceeded the package's
+ * 30s `testTimeout` (run 33717568270), the coverage upload failed, and #817
+ * was filed. The fix registers RuleTester's `it` with a case timeout of at
+ * least 60s.
+ *
+ * Sabotage proof: set `RuleTester.it = it` again, or lower the constant below
+ * 60_000, and "registers RuleTester.it with a type-aware case timeout" fails.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const SOURCE = readFileSync(resolve(__dirname, 'type-aware.test.ts'), 'utf-8');
+
+describe('type-aware.test.ts case timeout', () => {
+  it('registers RuleTester.it with a type-aware case timeout of at least 60s', () => {
+    const constant = SOURCE.match(/const TYPE_AWARE_CASE_TIMEOUT_MS = ([\d_]+);/);
+    expect(
+      constant,
+      'type-aware.test.ts must declare TYPE_AWARE_CASE_TIMEOUT_MS',
+    ).not.toBeNull();
+    const ms = Number(constant![1].replace(/_/g, ''));
+    expect(
+      ms,
+      'the type-aware case timeout must be at least 60_000ms — 30s is what ' +
+        'timed out under the coverage run (#817)',
+    ).toBeGreaterThanOrEqual(60_000);
+    expect(
+      SOURCE,
+      'RuleTester.it must pass TYPE_AWARE_CASE_TIMEOUT_MS to vitest\'s it()',
+    ).toMatch(/RuleTester\.it = \(text, callback\) =>\s*it\(text, callback, TYPE_AWARE_CASE_TIMEOUT_MS\)/);
+    expect(SOURCE).not.toMatch(/^RuleTester\.it = it;$/m);
+  });
+});

--- a/packages/eslint-plugin-nestjs-security/src/type-aware.test.ts
+++ b/packages/eslint-plugin-nestjs-security/src/type-aware.test.ts
@@ -68,9 +68,21 @@ const nest = <T,>(cases: T[]): T[] =>
   });
 
 
+/**
+ * Every case here builds a real TypeScript program through `projectService`,
+ * and the first one pays for the whole program. Under the scheduled coverage
+ * run — a turbo fan-out of every package's `test:coverage` with v8
+ * instrumentation on — that first case took longer than the package's 30s
+ * `testTimeout` (codecov.yml run 33717568270, "Test timed out in 30000ms"),
+ * which made the coverage upload fail and filed #817. The syntax-only suites
+ * keep the 30s default; only type-aware cases get this budget.
+ * Locked by ./type-aware-timeout.lock.test.ts.
+ */
+const TYPE_AWARE_CASE_TIMEOUT_MS = 120_000;
+
 RuleTester.afterAll = afterAll;
 RuleTester.describe = describe;
-RuleTester.it = it;
+RuleTester.it = (text, callback) => it(text, callback, TYPE_AWARE_CASE_TIMEOUT_MS);
 
 const ruleTester = new RuleTester({
   languageOptions: {


### PR DESCRIPTION
## Summary

- `type-aware.test.ts` registers `RuleTester.it` with a 120s case timeout. Every case there builds a TypeScript program through `projectService`, and under `codecov.yml` (turbo fan-out of every package's `test:coverage` with v8 instrumentation) the first case exceeded the package's 30s default (run 33717568270, "Test timed out in 30000ms"). That failure is what files #817. Syntax-only suites keep 30s.

## Test plan

- [x] `npx vitest run src/type-aware.test.ts src/type-aware-timeout.lock.test.ts` in the package — 15 passed.
- [x] Sabotage: with the wrapper reverted, `type-aware-timeout.lock.test.ts` fails.
- [x] `npx tsc --noEmit -p packages/eslint-plugin-nestjs-security/tsconfig.json` — clean.

## After merge

Dispatch `codecov.yml`; close #817 when the coverage upload is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)