### PR TITLE
fix(ci): the failure reporter could not report

### DIFF
--- a/.github/workflows/real-source-scan.yml
+++ b/.github/workflows/real-source-scan.yml
@@ -161,19 +161,32 @@ jobs:
       contents: read
       issues: write
     steps:
+      # `-R "$GH_REPO"` on every call, and no checkout.
+      #
+      # This job had neither. `gh` falls back to inferring owner/repo from the
+      # git remote of the working directory, and a job that never checks out
+      # has no working directory to infer from — so every invocation died with
+      # "fatal: not a git repository". The reporter whose whole purpose is to
+      # announce a failed scan was itself the second failure, and it reported
+      # nothing.
+      #
+      # Passing the repo explicitly is better than adding a checkout: filing an
+      # issue does not need the source tree, and a clone here would be ~20s of
+      # runner time to satisfy an inference that an env var already answers.
       - name: 🚨 Open or update an issue
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
           TITLE="Real-source scan is failing"
-          EXISTING=$(gh issue list --state open --search "$TITLE in:title" \
+          EXISTING=$(gh issue list -R "$GH_REPO" --state open --search "$TITLE in:title" \
             --json number --jq '.[0].number // empty')
           BODY=$(printf '%s\n\n[Run](%s)\n' \
             'The weekly real-source scan did not complete, so the rule inventory keeps whatever numbers it already had. Until it runs, no rule may be described as having no real-world instance — check:audit-freshness will say so.' "$RUN_URL")
           if [ -n "$EXISTING" ]; then
-            gh issue comment "$EXISTING" --body "$BODY"
+            gh issue comment -R "$GH_REPO" "$EXISTING" --body "$BODY"
           else
-            gh issue create --title "$TITLE" --body "$BODY"
+            gh issue create -R "$GH_REPO" --title "$TITLE" --body "$BODY"
           fi

--- a/scripts/__tests__/gh-cli-can-resolve-repo-lock.test.ts
+++ b/scripts/__tests__/gh-cli-can-resolve-repo-lock.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * A job that calls `gh` can tell it which repository to act on.
+ *
+ * `gh` infers owner/repo from the git remote of the working directory. A job
+ * that never checks out has no working directory to infer from, and every
+ * invocation dies with `fatal: not a git repository`.
+ *
+ * `real-source-scan.yml`'s `report` job had neither a checkout nor `-R`. Its
+ * entire purpose is to open an issue when the scan fails — so when the scan
+ * failed on 2026-09-03, the reporter failed too, and nothing was reported. A
+ * broken failure reporter does not announce itself; it is only ever noticed by
+ * someone reading run history for another reason.
+ *
+ * Two ways to satisfy this, and both are fine: check out the repo, or pass the
+ * repo explicitly. For a job that only files an issue the second is better —
+ * it needs no source tree, and a clone is ~20s of runner time spent on an
+ * inference an env var already answers.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const WORKFLOWS = resolve(__dirname, '..', '..', '.github/workflows');
+
+type Job = { file: string; id: string; body: string };
+
+function jobsCallingGh(): Job[] {
+  const out: Job[] = [];
+  for (const file of readdirSync(WORKFLOWS).filter((f) => f.endsWith('.yml'))) {
+    const src = readFileSync(join(WORKFLOWS, file), 'utf8');
+    const at = src.indexOf('\njobs:');
+    if (at === -1) continue;
+    const body = src.slice(at);
+    const heads = [...body.matchAll(/^ {2}([A-Za-z0-9_-]+):[ \t]*$/gm)];
+    heads.forEach((h, i) => {
+      const raw = body.slice(h.index!, heads[i + 1]?.index ?? body.length);
+      // Strip comments FIRST. The first version of this check ran against the
+      // raw segment, and the comment added beside the fix — which quotes
+      // `-R "$GH_REPO"` to explain it — satisfied the very pattern the check
+      // looks for. Stripping the flags out of the real commands left the lock
+      // green, defeated by its own documentation.
+      const seg = raw
+        .split('\n')
+        .filter((l) => !/^\s*#/.test(l))
+        .join('\n');
+      // `gh api` takes a full path and never infers, so it is not at risk.
+      if (/\bgh (issue|pr|release|run|workflow) /.test(seg))
+        out.push({ file, id: h[1], body: seg });
+    });
+  }
+  return out;
+}
+
+describe('every job that calls gh can resolve the repository', () => {
+  const jobs = jobsCallingGh();
+
+  it('finds jobs that call gh', () => {
+    // Guards the assertion below from passing on an empty list if the job or
+    // command syntax ever changes shape.
+    expect(jobs.length).toBeGreaterThan(0);
+  });
+
+  it('each has a checkout or passes the repo explicitly', () => {
+    const unresolvable = jobs
+      .filter(
+        (j) =>
+          !j.body.includes('actions/checkout') &&
+          !/-R\s|--repo\s|GH_REPO:/.test(j.body),
+      )
+      .map((j) => `${j.file} job \`${j.id}\``);
+
+    expect(
+      unresolvable,
+      "gh infers owner/repo from the working directory's git remote; without a " +
+        'checkout or an explicit -R every call fails with "fatal: not a git ' +
+        'repository" — and in a failure-reporting job that failure is silent',
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
`real-source-scan.yml`'s `report` job exists to open an issue when the scan fails. On 2026-09-03 the scan failed, the reporter ran, and it died with:

```
failed to run git: fatal: not a git repository
```

`gh` infers owner/repo from the working directory's git remote, and that job has **no checkout** — so every `gh issue` call in it had always been broken. The second failure went unannounced, which is the entire purpose of the job.

## The fix

`-R "$GH_REPO"` on all three calls, rather than adding a checkout: filing an issue needs no source tree, and a clone is ~20s of runner time to answer what an env var already answers.

An audit of every job calling `gh issue|pr|release|run|workflow` found this was the **only** one. `gh api` takes a full path and never infers, so it isn't at risk.

## The lock took two attempts, and the first failure is the interesting part

Version one matched against the raw job text. The comment I added beside the fix quotes `-R "$GH_REPO"` to explain it — so stripping the flags out of the *real commands* left the lock green, **satisfied by its own documentation**. It now strips comment lines before matching.

That is the same defect this repo keeps finding, produced while writing the check meant to prevent it.

## Test plan

- [x] 2 passed.
- [x] **Sabotage-proven**: removing the flags fails with ``real-source-scan.yml job `report` ``. Verified the sabotage was real (8694 → 8608 bytes) — an earlier attempt was a silent no-op because `$GH_REPO` expanded in the shell before the edit ran.
- [x] Non-vacuous: asserts it found jobs calling `gh` before checking them.
- [x] `lint:workflows` 44/44; the workflow parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)