### PR TITLE
perf(ci): only main saves the Next.js build cache

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -411,8 +411,30 @@ runs:
     # worth 25s. `scripts/__tests__/tsbuildinfo-cache-pairing-lock.test.ts`
     # fails if either half is ever cached without the other.
 
-    - name: Restore Next.js build cache
-      if: inputs.next-cache == 'true'
+    # Branches RESTORE, only main SAVES — the same split the Turbo cache above
+    # uses, for the same reason.
+    #
+    # The key's second hash covers every source file in apps/docs and
+    # packages/ui, so it changes on essentially every PR. `actions/cache` saves
+    # whenever the key missed, so each PR was writing a fresh ~400 MB entry that
+    # nothing would ever look up again — the key that produced it cannot recur.
+    # Measured 2026-09-03: 9 entries, 3.56 GB, the largest single consumer of a
+    # 10 GB allowance that was sitting at 11.98 GB and evicting.
+    #
+    # Restores are unchanged: the restore-keys prefix already meant a PR was
+    # reading main's entry, not its own. It just stops leaving a copy behind.
+    - name: Restore Next.js build cache (branches — read-only)
+      if: inputs.next-cache == 'true' && github.ref != 'refs/heads/main'
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      with:
+        path: apps/docs/.next/cache
+        key: nextjs-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-${{ hashFiles('apps/docs/**/*.[jt]s', 'apps/docs/**/*.[jt]sx', 'apps/docs/**/*.mdx', 'packages/ui/src/**') }}
+        restore-keys: |
+          nextjs-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-
+          nextjs-${{ runner.os }}-
+
+    - name: Next.js build cache (main — restore + save)
+      if: inputs.next-cache == 'true' && github.ref == 'refs/heads/main'
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
         path: apps/docs/.next/cache

--- a/scripts/__tests__/cache-budget-lock.test.ts
+++ b/scripts/__tests__/cache-budget-lock.test.ts
@@ -61,6 +61,41 @@ describe('the Actions cache budget', () => {
   });
 });
 
+describe('only main writes the big caches', () => {
+  /**
+   * `actions/cache` saves whenever its key missed. A key that changes on every
+   * PR therefore writes a fresh entry per PR that nothing can ever look up
+   * again, because the key that produced it cannot recur.
+   *
+   * The Next.js key hashes every source file in apps/docs and packages/ui, so
+   * it changed on essentially every PR: 9 entries, 3.56 GB, the largest single
+   * consumer of a 10 GB allowance measured at 11.98 GB and evicting. Restores
+   * were always coming from main via the restore-keys prefix; the per-PR save
+   * was pure cost.
+   */
+  const bigWriters = ['Next.js build cache', 'Turbo cache'];
+
+  it.each(bigWriters)('%s only SAVES on main', (label) => {
+    const at = SETUP.indexOf(`${label} (main`);
+    expect(at, `no "${label} (main — restore + save)" step`).toBeGreaterThan(
+      -1,
+    );
+    expect(SETUP.slice(at, at + 300)).toMatch(
+      /if:.*github\.ref == 'refs\/heads\/main'/,
+    );
+  });
+
+  it('the branch path restores without saving', () => {
+    // `actions/cache/restore`, not `actions/cache` — the plain action registers
+    // a post-job save, which is the whole cost being removed here.
+    const at = SETUP.indexOf('Restore Next.js build cache (branches');
+    expect(at, 'no branch-scoped Next.js restore step').toBeGreaterThan(-1);
+    const step = SETUP.slice(at, at + 400);
+    expect(step).toMatch(/uses: actions\/cache\/restore@/);
+    expect(step).toMatch(/if:.*github\.ref != 'refs\/heads\/main'/);
+  });
+});
+
 describe('exactly one Turborepo remote-cache backend can be active', () => {
   // Both at once would leave the shim's TURBO_API pointing at a localhost
   // server while the credentials in the environment name Vercel. The failure


### PR DESCRIPTION
## The waste

`actions/cache` saves whenever its key **missed**. The Next.js key hashes every source file in `apps/docs` and `packages/ui`:

```
nextjs-${os}-${hash(package-lock)}-${hash(apps/docs/**, packages/ui/src/**)}
```

So it changed on essentially every PR, and each PR wrote a fresh **~400 MB** entry that nothing could ever look up again — the key that produced it cannot recur.

Measured 2026-09-03: **9 entries, 3.56 GB** — the largest single consumer of a 10 GB allowance sitting at **11.98 GB and evicting**. Every write-only entry was pushing a useful cache out.

## The change

Branches RESTORE, only main SAVES — the same split the **Turbo cache in this same file already uses**, for the same reason.

Restores are unchanged: the `restore-keys` prefix already meant a PR read main's entry rather than its own. It just stops leaving a copy behind.

## Test plan

- [x] `cache-budget-lock` — 21 passed.
- [x] **Sabotage-proven**: swapping the branch step back to `actions/cache` (the variant that registers a post-job save) fails 1 assertion — that swap *is* the regression.
- [x] Both big writers asserted guarded on `github.ref == 'refs/heads/main'`.
- [x] `lint:workflows` 44/44; the composite action parses.

## Expected effect

`nextjs-*` should fall from ~9 entries toward 1–2 as branch entries age out, freeing roughly 3 GB against a budget currently 2 GB over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)