### PR TITLE
ci(workspace): the last eight silent crons can now reach a human

### DIFF
--- a/.github/cron-alerting-debt.json
+++ b/.github/cron-alerting-debt.json
@@ -1,31 +1,5 @@
 {
-  "note": "Scheduled-workflow jobs that can fail with nobody reporting it. This is a RATCHET: entries may be removed, never added. See docs/intents/cron-failure-delivery/.",
-  "recorded": "2026-09-01",
-  "uncovered": {
-    "check-links.yml": [
-      "gate"
-    ],
-    "codeql.yml": [
-      "gate"
-    ],
-    "lighthouse.yml": [
-      "lighthouse"
-    ],
-    "metrics-freshness.yml": [
-      "check"
-    ],
-    "npm-token-health.yml": [
-      "check-npm-token"
-    ],
-    "quality-full.yml": [
-      "bench-configs",
-      "test-scope"
-    ],
-    "release-drift.yml": [
-      "drift"
-    ],
-    "release-hygiene.yml": [
-      "reconcile"
-    ]
-  }
+  "note": "Scheduled-workflow jobs that can fail with nobody reporting it. This is a RATCHET: entries may be removed, never added. Empty means every scheduled job reaches a human when it fails \u2014 the state this file exists to reach, not a reason to delete it. See docs/intents/cron-failure-delivery/.",
+  "recorded": "2026-09-04",
+  "uncovered": {}
 }

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -141,3 +141,28 @@ jobs:
           else
             gh issue create --title "$TITLE" --body "$BODY"
           fi
+
+  # Without this the jobs above can fail on a schedule with nobody watching:
+  # a red cron produces no PR, no reviewer and no notification, so silence and
+  # success look identical. Tracked as debt in .github/cron-alerting-debt.json.
+  report:
+    name: "\U0001F6A8 Report a scheduled failure"
+    needs: [gate]
+    if: >-
+      always() && github.event_name == 'schedule' &&
+      contains(needs.*.result, 'failure')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/report-failure
+        with:
+          title: "Link integrity scan is failing"
+          body: >-
+            The scheduled link check did not complete, so dead links in docs and READMEs are no longer being found. Readers hit them before we do.
+          token: ${{ github.token }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -134,3 +134,28 @@ jobs:
             a failing scan means the SAST coverage gap widens silently until
             this is fixed.
           token: ${{ github.token }}
+
+  # Without this the jobs above can fail on a schedule with nobody watching:
+  # a red cron produces no PR, no reviewer and no notification, so silence and
+  # success look identical. Tracked as debt in .github/cron-alerting-debt.json.
+  report:
+    name: "\U0001F6A8 Report a scheduled failure"
+    needs: [gate]
+    if: >-
+      always() && github.event_name == 'schedule' &&
+      contains(needs.*.result, 'failure')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/report-failure
+        with:
+          title: "CodeQL scan is failing"
+          body: >-
+            The scheduled CodeQL analysis did not complete, so new security findings in this repo's own source are not being surfaced.
+          token: ${{ github.token }}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -133,3 +133,28 @@ jobs:
             apps/docs/.lighthouseci/
             ${{ runner.temp }}/lighthouse-report.md
           retention-days: 90
+
+  # Without this the jobs above can fail on a schedule with nobody watching:
+  # a red cron produces no PR, no reviewer and no notification, so silence and
+  # success look identical. Tracked as debt in .github/cron-alerting-debt.json.
+  report:
+    name: "\U0001F6A8 Report a scheduled failure"
+    needs: [lighthouse]
+    if: >-
+      always() && github.event_name == 'schedule' &&
+      contains(needs.*.result, 'failure')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/report-failure
+        with:
+          title: "Lighthouse audit is failing"
+          body: >-
+            The scheduled Lighthouse run did not complete, so regressions in docs-site performance and accessibility scores are going unmeasured.
+          token: ${{ github.token }}

--- a/.github/workflows/metrics-freshness.yml
+++ b/.github/workflows/metrics-freshness.yml
@@ -69,3 +69,28 @@ jobs:
           else
             gh issue create --title "$title" --body "$body" --label "chore"
           fi
+
+  # Without this the jobs above can fail on a schedule with nobody watching:
+  # a red cron produces no PR, no reviewer and no notification, so silence and
+  # success look identical. Tracked as debt in .github/cron-alerting-debt.json.
+  report:
+    name: "\U0001F6A8 Report a scheduled failure"
+    needs: [check]
+    if: >-
+      always() && github.event_name == 'schedule' &&
+      contains(needs.*.result, 'failure')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/report-failure
+        with:
+          title: "Metrics freshness check is failing"
+          body: >-
+            The freshness check did not complete, so stale cached metrics can now sit on the docs site without anything noticing they stopped updating.
+          token: ${{ github.token }}

--- a/.github/workflows/npm-token-health.yml
+++ b/.github/workflows/npm-token-health.yml
@@ -225,3 +225,28 @@ jobs:
               echo "$MESSAGE" >> $GITHUB_STEP_SUMMARY
               ;;
           esac
+
+  # Without this the jobs above can fail on a schedule with nobody watching:
+  # a red cron produces no PR, no reviewer and no notification, so silence and
+  # success look identical. Tracked as debt in .github/cron-alerting-debt.json.
+  report:
+    name: "\U0001F6A8 Report a scheduled failure"
+    needs: [check-npm-token]
+    if: >-
+      always() && github.event_name == 'schedule' &&
+      contains(needs.*.result, 'failure')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/report-failure
+        with:
+          title: "npm token health check is failing"
+          body: >-
+            The token check did not complete. If NPM_TOKEN has expired or lost scope, the next release fails at publish time instead of here.
+          token: ${{ github.token }}

--- a/.github/workflows/quality-full.yml
+++ b/.github/workflows/quality-full.yml
@@ -833,3 +833,28 @@ jobs:
             unsynced MDX, failed rule-docs-sync-drift on main's tip, and was
             found four days later by accident.
           token: ${{ github.token }}
+
+  # Without this the jobs above can fail on a schedule with nobody watching:
+  # a red cron produces no PR, no reviewer and no notification, so silence and
+  # success look identical. Tracked as debt in .github/cron-alerting-debt.json.
+  report:
+    name: "\U0001F6A8 Report a scheduled failure"
+    needs: [bench-configs, test-scope]
+    if: >-
+      always() && github.event_name == 'schedule' &&
+      contains(needs.*.result, 'failure')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/report-failure
+        with:
+          title: "Scheduled Quality (Full) job is failing"
+          body: >-
+            A job in the scheduled heavy gate did not complete, so the checks it owns are not running against main on their cadence.
+          token: ${{ github.token }}

--- a/.github/workflows/release-drift.yml
+++ b/.github/workflows/release-drift.yml
@@ -87,3 +87,28 @@ jobs:
           else
             gh issue create --title "$title" --body "$body" --label "release"
           fi
+
+  # Without this the jobs above can fail on a schedule with nobody watching:
+  # a red cron produces no PR, no reviewer and no notification, so silence and
+  # success look identical. Tracked as debt in .github/cron-alerting-debt.json.
+  report:
+    name: "\U0001F6A8 Report a scheduled failure"
+    needs: [drift]
+    if: >-
+      always() && github.event_name == 'schedule' &&
+      contains(needs.*.result, 'failure')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/report-failure
+        with:
+          title: "Release drift check is failing"
+          body: >-
+            The drift check did not complete, so a divergence between the tags, the changelogs and what is published to npm would now go unreported.
+          token: ${{ github.token }}

--- a/.github/workflows/release-hygiene.yml
+++ b/.github/workflows/release-hygiene.yml
@@ -286,3 +286,28 @@ jobs:
               });
               core.notice(`Opened tracking issue #${created.number}.`);
             }
+
+  # Without this the jobs above can fail on a schedule with nobody watching:
+  # a red cron produces no PR, no reviewer and no notification, so silence and
+  # success look identical. Tracked as debt in .github/cron-alerting-debt.json.
+  report:
+    name: "\U0001F6A8 Report a scheduled failure"
+    needs: [reconcile]
+    if: >-
+      always() && github.event_name == 'schedule' &&
+      contains(needs.*.result, 'failure')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/report-failure
+        with:
+          title: "Release hygiene check is failing"
+          body: >-
+            The hygiene check did not complete, so release metadata problems accumulate silently until someone reads a bad release page.
+          token: ${{ github.token }}


### PR DESCRIPTION
Closes the ratchet opened in #812. **Every scheduled job in this repo now reports its own failure as an issue**, and `cron-alerting-debt.json` is empty.

A red cron produces no PR, no reviewer and no notification — silence and success look identical from outside. These eight were the remaining cases:

| workflow | job(s) | what stops being protected |
|---|---|---|
| `check-links` | `gate` | dead links in docs/READMEs stop being found |
| `codeql` | `gate` | new security findings stop surfacing |
| `lighthouse` | `lighthouse` | perf/a11y regressions go unmeasured |
| `metrics-freshness` | `check` | stale cached metrics stop being noticed |
| `npm-token-health` | `check-npm-token` | an expired `NPM_TOKEN` surfaces at publish instead |
| `quality-full` | `bench-configs`, `test-scope` | the scheduled heavy gate stops running |
| `release-drift` | `drift` | tag/changelog/npm divergence goes unreported |
| `release-hygiene` | `reconcile` | release metadata rots quietly |

Each issue body says **what stops being protected**, not that a job failed. "Dead links in docs and READMEs are no longer being found" is actionable in a way "workflow failed" isn't.

## One thing I checked rather than assumed

Every `needs` was verified against the workflow's **real job list**, not the debt file's job names — those are two different things, and only one is what GitHub schedules. All eight resolve:

```
ok  check-links.yml       needs=[gate]
ok  codeql.yml            needs=[gate]
ok  lighthouse.yml        needs=[lighthouse]
ok  metrics-freshness.yml needs=[check]
ok  npm-token-health.yml  needs=[check-npm-token]
ok  quality-full.yml      needs=[bench-configs, test-scope]
ok  release-drift.yml     needs=[drift]
ok  release-hygiene.yml   needs=[reconcile]
```

## The ratchet did its own job

With the reporting added and the baseline untouched, it failed with:

> `check-links.yml: gate are listed in cron-alerting-debt.json but are now covered. Remove them so the baseline keeps meaning what it says.`

It refuses to let the file claim debt that no longer exists — which is why the entries are removed in the same commit that covers them. The note now records that **empty is the state this file exists to reach**, not a reason to delete the ratchet.

## Test plan

- [x] `test:scripts` — 2502 passed (124 files).
- [x] `lint:workflows` — 44/44.
- [x] Every new `report` job parsed from YAML and its `needs` checked against real job ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)