### PR TITLE
chore(docs): sync generated data

### DIFF
--- a/apps/docs/src/data/changelog.json
+++ b/apps/docs/src/data/changelog.json
@@ -1,9 +1,24 @@
 {
-  "releaseCount": 650,
+  "releaseCount": 651,
   "packageCount": 35,
-  "entryCount": 2037,
+  "entryCount": 2038,
   "oldestYear": 2024,
   "releases": [
+    {
+      "package": "eslint-plugin-import-next",
+      "short": "eslint-plugin-import-next",
+      "version": "2.7.6",
+      "date": "2026-09-07T23:22:14Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "`no-cross-domain-imports` and `enforce-dependency-direction` no longer crash on a non-string dynamic import",
+          "pr": null
+        }
+      ]
+    },
     {
       "package": "eslint-plugin-reliability",
       "short": "eslint-plugin-reliability",
@@ -16372,6 +16387,21 @@
     {
       "package": "@interlace/eslint-formatter",
       "short": "eslint-formatter",
+      "version": "0.2.1",
+      "date": null,
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "ship the `./schema.json` the manifest promises",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "@interlace/eslint-formatter",
+      "short": "eslint-formatter",
       "version": "0.2.0",
       "date": null,
       "isApp": false,
@@ -16426,21 +16456,6 @@
           "kind": "feature",
           "title": "`RemoteMarkdown` accepts `tags`, forwarded to the underlying fetch as `next.tags`.",
           "pr": 628
-        }
-      ]
-    },
-    {
-      "package": "eslint-plugin-import-next",
-      "short": "eslint-plugin-import-next",
-      "version": "2.7.6",
-      "date": null,
-      "isApp": false,
-      "isPrivate": false,
-      "entries": [
-        {
-          "kind": "fix",
-          "title": "`no-cross-domain-imports` and `enforce-dependency-direction` no longer crash on a non-string dynamic import",
-          "pr": null
         }
       ]
     },


### PR DESCRIPTION
Regenerated apps/docs/src/data/ (trigger: push). Opened by the Docs Data Sync workflow; contents come entirely from the apps/docs/scripts/sync-* scripts, so review the diff rather than hand-editing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release metadata to reflect 651 releases and 2,038 entries.
  * Added release notes for `eslint-plugin-import-next` 2.7.6, including a fix for dynamic imports with non-string values.
  * Added release notes for `@interlace/eslint-formatter` 0.2.1, which includes the promised `schema.json`.
  * Removed a duplicate unpublished entry for `eslint-plugin-import-next` 2.7.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->