### PR TITLE
perf(ci): stop paying 124s of review for a diff of prose

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -42,7 +42,74 @@ permissions:
   id-token: write
 
 jobs:
+  # Decide whether this diff is worth a review before spending ~120s and a
+  # slice of the monthly credit on it.
+  #
+  # `review` is the CRITICAL PATH of PR CI. Measured 2026-09-03 over the last
+  # eight merged PRs, it was 88-99% of end-to-end wall clock (median 124s on
+  # success); all ~26 other checks finish inside its shadow. So the only diffs
+  # worth paying that for are the ones a reviewer can actually find something
+  # in.
+  #
+  # Over 60 merged PRs: 83% touched code, 13% were documentation only. Those
+  # 13% pay full price for a reviewer reading prose — and one of them (#821)
+  # was 100 files of it.
+  #
+  # NOT skipped for `.github/`-only diffs, though they are 3% and tempting.
+  # Two CI outages on 2026-09-02 came from exactly that kind of change (an
+  # unquoted colon that made a composite action unparseable, and a formatter
+  # run that broke a lock). A workflow diff is the last place to remove a
+  # reviewer.
+  scope:
+    name: Review scope
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      run: ${{ steps.decide.outputs.run }}
+    steps:
+      - id: decide
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+        shell: bash
+        run: |
+          set -uo pipefail
+
+          # No PR number means `merge_group`: the review already ran on the PR,
+          # and re-reviewing the queue's synthetic merge commit would buy
+          # nothing. The job below skips, and a skipped required check
+          # satisfies the queue.
+          if [ -z "${PR:-}" ]; then
+            echo "merge_group — review already ran on the PR"
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Fail OPEN. Every unexpected state here — API error, empty list, a
+          # path shape not anticipated — must end in a review running, never in
+          # one silently skipped. A gate that quietly disables the reviewer it
+          # guards is worse than no gate.
+          files=$(gh -R "$GITHUB_REPOSITORY" pr view "$PR" --json files \
+                    --jq '.files[].path' 2>/dev/null) || files=""
+          if [ -z "$files" ]; then
+            echo "could not list changed files — reviewing to be safe"
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Documentation only: Markdown anywhere, and the docs content tree.
+          # Anything else — including .github/ — is code for this purpose.
+          if printf '%s\n' "$files" | grep -qvE '(\.mdx?$|^docs/|^apps/docs/content/)'; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "code in the diff — reviewing"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "documentation only ($(printf '%s\n' "$files" | wc -l) files) — skipping"
+          fi
+          printf '%s\n' "$files" | head -20
+
   review:
+    needs: scope
     # Skip draft PRs -- review once a PR is opened or marked ready for review.
     #
     # Also skip PRs opened by a bot. `claude-code-action` refuses non-human
@@ -58,7 +125,8 @@ jobs:
     # and paying for the review would be spending the monthly credit to read a
     # diff of version numbers.
     if: >-
-      github.event.pull_request.draft == false
+      needs.scope.outputs.run == 'true'
+      && github.event.pull_request.draft == false
       && github.event.pull_request.user.type != 'Bot'
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/scripts/__tests__/review-scope-lock.test.ts
+++ b/scripts/__tests__/review-scope-lock.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * The scope gate on `claude-code-review.yml`, executed rather than read.
+ *
+ * `review` is the critical path of PR CI: measured 2026-09-03 across the last
+ * eight merged PRs it was 88-99% of end-to-end wall clock, median 124s, while
+ * all ~26 other checks finished inside its shadow. The gate exists so that the
+ * 13% of PRs which are documentation only stop paying that, and stop spending
+ * the monthly review credit on prose.
+ *
+ * It is also a control that can fail silently in the expensive direction. A
+ * pattern that accidentally matches source files does not break a build — it
+ * disables the reviewer, on exactly the diffs that needed one, and every check
+ * stays green. So the classifier is EXTRACTED from the workflow and run against
+ * fixtures. Asserting the pattern's text would pass on a version that reads
+ * plausibly and classifies wrongly.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const ROOT = resolve(__dirname, '..', '..');
+const WORKFLOW = readFileSync(
+  join(ROOT, '.github/workflows/claude-code-review.yml'),
+  'utf8',
+);
+
+/** The doc-path regex from the workflow, verbatim. */
+function documentedPattern(): string {
+  const m = /grep -qvE '\(([^']+)\)'/.exec(WORKFLOW);
+  expect(
+    m,
+    'no `grep -qvE` classifier found in claude-code-review.yml',
+  ).not.toBeNull();
+  return `(${m![1]})`;
+}
+
+/** Run the classifier and return its exit status as a boolean. */
+function shouldReview(files: string[]): boolean {
+  try {
+    execFileSync(
+      'bash',
+      [
+        '-c',
+        `printf '%s\\n' "$0" | grep -qvE ${JSON.stringify(documentedPattern())}`,
+        files.join('\n'),
+      ],
+      { stdio: 'ignore' },
+    );
+    return true; // grep -qv found a non-doc path
+  } catch {
+    return false; // every path matched the doc pattern
+  }
+}
+
+describe('the review scope classifier', () => {
+  it.each([
+    ['a rule source file', ['packages/eslint-plugin-x/src/rules/a.ts']],
+    ['a workflow', ['.github/workflows/quality.yml']],
+    ['the lockfile', ['package-lock.json']],
+    ['docs mixed with code', ['docs/adr/0001.md', 'packages/x/src/index.ts']],
+    ['a page in the docs APP', ['apps/docs/src/app/page.tsx']],
+    ['code that merely says docs', ['scripts/docs.ts']],
+    ['a lib inside apps/docs', ['apps/docs/src/lib/util.ts']],
+  ])('reviews %s', (_label, files) => {
+    expect(shouldReview(files as string[])).toBe(true);
+  });
+
+  it.each([
+    ['a root readme', ['README.md']],
+    ['an intent', ['docs/intents/x/intent.md']],
+    ['docs content', ['apps/docs/content/docs/rules/foo.mdx']],
+    ['agent instructions', ['CLAUDE.md', 'AGENTS.md']],
+    ['a rule doc in a package', ['packages/eslint-plugin-x/docs/rules/a.md']],
+  ])('skips %s', (_label, files) => {
+    expect(shouldReview(files as string[])).toBe(false);
+  });
+
+  it('reviews a .github-only diff — deliberately not skipped', () => {
+    // 3% of PRs, and tempting to skip alongside docs. Both CI outages on
+    // 2026-09-02 were workflow diffs: an unquoted colon that made a composite
+    // action unparseable, and a formatter run that broke a lock. A workflow
+    // change is the last place to remove a reviewer.
+    expect(shouldReview(['.github/actions/setup/action.yml'])).toBe(true);
+  });
+});
+
+describe('the gate fails open', () => {
+  const scope = WORKFLOW.slice(
+    WORKFLOW.indexOf('  scope:'),
+    WORKFLOW.indexOf('  review:'),
+  );
+
+  it('reviews when the file list cannot be read', () => {
+    // Every unexpected state must end in a review running. A gate that
+    // quietly disables the reviewer it guards is worse than no gate, and it
+    // reports success either way.
+    expect(scope).toMatch(/if \[ -z "\$files" \][\s\S]{0,200}run=true/);
+  });
+
+  it('does not let a gh failure abort into a skip', () => {
+    expect(scope).toContain('|| files=""');
+  });
+});
+
+describe('the required check still reports', () => {
+  it('review is still the job id branch protection requires', () => {
+    // Renaming the job renames the check, and a required context that never
+    // arrives blocks every merge with no error message.
+    expect(WORKFLOW).toMatch(/^ {2}review:$/m);
+  });
+
+  it('review still triggers on merge_group', () => {
+    expect(WORKFLOW).toMatch(/^ {2}merge_group:$/m);
+  });
+});


### PR DESCRIPTION
## Why

`review` is the critical path of PR CI and nothing else is close. Measured 2026-09-03 over the last eight merged PRs:

| PR | e2e | review | share |
|---|---|---|---|
| #832 | 99s | 97s | 97% |
| #830 | 146s | 143s | 97% |
| #815 | 122s | 108s | 88% |
| #814 | 113s | 111s | 98% |
| #813 | 106s | 105s | 99% |
| #812 | 269s | 262s | 97% |

Median 124s on success (n=19). All ~26 other checks finish inside its shadow.

Over 60 merged PRs: **83% code, 13% documentation-only, 3% `.github`-only.** The documentation-only ones pay full price for a reviewer reading prose — one (#821) was 100 files of it, plus a slice of the monthly credit.

## What

A `scope` job classifies the diff; `review` `needs` it. Documentation-only diffs skip — and a skipped required check satisfies branch protection, so the merge path is unchanged.

**Not skipped for `.github`-only diffs**, though they're 3% and tempting. Both CI outages on 2026-09-02 were exactly that shape (an unquoted colon that made a composite action unparseable; a formatter run that broke a lock). A workflow diff is the last place to remove a reviewer.

**The gate fails open.** Any unexpected state — API error, empty file list, unanticipated path shape — ends in a review running. A gate that quietly disables the reviewer it guards is worse than no gate, and it reports success either way.

## Test plan

- [x] `review-scope-lock.test.ts` — 17 passed.
- [x] The lock **extracts the classifier from the workflow and executes it** against fixtures rather than asserting its text. A pattern that reads plausibly but classifies wrongly passes a grep, and its failure mode is a silent skip on the diffs that most needed review.
- [x] Cases include the traps: `apps/docs/src/lib/util.ts` (code inside the docs app) → review; `scripts/docs.ts` → review; `docs/adr/x.md` + `packages/x/src/index.ts` → review; `.github/actions/setup/action.yml` → review.
- [x] `prettier --check`, `lint:workflows` (44/44) clean.

## Expected effect

~13% of PRs drop from ~124s to ~40s. Modest by design — the larger latency win is the merge queue (3.2 cycles → 1), which remains a repo setting and is not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)