### PR TITLE
fix(node-security): its coverage has never been uploaded

### DIFF
--- a/packages/eslint-plugin-node-security/vitest.config.mts
+++ b/packages/eslint-plugin-node-security/vitest.config.mts
@@ -31,7 +31,19 @@ export default defineConfig({
     reporters: ['default'],
     coverage: {
       enabled: true,
-      reportsDirectory: '../../coverage/packages/eslint-plugin-node-security',
+      /*
+       * `./coverage`, like every other package.
+       *
+       * This wrote to the REPO ROOT — `../../coverage/packages/…` — and the
+       * upload workflow looks for `packages/*​/coverage/lcov.info`. So
+       * node-security's coverage has never been uploaded to Codecov. Its 99.80%
+       * there is a fossil: `carryforward: true` on every flag means Codecov
+       * keeps showing the last value it ever received for a flag that stops
+       * reporting, so the number looked plausible and simply stopped moving.
+       *
+       * The path arrived in a "chore: organize repo" commit, not a decision.
+       */
+      reportsDirectory: './coverage',
       provider: 'v8',
       // Coverage ratchet — policy target is 100/100/100/100 (docs/QUALITY_STANDARDS.md §2).
       // Pinned at the 100% policy target — this branch is the integration target for the test wave.

--- a/packages/eslint-plugin-node-security/vitest.config.mts
+++ b/packages/eslint-plugin-node-security/vitest.config.mts
@@ -35,7 +35,7 @@ export default defineConfig({
        * `./coverage`, like every other package.
        *
        * This wrote to the REPO ROOT — `../../coverage/packages/…` — and the
-       * upload workflow looks for `packages/*​/coverage/lcov.info`. So
+       * upload workflow looks for `packages/<pkg>/coverage/lcov.info`. So
        * node-security's coverage has never been uploaded to Codecov. Its 99.80%
        * there is a fossil: `carryforward: true` on every flag means Codecov
        * keeps showing the last value it ever received for a flag that stops

--- a/scripts/__tests__/coverage-lands-where-the-uploader-looks.lock.test.ts
+++ b/scripts/__tests__/coverage-lands-where-the-uploader-looks.lock.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * A package must write its coverage where the uploader looks for it.
+ *
+ * `.github/workflows/codecov.yml` finds reports with
+ *
+ *     find packages -path '*​/coverage/lcov.info'
+ *     for lcov in packages/*​/coverage/lcov.info
+ *
+ * so a package whose `reportsDirectory` points anywhere else produces a
+ * perfectly good lcov that is never uploaded.
+ *
+ * `eslint-plugin-node-security` did exactly that. It wrote to
+ * `../../coverage/packages/eslint-plugin-node-security` — the repo root — and
+ * its coverage had never reached Codecov. The path arrived in a "chore:
+ * organize repo" commit rather than a decision.
+ *
+ * What made it survive is the reporting model: every flag in `codecov.yml` sets
+ * `carryforward: true`, so when a flag stops reporting Codecov keeps showing
+ * the last value it ever received. node-security sat at a plausible 99.80% —
+ * close enough to the 100% it actually measures that nothing looked wrong —
+ * while the number had simply stopped moving. A silent, believable, permanently
+ * stale figure is worse than a missing one.
+ *
+ * Two things have to agree, so both are asserted here: the directory each
+ * package writes to, and the glob the workflow reads from.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const ROOT = resolve(__dirname, '../..');
+const PACKAGES = join(ROOT, 'packages');
+
+/** Every package that declares a vitest config. */
+function configs(): { pkg: string; file: string; text: string }[] {
+  const out: { pkg: string; file: string; text: string }[] = [];
+  for (const pkg of readdirSync(PACKAGES)) {
+    for (const name of ['vitest.config.mts', 'vitest.config.ts']) {
+      const file = join(PACKAGES, pkg, name);
+      if (existsSync(file))
+        out.push({ pkg, file, text: readFileSync(file, 'utf-8') });
+    }
+  }
+  return out;
+}
+
+const CONFIGS = configs();
+
+describe('coverage lands where the uploader looks', () => {
+  it('finds package configs to check', () => {
+    // Guard against the glob silently matching nothing.
+    expect(CONFIGS.length).toBeGreaterThan(20);
+  });
+
+  it.each(CONFIGS.map((c) => c.pkg))(
+    '%s writes into its own coverage/',
+    (pkg) => {
+      const { text } = CONFIGS.find((c) => c.pkg === pkg)!;
+      const declared = /reportsDirectory:\s*'([^']+)'/.exec(text)?.[1];
+
+      // Not declaring one is fine — vitest defaults to ./coverage, which is
+      // exactly where the uploader looks.
+      if (declared === undefined) return;
+
+      expect(
+        declared,
+        `${pkg} writes coverage to "${declared}". The upload workflow only reads ` +
+          "packages/*/coverage/lcov.info, so this package's coverage would never " +
+          'reach Codecov — and with carryforward on, its badge would keep showing ' +
+          'a stale number instead of going blank.',
+      ).toMatch(/^\.\/coverage$|^coverage$/);
+    },
+  );
+
+  it('the workflow still reads from packages/*/coverage', () => {
+    // If the workflow's glob moves, the assertion above is pinning the wrong
+    // location and would pass while every package became invisible.
+    const wf = readFileSync(
+      join(ROOT, '.github/workflows/codecov.yml'),
+      'utf-8',
+    );
+    expect(wf).toContain("find packages -path '*/coverage/lcov.info'");
+    expect(wf).toContain('for lcov in packages/*/coverage/lcov.info');
+  });
+});

--- a/scripts/__tests__/coverage-lands-where-the-uploader-looks.lock.test.ts
+++ b/scripts/__tests__/coverage-lands-where-the-uploader-looks.lock.test.ts
@@ -9,8 +9,10 @@
  *
  * `.github/workflows/codecov.yml` finds reports with
  *
- *     find packages -path '*​/coverage/lcov.info'
- *     for lcov in packages/*​/coverage/lcov.info
+ *     find packages -path (star)/coverage/lcov.info
+ *     for lcov in packages/(star)/coverage/lcov.info
+ *
+ * written with (star) because the literal glob would close this comment.
  *
  * so a package whose `reportsDirectory` points anywhere else produces a
  * perfectly good lcov that is never uploaded.


### PR DESCRIPTION
## Summary

Chasing "get every plugin to 100%" turned up that the four plugins below 100% on Codecov **all measure 100% locally**. None of them needs a test written. Three were stale carryforward data from the upload failures fixed in #866. The fourth is a real config bug.

`eslint-plugin-node-security` sets `reportsDirectory` to the repo root —
`../../coverage/packages/eslint-plugin-node-security` — while the upload workflow reads `packages/*/coverage/lcov.info`. It has been producing a perfectly good lcov in a place nothing looks, since the `chore: organize repo` commit that moved it. **It is the only package of 29 that does this.**

Its 99.80% is a fossil. Every flag in `codecov.yml` sets `carryforward: true`, so when a flag stops reporting Codecov keeps showing the last value it ever received — and 99.80 is close enough to the 100% it actually measures that nothing looked wrong. The number had simply stopped moving.

**A believable stale figure is worse than a missing one.** A blank badge gets investigated.

## Measured

| | before | after |
|---|---|---|
| lcov written to | `../../coverage/packages/…` (unread) | `packages/…/coverage/lcov.info` |
| lines | not uploaded | `3719/3719` = 100% |
| Codecov | 99.80% (carried forward) | will reflect a real upload |

## Test plan

- [x] `coverage-lands-where-the-uploader-looks.lock.test.ts` — 31 assertions
- [x] Asserts **both halves** of the agreement: every package's `reportsDirectory` resolves inside its own `coverage/`, **and** the workflow still reads `packages/*/coverage`. Pinning one alone is useless — if the glob moves, the per-package assertion pins the wrong location and stays green while every package goes invisible.
- [x] Proven in both directions: restoring the old path fails the package assertion; changing the workflow glob fails the workflow one.
- [x] Not declaring `reportsDirectory` stays legal — vitest defaults to `./coverage`, which is exactly right.

## The other three

`secure-coding` (68.55%), `browser-security` (94.45%) and `postgresql-security` (99.61%) each produce a 100% lcov locally — `5328/5328`, `3254/3254`, `1260/1260`. Their Codecov numbers are carried-forward sessions merged from the era when 8 of 13 scheduled runs uploaded nothing. Now that #866 keeps uploads alive, fresh full uploads should displace them; I'll confirm rather than assume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)