### PR TITLE
chore(docs): sync generated data

### DIFF
--- a/apps/docs/src/data/changelog.json
+++ b/apps/docs/src/data/changelog.json
@@ -1,7 +1,7 @@
 {
-  "releaseCount": 647,
-  "packageCount": 34,
-  "entryCount": 2034,
+  "releaseCount": 648,
+  "packageCount": 35,
+  "entryCount": 2035,
   "oldestYear": 2024,
   "releases": [
     {
@@ -16365,6 +16365,21 @@
         {
           "kind": "other",
           "title": "TypeScript type exports for all rule options",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "@interlace/eslint-formatter-sarif",
+      "short": "eslint-formatter-sarif",
+      "version": "0.2.0",
+      "date": null,
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "feature",
+          "title": "publish the SARIF formatter to npm",
           "pr": null
         }
       ]


### PR DESCRIPTION
Regenerated apps/docs/src/data/ (trigger: push). Opened by the Docs Data Sync workflow; contents come entirely from the apps/docs/scripts/sync-* scripts, so review the diff rather than hand-editing.