### PR TITLE
fix(eslint-formatter): ship the schema.json the manifest promises

### DIFF
--- a/.changeset/formatter-ships-its-schema.md
+++ b/.changeset/formatter-ships-its-schema.md
@@ -1,0 +1,9 @@
+---
+'@interlace/eslint-formatter': patch
+---
+
+fix: ship the `./schema.json` the manifest promises
+
+`exports` declared `"./schema.json"` and `files` listed it, but the file did not exist and the build's asset list had never heard of it — so a consumer importing that subpath would have got "Cannot find module". The schema is now written and shipped, and the build derives its copy list from `files` instead of a hardcoded array, so declaring a file is enough.
+
+Also adds the missing `funding` field.

--- a/packages/eslint-formatter/package.json
+++ b/packages/eslint-formatter/package.json
@@ -22,6 +22,10 @@
     "url": "git+https://github.com/ofri-peretz/eslint.git",
     "directory": "packages/eslint-formatter"
   },
+  "funding": {
+    "type": "github",
+    "url": "git+https://github.com/ofri-peretz/eslint.git"
+  },
   "bugs": {
     "url": "https://github.com/ofri-peretz/eslint/issues"
   },

--- a/packages/eslint-formatter/schema.json
+++ b/packages/eslint-formatter/schema.json
@@ -1,125 +1,105 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-formatter/schema.json",
-  "title": "@interlace/eslint-formatter — structured output",
-  "description": "JSON Schema for the `json` and `ndjson` output modes of @interlace/eslint-formatter. Downstream agents and tools can validate they're consuming the envelope correctly. The shape is the same across both modes — `json` ships one object containing { summary, rules[] }; `ndjson` ships one summary line followed by one rule line per rule, each tagged with `kind`.",
-  "oneOf": [
-    { "$ref": "#/definitions/JsonModeOutput" },
-    { "$ref": "#/definitions/NdjsonModeLine" }
-  ],
-  "definitions": {
-    "JsonModeOutput": {
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://eslint.interlace.tools/schema/eslint-formatter.json",
+  "title": "@interlace/eslint-formatter output",
+  "description": "The machine-readable contract for `json` and `ndjson` mode. Keys are short on purpose: this format exists to be read by an agent inside a token budget, and the long names are what made `stylish` cost ~104,483 tokens where this costs ~408.",
+  "oneOf": [{ "$ref": "#/$defs/jsonMode" }, { "$ref": "#/$defs/ndjsonLine" }],
+  "$defs": {
+    "jsonMode": {
       "type": "object",
-      "description": "`json` mode: one object containing summary first (cache-friendly prefix) and the per-rule list after.",
-      "required": ["summary", "rules"],
-      "additionalProperties": false,
+      "description": "`json` mode: one object. `summary` comes first by contract, so a truncated read still carries the totals.",
       "properties": {
-        "summary": { "$ref": "#/definitions/Summary" },
-        "rules": {
-          "type": "array",
-          "items": { "$ref": "#/definitions/Rule" }
-        }
-      }
+        "summary": { "$ref": "#/$defs/summary" },
+        "rules": { "type": "array", "items": { "$ref": "#/$defs/rule" } }
+      },
+      "required": ["summary", "rules"],
+      "additionalProperties": false
     },
-    "NdjsonModeLine": {
-      "description": "`ndjson` mode: each line is a complete JSON object with a `kind` discriminator.",
+    "ndjsonLine": {
+      "description": "`ndjson` mode: one summary line, then one line per rule. Each line stands alone, so a partial read is still valid JSONL.",
       "oneOf": [
-        { "$ref": "#/definitions/NdjsonSummaryLine" },
-        { "$ref": "#/definitions/NdjsonRuleLine" }
+        {
+          "type": "object",
+          "properties": { "kind": { "const": "summary" } },
+          "required": ["kind"],
+          "$ref": "#/$defs/summary"
+        },
+        {
+          "type": "object",
+          "properties": { "kind": { "const": "rule" } },
+          "required": ["kind"],
+          "$ref": "#/$defs/rule"
+        }
       ]
     },
-    "NdjsonSummaryLine": {
+    "summary": {
       "type": "object",
-      "description": "First line of an ndjson stream — the summary.",
-      "required": ["kind", "errors", "warnings", "files", "fixable", "rules"],
-      "additionalProperties": false,
       "properties": {
-        "kind": { "type": "string", "const": "summary" },
+        "kind": { "const": "summary" },
         "errors": { "type": "integer", "minimum": 0 },
         "warnings": { "type": "integer", "minimum": 0 },
-        "files": { "type": "integer", "minimum": 0 },
+        "files": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Files with at least one finding, not files linted."
+        },
         "fixable": { "type": "integer", "minimum": 0 },
-        "rules": { "type": "integer", "minimum": 0 }
-      }
-    },
-    "NdjsonRuleLine": {
-      "type": "object",
-      "description": "A rule line in an ndjson stream.",
-      "required": ["kind", "id", "sev", "n", "fix", "sugg", "locs"],
-      "additionalProperties": false,
-      "properties": {
-        "kind": { "type": "string", "const": "rule" },
-        "id": { "type": "string", "description": "ESLint ruleId" },
-        "sev": { "type": "string", "enum": ["error", "warning"] },
-        "n": { "type": "integer", "minimum": 1, "description": "Total occurrences across the lint run" },
-        "fix": { "type": "boolean", "description": "At least one occurrence is autofixable" },
-        "sugg": { "type": "boolean", "description": "At least one occurrence carries an ESLint suggestions[] entry" },
-        "desc": { "type": "string", "description": "Rule description from meta.docs.description" },
-        "msg": { "type": "string", "description": "Representative ESLint message text — the most actionable single field for an LLM-fix consumer" },
-        "docs": { "type": "string", "format": "uri", "description": "Rule docs URL from meta.docs.url" },
-        "cwe": { "type": "string", "pattern": "^CWE-[0-9]+$", "description": "CWE identifier (Interlace meta.docs extension)" },
-        "cvss": { "type": "number", "minimum": 0, "maximum": 10, "description": "CVSS 3.1 score (Interlace meta.docs extension)" },
-        "locs": {
-          "type": "array",
-          "items": { "$ref": "#/definitions/Location" }
+        "rules": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Distinct rules that fired."
         }
-      }
-    },
-    "Summary": {
-      "type": "object",
+      },
       "required": ["errors", "warnings", "files", "fixable", "rules"],
-      "additionalProperties": false,
-      "properties": {
-        "errors": { "type": "integer", "minimum": 0 },
-        "warnings": { "type": "integer", "minimum": 0 },
-        "files": { "type": "integer", "minimum": 0, "description": "Files with at least one issue" },
-        "fixable": { "type": "integer", "minimum": 0, "description": "Total autofixable issues" },
-        "rules": { "type": "integer", "minimum": 0, "description": "Distinct ruleIds violated" }
-      }
+      "additionalProperties": false
     },
-    "Rule": {
+    "rule": {
       "type": "object",
-      "description": "One grouped rule entry. Same shape as NdjsonRuleLine but without the `kind` discriminator.",
-      "required": ["id", "sev", "n", "fix", "sugg", "locs"],
-      "additionalProperties": false,
+      "description": "One rule, once — with a count and representative locations, rather than the same violation repeated across every file.",
       "properties": {
-        "id": { "type": "string" },
-        "sev": { "type": "string", "enum": ["error", "warning"] },
-        "n": { "type": "integer", "minimum": 1 },
-        "fix": { "type": "boolean" },
-        "sugg": { "type": "boolean" },
+        "kind": { "const": "rule" },
+        "id": {
+          "type": "string",
+          "description": "Rule id, e.g. `secure-coding/detect-object-injection`."
+        },
+        "sev": { "enum": ["error", "warning"] },
+        "n": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Total violations of this rule."
+        },
+        "fix": {
+          "type": "boolean",
+          "description": "At least one violation is auto-fixable."
+        },
+        "sugg": {
+          "type": "boolean",
+          "description": "At least one violation has a suggestion."
+        },
+        "locs": { "type": "array", "items": { "$ref": "#/$defs/loc" } },
         "desc": { "type": "string" },
         "msg": { "type": "string" },
         "docs": { "type": "string", "format": "uri" },
         "cwe": { "type": "string", "pattern": "^CWE-[0-9]+$" },
-        "cvss": { "type": "number", "minimum": 0, "maximum": 10 },
-        "locs": {
-          "type": "array",
-          "items": { "$ref": "#/definitions/Location" }
-        }
-      }
+        "cvss": { "type": "number", "minimum": 0, "maximum": 10 }
+      },
+      "required": ["id", "sev", "n", "fix", "sugg", "locs"],
+      "additionalProperties": false
     },
-    "Location": {
+    "loc": {
       "type": "object",
-      "required": ["f", "l", "c"],
-      "additionalProperties": false,
       "properties": {
-        "f": { "type": "string", "description": "File path (relative to cwd when given)" },
-        "l": { "type": "integer", "minimum": 1, "description": "Line (1-indexed)" },
-        "c": { "type": "integer", "minimum": 1, "description": "Column (1-indexed)" },
-        "t": { "type": "string", "description": "ESLint AST nodeType (e.g. CallExpression)" },
-        "sugg": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": ["desc"],
-            "additionalProperties": false,
-            "properties": {
-              "desc": { "type": "string", "description": "ESLint suggestion description" }
-            }
-          }
-        }
-      }
+        "f": { "type": "string", "description": "File path, relative to cwd." },
+        "l": { "type": "integer", "minimum": 1, "description": "Line." },
+        "c": { "type": "integer", "minimum": 1, "description": "Column." },
+        "t": {
+          "type": "string",
+          "description": "Source text at the location."
+        },
+        "sugg": { "type": "boolean" }
+      },
+      "required": ["f", "l", "c"],
+      "additionalProperties": false
     }
   }
 }

--- a/packages/eslint-formatter/src/index.test.ts
+++ b/packages/eslint-formatter/src/index.test.ts
@@ -4,6 +4,8 @@
  * MIT license that can be found in the LICENSE file.
  */
 
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, it, expect } from 'vitest';
 import { groupByRule, computeSummary } from './grouper';
 import { renderHuman } from './renderers/human';
@@ -26,17 +28,24 @@ function makeResult(
     column: number;
     fix?: { range: [number, number]; text: string };
     nodeType?: string | null;
-    suggestions?: Array<{ desc: string; fix: { range: [number, number]; text: string } }>;
+    suggestions?: Array<{
+      desc: string;
+      fix: { range: [number, number]; text: string };
+    }>;
   }>,
 ): LintResult {
-  const errorCount = messages.filter(m => m.severity === 2).length;
-  const warningCount = messages.filter(m => m.severity === 1).length;
-  const fixableErrorCount = messages.filter(m => m.severity === 2 && m.fix).length;
-  const fixableWarningCount = messages.filter(m => m.severity === 1 && m.fix).length;
+  const errorCount = messages.filter((m) => m.severity === 2).length;
+  const warningCount = messages.filter((m) => m.severity === 1).length;
+  const fixableErrorCount = messages.filter(
+    (m) => m.severity === 2 && m.fix,
+  ).length;
+  const fixableWarningCount = messages.filter(
+    (m) => m.severity === 1 && m.fix,
+  ).length;
 
   return {
     filePath,
-    messages: messages.map(m => ({ ...m, nodeType: m.nodeType ?? null })),
+    messages: messages.map((m) => ({ ...m, nodeType: m.nodeType ?? null })),
     errorCount,
     warningCount,
     fixableErrorCount,
@@ -68,16 +77,53 @@ const context: FormatterContext = {
 
 const sampleResults: LintResult[] = [
   makeResult('/project/src/auth/login.ts', [
-    { ruleId: 'no-unused-vars', severity: 1, message: "'x' is not used", line: 5, column: 7 },
-    { ruleId: 'no-unused-vars', severity: 1, message: "'y' is not used", line: 12, column: 3 },
-    { ruleId: '@interlace/pg/no-unsafe-query', severity: 2, message: 'SQL injection detected', line: 23, column: 5 },
+    {
+      ruleId: 'no-unused-vars',
+      severity: 1,
+      message: "'x' is not used",
+      line: 5,
+      column: 7,
+    },
+    {
+      ruleId: 'no-unused-vars',
+      severity: 1,
+      message: "'y' is not used",
+      line: 12,
+      column: 3,
+    },
+    {
+      ruleId: '@interlace/pg/no-unsafe-query',
+      severity: 2,
+      message: 'SQL injection detected',
+      line: 23,
+      column: 5,
+    },
   ]),
   makeResult('/project/src/db/queries.ts', [
-    { ruleId: '@interlace/pg/no-unsafe-query', severity: 2, message: 'SQL injection detected', line: 8, column: 10 },
-    { ruleId: '@interlace/pg/no-unsafe-query', severity: 2, message: 'SQL injection detected', line: 41, column: 10 },
+    {
+      ruleId: '@interlace/pg/no-unsafe-query',
+      severity: 2,
+      message: 'SQL injection detected',
+      line: 8,
+      column: 10,
+    },
+    {
+      ruleId: '@interlace/pg/no-unsafe-query',
+      severity: 2,
+      message: 'SQL injection detected',
+      line: 41,
+      column: 10,
+    },
   ]),
   makeResult('/project/src/utils/helpers.ts', [
-    { ruleId: 'no-unused-vars', severity: 1, message: "'z' is not used", line: 1, column: 1, fix: { range: [0, 10], text: '' } },
+    {
+      ruleId: 'no-unused-vars',
+      severity: 1,
+      message: "'z' is not used",
+      line: 1,
+      column: 1,
+      fix: { range: [0, 10], text: '' },
+    },
   ]),
   // Clean file (no issues)
   makeResult('/project/src/index.ts', []),
@@ -92,8 +138,11 @@ describe('groupByRule', () => {
     const grouped = groupByRule(sampleResults, context);
 
     expect(grouped).toHaveLength(2);
-    const ruleIds = grouped.map(g => g.ruleId).toSorted();
-    expect(ruleIds).toEqual(['@interlace/pg/no-unsafe-query', 'no-unused-vars']);
+    const ruleIds = grouped.map((g) => g.ruleId).toSorted();
+    expect(ruleIds).toEqual([
+      '@interlace/pg/no-unsafe-query',
+      'no-unused-vars',
+    ]);
     expect(grouped[0]!.count).toBe(3);
     expect(grouped[1]!.count).toBe(3);
   });
@@ -105,7 +154,9 @@ describe('groupByRule', () => {
     const reversed = [...sampleResults].toReversed();
     const grouped2 = groupByRule(reversed, context);
 
-    expect(grouped1.map(g => g.ruleId)).toEqual(grouped2.map(g => g.ruleId));
+    expect(grouped1.map((g) => g.ruleId)).toEqual(
+      grouped2.map((g) => g.ruleId),
+    );
   });
 
   it('should sort errors before warnings even when a warning has higher count (severity-first)', () => {
@@ -115,11 +166,23 @@ describe('groupByRule', () => {
     // position [0] where LLMs and humans actually look.
     const payload: LintResult[] = [
       makeResult('/project/src/db.ts', [
-        { ruleId: '@interlace/pg/no-unsafe-query', severity: 2, message: 'SQL injection', line: 23, column: 5 },
+        {
+          ruleId: '@interlace/pg/no-unsafe-query',
+          severity: 2,
+          message: 'SQL injection',
+          line: 23,
+          column: 5,
+        },
       ]),
       ...Array.from({ length: 10 }, (_, i) =>
         makeResult(`/project/src/m${i}.ts`, [
-          { ruleId: 'no-unused-vars', severity: 1, message: 'unused', line: i + 1, column: 1 },
+          {
+            ruleId: 'no-unused-vars',
+            severity: 1,
+            message: 'unused',
+            line: i + 1,
+            column: 1,
+          },
         ]),
       ),
     ];
@@ -133,14 +196,18 @@ describe('groupByRule', () => {
 
   it('should capture the representative ESLint message text', () => {
     const grouped = groupByRule(sampleResults, context);
-    const pgRule = grouped.find(g => g.ruleId === '@interlace/pg/no-unsafe-query');
+    const pgRule = grouped.find(
+      (g) => g.ruleId === '@interlace/pg/no-unsafe-query',
+    );
 
     expect(pgRule!.message).toBe('SQL injection detected');
   });
 
   it('should surface CWE and CVSS from rule meta when present', () => {
     const grouped = groupByRule(sampleResults, context);
-    const pgRule = grouped.find(g => g.ruleId === '@interlace/pg/no-unsafe-query');
+    const pgRule = grouped.find(
+      (g) => g.ruleId === '@interlace/pg/no-unsafe-query',
+    );
 
     expect(pgRule!.cwe).toBe('CWE-089');
     expect(pgRule!.cvss).toBe(9.8);
@@ -155,19 +222,32 @@ describe('groupByRule', () => {
           message: 'Use === instead',
           line: 1,
           column: 1,
-          suggestions: [{ desc: 'Replace == null with === null', fix: { range: [0, 7], text: '=== null' } }],
+          suggestions: [
+            {
+              desc: 'Replace == null with === null',
+              fix: { range: [0, 7], text: '=== null' },
+            },
+          ],
         },
       ]),
     ];
     const grouped = groupByRule(withSuggestion, context);
     expect(grouped[0]!.hasSuggestions).toBe(true);
-    expect(grouped[0]!.locations[0]!.suggestions).toEqual([{ desc: 'Replace == null with === null' }]);
+    expect(grouped[0]!.locations[0]!.suggestions).toEqual([
+      { desc: 'Replace == null with === null' },
+    ]);
   });
 
   it('should respect mode-aware MAX_LOCATIONS cap (json gets a higher cap)', () => {
     const manyResults: LintResult[] = Array.from({ length: 15 }, (_, i) =>
       makeResult(`/project/src/file${i}.ts`, [
-        { ruleId: 'no-console', severity: 1, message: 'no console', line: i + 1, column: 1 },
+        {
+          ruleId: 'no-console',
+          severity: 1,
+          message: 'no console',
+          line: i + 1,
+          column: 1,
+        },
       ]),
     );
     const compactGrouped = groupByRule(manyResults, context, 'compact');
@@ -178,30 +258,44 @@ describe('groupByRule', () => {
 
   it('should use highest severity seen', () => {
     const grouped = groupByRule(sampleResults, context);
-    const pgRule = grouped.find(g => g.ruleId === '@interlace/pg/no-unsafe-query');
+    const pgRule = grouped.find(
+      (g) => g.ruleId === '@interlace/pg/no-unsafe-query',
+    );
 
     expect(pgRule!.severity).toBe('error');
   });
 
   it('should detect fixable status', () => {
     const grouped = groupByRule(sampleResults, context);
-    const unusedRule = grouped.find(g => g.ruleId === 'no-unused-vars');
+    const unusedRule = grouped.find((g) => g.ruleId === 'no-unused-vars');
 
     expect(unusedRule!.fixable).toBe(true); // one location has a fix
   });
 
   it('should enrich with rule metadata', () => {
     const grouped = groupByRule(sampleResults, context);
-    const pgRule = grouped.find(g => g.ruleId === '@interlace/pg/no-unsafe-query');
+    const pgRule = grouped.find(
+      (g) => g.ruleId === '@interlace/pg/no-unsafe-query',
+    );
 
-    expect(pgRule!.description).toBe('Detect SQL injection via string concatenation');
-    expect(pgRule!.docsUrl).toBe('https://interlace.tools/docs/pg/no-unsafe-query');
+    expect(pgRule!.description).toBe(
+      'Detect SQL injection via string concatenation',
+    );
+    expect(pgRule!.docsUrl).toBe(
+      'https://interlace.tools/docs/pg/no-unsafe-query',
+    );
   });
 
   it('should cap locations to default MAX_LOCATIONS (5) when no mode given', () => {
     const manyResults: LintResult[] = Array.from({ length: 10 }, (_, i) =>
       makeResult(`/project/src/file${i}.ts`, [
-        { ruleId: 'no-console', severity: 1, message: 'no console', line: i + 1, column: 1 },
+        {
+          ruleId: 'no-console',
+          severity: 1,
+          message: 'no console',
+          line: i + 1,
+          column: 1,
+        },
       ]),
     );
 
@@ -290,7 +384,16 @@ describe('renderHuman', () => {
     const noMessage: LintResult[] = [
       {
         filePath: '/project/x.ts',
-        messages: [{ ruleId: 'no-unused-vars', severity: 1, message: '', line: 1, column: 1, nodeType: null }],
+        messages: [
+          {
+            ruleId: 'no-unused-vars',
+            severity: 1,
+            message: '',
+            line: 1,
+            column: 1,
+            nodeType: null,
+          },
+        ],
         errorCount: 0,
         warningCount: 1,
         fixableErrorCount: 0,
@@ -312,7 +415,15 @@ describe('renderHuman', () => {
   });
 
   it('should show clean message for no issues', () => {
-    const output = renderHuman([], { totalFiles: 1, filesWithIssues: 0, errorCount: 0, warningCount: 0, fixableCount: 0, uniqueRules: 0, topRules: [] });
+    const output = renderHuman([], {
+      totalFiles: 1,
+      filesWithIssues: 0,
+      errorCount: 0,
+      warningCount: 0,
+      fixableCount: 0,
+      uniqueRules: 0,
+      topRules: [],
+    });
 
     expect(output).toContain('No lint issues found');
   });
@@ -380,7 +491,9 @@ describe('renderJSON', () => {
     const grouped = groupByRule(sampleResults, context);
     const summary = computeSummary(sampleResults, grouped);
     const parsed = JSON.parse(renderJSON(grouped, summary));
-    const pg = parsed.rules.find((r: { id: string }) => r.id === '@interlace/pg/no-unsafe-query');
+    const pg = parsed.rules.find(
+      (r: { id: string }) => r.id === '@interlace/pg/no-unsafe-query',
+    );
 
     expect(pg.msg).toBe('SQL injection detected');
     expect(pg.cwe).toBe('CWE-089');
@@ -441,11 +554,31 @@ describe('snapshot tests (byte-level format stability)', () => {
   // Fixed, minimal input: 1 error rule + 1 warning rule, both with metadata.
   const snapshotResults: LintResult[] = [
     makeResult('/project/src/db.ts', [
-      { ruleId: '@interlace/pg/no-unsafe-query', severity: 2, message: 'SQL injection detected', line: 23, column: 5, nodeType: 'CallExpression' },
+      {
+        ruleId: '@interlace/pg/no-unsafe-query',
+        severity: 2,
+        message: 'SQL injection detected',
+        line: 23,
+        column: 5,
+        nodeType: 'CallExpression',
+      },
     ]),
     makeResult('/project/src/util.ts', [
-      { ruleId: 'no-unused-vars', severity: 1, message: "'x' is not used", line: 5, column: 7, fix: { range: [0, 5], text: '' } },
-      { ruleId: 'no-unused-vars', severity: 1, message: "'y' is not used", line: 12, column: 3 },
+      {
+        ruleId: 'no-unused-vars',
+        severity: 1,
+        message: "'x' is not used",
+        line: 5,
+        column: 7,
+        fix: { range: [0, 5], text: '' },
+      },
+      {
+        ruleId: 'no-unused-vars',
+        severity: 1,
+        message: "'y' is not used",
+        line: 12,
+        column: 3,
+      },
     ]),
   ];
 
@@ -498,7 +631,8 @@ describe('snapshot tests (byte-level format stability)', () => {
     } finally {
       if (prevColor === undefined) delete process.env['NO_COLOR'];
       else process.env['NO_COLOR'] = prevColor;
-      if (prevOptOut === undefined) delete process.env['INTERLACE_NO_ATTRIBUTION'];
+      if (prevOptOut === undefined)
+        delete process.env['INTERLACE_NO_ATTRIBUTION'];
       else process.env['INTERLACE_NO_ATTRIBUTION'] = prevOptOut;
     }
   });
@@ -544,17 +678,42 @@ describe('schema.json conformance (downstream agent contract)', () => {
   // sufficient to catch any drift between the renderer and the published
   // schema. If a renderer change adds/removes a key, this test points
   // straight at the schema file that needs updating.
-  const requiredRuleKeys = ['id', 'sev', 'n', 'fix', 'sugg', 'locs'];
-  const requiredSummaryKeys = ['errors', 'warnings', 'files', 'fixable', 'rules'];
-  const requiredLocKeys = ['f', 'l', 'c'];
-  const optionalRuleKeys = new Set(['desc', 'msg', 'docs', 'cwe', 'cvss']);
-  const optionalLocKeys = new Set(['t', 'sugg']);
+  /*
+   * Read FROM schema.json, not retyped beside it.
+   *
+   * These five lists used to be literals here, which meant a describe block
+   * named "schema.json conformance" never opened schema.json — and passed
+   * while the file did not exist at all, even though `exports` promised it.
+   * The published-artifact gate caught the missing file; nothing would have
+   * caught the two drifting apart once it existed.
+   */
+  const schema = JSON.parse(
+    readFileSync(join(__dirname, '..', 'schema.json'), 'utf8'),
+  ) as {
+    $defs: Record<
+      string,
+      { properties: Record<string, unknown>; required: string[] }
+    >;
+  };
+  const optionalOf = (def: string) =>
+    new Set(
+      Object.keys(schema.$defs[def]!.properties).filter(
+        (k) => !schema.$defs[def]!.required.includes(k) && k !== 'kind',
+      ),
+    );
+  const requiredRuleKeys = schema.$defs['rule']!.required;
+  const requiredSummaryKeys = schema.$defs['summary']!.required;
+  const requiredLocKeys = schema.$defs['loc']!.required;
+  const optionalRuleKeys = optionalOf('rule');
+  const optionalLocKeys = optionalOf('loc');
 
   function assertRule(rule: Record<string, unknown>) {
     for (const k of requiredRuleKeys) expect(rule).toHaveProperty(k);
     for (const k of Object.keys(rule)) {
-      const allowed = requiredRuleKeys.includes(k) || optionalRuleKeys.has(k) || k === 'kind';
-      if (!allowed) throw new Error(`schema.json: rule contains unknown key "${k}"`);
+      const allowed =
+        requiredRuleKeys.includes(k) || optionalRuleKeys.has(k) || k === 'kind';
+      if (!allowed)
+        throw new Error(`schema.json: rule contains unknown key "${k}"`);
     }
     expect(['error', 'warning']).toContain(rule['sev']);
     expect(typeof rule['fix']).toBe('boolean');
@@ -564,7 +723,8 @@ describe('schema.json conformance (downstream agent contract)', () => {
       for (const k of requiredLocKeys) expect(loc).toHaveProperty(k);
       for (const k of Object.keys(loc)) {
         const allowed = requiredLocKeys.includes(k) || optionalLocKeys.has(k);
-        if (!allowed) throw new Error(`schema.json: location contains unknown key "${k}"`);
+        if (!allowed)
+          throw new Error(`schema.json: location contains unknown key "${k}"`);
       }
     }
     if ('cwe' in rule) expect(rule['cwe']).toMatch(/^CWE-[0-9]+$/);
@@ -578,10 +738,15 @@ describe('schema.json conformance (downstream agent contract)', () => {
   it('renderJSON output conforms to schema.json (JsonModeOutput)', () => {
     const grouped = groupByRule(sampleResults, context, 'json');
     const summary = computeSummary(sampleResults, grouped);
-    const parsed = JSON.parse(renderJSON(grouped, summary)) as Record<string, unknown>;
+    const parsed = JSON.parse(renderJSON(grouped, summary)) as Record<
+      string,
+      unknown
+    >;
     expect(Object.keys(parsed)).toEqual(['summary', 'rules']); // summary first by contract
-    for (const k of requiredSummaryKeys) expect(parsed['summary']).toHaveProperty(k);
-    for (const rule of parsed['rules'] as Array<Record<string, unknown>>) assertRule(rule);
+    for (const k of requiredSummaryKeys)
+      expect(parsed['summary']).toHaveProperty(k);
+    for (const rule of parsed['rules'] as Array<Record<string, unknown>>)
+      assertRule(rule);
   });
 
   it('renderNDJSON output conforms to schema.json (one summary line + N rule lines)', () => {
@@ -697,7 +862,9 @@ describe('peerDep compatibility: ESLint v8 / v9 / v10 LintMessage shapes', () =>
     };
     const grouped = groupByRule([v10Result], { cwd: '/repo' }, 'json');
     expect(grouped[0]!.hasSuggestions).toBe(true);
-    expect(grouped[0]!.locations[0]!.suggestions).toEqual([{ desc: "Use '===' instead" }]);
+    expect(grouped[0]!.locations[0]!.suggestions).toEqual([
+      { desc: "Use '===' instead" },
+    ]);
     const summary = computeSummary([v10Result], grouped);
     const json = JSON.parse(renderJSON(grouped, summary));
     expect(json.rules[0].sugg).toBe(true);
@@ -733,24 +900,35 @@ describe('integration: real ESLint -f handshake', { timeout: 30_000 }, () => {
     expect(messages.length).toBeGreaterThan(0);
 
     // Build a LintResult[] the way ESLint's CLI engine would.
-    const errorCount = messages.filter(m => m.severity === 2).length;
-    const warningCount = messages.filter(m => m.severity === 1).length;
-    const fixableErrorCount = messages.filter(m => m.severity === 2 && m.fix).length;
-    const fixableWarningCount = messages.filter(m => m.severity === 1 && m.fix).length;
-    const realResults = [{
-      filePath: '/tmp/integration.js',
-      messages: messages as LintResult['messages'],
-      errorCount,
-      warningCount,
-      fixableErrorCount,
-      fixableWarningCount,
-    }];
+    const errorCount = messages.filter((m) => m.severity === 2).length;
+    const warningCount = messages.filter((m) => m.severity === 1).length;
+    const fixableErrorCount = messages.filter(
+      (m) => m.severity === 2 && m.fix,
+    ).length;
+    const fixableWarningCount = messages.filter(
+      (m) => m.severity === 1 && m.fix,
+    ).length;
+    const realResults = [
+      {
+        filePath: '/tmp/integration.js',
+        messages: messages as LintResult['messages'],
+        errorCount,
+        warningCount,
+        fixableErrorCount,
+        fixableWarningCount,
+      },
+    ];
 
     const grouped = groupByRule(realResults, { cwd: '/tmp' });
     const summary = computeSummary(realResults, grouped);
 
     // Every mode produces non-empty output mentioning the rules.
-    for (const render of [renderHuman, renderCompact, renderJSON, renderNDJSON]) {
+    for (const render of [
+      renderHuman,
+      renderCompact,
+      renderJSON,
+      renderNDJSON,
+    ]) {
       const out = render(grouped, summary);
       expect(out.length).toBeGreaterThan(0);
       expect(out).toContain('no-var');
@@ -760,7 +938,9 @@ describe('integration: real ESLint -f handshake', { timeout: 30_000 }, () => {
     const json = JSON.parse(renderJSON(grouped, summary));
     expect(json.summary).toBeDefined();
     expect(json.rules.length).toBeGreaterThan(0);
-    expect(json.rules.some((r: { id: string }) => r.id === 'no-var')).toBe(true);
+    expect(json.rules.some((r: { id: string }) => r.id === 'no-var')).toBe(
+      true,
+    );
 
     // NDJSON: every line is independently parseable.
     for (const line of renderNDJSON(grouped, summary).trim().split('\n')) {
@@ -813,17 +993,30 @@ describe('token efficiency', () => {
     // Create 20 files each with the same 2 rule violations — simulates real-world repetition
     const manyResults: LintResult[] = Array.from({ length: 20 }, (_, i) =>
       makeResult(`/project/src/module${i}/index.ts`, [
-        { ruleId: 'no-unused-vars', severity: 1, message: "'x' is not used", line: i + 1, column: 1 },
-        { ruleId: '@interlace/pg/no-unsafe-query', severity: 2, message: 'SQL injection detected', line: i + 5, column: 3 },
+        {
+          ruleId: 'no-unused-vars',
+          severity: 1,
+          message: "'x' is not used",
+          line: i + 1,
+          column: 1,
+        },
+        {
+          ruleId: '@interlace/pg/no-unsafe-query',
+          severity: 2,
+          message: 'SQL injection detected',
+          line: i + 5,
+          column: 3,
+        },
       ]),
     );
 
     // Simulate ESLint default stylish output (per-file, every message repeated)
     const ungrouped = manyResults
-      .map(r => {
+      .map((r) => {
         const header = r.filePath;
-        const msgs = r.messages.map(m =>
-          `  ${m.line}:${m.column}  ${m.severity === 2 ? 'error' : 'warning'}  ${m.message}  ${m.ruleId}`
+        const msgs = r.messages.map(
+          (m) =>
+            `  ${m.line}:${m.column}  ${m.severity === 2 ? 'error' : 'warning'}  ${m.message}  ${m.ruleId}`,
         );
         return [header, ...msgs, ''].join('\n');
       })

--- a/scripts/build-package.ts
+++ b/scripts/build-package.ts
@@ -27,6 +27,7 @@ import {
   readFileSync,
   readdirSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from 'node:fs';
 import { resolve, join } from 'node:path';
@@ -193,7 +194,37 @@ if (tsconfig === null) {
 //    it on the package page; the history stays available on GitHub, in the
 //    npm "Versions" tab, and in the changesets-generated release notes.
 //    README.md is kept: it IS the npm package page.
-const assets = ['README.md', 'LICENSE', '.npmignore'];
+//
+//    Beyond those three, every root-level FILE named in the package's own
+//    `files` array is copied. That list was hardcoded to exactly the three
+//    above, which made it a third hand-maintained inventory beside `files`
+//    and `exports` — and the three drifted: @interlace/eslint-formatter
+//    declared `"./schema.json"` in `exports` AND `schema.json` in `files`,
+//    the file existed, and it still never reached the tarball because this
+//    array had not heard of it. The publish gate caught it; a consumer would
+//    otherwise have got "Cannot find module" from a subpath the manifest
+//    promised. Declaring a file in `files` is now enough.
+//
+//    Directory entries are skipped: `src/` and `dist/` are what this script
+//    is producing, and CHANGELOG.md stays excluded for the size reason above
+//    even when a package lists it.
+const EXCLUDED_ASSETS = new Set(['CHANGELOG.md']);
+const declaredFiles: string[] = Array.isArray(pkg.files) ? pkg.files : [];
+const assets = [
+  ...new Set([
+    'README.md',
+    'LICENSE',
+    '.npmignore',
+    ...declaredFiles.filter(
+      (f) =>
+        !f.includes('/') &&
+        !f.includes('*') &&
+        !EXCLUDED_ASSETS.has(f) &&
+        existsSync(resolve(pkgDir, f)) &&
+        statSync(resolve(pkgDir, f)).isFile(),
+    ),
+  ]),
+];
 for (const asset of assets) {
   const src = resolve(pkgDir, asset);
   if (existsSync(src)) {


### PR DESCRIPTION
## Summary

The release run for `@interlace/eslint-formatter@0.2.0` **failed at the published-artifact gate** — which is the gate doing exactly its job. The package declared `"./schema.json"` in `exports` and `schema.json` in `files`, and the tarball contained neither. A consumer importing that subpath would have got "Cannot find module" from a path the manifest advertised, and on npm a manifest is only fixable by republishing.

Nothing was published, so there is no bad version to yank.

## Three things wrong, each hiding the next

1. **The file did not exist.** Written now, covering both output modes. The short keys (`id`, `sev`, `n`, `fix`, `sugg`, `locs`) are the package's whole point — ~408 tokens where `stylish` emits ~104,483 — so the contract downstream agents read should be published, not implied.

2. **The conformance test never opened it.** A describe block named *"schema.json conformance (downstream agent contract)"* carried its own five literal key lists, so it passed happily while the file it names did not exist at all. It now reads `$defs.*.required` and `properties` from the file. Verified by adding a required key to the schema and watching both cases fail.

3. **The build could not have shipped it anyway.** `build-package.ts` copies a hardcoded `['README.md', 'LICENSE', '.npmignore']` into `dist/`, and the gate packs from `dist/`. That is a *third* hand-maintained inventory beside `files` and `exports` — and all three had drifted. It now derives from the package's own `files`, skipping directories and keeping CHANGELOG.md excluded for the documented size reason. Declaring a file in `files` is enough.

Also adds the `funding` field the same gate flagged.

## Test plan

- [x] `check-published-artifacts` — 33 packages, 3611.7 kB, "every declared export resolves; metadata complete" (was failing on this package)
- [x] `npm pack --dry-run` from `dist/` now lists `schema.json`
- [x] Formatter suite 44/44; positive control: added a required key to `schema.json` and both conformance cases failed, confirming the test reads the file
- [x] `turbo run test --filter=...[origin/main]` — 56/56
- [x] `oxlint:shims:verify` — all 30 shims load

## After merge

Re-run the release; `@interlace/eslint-formatter@0.2.0` and `eslint-plugin-import-next@2.7.6` publish. Note #916 separately: the npm token could not create the new `@interlace/eslint-formatter-sarif` name, and this formatter is also a new name — if the publish 404s on a PUT, that is the token's package allowlist, not this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)