### PR TITLE
fix(deps): fflate GHSA-px8p-9vwx-vf98, patched per consumer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18310,7 +18310,9 @@
       }
     },
     "node_modules/fflate": {
-      "version": "0.8.2",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "dev": true,
       "license": "MIT"
     },
@@ -26155,7 +26157,9 @@
       }
     },
     "node_modules/posthog-js/node_modules/fflate": {
-      "version": "0.4.8",
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.9.tgz",
+      "integrity": "sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==",
       "license": "MIT"
     },
     "node_modules/preact": {

--- a/package.json
+++ b/package.json
@@ -419,6 +419,12 @@
     },
     "sequelize": {
       "uuid": "^11.1.1"
+    },
+    "posthog-js": {
+      "fflate": "^0.4.9"
+    },
+    "@vitest/ui": {
+      "fflate": "^0.8.3"
     }
   },
   "dependencies": {


### PR DESCRIPTION
## The finding

`Supply-chain floor` is failing on **every PR** — including branches with no dependency changes — and it is right to.

| advisory | package | from | to | consumer |
|---|---|---|---|---|
| [GHSA-px8p-9vwx-vf98](https://osv.dev/GHSA-px8p-9vwx-vf98) · CVSS **7.5 High** | `fflate` | 0.4.8 | 0.4.9 | `posthog-js` (prod) |
| same | `fflate` | 0.8.2 | 0.8.3 | `@vitest/ui` (dev) |

**`npm audit` reports zero vulnerabilities in every committed lockfile.** npm's registry advisory set and OSV.dev disagree, and this repo gates on OSV — so `npm audit` was not a usable proxy here. Worth remembering next time.

## Why scoped, not one top-level override

The two consumers sit on different `0.x` lines and each has its own patched release. A single top-level `fflate` override resolves both to 0.8.3 — dragging `posthog-js` across a `0.x` minor, which is a breaking boundary, to fix something 0.4.9 already fixes. I tried it first and reverted: it collapsed to one hoisted `fflate@0.8.3` that `posthog-js` would have loaded despite declaring `^0.4.8`.

Upgrading `posthog-js` does not help — 1.422.5 and latest 1.425.1 both still declare `fflate ^0.4.8`.

## Result

```
0.8.3  dev=True   node_modules/fflate                        (@vitest/ui)
0.4.9  dev=False  node_modules/posthog-js/node_modules/fflate
```

Both patched, neither crossed a breaking boundary. **12 changed lines, no full lockfile regeneration** — a full regen has broken the storybook build here before.

## Test plan

- [x] `check-versions` (lockfile sync) — exit 0.
- [x] Both fflate instances verified at patched versions in the lockfile.
- [x] `posthog-js` range `^0.4.8` is satisfied natively by 0.4.9 — no override fighting a declared constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)