### PR TITLE
fix(workspace): five plugins had no coverage config and reported none

### DIFF
--- a/packages/eslint-plugin-conventions/src/oxlint.test.ts
+++ b/packages/eslint-plugin-conventions/src/oxlint.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { plugin as mainPlugin } from './index';
+
+/**
+ * Smoke test for the `./oxlint` sub-export.
+ *
+ * Runtime shape: `oxlint.ts` uses `export = plugin`, which compiles to
+ * `module.exports = plugin`. From an ESM dynamic `import('./oxlint')` view,
+ * Node's CJS interop surfaces that value at `.default`. From oxlint's
+ * `require('eslint-plugin-conventions/oxlint')` view, it sits at the top of
+ * `module.exports` — exactly the `{ meta, rules }` shape oxlint's JS plugin
+ * loader expects.
+ */
+
+type Plugin = typeof mainPlugin;
+
+describe('eslint-plugin-conventions/oxlint sub-export', () => {
+  it('declares the ./oxlint sub-export in package.json', () => {
+    const pkgJson = JSON.parse(
+      fs.readFileSync(path.resolve(__dirname, '..', 'package.json'), 'utf8'),
+    );
+    expect(pkgJson.exports['./oxlint']).toEqual({
+      types: './dist/src/oxlint.d.ts',
+      default: './dist/src/oxlint.js',
+    });
+  });
+
+  it('re-exports the plugin object (meta + rules at top level)', async () => {
+    const oxlintModule = await import('./oxlint.js');
+    const oxlintPlugin = (oxlintModule as unknown as { default: Plugin })
+      .default;
+    expect(oxlintPlugin).toBeDefined();
+    expect(oxlintPlugin.meta?.name).toBe('eslint-plugin-conventions');
+    expect(oxlintPlugin.rules).toBeDefined();
+  });
+
+  it('exposes the same rule names as the main entry (no rules dropped)', async () => {
+    const oxlintModule = await import('./oxlint.js');
+    const oxlintPlugin = (oxlintModule as unknown as { default: Plugin })
+      .default;
+    expect(Object.keys(oxlintPlugin.rules || {}).toSorted()).toEqual(
+      Object.keys(mainPlugin.rules || {}).toSorted(),
+    );
+  });
+
+  it('exposes the same rule references (pass-through, not a copy)', async () => {
+    const oxlintModule = await import('./oxlint.js');
+    const oxlintPlugin = (oxlintModule as unknown as { default: Plugin })
+      .default;
+    for (const ruleName of Object.keys(mainPlugin.rules || {})) {
+      expect(oxlintPlugin.rules?.[ruleName]).toBe(
+        (mainPlugin.rules as Record<string, unknown>)[ruleName],
+      );
+    }
+  });
+});

--- a/packages/eslint-plugin-conventions/vitest.config.mts
+++ b/packages/eslint-plugin-conventions/vitest.config.mts
@@ -1,0 +1,66 @@
+import { configDefaults, defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+
+/**
+ * This package had NO vitest config at all.
+ *
+ * `test:coverage` ran `vitest run --coverage` against vitest's defaults, whose
+ * reporter list does not include lcov — so no `coverage/lcov.info` was ever
+ * written, the upload loop (which globs exactly that path) skipped the package
+ * every run, and no threshold was enforced on it either.
+ *
+ * Codecov still showed a number, because `carryforward: true` served the last
+ * value the flag had ever received. Once carryforward was turned off and the
+ * stray-report sweep was fixed, the component went blank — which is what
+ * finally made the gap visible. Five packages were in this state.
+ *
+ * Mirrors the sibling plugin configs: v8, lcov, and the 100/100/100/100 policy
+ * target from docs/QUALITY_STANDARDS.md §2.
+ */
+export default defineConfig({
+  // ponytail: alias devkit to source so vitest-direct runs don't need a pre-built dist
+  resolve: {
+    alias: {
+      '@interlace/eslint-devkit': resolve(
+        __dirname,
+        '../eslint-devkit/src/index.ts',
+      ),
+    },
+  },
+  test: {
+    // Repo-wide floor: pre-push runs turbo tasks concurrently, so I/O-bound
+    // tests are routinely starved. Vitest's 5s default mis-reports contention
+    // as failure.
+    testTimeout: 30_000,
+    // hookTimeout does NOT inherit testTimeout and defaults to 10s, which fails
+    // as "Hook timed out in 10000ms" rather than as a test failure.
+    hookTimeout: 30_000,
+
+    name: 'eslint-plugin-conventions',
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    exclude: [...configDefaults.exclude, 'src/__compatibility__/**'],
+    coverage: {
+      enabled: true,
+      provider: 'v8',
+      // Coverage ratchet — policy target 100/100/100/100
+      // (docs/QUALITY_STANDARDS.md §2). Measured at 100 on all four before
+      // this was pinned, so it starts enforcing rather than aspiring.
+      thresholds: {
+        lines: 100,
+        statements: 100,
+        functions: 100,
+        branches: 100,
+      },
+      reporter: ['text', 'lcov', 'html'],
+      reportsDirectory: './coverage',
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.spec.ts', 'src/**/*.test.ts', 'src/types/**'],
+    },
+    reporters: ['default', 'junit'],
+    outputFile: {
+      junit: './test-results/junit.xml',
+    },
+  },
+});

--- a/packages/eslint-plugin-modernization/src/oxlint.test.ts
+++ b/packages/eslint-plugin-modernization/src/oxlint.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { plugin as mainPlugin } from './index';
+
+/**
+ * Smoke test for the `./oxlint` sub-export.
+ *
+ * Runtime shape: `oxlint.ts` uses `export = plugin`, which compiles to
+ * `module.exports = plugin`. From an ESM dynamic `import('./oxlint')` view,
+ * Node's CJS interop surfaces that value at `.default`. From oxlint's
+ * `require('eslint-plugin-modernization/oxlint')` view, it sits at the top of
+ * `module.exports` — exactly the `{ meta, rules }` shape oxlint's JS plugin
+ * loader expects.
+ */
+
+type Plugin = typeof mainPlugin;
+
+describe('eslint-plugin-modernization/oxlint sub-export', () => {
+  it('declares the ./oxlint sub-export in package.json', () => {
+    const pkgJson = JSON.parse(
+      fs.readFileSync(path.resolve(__dirname, '..', 'package.json'), 'utf8'),
+    );
+    expect(pkgJson.exports['./oxlint']).toEqual({
+      types: './dist/src/oxlint.d.ts',
+      default: './dist/src/oxlint.js',
+    });
+  });
+
+  it('re-exports the plugin object (meta + rules at top level)', async () => {
+    const oxlintModule = await import('./oxlint.js');
+    const oxlintPlugin = (oxlintModule as unknown as { default: Plugin })
+      .default;
+    expect(oxlintPlugin).toBeDefined();
+    expect(oxlintPlugin.meta?.name).toBe('eslint-plugin-modernization');
+    expect(oxlintPlugin.rules).toBeDefined();
+  });
+
+  it('exposes the same rule names as the main entry (no rules dropped)', async () => {
+    const oxlintModule = await import('./oxlint.js');
+    const oxlintPlugin = (oxlintModule as unknown as { default: Plugin })
+      .default;
+    expect(Object.keys(oxlintPlugin.rules || {}).toSorted()).toEqual(
+      Object.keys(mainPlugin.rules || {}).toSorted(),
+    );
+  });
+
+  it('exposes the same rule references (pass-through, not a copy)', async () => {
+    const oxlintModule = await import('./oxlint.js');
+    const oxlintPlugin = (oxlintModule as unknown as { default: Plugin })
+      .default;
+    for (const ruleName of Object.keys(mainPlugin.rules || {})) {
+      expect(oxlintPlugin.rules?.[ruleName]).toBe(
+        (mainPlugin.rules as Record<string, unknown>)[ruleName],
+      );
+    }
+  });
+});

--- a/packages/eslint-plugin-modernization/vitest.config.mts
+++ b/packages/eslint-plugin-modernization/vitest.config.mts
@@ -1,0 +1,66 @@
+import { configDefaults, defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+
+/**
+ * This package had NO vitest config at all.
+ *
+ * `test:coverage` ran `vitest run --coverage` against vitest's defaults, whose
+ * reporter list does not include lcov — so no `coverage/lcov.info` was ever
+ * written, the upload loop (which globs exactly that path) skipped the package
+ * every run, and no threshold was enforced on it either.
+ *
+ * Codecov still showed a number, because `carryforward: true` served the last
+ * value the flag had ever received. Once carryforward was turned off and the
+ * stray-report sweep was fixed, the component went blank — which is what
+ * finally made the gap visible. Five packages were in this state.
+ *
+ * Mirrors the sibling plugin configs: v8, lcov, and the 100/100/100/100 policy
+ * target from docs/QUALITY_STANDARDS.md §2.
+ */
+export default defineConfig({
+  // ponytail: alias devkit to source so vitest-direct runs don't need a pre-built dist
+  resolve: {
+    alias: {
+      '@interlace/eslint-devkit': resolve(
+        __dirname,
+        '../eslint-devkit/src/index.ts',
+      ),
+    },
+  },
+  test: {
+    // Repo-wide floor: pre-push runs turbo tasks concurrently, so I/O-bound
+    // tests are routinely starved. Vitest's 5s default mis-reports contention
+    // as failure.
+    testTimeout: 30_000,
+    // hookTimeout does NOT inherit testTimeout and defaults to 10s, which fails
+    // as "Hook timed out in 10000ms" rather than as a test failure.
+    hookTimeout: 30_000,
+
+    name: 'eslint-plugin-modernization',
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    exclude: [...configDefaults.exclude, 'src/__compatibility__/**'],
+    coverage: {
+      enabled: true,
+      provider: 'v8',
+      // Coverage ratchet — policy target 100/100/100/100
+      // (docs/QUALITY_STANDARDS.md §2). Measured at 100 on all four before
+      // this was pinned, so it starts enforcing rather than aspiring.
+      thresholds: {
+        lines: 100,
+        statements: 100,
+        functions: 100,
+        branches: 100,
+      },
+      reporter: ['text', 'lcov', 'html'],
+      reportsDirectory: './coverage',
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.spec.ts', 'src/**/*.test.ts', 'src/types/**'],
+    },
+    reporters: ['default', 'junit'],
+    outputFile: {
+      junit: './test-results/junit.xml',
+    },
+  },
+});

--- a/packages/eslint-plugin-modularity/src/oxlint.test.ts
+++ b/packages/eslint-plugin-modularity/src/oxlint.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { plugin as mainPlugin } from './index';
+
+/**
+ * Smoke test for the `./oxlint` sub-export.
+ *
+ * Runtime shape: `oxlint.ts` uses `export = plugin`, which compiles to
+ * `module.exports = plugin`. From an ESM dynamic `import('./oxlint')` view,
+ * Node's CJS interop surfaces that value at `.default`. From oxlint's
+ * `require('eslint-plugin-modularity/oxlint')` view, it sits at the top of
+ * `module.exports` — exactly the `{ meta, rules }` shape oxlint's JS plugin
+ * loader expects.
+ */
+
+type Plugin = typeof mainPlugin;
+
+describe('eslint-plugin-modularity/oxlint sub-export', () => {
+  it('declares the ./oxlint sub-export in package.json', () => {
+    const pkgJson = JSON.parse(
+      fs.readFileSync(path.resolve(__dirname, '..', 'package.json'), 'utf8'),
+    );
+    expect(pkgJson.exports['./oxlint']).toEqual({
+      types: './dist/src/oxlint.d.ts',
+      default: './dist/src/oxlint.js',
+    });
+  });
+
+  it('re-exports the plugin object (meta + rules at top level)', async () => {
+    const oxlintModule = await import('./oxlint.js');
+    const oxlintPlugin = (oxlintModule as unknown as { default: Plugin })
+      .default;
+    expect(oxlintPlugin).toBeDefined();
+    expect(oxlintPlugin.meta?.name).toBe('eslint-plugin-modularity');
+    expect(oxlintPlugin.rules).toBeDefined();
+  });
+
+  it('exposes the same rule names as the main entry (no rules dropped)', async () => {
+    const oxlintModule = await import('./oxlint.js');
+    const oxlintPlugin = (oxlintModule as unknown as { default: Plugin })
+      .default;
+    expect(Object.keys(oxlintPlugin.rules || {}).toSorted()).toEqual(
+      Object.keys(mainPlugin.rules || {}).toSorted(),
+    );
+  });
+
+  it('exposes the same rule references (pass-through, not a copy)', async () => {
+    const oxlintModule = await import('./oxlint.js');
+    const oxlintPlugin = (oxlintModule as unknown as { default: Plugin })
+      .default;
+    for (const ruleName of Object.keys(mainPlugin.rules || {})) {
+      expect(oxlintPlugin.rules?.[ruleName]).toBe(
+        (mainPlugin.rules as Record<string, unknown>)[ruleName],
+      );
+    }
+  });
+});

--- a/packages/eslint-plugin-modularity/vitest.config.mts
+++ b/packages/eslint-plugin-modularity/vitest.config.mts
@@ -1,0 +1,66 @@
+import { configDefaults, defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+
+/**
+ * This package had NO vitest config at all.
+ *
+ * `test:coverage` ran `vitest run --coverage` against vitest's defaults, whose
+ * reporter list does not include lcov — so no `coverage/lcov.info` was ever
+ * written, the upload loop (which globs exactly that path) skipped the package
+ * every run, and no threshold was enforced on it either.
+ *
+ * Codecov still showed a number, because `carryforward: true` served the last
+ * value the flag had ever received. Once carryforward was turned off and the
+ * stray-report sweep was fixed, the component went blank — which is what
+ * finally made the gap visible. Five packages were in this state.
+ *
+ * Mirrors the sibling plugin configs: v8, lcov, and the 100/100/100/100 policy
+ * target from docs/QUALITY_STANDARDS.md §2.
+ */
+export default defineConfig({
+  // ponytail: alias devkit to source so vitest-direct runs don't need a pre-built dist
+  resolve: {
+    alias: {
+      '@interlace/eslint-devkit': resolve(
+        __dirname,
+        '../eslint-devkit/src/index.ts',
+      ),
+    },
+  },
+  test: {
+    // Repo-wide floor: pre-push runs turbo tasks concurrently, so I/O-bound
+    // tests are routinely starved. Vitest's 5s default mis-reports contention
+    // as failure.
+    testTimeout: 30_000,
+    // hookTimeout does NOT inherit testTimeout and defaults to 10s, which fails
+    // as "Hook timed out in 10000ms" rather than as a test failure.
+    hookTimeout: 30_000,
+
+    name: 'eslint-plugin-modularity',
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    exclude: [...configDefaults.exclude, 'src/__compatibility__/**'],
+    coverage: {
+      enabled: true,
+      provider: 'v8',
+      // Coverage ratchet — policy target 100/100/100/100
+      // (docs/QUALITY_STANDARDS.md §2). Measured at 100 on all four before
+      // this was pinned, so it starts enforcing rather than aspiring.
+      thresholds: {
+        lines: 100,
+        statements: 100,
+        functions: 100,
+        branches: 100,
+      },
+      reporter: ['text', 'lcov', 'html'],
+      reportsDirectory: './coverage',
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.spec.ts', 'src/**/*.test.ts', 'src/types/**'],
+    },
+    reporters: ['default', 'junit'],
+    outputFile: {
+      junit: './test-results/junit.xml',
+    },
+  },
+});

--- a/packages/eslint-plugin-operability/src/oxlint.test.ts
+++ b/packages/eslint-plugin-operability/src/oxlint.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { plugin as mainPlugin } from './index';
+
+/**
+ * Smoke test for the `./oxlint` sub-export.
+ *
+ * Runtime shape: `oxlint.ts` uses `export = plugin`, which compiles to
+ * `module.exports = plugin`. From an ESM dynamic `import('./oxlint')` view,
+ * Node's CJS interop surfaces that value at `.default`. From oxlint's
+ * `require('eslint-plugin-operability/oxlint')` view, it sits at the top of
+ * `module.exports` — exactly the `{ meta, rules }` shape oxlint's JS plugin
+ * loader expects.
+ */
+
+type Plugin = typeof mainPlugin;
+
+describe('eslint-plugin-operability/oxlint sub-export', () => {
+  it('declares the ./oxlint sub-export in package.json', () => {
+    const pkgJson = JSON.parse(
+      fs.readFileSync(path.resolve(__dirname, '..', 'package.json'), 'utf8'),
+    );
+    expect(pkgJson.exports['./oxlint']).toEqual({
+      types: './dist/src/oxlint.d.ts',
+      default: './dist/src/oxlint.js',
+    });
+  });
+
+  it('re-exports the plugin object (meta + rules at top level)', async () => {
+    const oxlintModule = await import('./oxlint.js');
+    const oxlintPlugin = (oxlintModule as unknown as { default: Plugin })
+      .default;
+    expect(oxlintPlugin).toBeDefined();
+    expect(oxlintPlugin.meta?.name).toBe('eslint-plugin-operability');
+    expect(oxlintPlugin.rules).toBeDefined();
+  });
+
+  it('exposes the same rule names as the main entry (no rules dropped)', async () => {
+    const oxlintModule = await import('./oxlint.js');
+    const oxlintPlugin = (oxlintModule as unknown as { default: Plugin })
+      .default;
+    expect(Object.keys(oxlintPlugin.rules || {}).toSorted()).toEqual(
+      Object.keys(mainPlugin.rules || {}).toSorted(),
+    );
+  });
+
+  it('exposes the same rule references (pass-through, not a copy)', async () => {
+    const oxlintModule = await import('./oxlint.js');
+    const oxlintPlugin = (oxlintModule as unknown as { default: Plugin })
+      .default;
+    for (const ruleName of Object.keys(mainPlugin.rules || {})) {
+      expect(oxlintPlugin.rules?.[ruleName]).toBe(
+        (mainPlugin.rules as Record<string, unknown>)[ruleName],
+      );
+    }
+  });
+});

--- a/packages/eslint-plugin-operability/vitest.config.mts
+++ b/packages/eslint-plugin-operability/vitest.config.mts
@@ -1,0 +1,66 @@
+import { configDefaults, defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+
+/**
+ * This package had NO vitest config at all.
+ *
+ * `test:coverage` ran `vitest run --coverage` against vitest's defaults, whose
+ * reporter list does not include lcov — so no `coverage/lcov.info` was ever
+ * written, the upload loop (which globs exactly that path) skipped the package
+ * every run, and no threshold was enforced on it either.
+ *
+ * Codecov still showed a number, because `carryforward: true` served the last
+ * value the flag had ever received. Once carryforward was turned off and the
+ * stray-report sweep was fixed, the component went blank — which is what
+ * finally made the gap visible. Five packages were in this state.
+ *
+ * Mirrors the sibling plugin configs: v8, lcov, and the 100/100/100/100 policy
+ * target from docs/QUALITY_STANDARDS.md §2.
+ */
+export default defineConfig({
+  // ponytail: alias devkit to source so vitest-direct runs don't need a pre-built dist
+  resolve: {
+    alias: {
+      '@interlace/eslint-devkit': resolve(
+        __dirname,
+        '../eslint-devkit/src/index.ts',
+      ),
+    },
+  },
+  test: {
+    // Repo-wide floor: pre-push runs turbo tasks concurrently, so I/O-bound
+    // tests are routinely starved. Vitest's 5s default mis-reports contention
+    // as failure.
+    testTimeout: 30_000,
+    // hookTimeout does NOT inherit testTimeout and defaults to 10s, which fails
+    // as "Hook timed out in 10000ms" rather than as a test failure.
+    hookTimeout: 30_000,
+
+    name: 'eslint-plugin-operability',
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    exclude: [...configDefaults.exclude, 'src/__compatibility__/**'],
+    coverage: {
+      enabled: true,
+      provider: 'v8',
+      // Coverage ratchet — policy target 100/100/100/100
+      // (docs/QUALITY_STANDARDS.md §2). Measured at 100 on all four before
+      // this was pinned, so it starts enforcing rather than aspiring.
+      thresholds: {
+        lines: 100,
+        statements: 100,
+        functions: 100,
+        branches: 100,
+      },
+      reporter: ['text', 'lcov', 'html'],
+      reportsDirectory: './coverage',
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.spec.ts', 'src/**/*.test.ts', 'src/types/**'],
+    },
+    reporters: ['default', 'junit'],
+    outputFile: {
+      junit: './test-results/junit.xml',
+    },
+  },
+});

--- a/packages/eslint-plugin-reliability/src/oxlint.test.ts
+++ b/packages/eslint-plugin-reliability/src/oxlint.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { plugin as mainPlugin } from './index';
+
+/**
+ * Smoke test for the `./oxlint` sub-export.
+ *
+ * Runtime shape: `oxlint.ts` uses `export = plugin`, which compiles to
+ * `module.exports = plugin`. From an ESM dynamic `import('./oxlint')` view,
+ * Node's CJS interop surfaces that value at `.default`. From oxlint's
+ * `require('eslint-plugin-reliability/oxlint')` view, it sits at the top of
+ * `module.exports` — exactly the `{ meta, rules }` shape oxlint's JS plugin
+ * loader expects.
+ */
+
+type Plugin = typeof mainPlugin;
+
+describe('eslint-plugin-reliability/oxlint sub-export', () => {
+  it('declares the ./oxlint sub-export in package.json', () => {
+    const pkgJson = JSON.parse(
+      fs.readFileSync(path.resolve(__dirname, '..', 'package.json'), 'utf8'),
+    );
+    expect(pkgJson.exports['./oxlint']).toEqual({
+      types: './dist/src/oxlint.d.ts',
+      default: './dist/src/oxlint.js',
+    });
+  });
+
+  it('re-exports the plugin object (meta + rules at top level)', async () => {
+    const oxlintModule = await import('./oxlint.js');
+    const oxlintPlugin = (oxlintModule as unknown as { default: Plugin })
+      .default;
+    expect(oxlintPlugin).toBeDefined();
+    expect(oxlintPlugin.meta?.name).toBe('eslint-plugin-reliability');
+    expect(oxlintPlugin.rules).toBeDefined();
+  });
+
+  it('exposes the same rule names as the main entry (no rules dropped)', async () => {
+    const oxlintModule = await import('./oxlint.js');
+    const oxlintPlugin = (oxlintModule as unknown as { default: Plugin })
+      .default;
+    expect(Object.keys(oxlintPlugin.rules || {}).toSorted()).toEqual(
+      Object.keys(mainPlugin.rules || {}).toSorted(),
+    );
+  });
+
+  it('exposes the same rule references (pass-through, not a copy)', async () => {
+    const oxlintModule = await import('./oxlint.js');
+    const oxlintPlugin = (oxlintModule as unknown as { default: Plugin })
+      .default;
+    for (const ruleName of Object.keys(mainPlugin.rules || {})) {
+      expect(oxlintPlugin.rules?.[ruleName]).toBe(
+        (mainPlugin.rules as Record<string, unknown>)[ruleName],
+      );
+    }
+  });
+});

--- a/packages/eslint-plugin-reliability/vitest.config.mts
+++ b/packages/eslint-plugin-reliability/vitest.config.mts
@@ -1,0 +1,66 @@
+import { configDefaults, defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+
+/**
+ * This package had NO vitest config at all.
+ *
+ * `test:coverage` ran `vitest run --coverage` against vitest's defaults, whose
+ * reporter list does not include lcov — so no `coverage/lcov.info` was ever
+ * written, the upload loop (which globs exactly that path) skipped the package
+ * every run, and no threshold was enforced on it either.
+ *
+ * Codecov still showed a number, because `carryforward: true` served the last
+ * value the flag had ever received. Once carryforward was turned off and the
+ * stray-report sweep was fixed, the component went blank — which is what
+ * finally made the gap visible. Five packages were in this state.
+ *
+ * Mirrors the sibling plugin configs: v8, lcov, and the 100/100/100/100 policy
+ * target from docs/QUALITY_STANDARDS.md §2.
+ */
+export default defineConfig({
+  // ponytail: alias devkit to source so vitest-direct runs don't need a pre-built dist
+  resolve: {
+    alias: {
+      '@interlace/eslint-devkit': resolve(
+        __dirname,
+        '../eslint-devkit/src/index.ts',
+      ),
+    },
+  },
+  test: {
+    // Repo-wide floor: pre-push runs turbo tasks concurrently, so I/O-bound
+    // tests are routinely starved. Vitest's 5s default mis-reports contention
+    // as failure.
+    testTimeout: 30_000,
+    // hookTimeout does NOT inherit testTimeout and defaults to 10s, which fails
+    // as "Hook timed out in 10000ms" rather than as a test failure.
+    hookTimeout: 30_000,
+
+    name: 'eslint-plugin-reliability',
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    exclude: [...configDefaults.exclude, 'src/__compatibility__/**'],
+    coverage: {
+      enabled: true,
+      provider: 'v8',
+      // Coverage ratchet — policy target 100/100/100/100
+      // (docs/QUALITY_STANDARDS.md §2). Measured at 100 on all four before
+      // this was pinned, so it starts enforcing rather than aspiring.
+      thresholds: {
+        lines: 100,
+        statements: 100,
+        functions: 100,
+        branches: 100,
+      },
+      reporter: ['text', 'lcov', 'html'],
+      reportsDirectory: './coverage',
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.spec.ts', 'src/**/*.test.ts', 'src/types/**'],
+    },
+    reporters: ['default', 'junit'],
+    outputFile: {
+      junit: './test-results/junit.xml',
+    },
+  },
+});

--- a/scripts/__tests__/coverage-lands-where-the-uploader-looks.lock.test.ts
+++ b/scripts/__tests__/coverage-lands-where-the-uploader-looks.lock.test.ts
@@ -81,6 +81,35 @@ describe('coverage lands where the uploader looks', () => {
     },
   );
 
+  it.each(
+    CONFIGS.filter((c) => c.pkg.startsWith('eslint-plugin-')).map((c) => c.pkg),
+  )('%s emits lcov and enforces a threshold', (pkg) => {
+    /*
+     * A package with NO vitest config inherits vitest's defaults, whose
+     * coverage reporters do not include lcov. Five plugins were in that state:
+     * `test:coverage` ran, wrote no `coverage/lcov.info`, the upload loop
+     * skipped them every run, and no threshold was enforced either. Codecov
+     * still showed a number for each, because `carryforward: true` served the
+     * last value the flag had ever received.
+     *
+     * Turning carryforward off is what made the gap visible — the components
+     * went blank. Measured for the first time, all five were at 100%, so the
+     * missing config had cost nothing yet. It was one uncovered line away from
+     * costing something silently.
+     */
+    const { text } = CONFIGS.find((c) => c.pkg === pkg)!;
+    expect(
+      text,
+      `${pkg} does not request the lcov reporter. Without it no ` +
+        'coverage/lcov.info is written and the upload loop skips the package.',
+    ).toMatch(/reporter:\s*\[[^\]]*'lcov'/);
+    expect(
+      text,
+      `${pkg} sets no coverage thresholds, so its coverage is measured but ` +
+        'never enforced.',
+    ).toMatch(/thresholds:\s*\{/);
+  });
+
   it('the workflow still reads from packages/*/coverage', () => {
     // If the workflow's glob moves, the assertion above is pinning the wrong
     // location and would pass while every package became invisible.


### PR DESCRIPTION
## Summary

`conventions`, `modernization`, `modularity`, `operability` and `reliability` had **no `vitest.config.mts` at all**. `test:coverage` ran against vitest's defaults, whose reporter list does not include lcov — so no `coverage/lcov.info` was ever written, the upload loop (which globs exactly that path) skipped all five every run, and **no threshold was enforced on any of them**.

Codecov still showed a number for each, because `carryforward: true` served the last value the flag had ever received.

Turning carryforward off (#870) is what made this visible: the five components went blank, which is the correct reading of *"this commit measured nothing here"*. A blank reads as a problem; a stale 100% does not.

## Measured for the first time

| package | statements | branches | functions | lines |
|---|---|---|---|---|
| conventions | 780/780 | 692/692 | 135/135 | 694/694 |
| modernization | 131/131 | 158/158 | — | 124/124 |
| modularity | 310/310 | 324/324 | — | 298/298 |
| operability | 153/153 | 143/143 | — | 141/141 |
| reliability | 640/640 | 663/663 | — | 606/606 |

All five at **100% on every metric** — so the missing config had not cost anything yet. It was one uncovered line away from costing it silently, which is the point.

## One test each

`src/oxlint.ts` line 23 was the only uncovered line in all five, and the other plugins already cover it with a `src/oxlint.test.ts` smoke test. I copied that existing pattern rather than inventing one, and checked the `./oxlint` export shape it asserts against each package's `package.json` first.

## Thresholds written last

Written as `0`, packages measured, then pinned at `100`. The ratchet starts by enforcing what is true rather than asserting what is hoped.

## Test plan

- [x] All five: `test:coverage` exits 0 with thresholds at 100, and writes `coverage/lcov.info` where the uploader looks (694/694, 124/124, 298/298, 141/141, 606/606)
- [x] Lock now requires every plugin config to request the lcov reporter **and** set thresholds — 66 assertions
- [x] Both proven: dropping the reporter fails it; dropping the thresholds fails it
- [x] oxlint + format-drift clean

## After merge

Dispatch a coverage run — this should take the components from 27 reporting to 32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)