### PR TITLE
fix(ci): Codecov counted every line twice

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -123,12 +123,27 @@ jobs:
             sed -i "s|^SF:|SF:packages/${pkg}/|g" "$lcov"
           done
 
-      - name: Upload combined coverage to Codecov
-        if: "!cancelled() && steps.find.outputs.has_lcov == 'true'"
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
+      # The combined `codecov-action` upload used to sit here, and it was
+      # uploading the SAME lcov files the flag loop below already sends — it
+      # takes no `files:` input, so it auto-discovers
+      # `packages/<pkg>/coverage/lcov.info` and ships every one of them a second
+      # time.
+      #
+      # Codecov then held each line twice. Measured on
+      # `packages/eslint-plugin-secure-coding/src/index.ts`: our lcov reports
+      # `LF:7`, Codecov held 14 lines with 7 hits — an exact 2x, with the
+      # duplicate copy contributing lines and no hit data. Across the package
+      # that is 5,328 lines reported and 10,565 held, which is the whole of its
+      # published 68.54% against a measured 100%.
+      #
+      # It was invisible for most packages because 2N/2N is still 100%. Only
+      # where the second copy lost its hits did the number move, which is why
+      # exactly four components looked wrong and nobody could reproduce them.
+      #
+      # The per-package uploads below are sufficient on their own: they carry
+      # repo-root-relative paths, so `component_management` (which matches on
+      # path, not flag) resolves from them, and each one keeps its own flag for
+      # the per-plugin badge URLs.
 
       - name: Upload per-package coverage flags to Codecov
         if: "!cancelled() && steps.find.outputs.has_lcov == 'true'"

--- a/scripts/__tests__/coverage-upload-survives-failure.lock.test.ts
+++ b/scripts/__tests__/coverage-upload-survives-failure.lock.test.ts
@@ -32,7 +32,13 @@ import { readdirSync, readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { parse } from 'yaml';
 
-type Step = { name?: string; id?: string; if?: string; run?: string };
+type Step = {
+  name?: string;
+  id?: string;
+  if?: string;
+  run?: string;
+  uses?: string;
+};
 
 const ROOT = resolve(__dirname, '../..');
 const WORKFLOW = join(ROOT, '.github/workflows/codecov.yml');
@@ -59,8 +65,6 @@ const REQUIRED: Record<string, string> = {
   'Locate coverage + JUnit reports': '!cancelled()',
   'Rewrite lcov SF paths to repo-root-relative':
     "!cancelled() && steps.find.outputs.has_lcov == 'true'",
-  'Upload combined coverage to Codecov':
-    "!cancelled() && steps.find.outputs.has_lcov == 'true'",
   'Upload per-package coverage flags to Codecov':
     "!cancelled() && steps.find.outputs.has_lcov == 'true'",
   'Upload test results (Test Analytics)':
@@ -69,6 +73,28 @@ const REQUIRED: Record<string, string> = {
 };
 
 describe('coverage uploads survive one package failing', () => {
+  it('no step uploads the same lcov a second time', () => {
+    /*
+     * A combined `codecov-action` upload used to sit beside the per-package
+     * loop. It takes no `files:` input, so it auto-discovered the very lcovs
+     * the loop already sends and Codecov held every line twice — 2N lines
+     * against N hits wherever the duplicate lost its hit data, which is how
+     * secure-coding published 68.54% while measuring 100%.
+     *
+     * One upload path, not two.
+     */
+    const uploaders = steps.filter(
+      (s) =>
+        /codecov-action/.test(String(s.uses ?? '')) ||
+        /codecovcli upload-process/.test(String(s.run ?? '')),
+    );
+    expect(
+      uploaders.map((s) => s.name),
+      'Exactly one step may send coverage to Codecov. A second one uploads the ' +
+        'same files again and doubles every line count.',
+    ).toHaveLength(1);
+  });
+
   it('every named data step is still present', () => {
     const present = new Set(steps.map((s) => s.name).filter(Boolean));
     for (const name of Object.keys(REQUIRED)) {


### PR DESCRIPTION
## Summary

**Every plugin measures 100%.** Four published less, and the cause was that the same lcov was uploaded twice.

The combined `codecov-action` step took no `files:` input, so it auto-discovered `packages/<pkg>/coverage/lcov.info` — the very files the per-package loop beneath it already sends — and shipped every one a second time.

Measured on `packages/eslint-plugin-secure-coding/src/index.ts`: our lcov reports `LF:7`; **Codecov held 14 lines with 7 hits.** An exact 2×, where the duplicate copy contributed lines and no hit data. Across the package: 5,328 lines reported, 10,565 held — the whole of its published 68.54% against a measured 100%.

It stayed invisible for most packages because **2N/2N is still 100%**. Only where the second copy lost its hits did the number move — which is why exactly four components looked wrong and none of them could be reproduced locally.

## This is not a test gap

From the artifact CI itself produced and uploaded on `4dfad2788`:

| package | lcov | files | duplicate SF |
|---|---|---|---|
| secure-coding | `5328/5328` = 100% | 38 | 0 |
| browser-security | `3254/3254` = 100% | 64 | 0 |
| node-security | `3719/3719` = 100% | 48 | 0 |
| postgresql-security | `1260/1260` = 100% | 19 | 0 |
| **all 28 packages** | **`27454/27454` = 100%** | | |

Correct repo-root-relative paths, no duplicate `SF:` entries, uploads succeeded. Nothing on this side was wrong except sending it twice.

## Why the per-package uploads are enough

They carry repo-root-relative paths, so `component_management` — which matches on **path**, not flag — resolves from them, and each keeps its own flag for the per-plugin badge URLs. Nothing that worked before stops working.

## Test plan

- [x] `coverage-upload-survives-failure.lock.test.ts` now asserts **exactly one** step sends coverage to Codecov, proven by adding a second uploader
- [x] The `Upload combined coverage` entry removed from the required-conditions map deliberately, so the lock had to be updated rather than silently passing
- [x] `scripts/__tests__`: 123 files, 2,458 tests green
- [x] Workflow re-validated as YAML (10 steps)

## After merge

I'll dispatch a coverage run and confirm the four components move to 100% rather than assuming they will.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected coverage reporting to prevent duplicate uploads and inaccurate line-count percentages.
  - Coverage data is now uploaded through a single path for more reliable component metrics.

- **Tests**
  - Added validation to ensure coverage is uploaded exactly once, helping prevent future duplicate reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->