### PR TITLE
fix(eslint-rules): two false positives found by dogfooding the cli repo

### DIFF
--- a/.changeset/console-spaces-template-interior.md
+++ b/.changeset/console-spaces-template-interior.md
@@ -1,0 +1,16 @@
+---
+'eslint-plugin-conventions': patch
+---
+
+**🐛 Fix** — `no-console-spaces` no longer reports the space beside an interpolation in a template literal
+
+``console.error(`No workflows dir at ${dir}`)`` was reported because the
+quasi before `${dir}` ends with a space. The rule looped over every quasi and
+reported any that began or ended with whitespace, so every template literal
+that put a space next to `${…}` was a finding.
+
+The rule is about leading/trailing whitespace of the whole argument, which
+console would duplicate when it joins parameters. For a template literal that
+means only the first quasi's leading whitespace and the last quasi's trailing
+whitespace. Interior boundaries around interpolations are the body of one
+string, and are no longer checked.

--- a/.changeset/void-dom-capitalized-components.md
+++ b/.changeset/void-dom-capitalized-components.md
@@ -1,0 +1,14 @@
+---
+'eslint-plugin-react-features': patch
+---
+
+**🐛 Fix** — `void-dom-elements-no-children` no longer reports `<Link>`, `<Img>`, `<Input>` and other capitalized components
+
+`<Link href="/docs">Read the floor</Link>` from `next/link` was reported as
+"`<link>` is a void element and cannot have children". The tag-name check
+lower-cased the JSX name before looking it up, so any component whose name
+differed from a void element only by case was treated as that element.
+
+JSX resolves a capitalized name to a binding, never to a DOM tag. Only a
+lowercase `JSXIdentifier` (`link`, `img`, `br`, …) can be a void DOM element,
+and that is now the only thing the rule matches.

--- a/packages/eslint-plugin-conventions/src/rules/conventions/no-console-spaces.ts
+++ b/packages/eslint-plugin-conventions/src/rules/conventions/no-console-spaces.ts
@@ -113,9 +113,15 @@ export const noConsoleSpaces = createRule<RuleOptions, MessageIds>({
     }
 
     // oxlint-disable-next-line consistent-function-scoping
-    function hasLeadingOrTrailingSpacesInTemplate(text: string): boolean {
-      // For template literals, even whitespace-only quasis should be flagged
-      return /^\s|\s$/.test(text);
+    function templateHasLeadingOrTrailingSpaces(
+      node: TSESTree.TemplateLiteral,
+    ): boolean {
+      // Only the edges of the whole literal are padding. The quasis around an
+      // interpolation (`at ${dir}`) are the interior of one string; checking
+      // every quasi reported every template that put a space beside `${}`.
+      const first = node.quasis[0].value.raw;
+      const last = node.quasis[node.quasis.length - 1].value.raw;
+      return /^\s/.test(first) || /\s$/.test(last);
     }
 
     return {
@@ -146,16 +152,7 @@ export const noConsoleSpaces = createRule<RuleOptions, MessageIds>({
                 });
               }
             } else if (arg.type === 'TemplateLiteral') {
-              // Check template literal quasi values for leading/trailing spaces
-              let hasSpacesInTemplate = false;
-              for (const quasi of arg.quasis) {
-                if (hasLeadingOrTrailingSpacesInTemplate(quasi.value.raw)) {
-                  hasSpacesInTemplate = true;
-                  break;
-                }
-              }
-
-              if (hasSpacesInTemplate) {
+              if (templateHasLeadingOrTrailingSpaces(arg)) {
                 context.report({
                   node: arg,
                   messageId: 'noConsoleSpaces',

--- a/packages/eslint-plugin-conventions/src/tests/conventions/no-console-spaces.test.ts
+++ b/packages/eslint-plugin-conventions/src/tests/conventions/no-console-spaces.test.ts
@@ -43,7 +43,23 @@ describe('no-console-spaces', () => {
           code: 'console.log("hello", "world");',
         },
         {
+          name: 'a plain string with no padding',
           code: 'console.error("error message");',
+        },
+        // Only the edges of the whole argument count. The space before an
+        // interpolation is the separator between two words of one string,
+        // not padding console would add a second copy of.
+        {
+          name: 'a space before an interpolation is interior, not trailing',
+          code: 'console.error(`No workflows dir at ${dir}`);',
+        },
+        {
+          name: 'a space after an interpolation is interior, not leading',
+          code: 'console.log(`${count} files`);',
+        },
+        {
+          name: 'spaces around a middle interpolation are interior',
+          code: 'console.log(`found ${n} in ${dir}`);',
         },
         {
           code: 'console.warn("warning");',

--- a/packages/eslint-plugin-react-features/src/rules/react/void-dom-elements-no-children.ts
+++ b/packages/eslint-plugin-react-features/src/rules/react/void-dom-elements-no-children.ts
@@ -95,9 +95,13 @@ export const voidDomElementsNoChildren = createRule<RuleOptions, MessageIds>({
         const openingElement = node.openingElement;
         
         if (openingElement.name.type !== 'JSXIdentifier') return;
-        
-        const elementName = openingElement.name.name.toLowerCase();
-        
+
+        // JSX resolves a capitalized name to a binding, never to a DOM tag, so
+        // `<Link>` from next/link is a component and `link` is the void element.
+        // The former case-insensitive match reported every <Link>, <Img>,
+        // <Input> component that wrapped children.
+        const elementName = openingElement.name.name;
+
         if (!VOID_ELEMENTS.has(elementName)) return;
 
         const hasChildren = hasChildrenProp(openingElement) || 

--- a/packages/eslint-plugin-react-features/src/tests/react/void-dom-elements-no-children.test.ts
+++ b/packages/eslint-plugin-react-features/src/tests/react/void-dom-elements-no-children.test.ts
@@ -45,7 +45,15 @@ describe('void-dom-elements-no-children', () => {
       '<span>Text</span>',
       '<p>Paragraph</p>',
       // Custom components (not void elements)
-      '<MyComponent>Content</MyComponent>',
+      { name: 'a custom component is never a DOM element', code: '<MyComponent>Content</MyComponent>' },
+      // A component whose name only differs from a void element by case is a
+      // component, not that element: JSX resolves capitalized names to bindings.
+      {
+        name: "next/link's <Link> is a component, not the void <link>",
+        code: 'import Link from "next/link"; const a = <Link href="/docs">Read the floor</Link>;',
+      },
+      { name: 'a capitalized <Img> component may wrap children', code: '<Img src="x.png">caption</Img>' },
+      { name: 'a capitalized <Input> component may take a children prop', code: '<Input children={label} />' },
     ],
     invalid: [
       {


### PR DESCRIPTION
## What

Two false positives that the `cli` repo hit and worked around with scoped `'off'` entries (Findings 5 and 6 there).

**`react-features/void-dom-elements-no-children`** reported `<Link href="/docs">Read the floor</Link>` from `next/link` as "`<link>` is a void element and cannot have children". The rule lower-cased the JSX name before looking it up in the void-element set. JSX resolves a capitalized name to a binding, never a DOM tag, so only a lowercase `JSXIdentifier` can be a void element. The `.toLowerCase()` is gone.

**`conventions/no-console-spaces`** reported `` console.error(`No workflows dir at ${dir}`) `` because the quasi before `${dir}` ends with a space. The rule looped over every quasi. The intent (from unicorn) is leading/trailing whitespace of the whole argument, which for a template literal is only the first quasi's leading and the last quasi's trailing whitespace. Interior boundaries around interpolations are no longer checked.

## Locks

Six new named `valid` cases, three per rule. All six fail on the unfixed rules (verified before applying either fix: `Tests 6 failed | 75 passed`) and pass after. Existing `invalid` template cases (`` ` hello ${a} world ` ``, `` `hello ` ``) still fire, so the padding detection is intact.

## Follow-up

Once these versions are published and installed in `cli`, the two scoped `'off'` entries in its `eslint.config.mjs` come out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
