### PR TITLE
chore(workspace): codecov measures what ships, and says so

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -482,9 +482,44 @@ component_management:
 # ═══════════════════════════════════════════════════════════════════════════════
 # IGNORE PATHS
 # ═══════════════════════════════════════════════════════════════════════════════
-# Files that don't contain runtime logic or lack tests
+# Files that don't contain runtime logic or lack tests.
+#
+# ── Everything outside packages/ ───────────────────────────────────────────────
+#
+# Codecov is the CONSUMER-FACING number. It answers "is the code you install
+# tested", so its denominator is the code that ships: packages/. Internal
+# tooling is measured by whether it works, not by a coverage percentage.
+#
+# These paths were never uploaded — the workflow runs `turbo run test:coverage`
+# over packages only — so listing them changes no number. What it changes is
+# that the omission becomes a DECISION rather than an accident. An absent path
+# and a deliberately excluded one look identical in a report; that difference
+# is the whole reason every artefact in this repo carries a `command` field.
+#
+# Measured before deciding, so the trade is on the record:
+#
+#   scripts/      176 source files, 7.95% line coverage
+#   benchmarks/   361
+#   apps/         257
+#   tools/          6
+#
+# scripts/ is the interesting one and the answer is still no. It holds the
+# gates, and this repo has repeatedly shipped wrong numbers because a gate was
+# broken — a swallowed ReferenceError that made an artefact read STALE for
+# months, a lock that passed because it asserted its own prose. But those are
+# caught by scripts/__tests__ (125 files, 2,505 tests), which is a correctness
+# signal, not a percentage. Raising 7.95% to a gate would be a large project
+# for code no consumer ever receives, and it would put a second, louder number
+# next to the one customers actually read.
+#
+# If that calculus changes, the honest move is a SEPARATE Codecov project for
+# tooling, not diluting this one.
 
 ignore:
+  - 'apps/**'
+  - 'scripts/**'
+  - 'benchmarks/**'
+  - 'tools/**'
   - '**/*.test.ts'
   - '**/*.spec.ts'
   - '**/node_modules/**'

--- a/scripts/__tests__/codecov-measures-what-ships.lock.test.ts
+++ b/scripts/__tests__/codecov-measures-what-ships.lock.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * Codecov's denominator is the code that ships.
+ *
+ * The published number answers "is the code you install tested", so it covers
+ * `packages/` and nothing else. Internal tooling — scripts, benchmarks, the
+ * docs site — is held to a correctness signal (scripts/__tests__ alone is 125
+ * files and 2,505 tests) rather than to a percentage.
+ *
+ * Two ways that claim can rot, and both are pinned here:
+ *
+ *   the boundary moves   — someone uploads apps/ or scripts/ coverage and the
+ *                          consumer-facing number silently starts averaging in
+ *                          code no consumer receives
+ *   a package goes dark  — a new plugin lands with no component, so it is
+ *                          absent from the report rather than at 0%, and
+ *                          absent reads as fine
+ *
+ * The second is not hypothetical. Eleven plugins had no component at all and
+ * carried 38 rules between them; node-security wrote its lcov to a path the
+ * uploader never read and sat at a fossilised 99.80% for months. Both looked
+ * healthy from the outside.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { parse } from 'yaml';
+
+const ROOT = resolve(__dirname, '../..');
+
+type CodecovConfig = {
+  ignore?: string[];
+  component_management?: {
+    individual_components?: { component_id: string; paths?: string[] }[];
+  };
+};
+
+const config = parse(
+  readFileSync(join(ROOT, 'codecov.yml'), 'utf-8'),
+) as CodecovConfig;
+
+/** Packages that actually publish — `private: true` never reaches a consumer. */
+function publishedPackages(): string[] {
+  return readdirSync(join(ROOT, 'packages'), { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .filter((e) => {
+      const pkg = join(ROOT, 'packages', e.name, 'package.json');
+      if (!existsSync(pkg)) return false;
+      const json = JSON.parse(readFileSync(pkg, 'utf-8')) as {
+        private?: boolean;
+      };
+      return json.private !== true;
+    })
+    .map((e) => e.name)
+    .sort();
+}
+
+describe('codecov measures what ships', () => {
+  it('every non-package tree is explicitly ignored', () => {
+    const ignored = config.ignore ?? [];
+    for (const tree of ['apps', 'scripts', 'benchmarks', 'tools']) {
+      expect(
+        ignored,
+        `${tree}/ is not in codecov.yml \`ignore\`. It is internal tooling and ` +
+          'must not enter the consumer-facing number — and being merely ' +
+          'un-uploaded is not the same as being excluded on purpose.',
+      ).toContain(`${tree}/**`);
+    }
+  });
+
+  it('every PUBLISHED package has a component', () => {
+    const components = (
+      config.component_management?.individual_components ?? []
+    ).map((c) => c.component_id);
+
+    expect(
+      components.length,
+      'no components are defined, so this test would pass vacuously',
+    ).toBeGreaterThan(20);
+
+    const missing = publishedPackages().filter((p) => !components.includes(p));
+    expect(
+      missing,
+      `Published package(s) with no Codecov component: ${missing.join(', ')}. ` +
+        'A package with no component is ABSENT from the report rather than at ' +
+        '0%, and absent reads as fine — that is how eleven plugins went ' +
+        'unmeasured. Add a component, or mark the package private if it does ' +
+        'not ship.',
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Codecov is the **consumer-facing** number — it answers *"is the code you install tested"* — so its denominator is `packages/`. Internal tooling is now excluded **explicitly** rather than by omission.

**This changes no percentage.** `apps/`, `scripts/`, `benchmarks/` and `tools/` were never uploaded; the workflow runs `turbo run test:coverage` over packages only. What changes is that the exclusion becomes a *decision*. An absent path and a deliberately excluded one look identical in a report — and that distinction is the entire reason every artefact in this repo carries a `command` field.

## Measured before deciding

| tree | source files | line coverage |
|---|---|---|
| `scripts/` | 176 | **7.95%** |
| `benchmarks/` | 361 | — |
| `apps/` | 257 | — |
| `tools/` | 6 | — |

`scripts/` is the interesting one, and the answer is still no. It holds the gates, and this repo has repeatedly shipped wrong numbers *because* a gate was broken — a swallowed `ReferenceError` that made an artefact read STALE for months, a lock that passed because it asserted its own prose.

But those are caught by `scripts/__tests__` (**126 files, 2,507 tests**), which is a correctness signal, not a percentage. Raising 7.95% to a gate would be a large project for code no consumer receives, and would put a second, louder number beside the one customers read. If that calculus changes, the honest move is a **separate Codecov project for tooling**, not diluting this one.

## Locked in both directions

**The boundary cannot move** — each of the four trees must stay in `ignore`, so nobody can quietly start averaging internal code into the published figure.

**A package cannot go dark** — every package without `private: true` must have a component. A package with no component is *absent* from the report rather than at 0%, and absent reads as fine. That is exactly how eleven plugins carrying 38 rules went unmeasured, and how `node-security` sat at a fossilised 99.80% while writing its lcov where nothing read it.

Proven by removing `scripts/**` from `ignore` and by deleting the jwt-security component — each fails, naming what is wrong.

## Note

Three packages are `private: true` and correctly outside the published surface: `@interlace/ui`, `@interlace/eslint-formatter`, `@interlace/eslint-formatter-sarif`. The two formatters currently *do* have components; `ui` does not. The lock only requires components for packages that actually publish, so this is consistent either way — flagging it in case you'd rather the private ones came out too.

## Test plan

- [x] `scripts/__tests__` — 126 files, 2,507 tests
- [x] `codecov.yml` re-validated as YAML (16 ignore entries)
- [x] Both lock directions proven
- [x] oxlint + format-drift clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Coverage reporting now focuses on code shipped in published packages, excluding internal applications, scripts, benchmarks, and tooling.
  * Coverage exclusions are documented more clearly to explain which areas are not measured.

* **Tests**
  * Added validation to ensure every published package is represented in coverage reporting.
  * Added safeguards to detect incomplete or missing coverage configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->