### PR TITLE
fix(import-next): node: builtins are never dependencies

### DIFF
--- a/.changeset/node-builtins-are-never-dependencies.md
+++ b/.changeset/node-builtins-are-never-dependencies.md
@@ -1,0 +1,15 @@
+---
+'eslint-plugin-import-next': patch
+---
+
+fix(no-extraneous-dependencies): `node:` builtins are never dependencies
+
+`import process from 'node:process'` was reported as a missing dependency.
+The rule skipped builtins from a hand-written list of 29 names frozen at
+roughly Node 8 — no `process`, `module`, `worker_threads`, `perf_hooks`,
+`async_hooks` or `test` — so the spelling `unicorn/prefer-node-protocol`
+demands was the one this rule rejected.
+
+A `node:`-prefixed specifier is a builtin by definition and is now skipped
+outright; the bare names come from `builtinModules` in `node:module`, so the
+list is whatever the running Node says it is rather than one that rots.

--- a/packages/eslint-plugin-import-next/src/rules/no-extraneous-dependencies.ts
+++ b/packages/eslint-plugin-import-next/src/rules/no-extraneous-dependencies.ts
@@ -9,6 +9,7 @@
  * Forbid the use of extraneous packages (eslint-plugin-import inspired)
  */
 import type { TSESTree, TSESLint } from '@interlace/eslint-devkit';
+import { builtinModules } from 'node:module';
 import { createRule, staticString } from '@interlace/eslint-devkit';
 import { formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
 import { readJsonFileSync, findFileUpward } from '@interlace/eslint-devkit';
@@ -303,67 +304,18 @@ export const noExtraneousDependencies = createRule<RuleOptions, MessageIds>({
         return null;
       }
 
-      // Skip Node.js built-ins
-      const nodeBuiltins = [
-        'assert',
-        'buffer',
-        'child_process',
-        'cluster',
-        'crypto',
-        'dgram',
-        'dns',
-        'domain',
-        'events',
-        'fs',
-        'http',
-        'https',
-        'net',
-        'os',
-        'path',
-        'punycode',
-        'querystring',
-        'readline',
-        'stream',
-        'string_decoder',
-        'timers',
-        'tls',
-        'tty',
-        'url',
-        'util',
-        'v8',
-        'vm',
-        'zlib',
-        'node:assert',
-        'node:buffer',
-        'node:child_process',
-        'node:cluster',
-        'node:crypto',
-        'node:dgram',
-        'node:dns',
-        'node:domain',
-        'node:events',
-        'node:fs',
-        'node:http',
-        'node:https',
-        'node:net',
-        'node:os',
-        'node:path',
-        'node:punycode',
-        'node:querystring',
-        'node:readline',
-        'node:stream',
-        'node:string_decoder',
-        'node:timers',
-        'node:tls',
-        'node:tty',
-        'node:url',
-        'node:util',
-        'node:v8',
-        'node:vm',
-        'node:zlib',
-      ];
-
-      if (nodeBuiltins.includes(importPath)) {
+      // Skip Node.js built-ins.
+      //
+      // This was a hand-written list of 29 names, frozen at roughly Node 8:
+      // no `process`, `module`, `worker_threads`, `perf_hooks`, `async_hooks`
+      // or `test`. `import process from 'node:process'` — the spelling
+      // `unicorn/prefer-node-protocol` demands — was reported as a missing
+      // dependency. A `node:`-prefixed specifier is a builtin by definition,
+      // and the bare names are whatever the running Node says they are.
+      if (
+        importPath.startsWith('node:') ||
+        builtinModules.includes(importPath)
+      ) {
         return null;
       }
 

--- a/packages/eslint-plugin-import-next/src/tests/no-extraneous-dependencies.test.ts
+++ b/packages/eslint-plugin-import-next/src/tests/no-extraneous-dependencies.test.ts
@@ -72,11 +72,32 @@ ruleTester.run('no-extraneous-dependencies', noExtraneousDependencies, {
 
     // Builtins
     { 
+        name: 'a bare builtin',
         code: `import fs from 'fs';`,
         options: [{ packageJson: mockPackageJson }]
     },
     { 
+        name: 'a node: builtin',
         code: `import path from 'node:path';`,
+        options: [{ packageJson: mockPackageJson }]
+    },
+    // `node:process` was reported as a missing dependency: the hand-written
+    // builtin list never had `process`, `module`, `worker_threads` or
+    // `perf_hooks`. A `node:`-prefixed specifier is a builtin by definition,
+    // and the bare names come from `builtinModules` rather than a list that rots.
+    {
+        name: 'node:process is a builtin, not a dependency',
+        code: `import process from 'node:process';`,
+        options: [{ packageJson: mockPackageJson }]
+    },
+    {
+        name: 'a bare builtin newer than the old hand-written list',
+        code: `import { isMainThread } from 'worker_threads';`,
+        options: [{ packageJson: mockPackageJson }]
+    },
+    {
+        name: 'a required node: builtin',
+        code: `const { performance } = require('node:perf_hooks');`,
         options: [{ packageJson: mockPackageJson }]
     },
     

--- a/packages/eslint-plugin-secure-coding/src/rules/no-unlimited-resource-allocation/no-unlimited-resource-allocation.test.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/no-unlimited-resource-allocation/no-unlimited-resource-allocation.test.ts
@@ -28,6 +28,22 @@ describe('no-unlimited-resource-allocation', () => {
   describe('Valid Code', () => {
     ruleTester.run('valid - safe resource allocation', noUnlimitedResourceAllocation, {
       valid: [
+    // A loop bounded by a directory listing. `files` is what `readdirSync`
+    // returned — data the process already holds — so one read per entry
+    // allocates O(what is already on disk in that directory) and nobody can
+    // amplify it. eslint-plugin-secure-coding 3.7.1 reported this exact shape
+    // in scripts/lint-workflows.ts as CWE-770.
+    {
+      name: 'a read per entry of a directory listing is bounded by the listing',
+      code: `
+        const files = fs.readdirSync(WORKFLOWS_DIR).filter((f) => /\\.ya?ml$/.test(f));
+        const parsed = new Map();
+        for (const file of files) {
+          const full = path.join(WORKFLOWS_DIR, file);
+          parsed.set(file, yaml.load(fs.readFileSync(full, 'utf8')));
+        }
+      `,
+    },
     // Each reaches a `propertyName(...) ?? ''` sentinel with a key that cannot
     // be resolved, and each must fail CLOSED: an unnameable property is not a
     // request surface, not a size, and not an fs write.
@@ -56,6 +72,7 @@ describe('no-unlimited-resource-allocation', () => {
           code: 'const buf = Buffer.alloc(1024);',
         },
         {
+          name: 'a size clamped at the allocation is bounded',
           code: 'const limitedBuf = Buffer.alloc(Math.min(userSize, 1024 * 1024));',
         },
         // Safe array allocation

--- a/packages/eslint-plugin-secure-coding/src/rules/no-xpath-injection/no-xpath-injection.test.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/no-xpath-injection/no-xpath-injection.test.ts
@@ -27,12 +27,28 @@ describe('no-xpath-injection', () => {
   describe('Valid Code', () => {
     ruleTester.run('valid - safe XPath operations', noXpathInjection, {
       valid: [
+        // --- a GitHub Actions annotation is not an XPath axis ------------------
+        // `::error file=x::msg` is the Actions runner's command syntax. Two
+        // colons on their own are not an axis — an axis is `axisname::nodetest`
+        // — and nothing here reaches an evaluator. eslint-plugin-secure-coding
+        // 3.7.1 reported both lines of scripts/lint-workflows.ts at CVSS 9.8.
+        {
+          name: 'a workflow annotation with a file is not XPath',
+          code: 'function annotate(level, msg, file) { process.stdout.write(`::${level} file=${file}::${msg}\\n`); }',
+        },
+        {
+          name: 'a workflow annotation without a file is not XPath',
+          code: 'function annotate(level, msg) { process.stdout.write(`::${level}::${msg}\\n`); }',
+        },
     // --- a router wildcard is not a location step -------------------------
     // City-of-Helsinki/haitaton-ui reported CWE-643 at CVSS 9.8 twice on these,
     // in a repository importing no XPath package and containing no XPath at
     // all. `/*` is XPath's abbreviated `child::*` and also React Router's
     // wildcard segment; on its own it is not evidence of either.
-    'const p = `/${lang}/*`;',
+    {
+      name: 'a router wildcard segment is not a location step',
+      code: 'const p = `/${lang}/*`;',
+    },
     'const routes = LOCALES.map((l) => ({ path: `/${l}/*` }));',
     // The wildcard gate is corroboration, not amnesty: a module that imports an
     // XPath package gets the finding, so this one is deliberately NOT valid and


### PR DESCRIPTION
## Summary

Three rules reported false positives on `scripts/lint-workflows.ts` (the same file is copied verbatim into `ofri-peretz/cli`, where the rules are switched off pending this PR).

- **`import-next/no-extraneous-dependencies`** — `import process from 'node:process'` was reported as a missing dependency. The rule skipped builtins from a hand-written list of 29 names frozen at roughly Node 8 (no `process`, `module`, `worker_threads`, `perf_hooks`, `async_hooks`, `test`). Now: any `node:`-prefixed specifier is skipped outright, and bare names come from `builtinModules` in `node:module`, the same source `no-unresolved` already uses. Changeset: patch.
- **`secure-coding/no-xpath-injection`** — `process.stdout.write(\`::${level} file=${file}::${msg}\n\`)` (a GitHub Actions annotation) was reported as XPath at CVSS 9.8 by the published 3.7.1. The rule on `main` (5.3.3, also on npm) already requires a real axis name before `::`; this PR adds the lock so the shape cannot regress.
- **`secure-coding/no-unlimited-resource-allocation`** — `fs.readFileSync` inside `for (const file of files)` where `files` is a `readdirSync` listing was reported as CWE-770 by 3.7.1. On `main` a loop allocation only reports when the loop bound is invoker-controlled; this PR adds the lock.

## Test plan

- [x] The three new `no-extraneous-dependencies` valid cases fail with the rule change stashed (`× import process from 'node:process'`, `× worker_threads`, `× node:perf_hooks`) and pass with it. Suite: 30/30.
- [x] The two secure-coding locks pass on `main`; the same reduced snippets reported under the published 3.7.1 (run via the `cli` repo's installed build), which is the "before".
- [x] `turbo run typecheck --filter=eslint-plugin-import-next` green; every pre-commit hook (rule-audit, case-descriptions, spellings, key-vocabulary, case-registry, format-drift, tests-affected) green.

## After merge

The Version Packages PR releases `eslint-plugin-import-next` 2.7.5. Then in `ofri-peretz/cli`: bump `eslint-plugin-secure-coding` to `^5.3.3` and `eslint-plugin-import-next` to `^2.7.5`, and delete the `scripts/lint-workflows.ts` override block in `eslint.config.mjs`.

Not done here, deliberately: gating every `unsafeXpathConcatenation` template report on sink evidence. `main` already gates the call path and the wildcard shape on an XPath import or DOM member; extending that to all templates changes recall on the CWE-643 corpus and needs the recall gate run alongside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)