### PR TITLE
fix(workspace): refuse npm install in a worktree that borrows node_modules

### DIFF
--- a/docs/WORKTREE_NODE_MODULES.md
+++ b/docs/WORKTREE_NODE_MODULES.md
@@ -1,0 +1,89 @@
+# Worktrees and `node_modules`
+
+This repo is developed across ~75 git worktrees. Most of them **do not own their
+dependencies** — they borrow another worktree's `node_modules`. That is
+deliberate: a full install is minutes and gigabytes, and a worktree that exists
+to review one PR does not need its own copy.
+
+It also has a sharp edge that is invisible until something else breaks.
+
+## The three shapes
+
+| shape                  | what it looks like                                                | owns deps? |
+| :--------------------- | :---------------------------------------------------------------- | :--------- |
+| **host**               | real `node_modules`, ~31 symlinks pointing INSIDE at `packages/*` | yes        |
+| **whole-tree borrow**  | `node_modules` is itself a symlink to a host                      | no         |
+| **per-package borrow** | real `node_modules` dir, but ~1,200 entries symlink OUT to a host | no         |
+
+The third is the one that catches people. It looks like a normal install —
+`ls node_modules` shows everything you expect — and nothing about it announces
+that the contents live somewhere else.
+
+## Why `npm install` in a borrowed worktree is destructive
+
+npm does not know the links are borrowed. It follows them and writes **through**
+them into the host, so an install in one worktree silently rewrites dependencies
+for every worktree sharing that host.
+
+Observed on 2026-09-04, from a single `npm install`:
+
+1. It wrote through the links and left `@vitest/utils` an empty directory in the
+   host — breaking vitest in **every** worktree pointing at that host, not just
+   the one where the command ran.
+2. Repairing it with `npm install` in the host modified the host's
+   `package-lock.json` and pruned packages another worktree needed.
+3. Restoring the lockfile with `npm ci` deleted and recreated `node_modules`,
+   which dangled `.vite-temp` and left 470 scoped symlinks missing.
+
+One command, three rounds of damage, none of it visible at the point of failure.
+The symptom appeared as unrelated test files failing to load.
+
+## The rule
+
+**Install in the host. Never in a borrower.**
+
+```bash
+# find out which you are in
+node --experimental-strip-types scripts/guard-borrowed-node-modules.mts
+
+# install where the dependencies actually live
+cd <host printed above> && npm ci
+```
+
+`npm ci` rather than `npm install` in a host: it installs exactly what the
+lockfile says instead of re-resolving, so it cannot quietly change versions for
+every worktree downstream.
+
+## The guard
+
+`scripts/guard-borrowed-node-modules.mts` runs as `preinstall` and refuses when
+this worktree's dependencies are borrowed, naming the host to use instead.
+
+It keys on **where symlinks point**, not that symlinks exist — a host has ~31 of
+them too, pointing inward at `packages/*`, which is ordinary npm workspace
+behaviour. Measured:
+
+```
+eslint-ci2   31 inside,    0 outside   <- host, install is fine
+eslint-mq    31 inside, 1241 outside   <- borrowed, install is destructive
+```
+
+It stays silent when `node_modules` does not exist, so a fresh clone and CI are
+unaffected.
+
+Override for a single command when you genuinely mean it:
+
+```bash
+ALLOW_BORROWED_INSTALL=1 npm install
+```
+
+## Repairing a borrowed worktree
+
+If a borrowed worktree has lost symlinks — packages that exist in the host but
+resolve nowhere here — relink rather than install:
+
+```bash
+node --experimental-strip-types scripts/relink-borrowed-node-modules.mts <host>
+```
+
+That recreates only what is missing and never touches an entry with content.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "interlace-monorepo",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "node": "24.x"
   },
   "scripts": {
+    "preinstall": "node --experimental-strip-types scripts/guard-borrowed-node-modules.mts",
     "prepare": "[ -d .git ] && lefthook install || true",
     "ci:local": "lefthook run pre-push --all-files --force",
     "lint:triage-sampling": "tsx scripts/lint-triage-sampling.ts",

--- a/scripts/guard-borrowed-node-modules.mts
+++ b/scripts/guard-borrowed-node-modules.mts
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Refuse `npm install` in a worktree whose node_modules is borrowed.
+ *
+ * This repo is developed across ~75 git worktrees, and most of them do not own
+ * their dependencies. They reach a HOST worktree instead, in one of two shapes:
+ *
+ *   node_modules -> /Users/.../eslint-litmus/node_modules      (whole tree)
+ *   node_modules/<pkg> -> /Users/.../eslint-ci2/node_modules/<pkg>   (per package)
+ *
+ * npm does not know that. It follows the links and writes THROUGH them into the
+ * host — so an install here silently rewrites dependencies for every worktree
+ * sharing that host.
+ *
+ * That happened on 2026-09-04. One `npm install` in a borrowed worktree emptied
+ * `@vitest/utils` in the host, which broke vitest in every worktree pointing at
+ * it. Repairing it modified the host's package-lock.json and pruned packages,
+ * and restoring THAT deleted node_modules and left 470 scoped symlinks dangling.
+ * One command, three rounds of damage, none of it visible until tests failed
+ * somewhere else.
+ *
+ * The discriminator is where the symlinks point, not that they exist. A host has
+ * ~31 symlinks too — `node_modules/eslint-plugin-x -> ../packages/...` — and
+ * those are normal npm workspace links. Measured:
+ *
+ *   eslint-ci2   31 inside,    0 outside   <- host, install is fine
+ *   eslint-mq    31 inside, 1241 outside   <- borrowed, install is destructive
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROOT = path.resolve(import.meta.dirname, '..');
+const NM = path.join(ROOT, 'node_modules');
+
+/** Where an install would actually land, and how we know. */
+function borrowedFrom(): { host: string; how: string } | null {
+  if (!fs.existsSync(NM)) return null; // fresh clone / CI — nothing to borrow yet
+
+  if (fs.lstatSync(NM).isSymbolicLink()) {
+    return {
+      host: fs.realpathSync(NM),
+      how: 'node_modules is itself a symlink',
+    };
+  }
+
+  const real = fs.realpathSync(ROOT) + path.sep;
+  const outside: string[] = [];
+  for (const entry of fs.readdirSync(NM)) {
+    const p = path.join(NM, entry);
+    let target: string;
+    try {
+      if (!fs.lstatSync(p).isSymbolicLink()) continue;
+      target = fs.realpathSync(p);
+    } catch {
+      continue; // dangling link — not evidence of borrowing
+    }
+    if (!target.startsWith(real)) outside.push(target);
+  }
+
+  // A handful could be deliberate. A thousand is a mirror of another tree.
+  if (outside.length < 50) return null;
+  const host = outside[0].split(`${path.sep}node_modules${path.sep}`)[0];
+  return {
+    host,
+    how: `${outside.length} packages are symlinks into another worktree`,
+  };
+}
+
+const borrowed = borrowedFrom();
+if (borrowed) {
+  console.error(`
+  ┌─ refusing to install here ─────────────────────────────────────────────
+  │
+  │  This worktree does not own its dependencies.
+  │    ${borrowed.how}
+  │    host: ${borrowed.host}
+  │
+  │  npm follows those links and writes THROUGH them, so installing here
+  │  rewrites dependencies for EVERY worktree sharing that host — and the
+  │  damage only shows up later, as failures somewhere else.
+  │
+  │  Install in the host instead:
+  │      cd ${borrowed.host} && npm ci
+  │
+  │  If you genuinely mean to install here, this worktree needs its own tree:
+  │      rm -rf node_modules && npm ci        (slow, and unshares it)
+  │
+  │  To override for one command:  ALLOW_BORROWED_INSTALL=1 npm install
+  └────────────────────────────────────────────────────────────────────────
+`);
+  if (process.env.ALLOW_BORROWED_INSTALL !== '1') process.exit(1);
+  console.error('  ALLOW_BORROWED_INSTALL=1 set — proceeding anyway.\n');
+}

--- a/scripts/relink-borrowed-node-modules.mts
+++ b/scripts/relink-borrowed-node-modules.mts
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Repair a borrowed worktree's node_modules by relinking, not installing.
+ *
+ * See docs/WORKTREE_NODE_MODULES.md. When a borrowed worktree loses symlinks —
+ * an install wrote real empty directories over them, or the host's
+ * node_modules was recreated — the fix is to restore the links, NOT to run
+ * `npm install`, which is what caused the damage in the first place.
+ *
+ * Written after exactly that: on 2026-09-04 an install in a borrowed worktree
+ * left 470 scoped packages (`@types/*`, `@eslint-community/*`, …) as empty real
+ * directories, and the symptom was unrelated test files failing to load with
+ * "Cannot find package".
+ *
+ * Safety: creates only what is MISSING, and removes only directories that are
+ * both real and empty. Anything with content is left alone and reported.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROOT = path.resolve(import.meta.dirname, '..');
+const host = process.argv[2];
+
+if (!host) {
+  console.error(
+    'usage: relink-borrowed-node-modules.mts <host-worktree>\n' +
+      '  the host is printed by scripts/guard-borrowed-node-modules.mts',
+  );
+  process.exit(2);
+}
+
+const SRC = path.join(path.resolve(host), 'node_modules');
+const DST = path.join(ROOT, 'node_modules');
+
+if (!fs.existsSync(SRC)) {
+  console.error(`no node_modules in host: ${SRC}`);
+  process.exit(2);
+}
+if (fs.lstatSync(DST).isSymbolicLink()) {
+  console.log('node_modules is a whole-tree symlink — nothing to relink.');
+  process.exit(0);
+}
+
+/** Scoped packages nest one level, so `@scope/pkg` is the unit, not `@scope`. */
+function* packages(): Generator<string> {
+  for (const entry of fs.readdirSync(SRC)) {
+    const p = path.join(SRC, entry);
+    if (
+      entry.startsWith('@') &&
+      fs.lstatSync(p).isDirectory() &&
+      !fs.lstatSync(p).isSymbolicLink()
+    ) {
+      for (const sub of fs.readdirSync(p)) yield path.join(entry, sub);
+    } else {
+      yield entry;
+    }
+  }
+}
+
+let linked = 0;
+let kept = 0;
+const occupied: string[] = [];
+
+for (const rel of packages()) {
+  const src = path.join(SRC, rel);
+  const dst = path.join(DST, rel);
+
+  if (fs.existsSync(dst) || fs.lstatSync(dst, { throwIfNoEntry: false })) {
+    const st = fs.lstatSync(dst, { throwIfNoEntry: false });
+    if (st?.isSymbolicLink()) {
+      kept++;
+      continue;
+    }
+    if (st?.isDirectory() && fs.readdirSync(dst).length === 0) {
+      fs.rmdirSync(dst); // empty real dir: the shape a failed install leaves
+    } else if (st) {
+      occupied.push(rel); // has content — never clobber it
+      continue;
+    }
+  }
+
+  fs.mkdirSync(path.dirname(dst), { recursive: true });
+  fs.symlinkSync(src, dst);
+  linked++;
+}
+
+console.log(`  relinked: ${linked}`);
+console.log(`  already linked: ${kept}`);
+if (occupied.length > 0) {
+  console.log(`  left alone (real content, not empty): ${occupied.length}`);
+  for (const o of occupied.slice(0, 10)) console.log(`    ${o}`);
+}


### PR DESCRIPTION
I damaged this environment on 2026-09-04. This is the guard that makes the mistake unavailable, plus the documentation that would have prevented it.

## The setup

~75 worktrees develop this repo and **most do not own their dependencies**. They borrow a host in one of two shapes:

```
node_modules -> /Users/.../eslint-litmus/node_modules            whole tree
node_modules/<pkg> -> /Users/.../eslint-ci2/node_modules/<pkg>   per package
```

The second looks like an ordinary install. `ls node_modules` shows everything you expect, and nothing announces that the contents live somewhere else.

## What one `npm install` did

npm follows those links and writes **through** them into the host, so an install in one worktree rewrites dependencies for every worktree sharing it.

1. `@vitest/utils` became an empty directory in the host — breaking vitest in **every** worktree pointing at it, not the one where the command ran.
2. Repairing with `npm install` in the host **modified the host's `package-lock.json`** and pruned packages another worktree needed.
3. Restoring that lockfile with `npm ci` deleted and recreated `node_modules`, dangling `.vite-temp` and leaving **470 scoped symlinks** missing.

Three rounds of damage from one command, surfacing as unrelated test files failing to load with "Cannot find package".

## The discriminator

Where symlinks **point**, not that they exist. A host has ~31 too, pointing inward at `packages/*` — ordinary npm workspace behaviour:

```
eslint-ci2   31 inside,    0 outside   <- host, install is fine
eslint-mq    31 inside, 1241 outside   <- borrowed, install is destructive
```

## Verified against all four cases

| worktree | shape | result |
|---|---|---|
| `eslint-mq` | per-package borrow | refuses, exit 1 |
| `eslint-778` | whole-tree symlink | refuses, names host |
| `eslint-ci2` | host | **allows**, exit 0 |
| `eslint-litmus` | host | **allows**, exit 0 |

Also: `ALLOW_BORROWED_INSTALL=1` overrides, and it stays silent when `node_modules` doesn't exist — so a fresh clone and CI are untouched. Confirmed firing on a real `npm ci --dry-run`.

## Also included

`relink-borrowed-node-modules.mts` — the repair I did by hand, as a command. Restores missing links, removes only directories that are both real and empty, never clobbers content. Against the current tree: `0 relinked, 1643 already linked`, which is what a healthy borrower looks like.

`docs/WORKTREE_NODE_MODULES.md` records the topology and the rule (**install in the host, `npm ci` not `npm install`**), because this failure mode is invisible at the point of failure.

## Test plan

- [x] `test:scripts` 2505 passed; `oxlint`, `prettier --check`, `check-links` clean.
- [x] Guard exercised against host, per-package borrower, whole-tree borrower, and the override.
- [x] All five host worktrees verified healthy: vitest 4.1.10, `@eslint-community/regexpp` resolving, `eslint-ci2` lockfile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)