### PR TITLE
fix(ci): say "your oxlint is someone else's" instead of "hash drift"

### DIFF
--- a/scripts/audit-rule-portability.ts
+++ b/scripts/audit-rule-portability.ts
@@ -453,6 +453,35 @@ async function checkOxlintRuntimeHashes() {
   if (!fs.existsSync(oxlintDist)) {
     return ['oxlint not installed at node_modules/oxlint/dist — run npm ci'];
   }
+  // Before hashing anything: is the oxlint being hashed even ours?
+  //
+  // In a git worktree, Node can resolve a dependency out to a SIBLING checkout
+  // when the local tree is incomplete. On 2026-09-03 this repo's own worktree
+  // resolved oxlint from ../eslint-ci2 at 1.79.0 while package.json pins
+  // ^1.80.0, and the gate dutifully reported hash drift — sending two rounds of
+  // work at pins that were already correct. Every bundle matches at 1.80.0.
+  //
+  // A wrong install and a moved runtime produce the same symptom, so the check
+  // has to distinguish them. This one is cheap and comes first.
+  // realpathSync, not resolve: the path is always in-repo, it is the SYMLINK
+  // TARGET that escapes. This repo's worktree setup deliberately symlinks
+  // node_modules at a sibling checkout, so `node_modules/oxlint` looks local
+  // and resolves to someone else's version.
+  const repoRoot = fs.realpathSync(path.resolve(__dirname, '..'));
+  const realDist = fs.existsSync(oxlintDist)
+    ? fs.realpathSync(oxlintDist)
+    : oxlintDist;
+  if (!realDist.startsWith(repoRoot + path.sep)) {
+    failures.push(
+      `oxlint resolves OUTSIDE this repository — ${realDist}\n` +
+        `      This is a local install problem, not a drift in oxlint. The hashes\n` +
+        `      below are almost certainly fine; your tree is resolving someone\n` +
+        `      else's copy (a sibling git worktree is the usual cause).\n` +
+        `      Fix: run \`npm install\` in ${repoRoot} and re-run.`,
+    );
+    return failures;
+  }
+
   for (const [file, expected] of Object.entries(
     VERIFIED_OXLINT_RUNTIME_HASHES,
   )) {


### PR DESCRIPTION
A wrong install and a moved runtime produce the **identical symptom** — four hashes that don't match — and the gate reported the second for both. That sent two rounds of work at pins which were already correct.

## What actually happened

This repo's worktree symlinks `node_modules` at a sibling checkout (the documented worktree setup), and that checkout carries **oxlint 1.79.0** while `package.json` pins `^1.80.0`.

Unpacking the exact tarball the lockfile resolves — `oxlint-1.80.0.tgz` — shows **all four bundles hash identically to what is pinned**. Nothing had drifted.

## The check must follow the symlink

`node_modules/oxlint` is always *inside* the repo; it's the **target** that escapes. My first version compared `path.resolve` and never fired for exactly that reason — it took a second attempt to get right:

```
lrwxr-xr-x node_modules/oxlint -> /Users/ofri/repos/eslint-ci2/node_modules/oxlint
```

It's ordered **before** the hash loop and returns early, because once this is true every hash below is noise:

```
✗ oxlint resolves OUTSIDE this repository — /Users/.../eslint-ci2/node_modules/oxlint/dist
  This is a local install problem, not a drift in oxlint. The hashes
  below are almost certainly fine; your tree is resolving someone else's copy.
  Fix: run `npm install` in /Users/.../eslint-mq and re-run.
```

In CI `node_modules` is real, so realpath stays inside the root and this never fires there.

## Why it's worth having

This exact environment defect misled me twice tonight — once as `next` resolving to the sibling and breaking a docs build, once here. Both times I read a local install problem as a repo problem and spent real effort on it. The gate now distinguishes them in one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)