### PR TITLE
fix(workspace): scheduled issue sweep

### DIFF
--- a/.github/workflows/release-liveness.yml
+++ b/.github/workflows/release-liveness.yml
@@ -24,13 +24,27 @@ on:
     # Every six hours at :05. Earlier than issue-sweep (:40) so a stall it finds
     # is already in the backlog by the time the sweep reads it.
     - cron: "5 */6 * * *"
-  # Also after a merge: a changeset that lands and produces no Version PR is
-  # worth knowing about in minutes, not hours.
-  push:
-    branches: [main]
-    paths:
-      - ".changeset/**"
-      - "packages/*/package.json"
+  # Was `push: {branches: [main], paths: [".changeset/**", "packages/*/package.json"]}`
+  # — the same push event that also triggers changesets-pr.yml's "version" job,
+  # which is the ONE thing that can make a "no Version PR" finding untrue. That
+  # job installs (~60s) before it can push a branch; this workflow's own
+  # checkout + install finished first every time, so the check ran BEFORE the
+  # Version PR existed and reported a stall against a pipeline that was not
+  # stalled.
+  #
+  # Measured, not theorized: issue #849 was filed at 15:14:01Z reporting
+  # "no Version Packages PR is open" for a push whose Version PR (#850) opened
+  # at 15:14:05Z — four seconds later, for that exact same push.
+  #
+  # `workflow_run` fires only once the named workflow's run has fully
+  # completed, so by the time this job starts, changesets-pr.yml has already
+  # had its one chance to open (or fail to open) the Version PR — the race is
+  # gone by construction, not by timing it out. The trade is coarser scope: it
+  # now runs after every push to main rather than only ones touching changeset
+  # paths, because changesets-pr.yml's "version" job itself has no path filter.
+  workflow_run:
+    workflows: ["Changesets"]
+    types: [completed]
   workflow_dispatch:
 
 concurrency:
@@ -43,6 +57,13 @@ permissions:
 jobs:
   check:
     name: Release pipeline is alive
+    # `workflow_run` fires for every completed run of "Changesets", including
+    # its PR-time `required` job (advisory changeset-presence check). Only the
+    # push-triggered `version` job can affect whether a Version PR exists, so
+    # restrict to that — anything else is `schedule` / `workflow_dispatch`.
+    if: >-
+      github.event_name != 'workflow_run' ||
+      (github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -74,15 +95,15 @@ jobs:
         with:
           turbo-cache: "false"
 
-      # On `push`, skip the publish-lag half.
+      # On `workflow_run`, skip the publish-lag half.
       #
-      # This trigger watches `.changeset/**` and `packages/*/package.json`, and
-      # a Version PR merge touches BOTH — it deletes the changesets it consumed
-      # and bumps every version. So the push fires on the release commit
-      # itself, at the one moment npm is legitimately behind main, and every
-      # package reports `unpublished-bump`. That is not a stall; it is a
-      # release in progress. It fired on all three push runs of 2026-09-01 and
-      # produced #791 and #795 against a healthy pipeline.
+      # This trigger follows every push-triggered "Changesets" run, and a
+      # Version PR merge is one of those pushes — it deletes the changesets it
+      # consumed and bumps every version in the same commit. So this fires on
+      # the release commit itself, at the one moment npm is legitimately behind
+      # main, and every package would report `unpublished-bump`. That is not a
+      # stall; it is a release in progress. It fired on all three push runs of
+      # 2026-09-01 and produced #791 and #795 against a healthy pipeline.
       #
       # The changeset half does not race and stays on, which is the reason this
       # trigger exists: a changeset that lands with no Version PR is worth
@@ -94,7 +115,7 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: >-
           node --experimental-strip-types scripts/check-release-liveness.ts
-          ${{ github.event_name == 'push' && '--skip-publish-lag' || '' }}
+          ${{ github.event_name == 'workflow_run' && '--skip-publish-lag' || '' }}
 
       - name: 🚨 Report a stalled release pipeline
         if: failure()

--- a/docs/ci/SKIP_PATHS.md
+++ b/docs/ci/SKIP_PATHS.md
@@ -232,7 +232,9 @@ failure is that together they can hold the pipeline indefinitely with no
 signal, and every existing check answers "did a step fail" rather than "did a
 release come out".
 
-`release-liveness.yml` runs the check every six hours at :05 and on main
-pushes touching `.changeset/**` or `packages/*/package.json`. It gates
-nothing; it files an issue, which is the only thing that would have surfaced
-this.
+`release-liveness.yml` runs the check every six hours at :05 and after every
+completed run of the `Changesets` workflow on a push to main (not on an
+independent `push` trigger of its own — that raced `changesets-pr.yml`'s own
+push-triggered job and produced a false `no-version-pr` finding, issue #849).
+It gates nothing; it files an issue, which is the only thing that would have
+surfaced this.

--- a/scripts/__tests__/release-liveness-race-lock.test.ts
+++ b/scripts/__tests__/release-liveness-race-lock.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Lock: release-liveness.yml must not re-introduce the push-vs-push race that
+ * produced issue #849.
+ *
+ * `release-liveness.yml` and `changesets-pr.yml` both used to trigger on the
+ * SAME `push` event to `main`. `changesets-pr.yml`'s "version" job installs
+ * (~60s) before it can push the Version PR branch; `release-liveness.yml`'s
+ * own checkout + install finished first every time, so its check ran BEFORE
+ * the Version PR existed and reported `no-version-pr` against a pipeline that
+ * was not stalled.
+ *
+ * Measured, not theorized: issue #849 was filed 2026-09-03T15:14:01Z reporting
+ * no open Version Packages PR; PR #850 opened 2026-09-03T15:14:05Z — four
+ * seconds later, for the identical push.
+ *
+ * The fix moves the trigger from an independent `push` to `workflow_run` on
+ * completion of the "Changesets" workflow, so by construction this check only
+ * ever runs after that workflow's push-triggered job has already had its one
+ * chance to open (or fail to open) the Version PR. This test pins the shape
+ * of that fix rather than the race itself — the race depends on relative job
+ * timing across two separate workflow runs, which nothing short of live
+ * GitHub Actions infrastructure can reproduce deterministically.
+ *
+ * Deliberately regex-over-text, not `js-yaml`: matches the convention in
+ * workflow-env-declared-lock.test.ts — js-yaml is present only transitively in
+ * this repo, and a lock should not depend on the tree it polices.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const WORKFLOW = join(
+  resolve(__dirname, '..', '..'),
+  '.github/workflows/release-liveness.yml',
+);
+
+describe('release-liveness.yml — no push-vs-push race with changesets-pr.yml', () => {
+  let source: string;
+  let onBlock: string;
+
+  beforeAll(() => {
+    source = readFileSync(WORKFLOW, 'utf-8');
+    // The `on:` block runs from its own line to the next top-level key.
+    const start = source.indexOf('\non:');
+    const rest = source.slice(start + 1);
+    const nextTopLevelKey = rest.slice(3).search(/\n[A-Za-z]/);
+    onBlock = rest.slice(0, nextTopLevelKey + 3);
+  });
+
+  it('does not trigger on a bare push to main', () => {
+    // A literal `push:` trigger key (2-space indent) is the exact shape that
+    // raced changesets-pr.yml's own `push` trigger. Prose mentioning "push"
+    // elsewhere (there is plenty, describing the history) is fine; a real
+    // trigger key is not.
+    expect(onBlock).not.toMatch(/^ {2}push:\s*$/m);
+  });
+
+  it('triggers on completion of the Changesets workflow instead', () => {
+    expect(onBlock).toMatch(/^ {2}workflow_run:\s*$/m);
+    expect(onBlock).toContain('workflows: ["Changesets"]');
+    expect(onBlock).toContain('types: [completed]');
+  });
+
+  it('restricts the workflow_run case to a push-triggered run on main', () => {
+    const jobBlock = source.slice(source.indexOf('\njobs:'));
+    expect(jobBlock).toMatch(
+      /github\.event\.workflow_run\.event == 'push'/,
+    );
+    expect(jobBlock).toMatch(
+      /github\.event\.workflow_run\.head_branch == 'main'/,
+    );
+  });
+
+  it('skips the publish-lag half on workflow_run, not on push', () => {
+    // The old condition (`github.event_name == 'push'`) would silently stop
+    // matching anything once the trigger changed, which would make the
+    // Version-PR-merge case wrongly run the publish-lag check and produce the
+    // exact `unpublished-bump` false alarm #791 / #795 already fixed once.
+    const script = source.slice(source.indexOf('Check release liveness'));
+    expect(script).toContain(
+      "github.event_name == 'workflow_run' && '--skip-publish-lag'",
+    );
+    expect(script).not.toContain(
+      "github.event_name == 'push' && '--skip-publish-lag'",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Backlog collected per `.github/workflows/issue-sweep.yml`'s policy: open issues filed by `github-actions[bot]` or `ofri-peretz`, minus any carrying `no-auto-fix`. Two issues qualified.

### #849 — Release pipeline is stalled (fixed)

**Root cause, verified against the failing run's logs (run `33771321709`):** `release-liveness.yml` and `changesets-pr.yml` both trigger on the same `push` to `main`. `changesets-pr.yml`'s "version" job installs dependencies (~60s) before it can push the Version Packages PR branch; `release-liveness.yml`'s own checkout + install finished first every time, so its `check-release-liveness.ts` ran **before** the Version PR existed and reported a false `no-version-pr` stall.

Measured, not guessed: issue #849 was filed at `2026-09-03T15:14:01Z` reporting no open Version Packages PR. PR #850 (the actual Version PR) opened at `2026-09-03T15:14:05Z` — four seconds later, for the identical push. By the time this sweep ran, #850 was already open, current, and mergeable — the pipeline was never actually stalled, only checked too early.

**Fix:** `.github/workflows/release-liveness.yml` now triggers on `workflow_run` (completion of the `Changesets` workflow) instead of an independent `push`, so the check only ever runs after `changesets-pr.yml`'s push-triggered job has already had its one chance to open (or fail to open) the Version PR — the race is closed by ordering, not by timing. The job restricts itself to `workflow_run` events whose underlying trigger was a `push` to `main` (so the PR-time advisory job doesn't also fire this check), and the `--skip-publish-lag` condition moved from `event_name == 'push'` to `event_name == 'workflow_run'` to keep skipping the publish-lag half on a Version-PR-merge commit (the case #791/#795 already fixed once).

Also updated `docs/ci/SKIP_PATHS.md` §5 to describe the new trigger instead of the old push-path one.

**Lock:** `scripts/__tests__/release-liveness-race-lock.test.ts` — pins the `workflow_run` trigger shape, the `event == 'push' && head_branch == 'main'` guard, and the `--skip-publish-lag` condition. Verified to fail on the pre-fix workflow (4/4 assertions fail against the old `push`-triggered shape) and pass on the fix.

### #764 — CI: CodeQL now analyses post-merge and nightly, not per-PR (NOT touched)

This is not a failure report. It's a maintainer-authored tracking issue (opened by `ofri-peretz`) documenting a deliberate, already-shipped tradeoff recorded in `docs/adr/0001-codeql-runs-post-merge-not-per-pr.md`. Its own body says it exists "so it stays visible and revisitable rather than quietly permanent" — i.e. it's meant to stay open as a living reference, not be closed by a code change. There is no cause to fix and no lock to add; closing or editing it is a human call (per the "when to revisit" section it already documents).

## Test plan

- [x] `npm run lint:workflows` — 44 workflow files pass conventions.
- [x] `npx vitest run scripts/__tests__/release-liveness-race-lock.test.ts` — 4/4 pass on the fix; re-ran against the pre-fix file and confirmed all 4 fail (positive control).
- [x] `npx vitest run scripts/__tests__/check-release-liveness.test.ts scripts/__tests__/release-workflow-lock.test.ts scripts/__tests__/workflow-env-declared-lock.test.ts` — 21/21 pass (existing release/workflow invariants unaffected).
- [x] Full `npx vitest run scripts/__tests__` — 9 pre-existing failures (`rule-docs-url-lock`, `ecosystem-integrity`, etc.), all `Failed to resolve entry for package "…"` from unbuilt plugin `dist/` output. Confirmed identical on unmodified `origin/main` (stashed my changes and re-ran) — unrelated to this change, which touches only `.github/workflows/` and `docs/`.
- [x] Full local pre-push battery (`lefthook` `pre-push`): workflows, portability, changelog, shim-drift, changelog-shape, markdown-full, lockfile, typecheck, build-and-test — all green.
- [x] No changeset needed — change touches only CI workflow config and docs, no consumer-visible package code.

## After merge

`release-liveness.yml` will stop firing on the changeset-adding push directly and instead fire once `changesets-pr.yml`'s run for that push completes — so it now also runs after every push to `main` (that workflow itself has no path filter), not just changeset/package.json-touching ones. Cost is a few extra ~30–90s runs a day; the previous comments in this same file already accepted that tradeoff for correctness ("An install costs ~30s, four times a day. Correctness is worth that."). Watch the next few pushes to `main` for a clean `Release pipeline is alive` run with no spurious issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UvsVwBAsrYwG2H1WwvwmP8

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvsVwBAsrYwG2H1WwvwmP8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release liveness checks to avoid false failures caused by timing conflicts with the Changesets workflow.
  * Release checks now run after the Changesets workflow completes for eligible changes on the main branch.

* **Documentation**
  * Updated CI documentation to reflect the revised release-check triggers and scheduling.

* **Tests**
  * Added coverage to verify the workflow triggers and safeguards against the previous race condition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->