### PR TITLE
fix(workspace): scheduled issue sweep

### DIFF
--- a/.github/workflows/metrics-freshness.yml
+++ b/.github/workflows/metrics-freshness.yml
@@ -67,12 +67,12 @@ jobs:
           if [ -n "$existing" ]; then
             gh issue comment "$existing" --body "$body"
           else
-            # No --label: this repo has no "chore" label, and `gh issue
-            # create --label "chore"` fails the whole step under the
-            # runner's default `bash -e` when a label does not exist
-            # (#924). Every sibling cadence workflow's `gh issue create`
-            # is unlabelled for the same reason — see
-            # scripts/__tests__/issue-create-label-exists-lock.test.ts.
+            # No --label: this repo has no "chore" label, and adding one
+            # to this command fails the whole step under the runner's
+            # default `bash -e` when the label does not exist (#924).
+            # Every sibling cadence workflow's issue-filing step is
+            # unlabelled for the same reason — see
+            # scripts/__tests__/metrics-freshness-issue-label-lock.test.ts.
             gh issue create --title "$title" --body "$body"
           fi
 

--- a/.github/workflows/metrics-freshness.yml
+++ b/.github/workflows/metrics-freshness.yml
@@ -67,7 +67,13 @@ jobs:
           if [ -n "$existing" ]; then
             gh issue comment "$existing" --body "$body"
           else
-            gh issue create --title "$title" --body "$body" --label "chore"
+            # No --label: this repo has no "chore" label, and `gh issue
+            # create --label "chore"` fails the whole step under the
+            # runner's default `bash -e` when a label does not exist
+            # (#924). Every sibling cadence workflow's `gh issue create`
+            # is unlabelled for the same reason — see
+            # scripts/__tests__/issue-create-label-exists-lock.test.ts.
+            gh issue create --title "$title" --body "$body"
           fi
 
   # Without this the jobs above can fail on a schedule with nobody watching:

--- a/scripts/__tests__/metrics-freshness-issue-label-lock.test.ts
+++ b/scripts/__tests__/metrics-freshness-issue-label-lock.test.ts
@@ -26,6 +26,8 @@
  * integration-health, report-failure) files unlabelled for exactly this
  * reason: an issue-filing step is not the place to depend on repo
  * configuration nothing keeps in sync.
+ *
+ * @provenBy {"file":".github/workflows/metrics-freshness.yml","find":"            gh issue create --title \"$title\" --body \"$body\"","replace":"            gh issue create --title \"$title\" --body \"$body\" --label \"chore\""}
  */
 
 import { describe, it, expect } from 'vitest';
@@ -54,9 +56,12 @@ describe('metrics-freshness issue filing does not depend on a label', () => {
     );
     expect(stepStart).toBeGreaterThan(-1);
     const step = raw.slice(stepStart);
+    // Anchored to the start of the (trimmed) line so an explanatory comment
+    // that merely mentions "gh issue create" in prose can never satisfy this
+    // — only the actual invocation does.
     const createLine = step
       .split('\n')
-      .find((line) => line.includes('gh issue create'));
+      .find((line) => /^\s*gh issue create\b/.test(line));
     expect(createLine).toBeDefined();
     expect(createLine).not.toMatch(/--label/);
   });

--- a/scripts/__tests__/metrics-freshness-issue-label-lock.test.ts
+++ b/scripts/__tests__/metrics-freshness-issue-label-lock.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * The weekly freshness check's issue-filing step failed on its own success
+ * path (#924).
+ *
+ * `check-audit-freshness.ts` ran fine and correctly found three stale
+ * artifacts. The step that reports them then ran:
+ *
+ *   gh issue create --title "$title" --body "$body" --label "chore"
+ *
+ * `.github/labels.yml` — the declarative source of every label this repo
+ * defines — has no `chore` entry, and nothing syncs it automatically (its own
+ * header says to run `gh label create ... --force` by hand). So the label
+ * does not exist on GitHub, `gh issue create` exits non-zero on
+ * "could not add label: 'chore' not found", and the runner's default
+ * `bash -e` turned that into a failed step — which is what actually filed
+ * #924 ("did not complete"), not the freshness finding itself.
+ *
+ * Every sibling cadence workflow's `gh issue create` (resource-profile,
+ * peer-health, real-source-scan, check-links, control-bands, evals,
+ * integration-health, report-failure) files unlabelled for exactly this
+ * reason: an issue-filing step is not the place to depend on repo
+ * configuration nothing keeps in sync.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const WORKFLOW = resolve(
+  __dirname,
+  '../../.github/workflows/metrics-freshness.yml',
+);
+
+describe('metrics-freshness issue filing does not depend on a label', () => {
+  const raw = readFileSync(WORKFLOW, 'utf8');
+
+  it('reproduces the bug: gh rejects a label absent from labels.yml', () => {
+    const labelsYml = readFileSync(
+      resolve(__dirname, '../../.github/labels.yml'),
+      'utf8',
+    );
+    expect(labelsYml).not.toMatch(/name:\s*chore\b/);
+  });
+
+  it('the "File an issue" step never passes --label to gh issue create', () => {
+    const stepStart = raw.indexOf(
+      'File an issue when something has gone stale',
+    );
+    expect(stepStart).toBeGreaterThan(-1);
+    const step = raw.slice(stepStart);
+    const createLine = step
+      .split('\n')
+      .find((line) => line.includes('gh issue create'));
+    expect(createLine).toBeDefined();
+    expect(createLine).not.toMatch(/--label/);
+  });
+});


### PR DESCRIPTION
## Description

Scheduled issue-sweep run per `.github/workflows/issue-sweep.yml`'s policy (executed as a Claude Code Routine with edit access to `.github/workflows/`, since the in-Actions token cannot write there). Backlog: 7 open issues authored by `github-actions[bot]` or `ofri-peretz`, none carrying `no-auto-fix`. Exactly one had a safe, certain, code-level fix; one turned out to already be fixed on `main`; the rest are documented below with why they were left alone.

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

### #924 — Metrics freshness check is failing — FIXED

**Root cause**, confirmed from the failed run's job logs (run [34134280161](https://github.com/ofri-peretz/eslint/actions/runs/34134280161)): `check-audit-freshness.ts` ran correctly and found 3 stale artifacts (API-surface manifest, per-rule p95 budget, stock-corpus overlap). The reporting step then ran:

```
gh issue create --title "$title" --body "$body" --label "chore"
```

`.github/labels.yml` — the declarative source of every label this repo defines — has no `chore` entry, and nothing syncs it to GitHub automatically (its own header says to run `gh label create ... --force` by hand). So the label doesn't exist, `gh issue create` exited non-zero on `could not add label: 'chore' not found`, and the runner's default `bash -e` turned that into a failed step. That's what actually filed #924 ("did not complete") — not the freshness finding itself, which had already succeeded.

**Fix:** `.github/workflows/metrics-freshness.yml` — dropped `--label "chore"`, matching every sibling cadence workflow's unlabelled `gh issue create` (resource-profile, peer-health, real-source-scan, check-links, control-bands, evals, integration-health, report-failure all file unlabelled for the same reason).

**Lock:** `scripts/__tests__/metrics-freshness-issue-label-lock.test.ts` — reproduces the bug (asserts `.github/labels.yml` has no `chore` entry) and asserts the "File an issue" step's `gh issue create` line never passes `--label`. Verified to fail on the unfixed workflow (`--label "chore"` present) and pass on the fix.

### #918 — ILB-Arena: `securityRelevant` is opt-out — ALREADY FIXED, verified

This was fixed and merged separately in #920 (`securityRelevant` now read as `=== true`, opt-in, set explicitly per peer) before this sweep ran. Confirmed by running `benchmarks/__tests__/security-relevant-is-opt-in.lock.test.ts` against current `main`: 22/22 pass. No changes needed here — a human can close #918 once they see #920 is what closed it.

## Not touched, and why

- **#919** — "Report unicorn's ESLint 10 crash upstream." The issue's own next step is to file a minimal repro on `sindresorhus/eslint-plugin-unicorn`; there is no code change to make in this repo (#917 already recorded the crash rather than failing the matrix on it). This session's GitHub access is also scoped to `ofri-peretz/eslint` only. Left as a tracking issue for a human to file upstream.
- **#916** — npm publish `E404` for `@interlace/eslint-formatter-sarif`. Root cause is the automation token's package allowlist on npmjs.com (a granular access token scoped to specific packages, and this one never existed there before). That requires npm account/registry access, not a code change.
- **#912** — Oxlint parity is 99.0%, not 100% (112 divergences, 82 of them spread across 12 `import-next/*` rules, the rest 1-5 each across ~17 other rules). The issue explicitly warns this must not be closed by allowlisting; each rule needs its own fix or documented reason. Too large and too uncertain to attempt safely in one sweep — a wrong fix to a detection rule is worse than the open issue.
- **#890** — Integration health check: `NEXT_PUBLIC_POSTHOG_KEY` marked Sensitive in Vercel on `serverless.interlace.tools`, so the build inlines `[SENSITIVE]` instead of the real key. Fix is a Vercel dashboard env-var change (`vercel env rm` / `vercel env add ... --no-sensitive`), not a code change.
- **#764** — CodeQL now runs post-merge/nightly instead of per-PR. This is a tracking issue for an already-accepted, documented trade-off (`docs/adr/0001-codeql-runs-post-merge-not-per-pr.md`), left open on purpose per its own text ("so it stays visible and revisitable"). Nothing to fix. (Also worth a human glance: `codeql.yml`'s current `push: branches: [main]` trigger was itself further removed on 2026-08-31, so the issue's description is now stale relative to `main` — not something this sweep should edit unattended.)

## Testing

- [x] `npm run lint:workflows` — 44 workflow files pass conventions
- [x] `npx vitest run scripts/__tests__/metrics-freshness-issue-label-lock.test.ts` — 2/2 pass on the fix; reverted the fix locally and confirmed the test fails (positive control)
- [x] `npx vitest run benchmarks/__tests__/security-relevant-is-opt-in.lock.test.ts` — 22/22 pass on current `main`, confirming #918 needs no further work
- [x] Full `npx vitest run scripts/__tests__` — 154 pre-existing failures, all `Failed to resolve entry for package "..."` from unbuilt plugin `dist/` output (`rule-docs-url-lock.test.ts` and similar). Confirmed identical on unmodified `origin/main` before this change (stashed my changes and re-ran) — unrelated to this diff, which touches only a workflow file and adds one new test file.
- [x] Local `lefthook` pre-commit and pre-push batteries ran in full, including a whole-graph `turbo run build` (34/34 packages) and `typecheck`: all green.

```bash
npx vitest run scripts/__tests__/metrics-freshness-issue-label-lock.test.ts
```

## Checklist

- [x] Code follows project style (prettier/oxlint clean)
- [ ] Documentation updated — not applicable, internal CI workflow fix
- [x] Tests added/updated (new lock test)
- [ ] CHANGELOG.md updated — not applicable, `.github/workflows/` and `scripts/__tests__/` are not a published package
- [x] No new warnings/errors

## After merge

The next scheduled `metrics-freshness.yml` run (Mondays 09:00 UTC) that finds a stale artifact will successfully open or comment on the rolling "Stale published metrics" issue instead of crashing on the label. Per policy, this sweep closes nothing by keyword — a human should close #924 once that run is confirmed green, and close #918 once they've seen #920 already fixed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJyyGmZ4BEffjTec4gWrKE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved weekly metrics freshness reporting so stale-metrics issues are created successfully without relying on an unavailable label.

- **Tests**
  - Added coverage to verify that stale-metrics issue creation does not depend on the missing label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->