### PR TITLE
chore(docs): sync generated data

### DIFF
--- a/apps/docs/src/data/articles.json
+++ b/apps/docs/src/data/articles.json
@@ -2,17 +2,17 @@
   "articles": [
     {
       "id": 4556473,
-      "title": "I Shipped ESLint to the Browser in 362 KB. Now My Blog Posts Lint Your Code, Not Mine.",
-      "description": "Articles about lint rules can only ever show you someone else's code. ESLint's own linter compresses to 362 KB with two real plugins inside it — small enough to just ship. Here's the ~60-line esbuild recipe that puts a working linter in a blog post, the four traps that cost me an evening, and the demo bug that shipped because my test grepped for a string instead of running the rule.",
+      "title": "ESLint Ships in 459 KB, So My Blog Posts Lint Your Code",
+      "description": "ESLint's linter ships in 459 KB with two real security plugins inside it. Here's the esbuild recipe that puts a working linter inside a blog post.",
       "url": "https://dev.to/ofri-peretz/i-shipped-eslint-to-the-browser-in-362-kb-now-my-blog-posts-lint-your-code-not-mine-3a4m",
       "canonical_url": "https://ofriperetz.dev/articles/eslint-in-the-browser-live-lint-playground",
       "cover_image": "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fofriperetz.dev%2Fcdn%2Fblog-cover-image%2Feslint-in-the-browser-live-lint-playground.jpg",
       "published_at": "2026-09-02T13:07:33Z",
       "readable_publish_date": "Sep 2",
-      "reading_time_minutes": 7,
+      "reading_time_minutes": 4,
       "page_views_count": 0,
-      "public_reactions_count": 2,
-      "positive_reactions_count": 2,
+      "public_reactions_count": 4,
+      "positive_reactions_count": 4,
       "comments_count": 0,
       "tag_list": [
         "javascript",
@@ -31,8 +31,8 @@
       "readable_publish_date": "Sep 1",
       "reading_time_minutes": 4,
       "page_views_count": 0,
-      "public_reactions_count": 4,
-      "positive_reactions_count": 4,
+      "public_reactions_count": 5,
+      "positive_reactions_count": 5,
       "comments_count": 0,
       "tag_list": [
         "security",
@@ -1745,6 +1745,6 @@
     }
   ],
   "total": 85,
-  "lastUpdated": "2026-09-02T21:20:28.616Z",
+  "lastUpdated": "2026-09-04T06:05:02.721Z",
   "source": "public"
 }


### PR DESCRIPTION
Regenerated apps/docs/src/data/ (trigger: push). Opened by the Docs Data Sync workflow; contents come entirely from the apps/docs/scripts/sync-* scripts, so review the diff rather than hand-editing.