### PR TITLE
fix(release): three changesets carried the badge the generator adds

### DIFF
--- a/.changeset/console-spaces-template-interior.md
+++ b/.changeset/console-spaces-template-interior.md
@@ -2,7 +2,7 @@
 'eslint-plugin-conventions': patch
 ---
 
-**🐛 Fix** — `no-console-spaces` no longer reports the space beside an interpolation in a template literal
+fix: `no-console-spaces` no longer reports the space beside an interpolation in a template literal
 
 ``console.error(`No workflows dir at ${dir}`)`` was reported because the
 quasi before `${dir}` ends with a space. The rule looped over every quasi and

--- a/.changeset/null-check-early-exit-guard.md
+++ b/.changeset/null-check-early-exit-guard.md
@@ -2,7 +2,7 @@
 'eslint-plugin-reliability': patch
 ---
 
-**🐛 Fix** — `no-missing-null-checks` understands `if (!x) return` and, given types, TypeScript's own narrowing
+fix: `no-missing-null-checks` understands `if (!x) return` and, given types, TypeScript's own narrowing
 
 The shape of every `getOrNotFound` helper reported on its return:
 

--- a/.changeset/void-dom-capitalized-components.md
+++ b/.changeset/void-dom-capitalized-components.md
@@ -2,7 +2,7 @@
 'eslint-plugin-react-features': patch
 ---
 
-**🐛 Fix** — `void-dom-elements-no-children` no longer reports `<Link>`, `<Img>`, `<Input>` and other capitalized components
+fix: `void-dom-elements-no-children` no longer reports `<Link>`, `<Img>`, `<Input>` and other capitalized components
 
 `<Link href="/docs">Read the floor</Link>` from `next/link` was reported as
 "`<link>` is a void element and cannot have children". The tag-name check


### PR DESCRIPTION
## What

`.changeset/changelog.cjs` prefixes every release line with a kind badge derived from the summary's conventional-commit prefix. Three pending changesets (`null-check-early-exit-guard`, `void-dom-capitalized-components`, `console-spaces-template-interior`) started their summary with a literal `**🐛 Fix** —` as well, so the Version Packages PR #902 rendered `**🐛 Fix** — **🐛 Fix** —` on three lines. CodeRabbit flagged the reliability one there and that unresolved thread is what blocks #902.

The three summaries now start with `fix:` as the changeset README documents. Running the generator over them locally yields a single `**🐛 Fix** —` per line. `scripts/lint-changesets.ts` passes.

No code change; the next refresh of #902 regenerates the three CHANGELOGs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
