### PR TITLE
fix(eslint-formatter): ship the schema its exports declare

### DIFF
--- a/.changeset/formatter-ships-its-schema.md
+++ b/.changeset/formatter-ships-its-schema.md
@@ -1,0 +1,5 @@
+---
+'@interlace/eslint-formatter': patch
+---
+
+fix: `./schema.json` now reaches the published tarball, and the package declares `funding`

--- a/packages/eslint-formatter/package.json
+++ b/packages/eslint-formatter/package.json
@@ -16,6 +16,10 @@
   },
   "author": "Ofri Peretz <ofriperetzdev@gmail.com>",
   "license": "MIT",
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/ofri-peretz/eslint"
+  },
   "homepage": "https://github.com/ofri-peretz/eslint/tree/main/packages/eslint-formatter#readme",
   "repository": {
     "type": "git",

--- a/scripts/build-package.ts
+++ b/scripts/build-package.ts
@@ -24,6 +24,7 @@ import {
   existsSync,
   mkdirSync,
   copyFileSync,
+  statSync,
   readFileSync,
   readdirSync,
   rmSync,
@@ -194,6 +195,25 @@ if (tsconfig === null) {
 //    npm "Versions" tab, and in the changesets-generated release notes.
 //    README.md is kept: it IS the npm package page.
 const assets = ['README.md', 'LICENSE', '.npmignore'];
+
+/*
+ * Plus any root-level file the manifest says it ships.
+ *
+ * The list above is fixed, but the package is published FROM dist/, so a root
+ * asset a package declares — @interlace/eslint-formatter's `schema.json`, which
+ * `exports` maps to `./schema.json` — never reached the tarball. A consumer
+ * importing that subpath got "Cannot find module", and the published-artifact
+ * gate caught it: `"./schema.json" -> schema.json (NOT SHIPPED)`.
+ *
+ * Directories are skipped: `src/` and `dist/` are handled by the build itself,
+ * and copying dist/ into dist/ would recurse.
+ */
+for (const declared of pkg.files ?? []) {
+  const name = String(declared).replace(/\/$/, '');
+  if (name.includes('/') || assets.includes(name)) continue;
+  const src = resolve(pkgDir, name);
+  if (existsSync(src) && statSync(src).isFile()) assets.push(name);
+}
 for (const asset of assets) {
   const src = resolve(pkgDir, asset);
   if (existsSync(src)) {


### PR DESCRIPTION
The 0.2.0 release never reached npm, and **not for the reason I predicted**.

I expected the npm-token wall from [#916](https://github.com/ofri-peretz/eslint/issues/916). It failed earlier than that — Dist integrity failed, cancelling its siblings and skipping the publish job entirely, so neither package shipped. `eslint-plugin-import-next` is still at 2.7.5.

The gate was right:

```
❌ 1 declared export path(s) missing from the tarball:
   @interlace/eslint-formatter  "./schema.json" -> schema.json  (NOT SHIPPED)
   A consumer importing that subpath gets "Cannot find module".

❌ 1 package(s) missing discoverability metadata:
   @interlace/eslint-formatter  funding
```

Both defects are mine, and both are only observable once the package is actually **packed** — the same reason `private: true` hid its missing build script and its broken emit layout in #928.

## The cause

`build-package.ts` publishes FROM `dist/` and copied a fixed asset list — `README.md`, `LICENSE`, `.npmignore`. A root asset a package declares in `files` never made the tarball. `schema.json` is in this package's `files` **and** mapped by `exports`, and still did not ship.

It now also copies any root-level file the manifest says it ships, skipping directories since `src/` and `dist/` are the build's own output. **That fixes the class rather than the instance** — the next package to declare a root asset gets it shipped without touching this script.

`funding` added, matching `eslint-formatter-sarif` and `eslint-devkit`.

## Test plan

- [x] Verified by **packing**, not reading: `tar tzf` now lists `package/schema.json`.
- [x] Published-artifact gate passes across **all 33 packages** — every declared export resolves, metadata complete, 3,613.8 kB unpacked.
- [x] Full build of all 33 packages clean.
- [x] Patch changeset included.

## After merge

The release retries. It will then reach the step I originally expected and stop there: the npm token cannot create a new package under the `@interlace` scope, which now blocks **two** packages (#916). One token fix ships both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)