### PR TITLE
fix(benchmarks): angular is measurable, and a peer crash no longer blanks the matrix

### DIFF
--- a/.github/workflows/quality-full.yml
+++ b/.github/workflows/quality-full.yml
@@ -247,7 +247,13 @@ jobs:
           # change in this repo) skipped measurement entirely while the workflow
           # comment claimed feedback was merely "slightly delayed". Source is
           # exactly what moves the number, so source has to open the gate.
-          if echo "$CHANGED" | grep -qE '^(benchmarks/suites/.*\.config\.(js|mjs)|benchmarks/package\.json|benchmarks/__tests__/configs-load\.test\.ts|benchmarks/vitest\.configs-load\.mts|packages/[^/]+/package\.json|packages/[^/]+/src/.*|scripts/(check-artifact-size|devkit-infra-metrics)\.ts|\.agent/(artifact-size-baseline|devkit-infra-baseline)\.json|\.github/workflows/quality-full\.yml)$'; then
+          #
+          # `benchmarks/suites/**` and `benchmarks/__tests__/**` are whole
+          # directories rather than the two filenames that used to be listed.
+          # ILB-Arena's runner and its peer-support module sit beside the
+          # configs and are what the configs are loaded to exercise; a PR
+          # rewriting run.js matched nothing here and this job did not run.
+          if echo "$CHANGED" | grep -qE '^(benchmarks/suites/.*|benchmarks/package\.json|benchmarks/__tests__/.*|benchmarks/vitest\.configs-load\.mts|packages/[^/]+/package\.json|packages/[^/]+/src/.*|scripts/(check-artifact-size|devkit-infra-metrics)\.ts|\.agent/(artifact-size-baseline|devkit-infra-baseline)\.json|\.github/workflows/quality-full\.yml)$'; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"
@@ -387,6 +393,14 @@ jobs:
         run: npx turbo run build --filter='eslint-plugin-*' --filter=@interlace/eslint-devkit
       - name: Load every benchmark config
         run: npm run --silent -w @interlace/benchmarks test:configs-load
+      # The rest of `benchmarks/__tests__` runs on the unit lanes. This one is
+      # pulled forward because it guards the arena, and the lanes are skipped
+      # for exactly the PRs that touch the arena: their gate opens on
+      # `packages/*/src`, which an arena-only change never touches. A lock that
+      # never runs on the PRs that can break it is the "green locally, never
+      # run by the gate" failure recorded above scripts-tests.
+      - name: ILB-Arena peer-support locks
+        run: npx vitest run --root benchmarks __tests__/peer-eslint-support.lock.test.ts
       # Same job because it needs the same thing this one already paid for: the
       # built dist/. The contradiction only exists in the RENDERED message, and
       # the score in it is enriched from the rule's CWE — a source-only checker

--- a/benchmarks/__tests__/peer-eslint-support.lock.test.ts
+++ b/benchmarks/__tests__/peer-eslint-support.lock.test.ts
@@ -25,6 +25,12 @@ import {
   peerEslintRange,
 } from '../suites/ilb-arena/peer-support.js';
 
+const ARENA = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../suites/ilb-arena',
+);
+const RUN_JS = fs.readFileSync(path.join(ARENA, 'run.js'), 'utf-8');
+
 describe('a peer is only excused when it never claimed the major', () => {
   it('reads a declared range through an exports map that hides package.json', () => {
     // eslint-plugin-unicorn omits "./package.json" from `exports`, so
@@ -204,5 +210,71 @@ describe('the summary tolerates records with no metrics', () => {
       ),
     ).not.toThrow();
     expect(scored).toHaveLength(1);
+  });
+});
+
+/*
+ * The guard that keeps @angular-eslint honest must itself be non-vacuous.
+ *
+ * angular.config.js excludes three rules that need a TypeScript program, by
+ * name, because `requiresTypeChecking` is set on none of them. The exclusion
+ * is only safe while something notices upstream changing the rule set — and
+ * the first version of that check compared `runnable.length` against
+ * `total - NEEDS_TYPE_PROGRAM.size`, which is the same subtraction on both
+ * sides. It cancelled, and a newly-added type-aware rule passed it.
+ */
+describe('the angular type-aware exclusion is guarded by a real check', () => {
+  const ANGULAR = fs.readFileSync(
+    path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      '../suites/ilb-arena/configs/angular.config.js',
+    ),
+    'utf-8',
+  );
+
+  it('pins the rule total it was measured against', () => {
+    // Without this, "upstream added a rule" is unobservable here.
+    expect(ANGULAR).toMatch(/MEASURED_RULE_TOTAL\s*=\s*\d+/);
+    expect(ANGULAR).toMatch(/all\.length !== MEASURED_RULE_TOTAL/);
+  });
+
+  it('rejects an entry upstream no longer publishes', () => {
+    // A rename holds the total at 50 while leaving a live type-aware rule on.
+    expect(ANGULAR).toMatch(/stale/);
+    expect(ANGULAR).toContain('!all.includes(rule)');
+  });
+
+  it('never restores the cancelling comparison', () => {
+    expect(ANGULAR).not.toMatch(/length\s*-\s*NEEDS_TYPE_PROGRAM\.size/);
+  });
+
+  it('scores angular for real — no unmeasurable flag anywhere', () => {
+    // The bug in #897 was a fabricated 0/40. Marking the plugin unmeasurable
+    // would hide the same absence behind a different word.
+    expect(ANGULAR).not.toMatch(/unmeasurable/i);
+    expect(RUN_JS).not.toMatch(/angular[\s\S]{0,200}?unmeasurable/i);
+  });
+
+  it('shows why the cancelling comparison could not catch a new rule', () => {
+    // Pure reproduction: upstream ships rule 51, type-aware, unlisted.
+    const listed = new Set(['a', 'b', 'c']);
+    const upstream = [
+      'a',
+      'b',
+      'c',
+      ...Array.from({ length: 48 }, (_, i) => `r${i}`),
+    ];
+    const runnable = upstream.filter((r) => !listed.has(r));
+
+    // Old guard, before rule 51 and after — passes both times.
+    expect(runnable.length).toBe(upstream.length - listed.size);
+    const grown = [...upstream, 'r48'];
+    expect(grown.filter((r) => !listed.has(r)).length).toBe(
+      grown.length - listed.size,
+    );
+
+    // New guard: the total moved, so it throws.
+    expect(upstream.length).toBe(51);
+    expect(grown.length).not.toBe(51);
   });
 });

--- a/benchmarks/__tests__/peer-eslint-support.lock.test.ts
+++ b/benchmarks/__tests__/peer-eslint-support.lock.test.ts
@@ -88,16 +88,40 @@ describe('a failed lint run is never scored as "found nothing"', () => {
     // Comments out first. This block explains the old `return []` in prose,
     // and a lock that reads its subject's commentary asserts nothing about
     // its code — the failure mode that made three locks vacuous this week.
+    // The window has to hold the whole catch, and it grew when the crash
+    // branch landed — at 1600 it stopped just short of `process.exit(3)` and
+    // the lock failed for a reason that had nothing to do with its subject.
+    // Sized to the block's closing brace instead of a guessed byte count.
+    const end = rest.indexOf('\n  }', start);
+    expect(end, 'catch block has no closing brace').toBeGreaterThan(start);
     return rest
-      .slice(start, start + 1600)
+      .slice(start, end)
       .replace(/\/\*[\s\S]*?\*\//g, '')
       .replace(/\/\/.*$/gm, '');
   };
 
-  it('stops the run instead of returning an empty result', () => {
+  it('never returns an empty result, whoever failed', () => {
+    // The property, not the mechanism. `[]` is the thing that scores as
+    // "found nothing" — that is what must never come back from here, and it
+    // is what the 36-run/0-F1 measurement above was made of.
+    expect(runCatch()).not.toMatch(/return\s*\[\s*\]/);
+  });
+
+  it('still stops the run when OUR plugin is the one that failed', () => {
+    // Interlace failing is our bug and must block. This is the half that
+    // stayed fatal when a peer's crash stopped being fatal (#897).
     const body = runCatch();
     expect(body).toContain('process.exit(3)');
-    expect(body).not.toMatch(/return\s*\[\s*\]/);
+    expect(body).toContain('OUR_PLUGIN_NAME');
+  });
+
+  it("records a peer's crash rather than scoring or halting on it", () => {
+    // A peer that DECLARES this ESLint and throws anyway is an upstream
+    // defect. Exiting there is honest about that plugin and dishonest about
+    // the other seventeen: it left the whole matrix unmeasured, so the last
+    // published numbers — the fabricated zeros — stayed the newest ones.
+    const body = runCatch();
+    expect(body).toContain('crash(');
   });
 
   it('still excuses a peer that never claimed the running major', () => {

--- a/benchmarks/suites/ilb-arena/configs/angular.config.js
+++ b/benchmarks/suites/ilb-arena/configs/angular.config.js
@@ -11,41 +11,63 @@
  * `requiresTypeChecking` is set on 0 of the 50 rules, so metadata filtering
  * finds nothing to filter. The list came from running each rule alone against
  * the corpus and recording which threw — the same method that will find the
- * next one if upstream adds it, and the reason the count is asserted below
+ * next one if upstream adds it, and the reason the shape is asserted below
  * rather than assumed.
  */
 
-import angular from "@angular-eslint/eslint-plugin";
+import angular from '@angular-eslint/eslint-plugin';
 
-/** Rules that need a TypeScript program. Measured 2026-09-06, plugin 22.1.0. */
+/**
+ * Rules that need a TypeScript program. Bisected 2026-09-06 against 22.1.0 and
+ * re-checked against 22.2.0, which the lockfile installs: identical rule names,
+ * same 50, `requiresTypeChecking` still on none of them.
+ */
 const NEEDS_TYPE_PROGRAM = new Set([
-  "no-developer-preview",
-  "no-experimental",
-  "no-uncalled-signals",
+  'no-developer-preview',
+  'no-experimental',
+  'no-uncalled-signals',
 ]);
 
-const runnable = Object.keys(angular.rules).filter(
-  (rule) => !NEEDS_TYPE_PROGRAM.has(rule),
-);
+/** Rule count in 22.1.0 and 22.2.0 alike. */
+const MEASURED_RULE_TOTAL = 50;
 
-// If upstream adds another type-aware rule, this throws at config load —
-// which the runner turns into a refusal to score, not a silent zero. A
-// surprise here is the signal to re-run the bisect, not to widen the set.
-const expected = Object.keys(angular.rules).length - NEEDS_TYPE_PROGRAM.size;
-if (runnable.length !== expected) {
+const all = Object.keys(angular.rules);
+
+// Two assertions, because they catch opposite things and neither implies the
+// other. A surprise from either is the signal to re-run the per-rule bisect,
+// not to widen the set — and both throw at config load, which the runner turns
+// into a refusal to score rather than a silent zero.
+//
+// (1) The total. `runnable.length` is DEFINED as total − |set ∩ rules|, so
+// comparing it against total − |set| is arithmetic that cancels: an upstream
+// rule we have never seen passes it unnoticed, gets enabled, throws at lint
+// time, and lands the plugin in "crashed". Pinning the total is what actually
+// notices a rule arriving or leaving.
+if (all.length !== MEASURED_RULE_TOTAL) {
   throw new Error(
-    `angular.config: expected ${expected} runnable rules, got ${runnable.length}`,
+    `angular.config: measured ${MEASURED_RULE_TOTAL} rules, upstream now has ${all.length}. Re-run the per-rule bisect.`,
   );
 }
 
+// (2) The names. A rename keeps the total at 50 while leaving a dead entry
+// here and a live type-aware rule enabled.
+const stale = [...NEEDS_TYPE_PROGRAM].filter((rule) => !all.includes(rule));
+if (stale.length > 0) {
+  throw new Error(
+    `angular.config: no longer published by the plugin: ${stale.join(', ')}. Re-run the per-rule bisect.`,
+  );
+}
+
+const runnable = all.filter((rule) => !NEEDS_TYPE_PROGRAM.has(rule));
+
 export default [
   {
-    files: ["**/*.js"],
+    files: ['**/*.js'],
     plugins: {
-      "@angular-eslint": angular,
+      '@angular-eslint': angular,
     },
     rules: Object.fromEntries(
-      runnable.map((rule) => [`@angular-eslint/${rule}`, "warn"]),
+      runnable.map((rule) => [`@angular-eslint/${rule}`, 'warn']),
     ),
   },
 ];

--- a/benchmarks/suites/ilb-arena/configs/angular.config.js
+++ b/benchmarks/suites/ilb-arena/configs/angular.config.js
@@ -1,9 +1,42 @@
 /**
  * ESLint Configuration for @angular-eslint/eslint-plugin
  * Angular best practices — 2.25M+ weekly downloads
+ *
+ * Three of its 50 rules need a TypeScript program and throw "requires type
+ * information" against this corpus, which is plain .js with no project. That
+ * threw the whole run, and before run failures became fatal it scored the
+ * plugin a silent 0/40 — a fabricated measurement (#897).
+ *
+ * They are listed BY NAME because they cannot be found any other way:
+ * `requiresTypeChecking` is set on 0 of the 50 rules, so metadata filtering
+ * finds nothing to filter. The list came from running each rule alone against
+ * the corpus and recording which threw — the same method that will find the
+ * next one if upstream adds it, and the reason the count is asserted below
+ * rather than assumed.
  */
 
 import angular from "@angular-eslint/eslint-plugin";
+
+/** Rules that need a TypeScript program. Measured 2026-09-06, plugin 22.1.0. */
+const NEEDS_TYPE_PROGRAM = new Set([
+  "no-developer-preview",
+  "no-experimental",
+  "no-uncalled-signals",
+]);
+
+const runnable = Object.keys(angular.rules).filter(
+  (rule) => !NEEDS_TYPE_PROGRAM.has(rule),
+);
+
+// If upstream adds another type-aware rule, this throws at config load —
+// which the runner turns into a refusal to score, not a silent zero. A
+// surprise here is the signal to re-run the bisect, not to widen the set.
+const expected = Object.keys(angular.rules).length - NEEDS_TYPE_PROGRAM.size;
+if (runnable.length !== expected) {
+  throw new Error(
+    `angular.config: expected ${expected} runnable rules, got ${runnable.length}`,
+  );
+}
 
 export default [
   {
@@ -11,13 +44,8 @@ export default [
     plugins: {
       "@angular-eslint": angular,
     },
-    rules: {
-      ...Object.fromEntries(
-        Object.keys(angular.rules).map((rule) => [
-          `@angular-eslint/${rule}`,
-          "warn",
-        ]),
-      ),
-    },
+    rules: Object.fromEntries(
+      runnable.map((rule) => [`@angular-eslint/${rule}`, "warn"]),
+    ),
   },
 ];

--- a/benchmarks/suites/ilb-arena/peer-support.js
+++ b/benchmarks/suites/ilb-arena/peer-support.js
@@ -92,3 +92,28 @@ export function declaresSupportFor(pluginName, eslintVersion) {
 
 /** Sentinel: the peer cannot run here and must be excluded, not scored. */
 export const UNSUPPORTED = Symbol('unsupported-on-this-eslint');
+
+/**
+ * A peer that DECLARES support for this ESLint and throws anyway.
+ *
+ * Distinct from UNSUPPORTED, which is a peer honestly saying it does not run
+ * here. This is an upstream defect, and it is data about that plugin — but it
+ * is not a score. The old code returned `[]`, which scored as "found nothing";
+ * #891 replaced that with `process.exit(3)`, which is honest but means one
+ * peer's bug leaves the whole matrix unmeasured. Neither is right: a crash is
+ * its own state, recorded and reported, never scored, and never fatal for
+ * somebody else's code.
+ *
+ * Our own plugin is exempt — if Interlace cannot run, that is our bug and it
+ * must stop the run.
+ */
+export const CRASHED = Symbol('crashed-at-runtime');
+
+/** Wrap a runtime failure so the caller can tell it from a result array. */
+export const crash = (message) => ({ [CRASHED]: message });
+
+/** The failure message, or null when `value` is a normal result. */
+export const crashMessage = (value) =>
+  value !== null && typeof value === 'object' && CRASHED in value
+    ? value[CRASHED]
+    : null;

--- a/benchmarks/suites/ilb-arena/run.js
+++ b/benchmarks/suites/ilb-arena/run.js
@@ -335,6 +335,11 @@ async function runEslint(configPath, targetFile, pluginName) {
       // support policy is not.
       return UNSUPPORTED;
     }
+    // A peer whose CONFIG will not load is broken here in a way the run
+    // cannot characterise — unlike a lint-time throw below, which is one
+    // upstream rule misbehaving on this corpus and is recorded per-plugin.
+    // Nothing distinguishes "broken plugin" from "broken bench" at this
+    // point, so this stays fatal for everyone.
     console.error(
       `\n❌ Config failed to load: ${configPath}\n   ${e.message}\n\nRefusing to score.`,
     );
@@ -791,7 +796,9 @@ async function runBenchmark() {
     }
     const safeCrash = crashMessage(safeRaw);
     if (safeCrash !== null) {
-      console.log(`   ⊘ Not scored — crashed on safe-patterns.js: ${safeCrash}`);
+      console.log(
+        `   ⊘ Not scored — crashed on safe-patterns.js: ${safeCrash}`,
+      );
       results.plugins[plugin.name] = {
         displayName: plugin.displayName,
         crashed: { on: 'safe', message: safeCrash },

--- a/benchmarks/suites/ilb-arena/run.js
+++ b/benchmarks/suites/ilb-arena/run.js
@@ -37,6 +37,8 @@ import {
   NPM_PACKAGE_NAMES,
   OUR_PLUGIN_NAME,
   UNSUPPORTED,
+  crash,
+  crashMessage,
   declaresSupportFor,
   peerEslintRange,
 } from './peer-support.js';
@@ -207,17 +209,17 @@ const ALL_PLUGINS = [
   },
   {
     /*
-     * Its recommended set includes rules that need a TypeScript program
-     * (@angular-eslint/no-developer-preview throws "requires type
-     * information"), and this corpus is plain .js with no project. The plugin
-     * does not mark those rules `requiresTypeChecking`, so they cannot be
-     * filtered out by metadata.
+     * Was declared unmeasurable — "needs a TypeScript program" — on the
+     * strength of one rule's error message. Bisecting all 50 rules against
+     * the corpus showed that 47 run fine and exactly 3 need a program, so the
+     * config excludes those 3 by name and the plugin is scored (#897).
      *
-     * This was always true. Until run failures became fatal it surfaced as a
-     * silent 0/40 — a fabricated measurement — on every run, v10 included.
-     * Declared, not scored, until the corpus can give it a program (#897).
+     * It scores a real 0, and that is a true measurement rather than the
+     * fabricated one it replaces: this corpus is Node/browser security
+     * fixtures, and Angular's rules look for Angular TypeScript. A 0 here
+     * says the corpus contains nothing in its domain — not that the plugin
+     * misses vulnerabilities.
      */
-    unmeasurable: 'needs a TypeScript program; the arena corpus is plain .js',
     name: 'angular',
     displayName: '@angular-eslint/eslint-plugin',
     config: './configs/angular.config.js',
@@ -368,6 +370,23 @@ async function runEslint(configPath, targetFile, pluginName) {
       !declaresSupportFor(pluginName, ESLint.version)
     ) {
       return UNSUPPORTED;
+    }
+    /*
+     * A peer that DECLARES this ESLint and throws anyway is an upstream
+     * defect. Exiting here is honest about that one plugin and dishonest
+     * about the other seventeen: it leaves the whole matrix unmeasured, so
+     * the arena publishes nothing and the last published numbers — which
+     * contain the very zeros #891 set out to kill — stay the newest ones.
+     *
+     * unicorn 72.0.0 is the live case. It declares `eslint: ">=10.4"`, we run
+     * 10.7.0, and `unicorn/prefer-string-slice` still throws "'text' must be
+     * a string" on this corpus.
+     *
+     * So: recorded, reported, never scored — and never fatal for someone
+     * else's bug. Our own plugin still stops the run, because that is ours.
+     */
+    if (pluginName !== undefined && pluginName !== OUR_PLUGIN_NAME) {
+      return crash(e.message?.slice(0, 300) ?? 'unknown runtime failure');
     }
     console.error(
       `\n❌ ESLint run failed for ${configPath}\n   ${e.message?.slice(0, 300)}\n\nRefusing to score.`,
@@ -737,6 +756,15 @@ async function runBenchmark() {
       };
       continue;
     }
+    const vulnCrash = crashMessage(vulnerableRaw);
+    if (vulnCrash !== null) {
+      console.log(`   ⊘ Not scored — crashed on vulnerable.js: ${vulnCrash}`);
+      results.plugins[plugin.name] = {
+        displayName: plugin.displayName,
+        crashed: { on: 'vulnerable', message: vulnCrash },
+      };
+      continue;
+    }
     const vulnerableViolations = extractViolations(vulnerableRaw);
     const vulnerableByFunction = mapViolationsToFunctions(
       vulnerableViolations,
@@ -758,6 +786,15 @@ async function runBenchmark() {
       results.plugins[plugin.name] = {
         displayName: plugin.displayName,
         unsupported: { declaredEslint: range, runningEslint: ESLint.version },
+      };
+      continue;
+    }
+    const safeCrash = crashMessage(safeRaw);
+    if (safeCrash !== null) {
+      console.log(`   ⊘ Not scored — crashed on safe-patterns.js: ${safeCrash}`);
+      results.plugins[plugin.name] = {
+        displayName: plugin.displayName,
+        crashed: { on: 'safe', message: safeCrash },
       };
       continue;
     }
@@ -900,9 +937,15 @@ async function runBenchmark() {
   if (notScored.length > 0) {
     console.log('\nNot scored:');
     for (const [, d] of notScored) {
+      // Three distinct reasons, and they must not borrow each other's
+      // wording. A crash reported as "declares eslint undefined, ran
+      // undefined" reads as a support-policy exclusion, which is somebody
+      // saying they do not run here — the opposite of what happened.
       const why = d.unmeasurable
         ? d.unmeasurable
-        : `declares eslint "${d.unsupported?.declaredEslint}", ran ${d.unsupported?.runningEslint}`;
+        : d.crashed
+          ? `crashed on ${d.crashed.on}.js — ${d.crashed.message}`
+          : `declares eslint "${d.unsupported?.declaredEslint}", ran ${d.unsupported?.runningEslint}`;
       console.log(`  ⊘ ${d.displayName} — ${why}`);
     }
   }
@@ -915,7 +958,12 @@ async function runBenchmark() {
     notScored: notScored.map(([name, d]) => ({
       plugin: name,
       displayName: d.displayName,
-      reason: d.unmeasurable ?? 'unsupported on this ESLint',
+      reason:
+        d.unmeasurable ??
+        (d.crashed
+          ? `crashed at runtime on ${d.crashed.on}.js`
+          : 'unsupported on this ESLint'),
+      ...(d.crashed ? { crashed: d.crashed } : {}),
       declaredEslint: d.unsupported?.declaredEslint,
       runningEslint: d.unsupported?.runningEslint,
     })),


### PR DESCRIPTION
Closes #897.

## angular was never unmeasurable

It was declared *"needs a TypeScript program"* on the strength of one rule's error message. Bisecting **all 50 rules** against the corpus — running each alone, recording which threw — shows **47 run fine and exactly 3 need a program**:

```
no-developer-preview · no-experimental · no-uncalled-signals
```

They're excluded by name because they cannot be found any other way: `requiresTypeChecking` is set on **0 of 50** rules, so metadata filtering has nothing to filter. The config asserts the expected count, so an upstream addition fails at load rather than silently widening the exclusion.

**angular now scores a real 0/40, F1 0.0%** — a true measurement replacing a fabricated one, and it means something different. This corpus is Node and browser security fixtures; Angular's rules look for Angular TypeScript. A 0 says *the corpus holds nothing in its domain*, not that the plugin misses vulnerabilities. The plugin table says so, because the number alone doesn't.

## One peer's crash left the whole matrix unmeasured

#891 made a failed lint run fatal — right about the plugin that fails, wrong about the other seventeen.

`unicorn@72.0.0` declares `eslint: ">=10.4"`, we run `10.7.0`, and `unicorn/prefer-string-slice` still throws `'text' must be a string` on this corpus. So `process.exit(3)` fired and **the arena published nothing at all** — leaving the last published numbers, the ones full of the fabricated zeros #891 set out to kill, as the newest ones.

A crash is now its own state: recorded with its message, reported by name, never scored, never fatal for somebody else's bug. **Our own plugin still stops the run**, because that one is ours.

The run completes end to end for the first time:

```
exit 0 · 17 scored · unicorn named as crashed · Interlace 39/40 F1 94.0%
```

## The lock that caught me

`peer-eslint-support.lock` failed on this change, **correctly**. It asserted the *mechanism* — "contains `process.exit(3)`" — inside a fixed 1600-byte window, and the added branch pushed the exit past it.

Rewritten to assert the property in three parts: never return `[]` whoever failed; still exit when **our** plugin fails; record a crash for a peer. The window is now sized to the block's closing brace instead of a guessed byte count.

## Verification

- [x] Benchmarks suite: **102 failures before this change and 102 after**, same 4 files — every one a plugin-load failure in an unbuilt worktree. Measured both ways rather than assumed.
- [x] Whole-graph typecheck: **562 errors before and 562 after**, identical — the worktree resolves the devkit through another checkout's `node_modules`.
- [x] `configs-load` suite: 20/20 pass.
- [x] `tests-affected`, `typecheck` and `build` excluded for this push, for the reasons measured above — **not `--no-verify`**: `shim-drift`, `format-drift`, `stale-build-artifacts` and `commitlint` all ran and passed. CI builds the packages and runs the rest for real.

## Not included, deliberately

**No regenerated results.** The published files still hold zeros for plugins that do work — `eslint-plugin-security` records `0/0` there and scores **11/40, F1 37.3%** on a live run. Regeneration belongs to a proper fixture run, not to the patched-together local install I used to verify this.

## Two things worth their own issues

1. **`securityRelevant` is `true` for 17 of 18 peers** — including vue, jest, react, jsx-a11y and promise. It's opt-out and only jsdoc opted out, so the published ledger's `securityRelevantPlugins: 17` claims something that isn't so.
2. **unicorn's crash is an upstream defect** on a major it declares support for. Worth reporting to them; the arena now records it instead of dying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)