### PR TITLE
chore(docs): sync generated data

### DIFF
--- a/apps/docs/src/data/changelog.json
+++ b/apps/docs/src/data/changelog.json
@@ -5,6 +5,201 @@
   "oldestYear": 2024,
   "releases": [
     {
+      "package": "eslint-plugin-secure-coding",
+      "short": "eslint-plugin-secure-coding",
+      "version": "5.3.2",
+      "date": "2026-09-03T20:25:03Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "five rules read a subscripted member the same as its dotted twin",
+          "pr": null
+        },
+        {
+          "kind": "fix",
+          "title": "`value['constructor'].name` is the same brittle type check",
+          "pr": null
+        },
+        {
+          "kind": "fix",
+          "title": "`this['password']` and `req['body']` read the same as their dotted twins",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.19.2`",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-import-next",
+      "short": "eslint-plugin-import-next",
+      "version": "2.7.3",
+      "date": "2026-09-03T20:24:30Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "`obj['deprecatedProp']` reads the same deprecated export",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.19.2`",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-node-security",
+      "short": "eslint-plugin-node-security",
+      "version": "5.4.2",
+      "date": "2026-09-03T20:24:28Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "`md5(user['password'])` weighs the same evidence",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.19.2`",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "@interlace/eslint-devkit",
+      "short": "eslint-devkit",
+      "version": "1.19.2",
+      "date": "2026-09-03T20:24:26Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "`createRawIdentifierRule` reads a subscripted tag and callee",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-express-security",
+      "short": "eslint-plugin-express-security",
+      "version": "3.2.3",
+      "date": "2026-09-03T20:24:26Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "`res['send'](err['stack'])` leaks the same trace",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.19.2`",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-lambda-security",
+      "short": "eslint-plugin-lambda-security",
+      "version": "2.1.3",
+      "date": "2026-09-03T20:24:26Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "`error['stack']` exposes the same trace as `error.stack`",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.19.2`",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-postgresql-security",
+      "short": "eslint-plugin-postgresql-security",
+      "version": "2.3.4",
+      "date": "2026-09-03T20:24:25Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "`no-missing-client-release` and `prefer-pool-query` now expose their CWE at `meta.docs.cwe`, so every formatter renders it.",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.19.2`",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-browser-security",
+      "short": "eslint-plugin-browser-security",
+      "version": "2.1.4",
+      "date": "2026-09-03T20:24:24Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "three rules read a subscripted member the same as its dotted twin",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.19.2`",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-react-features",
+      "short": "eslint-plugin-react-features",
+      "version": "1.7.2",
+      "date": "2026-09-03T20:24:21Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "`export default class extends Component` is still a component",
+          "pr": null
+        },
+        {
+          "kind": "fix",
+          "title": "`class A extends React['Component']` is the same base class",
+          "pr": null
+        },
+        {
+          "kind": "fix",
+          "title": "misspelled members and PropTypes validators read through a string subscript",
+          "pr": null
+        },
+        {
+          "kind": "deps",
+          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.19.2`",
+          "pr": null
+        }
+      ]
+    },
+    {
       "package": "eslint-plugin-browser-security",
       "short": "eslint-plugin-browser-security",
       "version": "2.1.3",
@@ -15635,21 +15830,6 @@
       ]
     },
     {
-      "package": "@interlace/eslint-devkit",
-      "short": "eslint-devkit",
-      "version": "1.19.2",
-      "date": null,
-      "isApp": false,
-      "isPrivate": false,
-      "entries": [
-        {
-          "kind": "fix",
-          "title": "`createRawIdentifierRule` reads a subscripted tag and callee",
-          "pr": null
-        }
-      ]
-    },
-    {
       "package": "@interlace/ui",
       "short": "ui",
       "version": "0.1.1",
@@ -15676,66 +15856,6 @@
           "kind": "feature",
           "title": "`RemoteMarkdown` accepts `tags`, forwarded to the underlying fetch as `next.tags`.",
           "pr": 628
-        }
-      ]
-    },
-    {
-      "package": "eslint-plugin-browser-security",
-      "short": "eslint-plugin-browser-security",
-      "version": "2.1.4",
-      "date": null,
-      "isApp": false,
-      "isPrivate": false,
-      "entries": [
-        {
-          "kind": "fix",
-          "title": "three rules read a subscripted member the same as its dotted twin",
-          "pr": null
-        },
-        {
-          "kind": "deps",
-          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.19.2`",
-          "pr": null
-        }
-      ]
-    },
-    {
-      "package": "eslint-plugin-express-security",
-      "short": "eslint-plugin-express-security",
-      "version": "3.2.3",
-      "date": null,
-      "isApp": false,
-      "isPrivate": false,
-      "entries": [
-        {
-          "kind": "fix",
-          "title": "`res['send'](err['stack'])` leaks the same trace",
-          "pr": null
-        },
-        {
-          "kind": "deps",
-          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.19.2`",
-          "pr": null
-        }
-      ]
-    },
-    {
-      "package": "eslint-plugin-import-next",
-      "short": "eslint-plugin-import-next",
-      "version": "2.7.3",
-      "date": null,
-      "isApp": false,
-      "isPrivate": false,
-      "entries": [
-        {
-          "kind": "fix",
-          "title": "`obj['deprecatedProp']` reads the same deprecated export",
-          "pr": null
-        },
-        {
-          "kind": "deps",
-          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.19.2`",
-          "pr": null
         }
       ]
     },
@@ -15855,66 +15975,6 @@
         {
           "kind": "other",
           "title": "Ofri Peretz",
-          "pr": null
-        }
-      ]
-    },
-    {
-      "package": "eslint-plugin-lambda-security",
-      "short": "eslint-plugin-lambda-security",
-      "version": "2.1.3",
-      "date": null,
-      "isApp": false,
-      "isPrivate": false,
-      "entries": [
-        {
-          "kind": "fix",
-          "title": "`error['stack']` exposes the same trace as `error.stack`",
-          "pr": null
-        },
-        {
-          "kind": "deps",
-          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.19.2`",
-          "pr": null
-        }
-      ]
-    },
-    {
-      "package": "eslint-plugin-node-security",
-      "short": "eslint-plugin-node-security",
-      "version": "5.4.2",
-      "date": null,
-      "isApp": false,
-      "isPrivate": false,
-      "entries": [
-        {
-          "kind": "fix",
-          "title": "`md5(user['password'])` weighs the same evidence",
-          "pr": null
-        },
-        {
-          "kind": "deps",
-          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.19.2`",
-          "pr": null
-        }
-      ]
-    },
-    {
-      "package": "eslint-plugin-postgresql-security",
-      "short": "eslint-plugin-postgresql-security",
-      "version": "2.3.4",
-      "date": null,
-      "isApp": false,
-      "isPrivate": false,
-      "entries": [
-        {
-          "kind": "fix",
-          "title": "`no-missing-client-release` and `prefer-pool-query` now expose their CWE at `meta.docs.cwe`, so every formatter renders it.",
-          "pr": null
-        },
-        {
-          "kind": "deps",
-          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.19.2`",
           "pr": null
         }
       ]
@@ -16040,66 +16100,6 @@
         {
           "kind": "other",
           "title": "Ofri Peretz",
-          "pr": null
-        }
-      ]
-    },
-    {
-      "package": "eslint-plugin-react-features",
-      "short": "eslint-plugin-react-features",
-      "version": "1.7.2",
-      "date": null,
-      "isApp": false,
-      "isPrivate": false,
-      "entries": [
-        {
-          "kind": "fix",
-          "title": "`export default class extends Component` is still a component",
-          "pr": null
-        },
-        {
-          "kind": "fix",
-          "title": "`class A extends React['Component']` is the same base class",
-          "pr": null
-        },
-        {
-          "kind": "fix",
-          "title": "misspelled members and PropTypes validators read through a string subscript",
-          "pr": null
-        },
-        {
-          "kind": "deps",
-          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.19.2`",
-          "pr": null
-        }
-      ]
-    },
-    {
-      "package": "eslint-plugin-secure-coding",
-      "short": "eslint-plugin-secure-coding",
-      "version": "5.3.2",
-      "date": null,
-      "isApp": false,
-      "isPrivate": false,
-      "entries": [
-        {
-          "kind": "fix",
-          "title": "five rules read a subscripted member the same as its dotted twin",
-          "pr": null
-        },
-        {
-          "kind": "fix",
-          "title": "`value['constructor'].name` is the same brittle type check",
-          "pr": null
-        },
-        {
-          "kind": "fix",
-          "title": "`this['password']` and `req['body']` read the same as their dotted twins",
-          "pr": null
-        },
-        {
-          "kind": "deps",
-          "title": "updated workspace dependencies: `@interlace/eslint-devkit@1.19.2`",
           "pr": null
         }
       ]


### PR DESCRIPTION
Regenerated apps/docs/src/data/ (trigger: push). Opened by the Docs Data Sync workflow; contents come entirely from the apps/docs/scripts/sync-* scripts, so review the diff rather than hand-editing.