### PR TITLE
fix(ci): the oxlint drift gate says which hash it saw

### DIFF
--- a/scripts/audit-rule-portability.ts
+++ b/scripts/audit-rule-portability.ts
@@ -467,14 +467,53 @@ async function checkOxlintRuntimeHashes() {
       .update(fs.readFileSync(fullPath))
       .digest('hex');
     if (actual !== expected) {
+      // Print the OBSERVED hash and the installed version.
+      //
+      // Without them a refresh needs a local tree resolving the same oxlint CI
+      // installed, and that is not a given: on 2026-09-03 this repo's own
+      // worktree resolved oxlint from a sibling checkout at 1.79.0 while
+      // package.json declares ^1.80.0, so the hashes computable locally were
+      // the wrong ones to pin. The drift was reported for two days with no way
+      // to act on it from the log alone.
+      //
+      // `plugins.js` / `plugins-dev.js` are the plugin API surface — drift
+      // there is the one that can invalidate this audit's blocker assumptions.
+      // `lint.js` / `bindings.js` have historically drifted on version literals
+      // and non-plugin changes, so they are noted separately rather than
+      // treated as equivalent.
+      const surface = file.startsWith('plugins')
+        ? 'PLUGIN API SURFACE'
+        : 'non-plugin bundle';
       failures.push(
-        `${file}: hash drift — runtime file changed since verification. ` +
-          `Re-read apps/oxlint/src-js/plugins/ at the installed tag, confirm the ` +
-          `support matrix still holds, then update VERIFIED_OXLINT_RUNTIME_HASHES.`,
+        `${file}: hash drift (${surface}) on oxlint ${installedOxlintVersion(oxlintDist)}\n` +
+          `      observed: ${actual}\n` +
+          `      expected: ${expected}\n` +
+          `      Run \`npx tsx scripts/verify-oxlint-runtime.ts\` — it probes the API ` +
+          `surfaces the blocker patterns depend on. If every probe passes, the ` +
+          `surface has not moved and the observed hash above can be pinned in ` +
+          `VERIFIED_OXLINT_RUNTIME_HASHES with a note saying what changed.`,
       );
     }
   }
   return failures;
+}
+
+/**
+ * The version of the oxlint actually being hashed, read from the package
+ * beside the file — NOT from package-lock.json.
+ *
+ * They can disagree. On 2026-09-03 this worktree resolved oxlint from a sibling
+ * checkout at 1.79.0 while the lockfile said 1.80.0, so a message sourcing its
+ * version from the lock would have labelled a 1.79.0 hash as 1.80.0 and sent
+ * the reader to diff the wrong tag. Report the version that produced the bytes.
+ */
+function installedOxlintVersion(oxlintDist: string): string {
+  try {
+    const pkg = path.join(path.dirname(oxlintDist), 'package.json');
+    return JSON.parse(fs.readFileSync(pkg, 'utf-8')).version ?? 'unknown';
+  } catch {
+    return 'unknown';
+  }
 }
 
 function readOxlintVersion() {


### PR DESCRIPTION
The portability gate has failed on every PR for days with:

```
lint.js: hash drift — runtime file changed since verification.
Re-read apps/oxlint/src-js/plugins/ at the installed tag ...
```

and nothing else. Acting on that requires a local tree resolving the same oxlint CI installed — **not a given**: this repo's own worktree resolves oxlint from a sibling checkout at **1.79.0** while `package.json` declares `^1.80.0`. The message asked for a re-verification the log gave no way to perform, so the drift sat.

## Now

```
lint.js: hash drift (non-plugin bundle) on oxlint 1.79.0
      observed: beae3473...
      expected: e022b351...
      Run `npx tsx scripts/verify-oxlint-runtime.ts` ...
```

**The plugin/non-plugin split is the part that carries meaning.** `plugins.js` and `plugins-dev.js` *are* the API surface this audit's blocker assumptions rest on. `lint.js` and `bindings.js` have historically drifted on version literals and non-plugin changes.

Measured today:

| file | |
|---|---|
| `plugins.js` | **hashes identically to what is pinned** |
| `plugins-dev.js` | **identical** |
| `lint.js` | drifted |
| `bindings.js` | drifted |

…and all **33 probes** in `verify-oxlint-runtime.ts` pass. So the evidence says the surface has not moved — but that conclusion now has to be reachable from the log, which is what this changes.

## One bug caught in my own first draft

It sourced the version from `package-lock.json`, which would have labelled a **1.79.0** hash as **1.80.0** and sent the reader to diff the wrong tag. It now reads the `package.json` beside the file being hashed — report the version that produced the bytes.

## Deliberately not done

**The hashes are not updated.** They must be pinned from the version CI installs, and this worktree cannot produce those. Doing it from 1.79.0 would make the guard assert something false — which is the failure mode the guard exists to prevent.

## Known unrelated

`scripts/tsconfig.json` has a pre-existing `TS2339` in `ci-changed-files.test.ts` (see the check output on `main`); untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)