### PR TITLE
fix(scripts): the real-source scan drops the `command` its own lock requires

### DIFF
--- a/scripts/lib/real-source-inventory.ts
+++ b/scripts/lib/real-source-inventory.ts
@@ -32,6 +32,13 @@ import path from 'node:path';
 import { createHash } from 'node:crypto';
 
 export type Inventory = {
+  /**
+   * The command that reproduces this file. Optional for the same reason
+   * `configHash` is: files written before the scan emitted it do not have one,
+   * and typing it as required would make the reader's cast a lie about them.
+   * The generated-artefact lock requires it on anything committed from now on.
+   */
+  command?: string;
   rules: Record<string, { count: number; repos: number }>;
   withoutMaterial: string[];
   filesLinted: number;

--- a/scripts/real-source-scan.mts
+++ b/scripts/real-source-scan.mts
@@ -577,6 +577,15 @@ function writeInventory(
   const silent = [...suite].filter((id) => !fired.has(id)).sort();
 
   const inventory = {
+    /*
+     * First key, and not optional. The generated-artefact lock requires every
+     * budget file to name the command that reproduces it — a typed number with
+     * no command reads as a measurement nobody can re-derive. The scan wrote
+     * every other field and dropped this one, so each automated refresh
+     * (#905) landed a file that failed the lock it had to satisfy.
+     */
+    command:
+      'npx tsx scripts/real-source-scan.mts  # CI only — never run on a developer machine',
     filesLinted: linted,
     filesFailed: failed,
     reposScanned,


### PR DESCRIPTION
Unblocks #905, and every future automated inventory refresh.

## The loop

#905 is the scheduled refresh of `benchmarks/budgets/real-world-rule-inventory.json`. Five checks fail on it, all one assertion:

```
benchmarks/budgets/real-world-rule-inventory.json has no `command`.
Add the command that regenerates it, or `"command": null` with
`"maintainedBy"` saying who decides it and on what evidence.
Absent is how a typed number comes to read as a measurement.
```

The committed file on `main` **has** `command`. The scan that regenerates it writes every other field and omits that one — so each automated refresh strips it back out and fails the lock it exists to satisfy. The bot cannot fix this; it faithfully commits what the generator produced.

## The fix

Emit `command` as the first key, matching what `main` already carries:

```
npx tsx scripts/real-source-scan.mts  # CI only — never run on a developer machine
```

One of the generators in the recorded "still dropping `command`" debt; the rest are untouched by this change.

## A note on verification

I did **not** run the scan. It clones and lints third-party repositories and is CI-only — which is precisely what its own `command` string says, and the repo's standing rule. So this is verified by reading the generator against the lock and against main's committed file, not by regenerating locally. The scheduled run is the real check; if the field still comes out missing, this PR was wrong and the failure will say so immediately rather than silently.

## Test plan

- [x] Traced the failure to the omission: main's file has `command`, the generator's object literal did not.
- [x] Typecheck clean.
- [x] Generated-artefact locks pass (13 assertions).
- [x] Full pre-commit gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Generated inventory artifacts now include the command used to reproduce them, improving traceability and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->