### PR TITLE
fix(ci): workflows that commit via PR can open the PR

### DIFF
--- a/.github/workflows/comparison-refresh.yml
+++ b/.github/workflows/comparison-refresh.yml
@@ -31,6 +31,11 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: write # commit the refreshed artifacts
+      # commit-via-pr pushes a branch and then opens the PR. Without this the
+      # push landed and `gh pr create` failed with "Resource not accessible by
+      # integration" (run 33718920771) — eleven refreshed artifacts on a branch
+      # nobody could see. Locked by commit-via-pr-permissions.lock.test.ts.
+      pull-requests: write
       issues: write # open the failure issue
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/real-source-scan.yml
+++ b/.github/workflows/real-source-scan.yml
@@ -92,6 +92,10 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: write
+      # commit-via-pr opens the PR after the push; without this the create
+      # call fails with "Resource not accessible by integration". Locked by
+      # scripts/__tests__/commit-via-pr-permissions.lock.test.ts.
+      pull-requests: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup

--- a/scripts/__tests__/commit-via-pr-permissions.lock.test.ts
+++ b/scripts/__tests__/commit-via-pr-permissions.lock.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Lock: every workflow that commits through `.github/actions/commit-via-pr`
+ * grants `pull-requests: write`.
+ *
+ * The action pushes a branch and then opens (or updates) a PR from it. With
+ * `contents: write` alone the push lands and `gh pr create` fails with
+ * "Resource not accessible by integration (createPullRequest)" — which is what
+ * comparison-refresh.yml did on 2026-09-03 (run 33718920771): eleven refreshed
+ * artifacts on a branch nobody could see, a red run, and #803 re-filed for a
+ * workflow whose actual work had succeeded.
+ *
+ * The check is deliberately coarse (the string must appear anywhere in the
+ * file) so it stays true whether the grant lives at workflow or job level.
+ *
+ * Sabotage proof: delete `pull-requests: write` from comparison-refresh.yml
+ * and this fails naming the file.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const WORKFLOWS = resolve(__dirname, '..', '..', '.github', 'workflows');
+
+const usingCommitViaPr = readdirSync(WORKFLOWS)
+  .filter((f) => f.endsWith('.yml'))
+  .map((f) => ({ file: f, text: readFileSync(resolve(WORKFLOWS, f), 'utf-8') }))
+  .filter(({ text }) => text.includes('.github/actions/commit-via-pr'));
+
+describe('workflows that commit via PR can open the PR', () => {
+  it('finds at least one workflow using commit-via-pr', () => {
+    expect(usingCommitViaPr.map((w) => w.file)).not.toHaveLength(0);
+  });
+
+  for (const { file, text } of usingCommitViaPr) {
+    it(`${file} grants pull-requests: write`, () => {
+      expect(
+        text,
+        `${file} uses .github/actions/commit-via-pr, which runs gh pr create. ` +
+          'Without `pull-requests: write` the push succeeds and the PR create ' +
+          'fails with "Resource not accessible by integration" (#803).',
+      ).toMatch(/^\s*pull-requests:\s*write\b/m);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- `comparison-refresh.yml` and `real-source-scan.yml` call `.github/actions/commit-via-pr` with `contents: write` only. The push lands and `gh pr create` fails with "Resource not accessible by integration (createPullRequest)" (run 33718920771). Grant `pull-requests: write` to both jobs.
- New lock `scripts/__tests__/commit-via-pr-permissions.lock.test.ts` checks every workflow that uses the action and fails naming the file.

## Test plan

- [x] `npx vitest run scripts/__tests__/commit-via-pr-permissions.lock.test.ts` — 6 passed.
- [x] Sabotage: with the comparison-refresh edit stashed, the lock fails for that file.
- [x] `npm run lint:workflows` — 44 pass.

## After merge

Dispatch `comparison-refresh.yml`; it should open its artifacts PR and go green, then #803 closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)