### PR TITLE
fix(ci): the uploader was sending 2,156 stray coverage reports

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -168,10 +168,31 @@ jobs:
             [ -f "$lcov" ] || continue
             pkg=$(basename "$(dirname "$(dirname "$lcov")")")
             echo "→ uploading $pkg …"
+            # `--disable-search` is load-bearing. Without it the CLI treats
+            # `--file` as an ADDITION to whatever it finds by scanning the
+            # working tree, and it found `.tmp-seal-cov/<pkg>__<rule>/
+            # coverage-final.json` — the per-rule snapshots `scripts/
+            # seal-audit.mts` writes, in which exactly one rule is exercised
+            # and every other file reads zero.
+            #
+            # 2,156 of them went up alongside the real lcov on the last run.
+            # Merged into the same commit report they contribute the same
+            # source files again with no hits, so Codecov held 10,565 lines
+            # for secure-coding where we upload 5,328 — the surplus all
+            # missed. On `src/index.ts`: our lcov says 7 lines, all hit;
+            # Codecov said 14 lines, 7 hit, 7 missed. An exact zero-hit
+            # duplicate.
+            #
+            # The four packages seal-audit runs over — secure-coding,
+            # browser-security, node-security, postgresql-security — are
+            # precisely the four that published below the 100% they measure.
+            #
+            # Upload the file we name. Nothing else.
             codecovcli upload-process \
               --token "$CODECOV_TOKEN" \
               --flag "$pkg" \
               --file "$lcov" \
+              --disable-search \
               --name "$pkg" || true
           done
 

--- a/scripts/__tests__/coverage-upload-survives-failure.lock.test.ts
+++ b/scripts/__tests__/coverage-upload-survives-failure.lock.test.ts
@@ -73,6 +73,41 @@ const REQUIRED: Record<string, string> = {
 };
 
 describe('coverage uploads survive one package failing', () => {
+  it('the uploader sends only the file it names', () => {
+    /*
+     * Without `--disable-search` the CLI adds whatever it finds by scanning
+     * the tree to whatever `--file` names. It found 2,156
+     * `.tmp-seal-cov/<pkg>__<rule>/coverage-final.json` snapshots — one rule
+     * exercised, every other file zero — and merged them into the same commit
+     * report, so Codecov held a zero-hit duplicate of every source file.
+     *
+     * The four packages seal-audit covers were exactly the four publishing
+     * below the 100% their lcov reports.
+     */
+    const upload = steps.find((s) =>
+      /codecovcli upload-process/.test(String(s.run ?? '')),
+    );
+    expect(upload, 'no codecovcli upload step found').toBeDefined();
+
+    /*
+     * COMMENT LINES STRIPPED FIRST. The explanation above the command names
+     * the flag, and the comment lives inside the same `run:` block — so a
+     * substring check over the raw script passed with the flag deleted. The
+     * proof caught it: removing the flag left the lock green, which is a lock
+     * asserting that the prose still mentions the flag.
+     */
+    const script = String(upload?.run)
+      .split('\n')
+      .filter((l) => !l.trim().startsWith('#'))
+      .join('\n');
+
+    expect(
+      script,
+      'codecovcli must pass --disable-search, or it uploads every stray ' +
+        'coverage report in the working tree alongside the one it was given.',
+    ).toContain('--disable-search');
+  });
+
   it('no step uploads the same lcov a second time', () => {
     /*
      * A combined `codecov-action` upload used to sit beside the per-package


### PR DESCRIPTION
## Summary

`codecovcli upload-process` treats `--file` as an **addition** to whatever it finds by scanning the working tree, not as the whole list. It found `.tmp-seal-cov/<pkg>__<rule>/coverage-final.json` — the per-rule snapshots `scripts/seal-audit.mts` writes, in which exactly one rule is exercised and every other file reads zero — and sent **2,156 of them** alongside the real lcov.

Merged into the same commit report, they contribute the same source files again with no hits.

| | our lcov | Codecov held |
|---|---|---|
| secure-coding | 5,328 lines, all hit | **10,565 lines**, surplus all missed |
| `secure-coding/src/index.ts` | `LF:7`, all hit | **14 lines, 7 hit, 7 missed** |

An exact zero-hit duplicate.

## The evidence

The four packages `seal-audit` runs over — **secure-coding, browser-security, node-security, postgresql-security** — are precisely the four that published below the 100% they measure. That correspondence is the evidence; my earlier explanations had none.

This is the third attempt, and I want the record straight:

- **#868** duplicate `codecov-action` upload — removed it, totals came back byte-identical. Falsified.
- lines + branches — `5328+6268=11596`, not 10,565. Falsified.
- **#870** carryforward — turned off, not a digit moved. Falsified.

What settled it was reading the uploader's own log instead of theorising about the API. The stray paths are printed, one per line, in every run — they had been there the whole time.

## The fix

`--disable-search`, so it uploads the file it names and nothing else.

## The lock caught itself being vacuous

Asserting `--disable-search` appears in the step's `run` **passed with the flag deleted** — because the comment explaining the flag lives in the same block. It was a lock checking that the prose still mentions the flag. It strips comment lines first now, and fails with the flag removed.

## Test plan

- [x] `coverage-upload-survives-failure.lock.test.ts` — 9 assertions, proven in both directions
- [x] Workflow re-validated as YAML (10 steps)
- [x] oxlint + format-drift clean
- [ ] **After merge:** dispatch a run and read the components endpoint. This gets reverted if the numbers do not move.

Note: `extract-changelog.test.ts` fails under the full parallel suite and passes 10/10 standalone — contention, and unrelated to this diff (which touches two files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)