### PR TITLE
chore(docs): sync generated data

### DIFF
--- a/apps/docs/src/data/changelog.json
+++ b/apps/docs/src/data/changelog.json
@@ -13230,7 +13230,7 @@
       "version": "0.1.0",
       "date": "2026-05-03T00:00:00Z",
       "isApp": false,
-      "isPrivate": true,
+      "isPrivate": false,
       "entries": [
         {
           "kind": "other",


### PR DESCRIPTION
Regenerated apps/docs/src/data/ (trigger: push). Opened by the Docs Data Sync workflow; contents come entirely from the apps/docs/scripts/sync-* scripts, so review the diff rather than hand-editing.