### PR TITLE
chore(docs): sync generated data

### DIFF
--- a/apps/docs/src/data/changelog.json
+++ b/apps/docs/src/data/changelog.json
@@ -1,7 +1,7 @@
 {
-  "releaseCount": 611,
+  "releaseCount": 613,
   "packageCount": 34,
-  "entryCount": 1998,
+  "entryCount": 2000,
   "oldestYear": 2024,
   "releases": [
     {
@@ -15862,6 +15862,21 @@
     {
       "package": "eslint-plugin-jwt-security",
       "short": "eslint-plugin-jwt-security",
+      "version": "3.2.1",
+      "date": null,
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "A computed or quoted option key is still a JWT option.",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-jwt-security",
+      "short": "eslint-plugin-jwt-security",
       "version": "2.2.9",
       "date": null,
       "isApp": false,
@@ -15975,6 +15990,21 @@
         {
           "kind": "other",
           "title": "Ofri Peretz",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-node-security",
+      "short": "eslint-plugin-node-security",
+      "version": "5.4.3",
+      "date": null,
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "A computed or quoted property key is still the same property.",
           "pr": null
         }
       ]

--- a/apps/docs/src/data/plugin-stats.json
+++ b/apps/docs/src/data/plugin-stats.json
@@ -13,7 +13,7 @@
       "rules": 42,
       "description": "ESLint plugin for Node.js security — detects command injection, path traversal, SSRF, zip slip, and weak crypto (MD5/SHA-1, ECB, static IV) in fs, child_process, vm, and crypto",
       "category": "security",
-      "version": "5.4.2",
+      "version": "5.4.3",
       "published": true
     },
     {
@@ -45,7 +45,7 @@
       "rules": 13,
       "description": "ESLint plugin for JWT security — detects algorithm confusion (CVE-2022-23540), alg:none, weak or hardcoded secrets, and decode-without-verify",
       "category": "security",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "published": true
     },
     {
@@ -244,5 +244,5 @@
   "totalRules": 477,
   "totalPlugins": 30,
   "allPluginsCount": 30,
-  "generatedAt": "2026-09-03"
+  "generatedAt": "2026-09-04"
 }


### PR DESCRIPTION
Regenerated apps/docs/src/data/ (trigger: push). Opened by the Docs Data Sync workflow; contents come entirely from the apps/docs/scripts/sync-* scripts, so review the diff rather than hand-editing.