### PR TITLE
fix(ci): five benchmark jobs ran against plugins nobody built

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -98,6 +98,13 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
       - run: npm ci
+      # Benchmark configs import plugins by package name, which resolves through
+      # `exports` to dist/. `npm ci` links a workspace; it never compiles one.
+      # Without this the run dies on the first config with
+      # "Cannot find module .../eslint-plugin-secure-coding/dist/src/index.js".
+      - name: Build plugins (dist/ is what the configs load)
+        run: npx turbo run build --filter='eslint-plugin-*' --filter=@interlace/eslint-devkit
+
       - name: Build @interlace/eslint-formatter
         run: npx tsc -p packages/eslint-formatter/tsconfig.lib.json
       - name: Unit + snapshot + ESLint integration tests
@@ -156,6 +163,13 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
       - run: npm ci
+      # Benchmark configs import plugins by package name, which resolves through
+      # `exports` to dist/. `npm ci` links a workspace; it never compiles one.
+      # Without this the run dies on the first config with
+      # "Cannot find module .../eslint-plugin-secure-coding/dist/src/index.js".
+      - name: Build plugins (dist/ is what the configs load)
+        run: npx turbo run build --filter='eslint-plugin-*' --filter=@interlace/eslint-devkit
+
       - name: Cache the pinned corpus
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
@@ -199,6 +213,13 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
       - run: npm ci
+      # Benchmark configs import plugins by package name, which resolves through
+      # `exports` to dist/. `npm ci` links a workspace; it never compiles one.
+      # Without this the run dies on the first config with
+      # "Cannot find module .../eslint-plugin-secure-coding/dist/src/index.js".
+      - name: Build plugins (dist/ is what the configs load)
+        run: npx turbo run build --filter='eslint-plugin-*' --filter=@interlace/eslint-devkit
+
       - name: Cache the pinned corpus
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
@@ -280,6 +301,13 @@ jobs:
           cache: npm
 
       - run: npm ci
+      # Benchmark configs import plugins by package name, which resolves through
+      # `exports` to dist/. `npm ci` links a workspace; it never compiles one.
+      # Without this the run dies on the first config with
+      # "Cannot find module .../eslint-plugin-secure-coding/dist/src/index.js".
+      - name: Build plugins (dist/ is what the configs load)
+        run: npx turbo run build --filter='eslint-plugin-*' --filter=@interlace/eslint-devkit
+
 
       # Cache cloned target repos between CI runs to keep things fast.
       - name: Restore .bench-repos cache

--- a/.github/workflows/eslint-version-matrix.yml
+++ b/.github/workflows/eslint-version-matrix.yml
@@ -100,6 +100,22 @@ jobs:
 
       - run: npm ci
 
+      # The arena resolves every plugin by package name, which goes through
+      # `exports` to dist/ — so without this the run dies on the first config
+      # with `Cannot find module '.../eslint-plugin-secure-coding/dist/src/index.js'`
+      # and exits 3. That is what it has done on every scheduled run since
+      # 2026-08-29.
+      #
+      # Before the ESLint swap below, not after: the swap installs eslint 8, 9
+      # or 10 with --no-save, and the plugin build should be the one this repo
+      # normally produces rather than whatever that swap leaves behind. The
+      # build is tsc/tsup and does not read ESLint at build time, so it is
+      # identical across the matrix — which also lets turbo cache it once.
+      #
+      # Same filter quality-full.yml uses, for the same reason.
+      - name: Build plugins (dist/ is what the configs load)
+        run: npx turbo run build --filter='eslint-plugin-*' --filter=@interlace/eslint-devkit
+
       - name: Install ESLint ${{ matrix.eslint }}
         run: |
           set -e

--- a/scripts/__tests__/benchmarks-need-built-plugins-lock.test.ts
+++ b/scripts/__tests__/benchmarks-need-built-plugins-lock.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * A job that runs a benchmark builds the plugins first.
+ *
+ * Every benchmark config imports plugins by package name, and that resolves
+ * through `exports` to `dist/`. A job that only runs `npm ci` has no `dist/`,
+ * so the first config to load dies with
+ *
+ *   Cannot find module '.../eslint-plugin-secure-coding/dist/src/index.js'
+ *
+ * `eslint-version-matrix.yml` did exactly that and failed every scheduled run
+ * from 2026-08-29. The failure is loud in the log but the workflow is weekly,
+ * so it sat for five days.
+ *
+ * `npm ci` is not enough and never will be: installing a workspace links the
+ * package directory, it does not compile it. The distinction is invisible in
+ * the workflow file, which is why it belongs in a lock rather than a comment.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const WORKFLOWS = resolve(__dirname, '..', '..', '.github/workflows');
+
+/** Scripts that load a benchmark config and therefore need built plugins. */
+const NEEDS_DIST = /npm run (--silent )?(-w \S+ )?(ilb:|bench)/;
+
+/** Any step that produces dist/ for the plugin packages. */
+const BUILDS = /turbo run build|npm run build|run: npx turbo build/;
+
+type Job = { file: string; id: string; body: string };
+
+function benchmarkJobs(): Job[] {
+  const out: Job[] = [];
+  for (const file of readdirSync(WORKFLOWS).filter((f) => f.endsWith('.yml'))) {
+    const src = readFileSync(join(WORKFLOWS, file), 'utf8');
+    const at = src.indexOf('\njobs:');
+    if (at === -1) continue;
+    const body = src.slice(at);
+    const heads = [...body.matchAll(/^ {2}([A-Za-z0-9_-]+):[ \t]*$/gm)];
+    heads.forEach((h, i) => {
+      const raw = body.slice(h.index!, heads[i + 1]?.index ?? body.length);
+      // Comments quote the very commands this looks for, so strip them —
+      // a lock satisfied by its own documentation is not a lock.
+      const seg = raw
+        .split('\n')
+        .filter((l) => !/^\s*#/.test(l))
+        .join('\n');
+      if (NEEDS_DIST.test(seg)) out.push({ file, id: h[1], body: seg });
+    });
+  }
+  return out;
+}
+
+describe('benchmark jobs build the plugins they load', () => {
+  const jobs = benchmarkJobs();
+
+  it('finds jobs that run a benchmark', () => {
+    expect(jobs.length).toBeGreaterThan(0);
+  });
+
+  it('each builds dist/ before running one', () => {
+    const unbuilt = jobs
+      .filter((j) => !BUILDS.test(j.body))
+      .map((j) => `${j.file} job \`${j.id}\``);
+
+    expect(
+      unbuilt,
+      'benchmark configs import plugins by package name and resolve to dist/; ' +
+        '`npm ci` links a workspace but never compiles it, so the run dies on ' +
+        'the first config with "Cannot find module .../dist/src/index.js"',
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
One root cause behind two of the repo's longest-failing crons.

Benchmark configs import plugins by package name, which resolves through `exports` to `dist/`. **`npm ci` links a workspace; it never compiles one.** So a job that goes straight from `npm ci` to a benchmark dies on the first config:

```
Cannot find module '.../eslint-plugin-secure-coding/dist/src/index.js'
```

`eslint-version-matrix.yml` has done exactly that on **every scheduled run since 2026-08-29**, exiting 3.

## Writing the lock found four more

| job | had a plugin build? |
|---|---|
| `eslint-version-matrix` / `matrix` | no |
| `benchmark` / `ilb-corpus-truth` | no |
| `benchmark` / `ilb-preset-budget` | no |
| `benchmark` / `ilb-wild` | no |
| `benchmark` / `ilb-formatter` | builds the *formatter*, not the plugins |

Three of those are among the five jobs `benchmark.yml` has been failing on since 2026-09-01. I verified each is genuine rather than a regex artifact by printing the jobs' actual steps.

## Ordering

In the matrix workflow the build goes **before** the ESLint swap. That swap installs eslint 8/9/10 with `--no-save`, and the plugin build should be the one this repo normally produces rather than whatever the swap leaves behind. The build is tsc/tsup and never reads ESLint, so it's identical across the matrix — which also lets turbo cache it once.

## Test plan

- [x] 2 passed; both workflows parse; `lint:workflows` 44/44.
- [x] **Sabotage-proven**: removing the build step fails with ``eslint-version-matrix.yml job `matrix` ``. Byte-verified real (8457 → 8301) — I've had three silent no-op sabotages tonight.
- [x] Each of the four insertions verified to sit *after* that job's own `npm ci`, not merely present in the file. That check exists because #845 inserted an input into the wrong step in three jobs by not doing it.
- [x] The lock strips comments before matching — the previous lock this session was green while broken because the comment beside its own fix quoted the pattern it searched for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)