### PR TITLE
fix(benchmarks): make the version matrix actually test the ESLint it claims

### DIFF
--- a/.github/workflows/eslint-version-matrix.yml
+++ b/.github/workflows/eslint-version-matrix.yml
@@ -116,28 +116,36 @@ jobs:
       - name: Build plugins (dist/ is what the configs load)
         run: npx turbo run build --filter='eslint-plugin-*' --filter=@interlace/eslint-devkit
 
+      # -w @interlace/benchmarks, NOT the repo root. benchmarks/package.json
+      # declares its own `eslint: ^10.9.1`, so a root install leaves
+      # benchmarks/node_modules/eslint in place and the bench keeps resolving
+      # that — every cell silently ran eslint 10 (#891). The root print below
+      # is what made it look right for months: it reports the root copy, which
+      # is not the one the bench imports.
       - name: Install ESLint ${{ matrix.eslint }}
         run: |
           set -e
           case "${{ matrix.eslint }}" in
             "8.x")
-              npm install --no-save eslint@^8
+              npm install --no-save -w @interlace/benchmarks eslint@^8
               ;;
             "9.39")
-              npm install --no-save eslint@9.39.0
+              npm install --no-save -w @interlace/benchmarks eslint@9.39.0
               ;;
             "9.x")
-              npm install --no-save eslint@^9
+              npm install --no-save -w @interlace/benchmarks eslint@^9
               ;;
             "10.x")
-              npm install --no-save eslint@^10
+              npm install --no-save -w @interlace/benchmarks eslint@^10
               ;;
             *)
               echo "::error::Unknown ESLint version selector: ${{ matrix.eslint }}"
               exit 1
               ;;
           esac
-          node -e "console.log('eslint@' + require('eslint/package.json').version)"
+          # Print what the BENCH resolves, not the root — see above.
+          node -e "console.log('bench resolves eslint@' + require('./benchmarks/node_modules/eslint/package.json').version)" \
+            || node -e "console.log('bench resolves eslint@' + require('eslint/package.json').version)"
 
       # The swap above installs at the repo ROOT, but benchmarks/package.json
       # declares its own `eslint` devDependency, so npm may keep a nested copy

--- a/benchmarks/__tests__/peer-eslint-support.lock.test.ts
+++ b/benchmarks/__tests__/peer-eslint-support.lock.test.ts
@@ -112,3 +112,73 @@ describe('a failed lint run is never scored as "found nothing"', () => {
     expect(RUN).toMatch(/>=\s*9\)\s*return ESLint/);
   });
 });
+
+/*
+ * The summary must survive records that carry no metrics.
+ *
+ * Every consumer below the table dereferences `data.metrics`. An excluded or
+ * unmeasurable plugin has none, so an unfiltered summary throws
+ * `Cannot read properties of undefined (reading 'f1Score')` — and the throw
+ * lands after the table is printed but BEFORE results are saved, so a run
+ * looks like it worked and silently writes nothing.
+ *
+ * It was invisible because the entrypoint was `.catch(console.error)`: the
+ * error printed and the process still exited 0. Verifying by exit code alone
+ * reported success on a run that produced no output file.
+ */
+describe('the summary tolerates records with no metrics', () => {
+  const RUN = fs.readFileSync(
+    path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      '../suites/ilb-arena/run.js',
+    ),
+    'utf-8',
+  );
+
+  it('ranks only scored records', () => {
+    // The sort must not read from every plugin entry.
+    expect(RUN).not.toMatch(
+      /sortedPlugins\s*=\s*Object\.entries\(results\.plugins\)\.sort/,
+    );
+    expect(RUN).toMatch(/const scored = Object\.entries\(results\.plugins\)/);
+    expect(RUN).toMatch(/d\.metrics !== undefined/);
+  });
+
+  it('still names what it did not score', () => {
+    expect(RUN).toContain('Not scored:');
+    expect(RUN).toMatch(/notScored:/);
+  });
+
+  it('fails the process when the run throws', () => {
+    // `.catch(console.error)` exits 0 on any error — a bench that cannot fail
+    // cannot gate, and this is what hid the summary crash.
+    expect(RUN).not.toMatch(/runBenchmark\(\)\.catch\(console\.error\)/);
+    expect(RUN).toMatch(
+      /runBenchmark\(\)\.catch\([\s\S]{0,120}process\.exit\(1\)/,
+    );
+  });
+
+  it('reproduces the crash on an unfiltered sort', () => {
+    const plugins = {
+      good: { displayName: 'Good', metrics: { f1Score: '50.0%' } },
+      excluded: { displayName: 'Excluded' },
+    };
+    expect(() =>
+      Object.entries(plugins).sort(
+        ([, a]: [string, any], [, b]: [string, any]) =>
+          parseFloat(b.metrics.f1Score) - parseFloat(a.metrics.f1Score),
+      ),
+    ).toThrow(/f1Score/);
+
+    const scored = Object.entries(plugins).filter(
+      ([, d]: [string, any]) => d.metrics !== undefined,
+    );
+    expect(() =>
+      scored.sort(
+        ([, a]: [string, any], [, b]: [string, any]) =>
+          parseFloat(b.metrics.f1Score) - parseFloat(a.metrics.f1Score),
+      ),
+    ).not.toThrow();
+    expect(scored).toHaveLength(1);
+  });
+});

--- a/benchmarks/__tests__/peer-eslint-support.lock.test.ts
+++ b/benchmarks/__tests__/peer-eslint-support.lock.test.ts
@@ -14,6 +14,9 @@
  * a peer that never claimed this major is excluded; anything else still stops
  * the run.
  */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import {
   NPM_PACKAGE_NAMES,
@@ -49,5 +52,63 @@ describe('a peer is only excused when it never claimed the major', () => {
   it('treats an undeclared range as a claim of support, so it still fails loud', () => {
     expect(peerEslintRange('no-such-plugin-anywhere')).toBeNull();
     expect(declaresSupportFor('no-such-plugin-anywhere', '8.57.1')).toBe(true);
+  });
+});
+
+/*
+ * The vacuity that hid three defects for months.
+ *
+ * `runEslint` refused to score a config that FAILED TO LOAD, but a failure of
+ * the lint RUN itself was downgraded to a warning returning []. An empty
+ * result is indistinguishable from a plugin that found nothing, so it scored
+ * as one. Measured on genuine ESLint 8 before this was closed: 36 run
+ * failures, all 18 plugins at 0/40 TP and F1 0.0%, exit code 0 — a green run
+ * that measured nothing. @angular-eslint scored that way on every published
+ * run, on every ESLint major (#897).
+ */
+describe('a failed lint run is never scored as "found nothing"', () => {
+  const RUN = fs.readFileSync(
+    path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      '../suites/ilb-arena/run.js',
+    ),
+    'utf-8',
+  );
+
+  /** The body of runEslint's lint-run catch block. */
+  const runCatch = (): string => {
+    const at = RUN.indexOf('const results = await eslint.lintFiles(');
+    expect(
+      at,
+      'lintFiles call not found — this lock is pointed at nothing',
+    ).toBeGreaterThan(-1);
+    const rest = RUN.slice(at);
+    const start = rest.indexOf('} catch (e) {');
+    expect(start, 'no catch around the lint run').toBeGreaterThan(-1);
+    // Comments out first. This block explains the old `return []` in prose,
+    // and a lock that reads its subject's commentary asserts nothing about
+    // its code — the failure mode that made three locks vacuous this week.
+    return rest
+      .slice(start, start + 1600)
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/\/\/.*$/gm, '');
+  };
+
+  it('stops the run instead of returning an empty result', () => {
+    const body = runCatch();
+    expect(body).toContain('process.exit(3)');
+    expect(body).not.toMatch(/return\s*\[\s*\]/);
+  });
+
+  it('still excuses a peer that never claimed the running major', () => {
+    expect(runCatch()).toContain('UNSUPPORTED');
+  });
+
+  it('picks ESLint 8s flat-config engine, which lives elsewhere', () => {
+    // v8 rejects `new ESLint({overrideConfigFile: true})` outright; its flat
+    // engine is FlatESLint behind eslint/use-at-your-own-risk, off `.default`.
+    expect(RUN).toContain('use-at-your-own-risk');
+    expect(RUN).toContain('FlatESLint');
+    expect(RUN).toMatch(/>=\s*9\)\s*return ESLint/);
   });
 });

--- a/benchmarks/suites/ilb-arena/run.js
+++ b/benchmarks/suites/ilb-arena/run.js
@@ -32,6 +32,7 @@ import path from 'path';
 import { createRequire } from 'module';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { ESLint } from 'eslint';
+import semver from 'semver';
 import {
   NPM_PACKAGE_NAMES,
   OUR_PLUGIN_NAME,
@@ -205,6 +206,18 @@ const ALL_PLUGINS = [
     category: 'Vue.js',
   },
   {
+    /*
+     * Its recommended set includes rules that need a TypeScript program
+     * (@angular-eslint/no-developer-preview throws "requires type
+     * information"), and this corpus is plain .js with no project. The plugin
+     * does not mark those rules `requiresTypeChecking`, so they cannot be
+     * filtered out by metadata.
+     *
+     * This was always true. Until run failures became fatal it surfaced as a
+     * silent 0/40 — a fabricated measurement — on every run, v10 included.
+     * Declared, not scored, until the corpus can give it a program (#897).
+     */
+    unmeasurable: 'needs a TypeScript program; the arena corpus is plain .js',
     name: 'angular',
     displayName: '@angular-eslint/eslint-plugin',
     config: './configs/angular.config.js',
@@ -265,6 +278,29 @@ function getPluginsToTest() {
 // dynamic imports of TS sources resolve, so we can use ESLint's Node API
 // with `overrideConfig: <imported-config>` and get real numbers.
 
+/*
+ * ESLint 8 cannot take a flat config through `new ESLint({overrideConfigFile:
+ * true})` — it rejects it with "'overrideConfigFile' must be a non-empty
+ * string or null". Its flat-config engine lives behind the
+ * `eslint/use-at-your-own-risk` entry point, and comes off `.default`.
+ * v9+ takes flat config on the main export directly.
+ */
+let enginePromise;
+function flatEngine() {
+  enginePromise ??= (async () => {
+    if (semver.major(semver.coerce(ESLint.version)) >= 9) return ESLint;
+    const mod = await import('eslint/use-at-your-own-risk');
+    const { FlatESLint } = mod.default ?? mod;
+    if (typeof FlatESLint !== 'function') {
+      throw new Error(
+        `ESLint ${ESLint.version} exposes no FlatESLint; cannot lint flat configs.`,
+      );
+    }
+    return FlatESLint;
+  })();
+  return enginePromise;
+}
+
 const configCache = new Map();
 
 async function loadConfig(configPath) {
@@ -304,7 +340,8 @@ async function runEslint(configPath, targetFile, pluginName) {
   }
 
   try {
-    const eslint = new ESLint({
+    const Engine = await flatEngine();
+    const eslint = new Engine({
       cwd: __dirname,
       overrideConfigFile: true,
       overrideConfig: config,
@@ -312,10 +349,30 @@ async function runEslint(configPath, targetFile, pluginName) {
     const results = await eslint.lintFiles([absoluteTarget]);
     return results;
   } catch (e) {
+    /*
+     * A run failure used to return [] with a warning. That is the same
+     * vacuity the config-load branch above refuses: [] is indistinguishable
+     * from a plugin that genuinely found nothing, and it scores as such.
+     * Measured on real ESLint 8 before this changed: 36 run failures, all 18
+     * plugins at 0/40 TP and F1 0.0%, exit code 0.
+     *
+     * unicorn is the live example — its rules need ESLint 10's rule-options
+     * semantics and throw "Cannot destructure property 'name' of 'options'"
+     * on v8, which is precisely what its `>=10.4` peer range declares. So the
+     * same exemption the load branch uses applies here: a peer that never
+     * claimed this major is excluded, anything else stops the run.
+     */
+    if (
+      pluginName !== undefined &&
+      pluginName !== OUR_PLUGIN_NAME &&
+      !declaresSupportFor(pluginName, ESLint.version)
+    ) {
+      return UNSUPPORTED;
+    }
     console.error(
-      `  ⚠️  ESLint run failed for ${configPath}: ${e.message?.slice(0, 200)}`,
+      `\n❌ ESLint run failed for ${configPath}\n   ${e.message?.slice(0, 300)}\n\nRefusing to score.`,
     );
-    return [];
+    process.exit(3);
   }
 }
 
@@ -653,6 +710,15 @@ async function runBenchmark() {
     );
     console.log('-'.repeat(70));
 
+    if (plugin.unmeasurable) {
+      console.log(`   ⊘ Not scored — ${plugin.unmeasurable}.`);
+      results.plugins[plugin.name] = {
+        displayName: plugin.displayName,
+        unmeasurable: plugin.unmeasurable,
+      };
+      continue;
+    }
+
     // Run on vulnerable code
     console.log('   Scanning vulnerable.js...');
     const vulnerableRaw = await runEslint(
@@ -684,6 +750,17 @@ async function runBenchmark() {
       FIXTURE_FILES.safe,
       plugin.name,
     );
+    if (safeRaw === UNSUPPORTED) {
+      const range = peerEslintRange(plugin.name);
+      console.log(
+        `   ⊘ Skipped — declares eslint "${range}", running ${ESLint.version}.`,
+      );
+      results.plugins[plugin.name] = {
+        displayName: plugin.displayName,
+        unsupported: { declaredEslint: range, runningEslint: ESLint.version },
+      };
+      continue;
+    }
     const safeViolations = extractViolations(safeRaw);
     const safeByFunction = mapViolationsToFunctions(safeViolations, safeCode);
 

--- a/benchmarks/suites/ilb-arena/run.js
+++ b/benchmarks/suites/ilb-arena/run.js
@@ -862,8 +862,22 @@ async function runBenchmark() {
     '|:--------------------------------|:--------|:------|:-------------------|:----|:---|:---|:----------|:-------|:-------|',
   );
 
+  /*
+   * Only scored records reach the table and the leaderboard. A plugin that was
+   * excluded (peer declares no support for this ESLint) or is unmeasurable
+   * (needs a TypeScript program this corpus lacks) carries no `metrics`, and
+   * every consumer below dereferences them. They are reported after the table
+   * instead — absent from the ranking, but never invisible.
+   */
+  const scored = Object.entries(results.plugins).filter(
+    ([, d]) => d.metrics !== undefined,
+  );
+  const notScored = Object.entries(results.plugins).filter(
+    ([, d]) => d.metrics === undefined,
+  );
+
   // Sort by F1 score descending
-  const sortedPlugins = Object.entries(results.plugins).sort(
+  const sortedPlugins = scored.sort(
     ([, a], [, b]) =>
       parseFloat(b.metrics.f1Score) - parseFloat(a.metrics.f1Score),
   );
@@ -882,9 +896,29 @@ async function runBenchmark() {
     );
   }
 
+  // Excluded plugins are named, never silently dropped from the comparison.
+  if (notScored.length > 0) {
+    console.log('\nNot scored:');
+    for (const [, d] of notScored) {
+      const why = d.unmeasurable
+        ? d.unmeasurable
+        : `declares eslint "${d.unsupported?.declaredEslint}", ran ${d.unsupported?.runningEslint}`;
+      console.log(`  ⊘ ${d.displayName} — ${why}`);
+    }
+  }
+
   // Build article-ready summary
   results.summary = {
-    totalPluginsTested: pluginsToTest.length,
+    // Counts the plugins that produced metrics, not the ones we attempted —
+    // `pluginsToTest.length` counted excluded plugins as tested.
+    totalPluginsTested: sortedPlugins.length,
+    notScored: notScored.map(([name, d]) => ({
+      plugin: name,
+      displayName: d.displayName,
+      reason: d.unmeasurable ?? 'unsupported on this ESLint',
+      declaredEslint: d.unsupported?.declaredEslint,
+      runningEslint: d.unsupported?.runningEslint,
+    })),
     securityRelevantPlugins: pluginsToTest.filter(
       (p) => p.securityRelevant !== false,
     ).length,
@@ -931,4 +965,12 @@ function groupByRule(violations) {
 }
 
 // Run if called directly
-runBenchmark().catch(console.error);
+/*
+ * `.catch(console.error)` printed the error and exited 0 — the benchmark
+ * reported success on every failure, including a TypeError in the summary
+ * that skipped saving results entirely. A bench that cannot fail cannot gate.
+ */
+runBenchmark().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
Reopens and finishes #891. Follow-up to #892 — whose premise my own gate disproved.

## What happened

I merged #892 believing CI genuinely ran ESLint 8 and only my laptop had a nested-copy problem. I dispatched the matrix on main to confirm, and the assertion #892 added fired immediately:

```
❌ Wrong ESLint under test.
   Expected major 8, resolved 10.10.0.
```

**The 8.x cell has never run ESLint 8.** Three nested defects.

### 1. The cell tested the wrong ESLint

The workflow installed at the repo **root**, but `benchmarks/package.json` declares `eslint: ^10.9.1`, so npm kept `benchmarks/node_modules/eslint@10.10.0` and the bench resolved that. The install step printed the *root* version — which is why this looked correct for months.

Now: `npm install --no-save -w @interlace/benchmarks eslint@^8`, and the step prints what the **bench** resolves.

### 2. On real ESLint 8 the harness's own API call is invalid

```
Invalid Options:
- 'overrideConfigFile' must be a non-empty string or null.
```

`overrideConfigFile: true` is the v9+ flat form. v8's flat engine is `FlatESLint` behind `eslint/use-at-your-own-risk`, and must be taken off `.default`.

### 3. The vacuity — through the door the guard did not cover

A config **load** failure was fatal, correctly. A lint **run** failure returned `[]` with a warning. `[]` is indistinguishable from a plugin that found nothing, so it scored as one. On genuine ESLint 8, before this changed:

```
run-failures: 36        (18 plugins × 2 fixtures)
every plugin:  0/40 TP,  F1 0.0%
exit code:     0
```

Had defect 1 been fixed alone, the cell would have gone **green while measuring nothing**. Run failures are now fatal, with the same peer exemption the load branch uses.

That exemption earns its keep: unicorn@74 really does fail on v8 — `Cannot destructure property 'name' of 'options'`, because its rules need ESLint 10's rule-options semantics, exactly as `>=10.4` declares.

## A defect this surfaced

`@angular-eslint` has never produced a real measurement on **any** major. Its config enables every rule; some need a TypeScript program the `.js` corpus cannot provide; it has been scored 0/40 on every published run. Now declared `unmeasurable` with its reason rather than scored zero. [#897](https://github.com/ofri-peretz/eslint/issues/897) tracks fixing it properly.

## Test plan

All three majors, each with the version gate asserting the resolved major:

| major | exit | notes |
|---|---|---|
| 8.57.1 | 0 | unicorn excluded; **Interlace 14/40 TP, 2 FP, F1 50.0% — first genuine v8 measurement** |
| 9.x | 0 | unicorn scores normally |
| 10.10.0 | 0 | 18 plugins, unchanged from before |

- [x] Lock extended to 8 cases in `benchmarks/__tests__/peer-eslint-support.lock.test.ts`.
- [x] **Each new assertion proven to bite:** exit → `return []` fails 1; dropping the exemption fails 2; assuming v8 uses the main export fails 1; restored passes 8.
- [x] The lock strips comments before matching — its first draft matched the prose in its own subject and passed vacuously. Caught and fixed before commit.
- [x] `benchmarks`: 279 tests, 10 files, all pass.
- [x] Full pre-commit gate green.

## After merge

Dispatch `eslint-version-matrix.yml` to confirm all cells. This is the first time it will have exercised ESLint 8 or 9 at all — `docs/ESLINT_VERSION_SUPPORT.md` gates on both (24% and 60% share), and neither has ever actually been measured by this workflow, so genuine failures may surface. That is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved benchmark compatibility across ESLint 8 and newer versions.
  - Unsupported plugin and ESLint-version combinations are now identified and skipped instead of producing misleading results.
  - Benchmark failures for supported plugins now stop execution rather than being reported as zero findings.
  - Angular scans are reported as unmeasurable when required project type information is unavailable.

- **Tests**
  - Added coverage for ESLint version support detection, plugin compatibility handling, and benchmark failure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->