### PR TITLE
fix(benchmarks): oxlint parity scored an empty run as 0% parity

### DIFF
--- a/benchmarks/suites/ilb-oxlint-parity/run.ts
+++ b/benchmarks/suites/ilb-oxlint-parity/run.ts
@@ -442,23 +442,27 @@ function lintEslint(corpus, configPath) {
 
 function lintOxlint(corpus, configPath) {
   /*
-   * cwd is the CORPUS, not the repo root.
+   * KNOWN BROKEN when the corpus is gitignored — see #906.
    *
-   * oxlint honours .gitignore relative to its cwd, and the harvested corpus is
-   * generated — .gitignore excludes it. Run from the repo root, oxlint reported
-   * "No files found to lint" and 0 diagnostics, while ESLint linted all 3,971
-   * fixtures: parity read 0.0% with 10,944 unexplained eslint-only findings,
-   * which looks exactly like a total parity collapse rather than a harness that
-   * never ran. `--no-ignore` does not lift it; cwd does.
+   * oxlint honours .gitignore, and the harvested corpus is generated, so
+   * .gitignore:146 excludes it. From here oxlint reports "No files found to
+   * lint" and 0 diagnostics while ESLint lints all 3,971 fixtures. Neither
+   * `--no-ignore` nor `--ignore-pattern` lifts it.
    *
-   * Safe for resolution: the config addresses its plugins by absolute path
-   * (see the jsPlugins comment above), so it does not depend on cwd.
+   * Running with cwd inside the corpus does make oxlint see files, but it then
+   * roots itself at benchmarks/ (the nearest package.json) and walks that whole
+   * tree — 4,183 files including benchmarks/rule-corpus and
+   * benchmarks/corpus/by-rule, which ESLint never sees. That trades a visible
+   * failure for a wrong measurement, so it is not done here.
+   *
+   * The fix is to harvest outside the ignored path. Until then the guards below
+   * make this fail loudly instead of scoring 0% parity.
    */
-  const cmd = `npx oxlint --config "${configPath}" --format json .`;
+  const cmd = `npx oxlint --config "${configPath}" --format json "${corpus}"`;
   let raw = '';
   try {
     raw = execSync(cmd, {
-      cwd: corpus,
+      cwd: REPO_ROOT,
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],
       maxBuffer: 64 * 1024 * 1024,
@@ -513,15 +517,9 @@ function lintOxlint(corpus, configPath) {
      * parity break.
      */
     if (!allowedPrefixes.some((prefix) => ruleId.startsWith(prefix))) continue;
-    /*
-     * Resolve against the CORPUS, which is oxlint's cwd — its filenames come
-     * back relative to that. Resolving them against REPO_ROOT instead produced
-     * paths that no ESLint finding could match: shared dropped to 0 while both
-     * sides were reporting thousands of real findings.
-     */
     const filename = d.filename ?? '';
     const rel = path
-      .relative(REPO_ROOT, path.resolve(corpus, filename))
+      .relative(REPO_ROOT, path.resolve(REPO_ROOT, filename))
       .split(path.sep)
       .join('/');
     const label = (d.labels ?? [])[0]?.span ?? {};

--- a/benchmarks/suites/ilb-oxlint-parity/run.ts
+++ b/benchmarks/suites/ilb-oxlint-parity/run.ts
@@ -441,11 +441,24 @@ function lintEslint(corpus, configPath) {
 }
 
 function lintOxlint(corpus, configPath) {
-  const cmd = `npx oxlint --config "${configPath}" --format json "${corpus}"`;
+  /*
+   * cwd is the CORPUS, not the repo root.
+   *
+   * oxlint honours .gitignore relative to its cwd, and the harvested corpus is
+   * generated — .gitignore excludes it. Run from the repo root, oxlint reported
+   * "No files found to lint" and 0 diagnostics, while ESLint linted all 3,971
+   * fixtures: parity read 0.0% with 10,944 unexplained eslint-only findings,
+   * which looks exactly like a total parity collapse rather than a harness that
+   * never ran. `--no-ignore` does not lift it; cwd does.
+   *
+   * Safe for resolution: the config addresses its plugins by absolute path
+   * (see the jsPlugins comment above), so it does not depend on cwd.
+   */
+  const cmd = `npx oxlint --config "${configPath}" --format json .`;
   let raw = '';
   try {
     raw = execSync(cmd, {
-      cwd: REPO_ROOT,
+      cwd: corpus,
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],
       maxBuffer: 64 * 1024 * 1024,
@@ -456,11 +469,24 @@ function lintOxlint(corpus, configPath) {
   }
   // oxlint --format json emits a single JSON object with `diagnostics[]`.
   // Each diagnostic's rule lives in `code` as `<source>(<rule>)`.
+  /*
+   * Returning [] here scored "oxlint found nothing", which is indistinguishable
+   * from a clean run and is how the gitignore bug above surfaced as a parity
+   * number instead of a crash. A harness that cannot fail cannot gate.
+   */
   let parsed;
   try {
     parsed = JSON.parse(raw);
   } catch {
-    return [];
+    throw new Error(
+      `oxlint did not emit JSON. It printed:\n${raw.slice(0, 800)}`,
+    );
+  }
+  if ((parsed.number_of_files ?? 0) === 0) {
+    throw new Error(
+      `oxlint linted 0 files under ${corpus}. Its ignore rules excluded the ` +
+        'whole corpus, so any parity number would be measuring nothing.',
+    );
   }
   const diags = parsed.diagnostics ?? [];
   const findings = [];

--- a/benchmarks/suites/ilb-oxlint-parity/run.ts
+++ b/benchmarks/suites/ilb-oxlint-parity/run.ts
@@ -478,9 +478,14 @@ function lintOxlint(corpus, configPath) {
    * from a clean run and is how the gitignore bug above surfaced as a parity
    * number instead of a crash. A harness that cannot fail cannot gate.
    */
+  // oxlint prefixes its JSON with human-readable notices ("No files found to
+  // lint...") on stdout, so parse from the first brace rather than the first
+  // byte — otherwise every such notice reads as "not JSON" and hides the more
+  // specific diagnosis below.
+  const jsonStart = raw.indexOf('{');
   let parsed;
   try {
-    parsed = JSON.parse(raw);
+    parsed = JSON.parse(jsonStart === -1 ? raw : raw.slice(jsonStart));
   } catch {
     throw new Error(
       `oxlint did not emit JSON. It printed:\n${raw.slice(0, 800)}`,

--- a/benchmarks/suites/ilb-oxlint-parity/run.ts
+++ b/benchmarks/suites/ilb-oxlint-parity/run.ts
@@ -513,9 +513,15 @@ function lintOxlint(corpus, configPath) {
      * parity break.
      */
     if (!allowedPrefixes.some((prefix) => ruleId.startsWith(prefix))) continue;
+    /*
+     * Resolve against the CORPUS, which is oxlint's cwd — its filenames come
+     * back relative to that. Resolving them against REPO_ROOT instead produced
+     * paths that no ESLint finding could match: shared dropped to 0 while both
+     * sides were reporting thousands of real findings.
+     */
     const filename = d.filename ?? '';
     const rel = path
-      .relative(REPO_ROOT, path.resolve(REPO_ROOT, filename))
+      .relative(REPO_ROOT, path.resolve(corpus, filename))
       .split(path.sep)
       .join('/');
     const label = (d.labels ?? [])[0]?.span ?? {};


### PR DESCRIPTION
Diagnoses #906. **Partial fix — the check now fails honestly, but the underlying visibility problem needs a decision (below).**

## What #906 actually was

The scheduled deep-parity run reported 10,944 unexplained eslint-only findings and `parity rate: 0.0%`. Nothing diverged. **oxlint never linted anything.**

oxlint honours `.gitignore`, and the harvested corpus is generated:

```
.gitignore:146  benchmarks/suites/ilb-oxlint-parity/harvested-fixtures/
```

So oxlint printed `No files found to lint` with `number_of_files: 0`, while ESLint linted all 3,971 fixtures.

## Why it read as a parity collapse instead of a crash

```js
try { parsed = JSON.parse(raw); } catch { return []; }
```

An empty result is indistinguishable from a clean run, so a harness that never executed scored as one where oxlint agreed with nothing — and the docs' parity claim would have been "verified" by it. Same failure shape as the arena bug in #898.

## What this PR changes

- A non-JSON oxlint response **throws**, quoting what it actually printed.
- A run that lints **0 files throws** — a parity number over an empty corpus is measuring nothing and must not be reportable.
- JSON is parsed from the first brace, since oxlint prefixes notices onto stdout; without that, every notice reads as "not JSON" and hides the specific diagnosis.

The run now stops with:

```
Error: oxlint linted 0 files under .../harvested-fixtures.
Its ignore rules excluded the whole corpus, so any parity number
would be measuring nothing.
```

## What I deliberately did NOT do

Running oxlint with `cwd` inside the corpus does make it see files — but it then roots itself at `benchmarks/` (the nearest `package.json`) and walks that entire tree: **4,183 files**, including `benchmarks/rule-corpus` and `benchmarks/corpus/by-rule`, which ESLint never sees. I tried it, measured it, and reverted it. It trades a visible failure for a silently wrong measurement, which is the exact trade this PR exists to stop.

Neither `--no-ignore` nor `--ignore-pattern` lifts the gitignore from the repo root; I verified both.

## The decision needed

The corpus has to live somewhere oxlint will look. Options, in the order I'd pick them:

1. **Harvest outside the repo** (`os.tmpdir()`). The corpus is ephemeral, so nothing is lost, and it sidesteps `.gitignore` entirely. Touches the harvest script and the workflow's `--corpus` argument.
2. Harvest to a path that is not gitignored and clean it up after the run.
3. Commit the corpus. Rejected — 3,971 generated files.

I stopped short of (1) because it changes the harness contract and #906 is now failing loudly rather than lying, which was the urgent part.

## Test plan

- [x] Reproduced the CI failure locally: 10,944 vs 0, parity 0.0%.
- [x] Root cause confirmed with `git check-ignore -v` on a fixture → `.gitignore:146`.
- [x] Confirmed oxlint sees the corpus only from inside it (4,183 files, 21,564 diagnostics) and that the file set is wrong.
- [x] Guards verified: the run stops with the message above instead of reporting 0%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)