### PR TITLE
fix: seven false positives burgee had to work around

### DIFF
--- a/.changeset/data-minimization-static-literal.md
+++ b/.changeset/data-minimization-static-literal.md
@@ -1,0 +1,20 @@
+---
+'eslint-plugin-operability': patch
+---
+
+fix(operability): `require-data-minimization` ignores a literal that collects nothing
+
+With `piiFields` configured, a wide object whose every value is a literal reported as excessive data collection:
+
+```ts
+export const HOSTS = [
+  {
+    name: 'commander',
+    repo: 'https://…',
+    testDir: 'tests',
+    runner: 'node:test' /* … */,
+  },
+];
+```
+
+Data collection means a value read from somewhere — a request, a form, a row, an argument. An object whose values are all literals, constants declared in the file, or arrays and objects of those, is configuration and is no longer reported. One collected value among literal defaults keeps the finding.

--- a/.changeset/dependency-version-strategy-manifest-is-not-a-map.md
+++ b/.changeset/dependency-version-strategy-manifest-is-not-a-map.md
@@ -1,0 +1,17 @@
+---
+'eslint-plugin-conventions': patch
+---
+
+fix(conventions): `prefer-dependency-version-strategy` no longer reads a manifest as a dependency map
+
+Any object literal holding one version-like string was checked as if every property were a dependency:
+
+```ts
+writeFileSync(
+  'package.json',
+  JSON.stringify({ name: 'x', version: '1.0.0', main: 'index.js' }),
+);
+// reported: Dependency "version" should use caret version
+```
+
+A dependency map is keyed by package name and every value is a version specifier. The object-literal fallback now stands down when any value is not one — a name, a path, a date, a number, an array — so package.json fixtures in tests and records that carry a `version` beside other fields are left alone. Homogeneous maps (`{ react: '18.0.0', lodash: '^4.17.21' }`), maps with dist-tags or `*`, and the `dependencies` block inside a manifest still report.

--- a/.changeset/error-context-custom-errors-and-rethrows.md
+++ b/.changeset/error-context-custom-errors-and-rethrows.md
@@ -1,0 +1,24 @@
+---
+'eslint-plugin-maintainability': patch
+---
+
+fix(maintainability): `no-missing-error-context` accepts a custom `*Error` argument and a re-throw
+
+```ts
+class UsageError extends Error {
+  constructor(
+    message: string,
+    readonly hint?: string,
+  ) {
+    super(message);
+  }
+}
+throw new UsageError(msg, 'pass --x'); // reported: "missing message"
+try {
+  run();
+} catch (err) {
+  throw err;
+} // reported: "missing message"
+```
+
+A class whose name ends in `Error` builds its own message from whatever it is given, so the argument is the context; a re-thrown identifier already carries the message and stack it was thrown with. `eslint-plugin-reliability`'s copy of this rule has accepted both for some time and this one had not — the two had drifted. The arms are now identical in both, and the same test cases sit in both files. `throw new Error(someVar)` and `throw undefined` still report.

--- a/.changeset/function-scoping-type-assertion.md
+++ b/.changeset/function-scoping-type-assertion.md
@@ -1,0 +1,13 @@
+---
+'eslint-plugin-maintainability': patch
+---
+
+fix(maintainability): `consistent-function-scoping` sees through a type assertion to module scope
+
+An arrow already at module scope was told to move to module scope when a type operator sat between it and its binding:
+
+```ts
+const noExit = (() => undefined) as unknown as (code: number) => never; // reported
+```
+
+The walk from the function up to `Program` stepped over the declarator and declaration only, so `as`, `satisfies`, `!` and `<T>` hid the fact that there was nowhere higher to go. A type operator changes what TypeScript believes about a value and nothing about where it lives; all four are now stepped over. The same cast inside a function still reports.

--- a/.changeset/null-checks-in-and-optional-chain-narrowing.md
+++ b/.changeset/null-checks-in-and-optional-chain-narrowing.md
@@ -1,0 +1,16 @@
+---
+'eslint-plugin-reliability': patch
+---
+
+fix(reliability): `no-missing-null-checks` reads `'k' in x` and optional-chain guards as narrowing
+
+Two shapes TypeScript accepts as narrowing reported as a possible null dereference when the rule ran without type information:
+
+```ts
+const value = 'value' in token ? token.value : undefined; // reported token.value
+if (found?.[1] !== undefined) return found[1]; // reported found[1]
+```
+
+`in` throws on `null` and `undefined`, so the consequent of an `in` test runs only with an object; an optional chain is non-nullish only when its root was. Both now count as a guard for the object they name, in an `if` test and in a ternary. Equality to `undefined` (`found?.[1] === undefined`), `x` on the left of `in`, a chain rooted at a different object, and the alternate arm of the ternary all still report.
+
+Reported by a CLI parser that had turned the rule off over exactly these lines.

--- a/.changeset/unhandled-promise-parameter-is-not-its-function.md
+++ b/.changeset/unhandled-promise-parameter-is-not-its-function.md
@@ -1,0 +1,16 @@
+---
+'eslint-plugin-maintainability': patch
+'eslint-plugin-reliability': patch
+---
+
+fix: `no-unhandled-promise` no longer treats a function-typed parameter as its enclosing async function
+
+Inside an `async` function, every call to a parameter reported as an unhandled promise:
+
+```ts
+async function main(argv: string[], write: (s: string) => void) {
+  write('hello'); // reported — write returns void
+}
+```
+
+The binding resolver returned the definition's node for every kind of definition, and for a parameter that node is the function that declares it — so `write` resolved to `main`, inherited its `async`, and was "evidence" of a promise. A parameter is now evidence only through what the file shows about it: a `() => Promise<…>` annotation or an `async` default still report; a `void`-typed or unannotated parameter does not. Both plugins that ship this rule carry the same fix and the same cases.

--- a/docs/intents/burgee-false-positives/design.md
+++ b/docs/intents/burgee-false-positives/design.md
@@ -1,0 +1,277 @@
+# Design — a consumer turned seven rules off
+
+Intent: [`intent.md`](./intent.md). **Status:** review.
+
+---
+
+## Requirements
+
+1. **R1** `no-missing-null-checks` treats `'k' in x` (x on the RIGHT) as
+   proving `x` is an object in the consequent of the `if` or ternary it tests,
+   and treats a truthy or `!= null` / `!== undefined` test on an optional chain
+   rooted at `x` as proving `x` non-null. Equality to null/undefined, `x` on the
+   left of `in`, a chain rooted elsewhere, and the alternate arm keep reporting.
+2. **R2** Both `no-unhandled-promise` twins stop resolving a parameter to the
+   function that declares it. A parameter is evidence only through what the file
+   shows about it: a `() => Promise<…>` annotation or an async default.
+3. **R3** The maintainability `no-missing-error-context` accepts the two shapes
+   its reliability twin already accepts — a re-thrown identifier, and a custom
+   `*Error` given a non-string argument — with identical source text.
+4. **R4** `prefer-dependency-version-strategy`'s object-literal fallback treats
+   an object as a dependency map only when every literal value is a version
+   specifier. The `dependencies` / `devDependencies` / `peerDependencies`
+   selector is unchanged.
+5. **R5** `require-data-minimization` does not report an object whose every
+   value is static — a literal, a file constant, or an array/object of those.
+6. **R6** No `invalid` case in any of the five suites changes verdict.
+7. **R7** FP 7 is recorded with evidence and left unfixed.
+8. **R8** `consistent-function-scoping` treats a function whose only ancestors
+   up to `Program` (or an export) are declarators, declarations and TypeScript
+   type operators — `as`, `satisfies`, `!`, `<T>` — as already at module scope.
+   The same cast inside a function keeps reporting.
+
+## Design
+
+### R1 — `no-missing-null-checks` (`packages/eslint-plugin-reliability/src/rules/reliability/no-missing-null-checks.ts`)
+
+The rule already had two guard readers: `isNullCheckForObject` for the test of
+an enclosing `if`, and a text-identity check for a ternary whose consequent
+holds the read. Neither read the two forms TypeScript narrows on:
+
+    'value' in token ? token.value : undefined      // in
+    if (found?.[1] !== undefined) return found[1];  // optional chain
+
+A new `narrowsToObject(test, object)` recognises exactly those:
+
+- `BinaryExpression` with operator `in` whose RIGHT operand is the object or a
+  prefix of it. `in` throws on null and undefined, so the consequent runs only
+  with an object. The left operand is a key and narrows nothing.
+- A `ChainExpression` whose root is the object, either as the whole test
+  (truthy) or as the operand of `!==` / `!=` against `null` / `undefined`. An
+  optional chain is non-nullish only when its root was.
+
+It is called from `isNullCheckForObject` (so `if` tests and the `&&` / `||`
+recursion pick it up) and from the ternary branch of `hasNullCheck`, in
+addition to the text-identity it already had. `===` / `==` against nil is
+deliberately not in it: `found?.[1] === undefined` passes when `found` is
+null. Root matching is by source text, the same convention the truthy branch
+of `isNullCheckForObject` uses (`objectText.startsWith(testText + '.')`).
+
+The consumer's third shape — `if (m === null) return undefined; m[1]` — is
+already understood on `main` through `isGuardedByEarlyExit` (4.1.4, #893).
+Burgee runs 4.1.3. It is pinned here anyway, and proven red by swapping in the
+4.1.3 rule source (below).
+
+### R2 — `no-unhandled-promise` (both twins)
+
+`resolveBinding` returned `def.node` for the first definition of a name.
+For a `Parameter` definition `def.node` is the FUNCTION that declares the
+parameter — so `write` inside `async function main(argv, write)` resolved to
+`main`, `isAsyncFunctionNode(main)` was true, and every `write(…)` in the body
+was an unhandled promise. The evidence gate that exists to stop the rule
+reporting every call was answering yes for a reason unrelated to the callee.
+
+The resolver now returns the parameter itself: its `AssignmentPattern.right`
+when it has a default, else its `Identifier`. `hasPromiseEvidence` keeps
+`isAsyncFunctionNode` (which now sees the async default) and adds
+`isPromiseReturningAnnotation`: an `Identifier` whose type annotation is a
+`TSFunctionType` returning `Promise<…>`. So:
+
+    async function main(write: (s: string) => void) { write('x') }   // quiet
+    async function main(write) { write('x') }                        // quiet
+    async function main(save: () => Promise<void>) { save() }        // reports
+    async function main(save = async () => {}) { save() }            // reports
+
+Same edit, same text, in
+`packages/eslint-plugin-maintainability/src/rules/error-handling/no-unhandled-promise.ts`
+and `packages/eslint-plugin-reliability/src/rules/error-handling/no-unhandled-promise.ts`.
+
+### R3 — `no-missing-error-context` (maintainability)
+
+The two `hasErrorMessage` / `hasErrorStack` arms the reliability twin gained
+earlier — an identifier that is not `undefined` / `NaN` / `Infinity` is a
+re-throw and carries its own context; a non-string argument to a class whose
+name ends in `Error` but is not `Error` is the context — are copied verbatim
+into `packages/eslint-plugin-maintainability/src/rules/error-handling/no-missing-error-context.ts`.
+The consumer's `throw new UsageError('missing required option', 'pass --x')`
+was already quiet in both twins; what it saw under this plugin was
+`throw err` at three sites and `new UsageError(msg, hint)`.
+
+### R4 — `prefer-dependency-version-strategy` (`packages/eslint-plugin-conventions/src/rules/conventions/prefer-dependency-version-strategy.ts`)
+
+The `ObjectExpression` fallback asked whether ANY property value looked like
+`^1.2.3` or `workspace:`, then checked every property as a dependency. A
+package.json fixture — `{ name: 'x', version: '1.0.0', main: 'index.js' }` —
+and a vendoring record with `version: '1.0.0'` beside a repo URL, a commit and
+a file count both qualified, and both reported `Dependency "version" should
+use caret version`.
+
+It now asks whether EVERY `Property` value is a string literal matching
+`VERSION_SPECIFIER` — semver and ranges, `*` / `x`, the `latest` / `next`
+dist-tags, and the `workspace:` / `file:` / `link:` / `npm:` / `git+` /
+`github:` / `http(s):` protocols npm documents. A spread is skipped; any other
+value (a name, a path, a date, a number, an array, an identifier) means the
+object is not a dependency map and the fallback stands down. The keyed
+selector for `dependencies` blocks is untouched, so the real map inside a
+manifest still reports.
+
+### R5 — `require-data-minimization` (`packages/eslint-plugin-operability/src/rules/operability/require-data-minimization.ts`)
+
+After the existing breadth and `piiFields` checks pass, the rule now asks
+whether the object collects anything. `isStaticValue` walks `ArrayExpression`
+and `ObjectExpression` containers and hands every leaf to the devkit's
+`isStaticExpression` — literals, template strings without expressions, and
+constants declared in the file. An object whose every value passes is
+configuration and is not reported; one value read from a request, a parameter
+or a shorthand binding keeps the finding.
+
+### R8 — `consistent-function-scoping` (`packages/eslint-plugin-maintainability/src/rules/maintainability/consistent-function-scoping.ts`)
+
+`analyzeFunction` walks from the function to its enclosing scope to decide
+whether there is anywhere higher to move it, stepping over `VariableDeclarator`
+and `VariableDeclaration`. Burgee's `help.test.ts` had
+
+    const noExit = (() => undefined) as unknown as (code: number) => never;
+
+The parent chain is `TSAsExpression → TSAsExpression → VariableDeclarator →
+VariableDeclaration → Program`; the walk stopped at the first `TSAsExpression`,
+saw something that was not `Program`, and told the consumer to move an arrow to
+the scope it was already in. The consumer hoisted the arrow into a `function`
+declaration and lost the cast.
+
+The two node types the walk stepped over become a `BINDING_WRAPPERS` set and
+gain the four TypeScript type operators — `TSAsExpression`,
+`TSSatisfiesExpression`, `TSNonNullExpression`, `TSTypeAssertion`. Each
+re-describes the value's type and none moves it. The ancestor test after the
+walk is unchanged, so `function outer() { const f = (() => 'ok') as unknown as
+() => string; }` still reports: its walk ends at `outer`'s block.
+
+The consumer's second FP 12 shape, `defineCommand({ run: () => 'ok' })`, is the
+`Property` exemption that landed in 3.2.0. Burgee's lockfile resolves 3.2.3, so
+the report it saw came from a test body on an earlier install; it is pinned
+`valid` inside an `it(…)` callback, the shape 3.0.3 reported.
+
+### R7 — `no-insecure-comparison`: recorded, not fixed
+
+The consumer's comment attributes the block to identifiers containing `env`.
+Against `main`, every shape it names is quiet: `env` is not in the secret
+vocabulary, comparison to `undefined` is exempt, and `in` is not an operator
+the rule reads. What `execute.ts` actually reports is
+
+    for (const token of argv) { if (token === '--') …          // 204:9
+    const { kind } = token; if (kind === 'option-terminator')  // 176:9, 177:14
+
+`token` is in the closed secret vocabulary, and `namesIn` follows `kind` to
+the binding it was destructured from. In a parser a token is a lexeme; the
+rule cannot tell that from the AST, and the fix options are all worse than
+the finding — see Rejected alternatives. The three shapes the comment names
+are pinned as `valid` in the rule's test file so they stay quiet, and the
+consumer's comment should say `token`.
+
+## Verification
+
+One command per package; each exits non-zero when this is wrong:
+
+    cd packages/eslint-plugin-reliability     && npx vitest run
+    cd packages/eslint-plugin-maintainability && npx vitest run
+    cd packages/eslint-plugin-conventions     && npx vitest run
+    cd packages/eslint-plugin-operability     && npx vitest run
+    cd packages/eslint-plugin-secure-coding   && npx vitest run
+
+**Red, on the unfixed rules** (new cases only; every existing case passed):
+
+| Package         | Failing | Which                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| :-------------- | :------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| reliability     | 9       | `no-missing-null-checks`: the `in` ternary, the `in` if, `found?.[1] !== undefined`, truthy `found?.[1]`, `hit?.meta != null`, the `!== undefined` ternary. `no-unhandled-promise`: the void-typed writer, the untyped parameter, and the "local async beside a quiet parameter" invalid case reporting 2 instead of 1.                                                                                                                  |
+| maintainability | 12      | `no-missing-error-context`: `new UsageError(msg, hint)`, `throw err`, `throw err` under `requireStackTrace`. `no-unhandled-promise`: the same three as above. `consistent-function-scoping`: the `as unknown as` cast, the same cast exported, `satisfies`, `!`, `<T>`, and a cast function expression — 6 of the 9 new cases; the inline-property pin and the two "same cast inside a function" invalid controls pass before and after. |
+| conventions     | 4       | both fixtures, the manifest with correct dependencies, and the "dependencies block inside a manifest" invalid case reporting 2 (`version` + `react`) instead of 1.                                                                                                                                                                                                                                                                       |
+| operability     | 2       | the `HOSTS` literal, and a literal whose values are file constants.                                                                                                                                                                                                                                                                                                                                                                      |
+| secure-coding   | 0       | pins; the three shapes were already quiet. The positive control (`presented === process.env.ANTHROPIC_API_KEY`) reports.                                                                                                                                                                                                                                                                                                                 |
+
+**Red against the version the consumer runs**, for the FP 1 early-return pins
+that `main` already understands: with `git show eslint-plugin-reliability@4.1.3:…/no-missing-null-checks.ts`
+swapped in, the `m[1]` and `m.at(1)` cases fail alongside the six above.
+
+**Red against the version the consumer resolves**, for FP 12: the
+`consistent-function-scoping` source at `eslint-plugin-maintainability@3.2.3`
+is byte-identical to `main`'s and reports all five cast spellings. At 3.0.3 the
+cast shapes were quiet — hidden by the `parent`-chain bug that made every arrow
+look as though it captured — and `define({ run: () => 'ok' })` inside a
+function reported.
+
+**Green, after:** reliability 487/487 across 15 files; maintainability 494/494
+across 21, 100% statements/branches/functions/lines; conventions 538 passed, 18
+skipped, across 22; operability 138/138 across 10; secure-coding 3724/3724
+across 83. `tsgo --build tsconfig.solution.json` and the maintainability package
+build exit 0.
+
+Test files:
+
+- `packages/eslint-plugin-reliability/src/tests/reliability/no-missing-null-checks.test.ts` — describe `narrowing the consumer wrote and TypeScript accepts (burgee)`
+- `packages/eslint-plugin-{maintainability,reliability}/src/tests/error-handling/no-unhandled-promise.test.ts` — describe `a parameter is not the function it belongs to (burgee)`
+- `packages/eslint-plugin-{maintainability,reliability}/src/tests/error-handling/no-missing-error-context.test.ts` — describe `a custom Error subclass carries its own context (burgee)`
+- `packages/eslint-plugin-conventions/src/tests/conventions/prefer-dependency-version-strategy.test.ts` — describe `an object with a version field is not a dependency map (burgee)`
+- `packages/eslint-plugin-operability/src/tests/operability/require-data-minimization.test.ts` — run `a static literal collects nothing`
+- `packages/eslint-plugin-secure-coding/src/rules/no-insecure-comparison/no-insecure-comparison.test.ts` — describe `environment lookups are presence checks, not secret comparisons (burgee)`
+- `packages/eslint-plugin-maintainability/src/tests/maintainability/consistent-function-scoping.test.ts` — describe `a type assertion does not move a function off module scope (burgee)`
+
+## Rejected alternatives
+
+**Route the ternary test through `isNullCheckForObject` wholesale.** It would
+have fixed `hit !== null ? hit.name : x` too, but that function also accepts
+`obj === null` as a "null check", which in a ternary consequent is the
+opposite of a guard. Only the new, direction-safe forms were added to the
+ternary path; the pre-existing looseness of the `if` path is untouched and
+out of scope.
+
+**Make `resolveBinding` return `null` for every parameter.** Simplest, and it
+would silence `async function main(save: () => Promise<void>) { save() }`,
+where the file plainly shows a promise. The annotation and the default are
+read instead, so the fix subtracts only the inference that was wrong.
+
+**Exempt comparisons against a string literal from the timing finding** (for
+FP 7). `token === '--'` would go quiet, and so would `presented === 'sk-live-…'`,
+where the literal IS the secret and timing leaks it one character at a time.
+That is a false negative on the rule's own CWE to buy silence on a lexer.
+
+**Drop `token` from the secret vocabulary**, or match it only in an "auth
+context". The first loses the single commonest credential name; the second
+is the name-of-the-enclosing-function heuristic this rule removed on purpose
+(see its own comment block). A consumer-owned vocabulary option is the honest
+shape and is a separate intent.
+
+**Gate `prefer-dependency-version-strategy`'s fallback on the filename** (skip
+`*.test.ts`). It would have hidden the consumer's two cases and kept the
+defect: a non-test file building a manifest object would still report its
+`version`. The shape of the object is the evidence, not where the file sits.
+
+**Exclude the key `version` from the fallback.** `version` is a real npm
+package name, and it leaves `{ repo: 'r', tag: 'v1.0.0', … }` records reporting
+on whichever other key happens to hold a semver string.
+
+**Skip `require-data-minimization` when the object is `export const`.** Export
+is not the evidence; a static literal is. `const HOSTS = [{…}]` inside a
+function is the same configuration, and an exported object assembled from
+`req.body` is still collection.
+
+**Unwrap the type assertion and analyse the inner function as the binding's
+value** (for FP 12), or exempt any function under a `TSAsExpression`. The first
+is the same walk spelled from the other end; the second silences `const f =
+(() => x) as T` inside a function, where the rule's one real job is. Stepping
+over the operator and keeping the existing `Program` / export test subtracts
+only the wrong stop.
+
+**Extend the devkit's `isStaticExpression` to walk arrays and objects.** The
+right long-term home, but it is consumed by every taint rule in the suite and
+widening it there changes verdicts this intent did not measure. The container
+walk lives in the one rule that needs it, delegating leaves to the devkit.
+
+## Out of scope
+
+- `no-unhandled-promise` (maintainability) lacking `isPromiseDelegatedToCaller`
+  — `return promise.then(…)` and `return cond ? Promise.resolve(x).then(f) : f(x)`
+  report in one twin and not the other (`commander-command.ts:909,1721,1725`).
+  Noticed while measuring; its own intent.
+- The `if` path of `isNullCheckForObject` accepting `=== null` as a guard.
+- A consumer-owned secret vocabulary for `no-insecure-comparison`.
+- Any change to burgee's repository.

--- a/docs/intents/burgee-false-positives/intent.md
+++ b/docs/intents/burgee-false-positives/intent.md
@@ -1,0 +1,122 @@
+---
+slug: burgee-false-positives
+opened: 2026-09-07
+packages:
+  - eslint-plugin-reliability
+  - eslint-plugin-maintainability
+  - eslint-plugin-conventions
+  - eslint-plugin-operability
+  - eslint-plugin-secure-coding
+cases: []
+---
+
+# Intent — a consumer turned seven rules off; the rules owe it a fix, not a workaround
+
+**Status:** review · **Opened:** 2026-09-07 · **Owner:** @ofri-peretz
+
+---
+
+## What is wanted
+
+The `burgee` CLI framework (`ofriperetz.dev/burgee`) can delete six `'off'`
+blocks from its `eslint.config.mjs` — the ones annotated `FP 1`, `FP 7`,
+`FP 8`, `FP 9`, `FP 10`, `FP 11` — and un-hoist the code it rewrote to dodge a
+seventh (`FP 12`), and the rules stay quiet on the code those blocks cover,
+without any of the rules losing a case they report today.
+
+Where a block turns out to silence something that is not a false positive of
+the rule as it stands on `main`, that is written down here with the evidence
+rather than fixed by loosening the rule.
+
+## Why now
+
+A consumer that has to write `'rule': 'off'` six times with a paragraph of
+justification each — and rewrite correct code a seventh time to satisfy a rule
+— has stopped trusting seven rules, and the README's own FP/FN
+section says what that costs: an ignored rule has zero recall regardless of
+what it detects. The workarounds are dated 2026-09-06/07 and cover real,
+shipped code — a CLI parser, a compatibility oracle, its test fixtures.
+
+Measured on `origin/main` at `79f9bc166`, by running the `src/` rule against
+the consumer's actual files (`scripts/probe-rule.mts` cannot address rules that
+live at `src/rules/<category>/<rule>.ts`, so the same Linter harness was run
+from a scratch script):
+
+| Block | Rule(s)                                                                            | Consumer's diagnosis                                                                                                    | On `main`, against the real file                                                                                                                                                                                                                   |
+| :---- | :--------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| FP 1  | `reliability/no-missing-null-checks`                                               | `m[1]` after `if (m === null) return`; `'value' in token` narrowing                                                     | The early-return shape is quiet since 4.1.4 (burgee runs 4.1.3). `'value' in token ? token.value : …` and `if (found?.[1] !== undefined) … found[1]` **report** — `execute.ts:206`.                                                                |
+| FP 7  | `secure-coding/no-insecure-comparison`                                             | `spec.env === undefined`, `fromEnv !== undefined`, `envVar in process.env` read as secret comparisons because of `env`  | All three **quiet**. The file reports at `execute.ts:176,177,204` — `token === '--'` and `kind === 'positional'` (via `const { kind } = token`): the word is `token`, a parseArgs lexeme.                                                          |
+| FP 8  | `maintainability/no-unhandled-promise`, `reliability/no-unhandled-promise`         | every `write(…)` in `async function main(argv, write: (s) => void)`                                                     | **Reports**, both twins, `report.ts:161,162,165`.                                                                                                                                                                                                  |
+| FP 9  | `conventions/prefer-dependency-version-strategy`                                   | a package.json fixture's `version: '1.0.0'`                                                                             | **Reports** — both fixture shapes.                                                                                                                                                                                                                 |
+| FP 10 | `maintainability/no-missing-error-context`, `reliability/no-missing-error-context` | `throw new UsageError('…', 'hint')`                                                                                     | The literal-message shape is **quiet** in both twins. The maintainability twin **reports** `throw err` re-throws (`commander-command.ts:416,458,1656`) and `new UsageError(msg, hint)`; the reliability twin does neither — the twins had drifted. |
+| FP 11 | `operability/require-data-minimization`                                            | a static `HOSTS` literal read as data collection                                                                        | Inert with default options since 4.0.0 (burgee runs 3.1.1). With `piiFields: ['name']` configured, the static literal **reports**.                                                                                                                 |
+| FP 12 | `maintainability/consistent-function-scoping`                                      | a module-scope arrow wrapped in `as unknown as T` told to move to module scope; `run: () => 'ok'` inline in an argument | The cast shape **reports** on `main` and on the 3.2.3 the consumer's lockfile resolves — `as`, `satisfies`, `!`, `<T>` all do. The inline-property shape is quiet since 3.2.0 (the `Property` exemption); it reported on 3.0.3 inside a test body. |
+
+Every row marked **reports** fails a RuleTester case on the unfixed rule:
+9 cases in `eslint-plugin-reliability`, 12 in `eslint-plugin-maintainability`
+(6 for FP 8 and FP 10, 6 for FP 12), 4 in `eslint-plugin-conventions`, 2 in
+`eslint-plugin-operability`.
+
+## Affected users and systems
+
+- `eslint-plugin-reliability` — `no-missing-null-checks`, `no-unhandled-promise`
+- `eslint-plugin-maintainability` — `no-unhandled-promise`, `no-missing-error-context`, `consistent-function-scoping`
+- `eslint-plugin-conventions` — `prefer-dependency-version-strategy`
+- `eslint-plugin-operability` — `require-data-minimization`
+- `eslint-plugin-secure-coding` — `no-insecure-comparison`: pins only, no rule change
+- Any consumer running the `recommended` presets on a codebase that narrows
+  with `in` or optional chains, passes callbacks into async functions, writes
+  package.json fixtures in tests, defines its own `Error` subclasses, exports
+  static configuration, or casts a module-scope function through `as`.
+
+## Constraints
+
+- **No rule loses a case it reports today.** Every fix is a `valid` case that
+  fails on the unfixed rule, beside an `invalid` case pinning the nearest shape
+  that must still report. The five package suites stay green.
+- **Evidence, never a name.** A fix may read what the file shows — an `in`
+  operand, a type annotation, a literal value, a default parameter — and may
+  not add a word to a vocabulary or a spelling to an allowlist.
+- **Twins agree.** `no-unhandled-promise` and `no-missing-error-context` ship
+  in two plugins; the same cases go into both files so they cannot drift apart
+  again silently.
+- **The consumer's repo is not touched.** Its overrides come out on its own
+  schedule, after the patched versions publish.
+- **A block that silences a true positive, or a report the rule does not make
+  on `main`, is documented — not fixed.** FP 7 is that row.
+
+## Success criteria
+
+- Each of the four packages with a rule change carries a `valid` case
+  reproducing the consumer's shape, proven red on the unfixed rule (recorded in
+  `design.md` § Verification), and green after.
+- Each carries an `invalid` case for the adjacent shape that must keep
+  reporting, green before and after.
+- `turbo run build` and `turbo run test` green across the graph; whole-graph
+  `tsgo` typecheck green.
+- One changeset per fixed defect, `patch`, written for the consumer reading the
+  CHANGELOG.
+- After the patched versions publish, burgee removes blocks FP 1, 8, 9, 10, 11,
+  may restore the `as unknown as` cast and inline callbacks FP 12 made it hoist,
+  and its own gate stays green. FP 7 stays, with its comment corrected to name
+  `token`, unless a later intent decides the vocabulary question.
+
+## Done when
+
+- The four rule changes and their locks are merged and released.
+- `design.md` § Verification records the red-then-green run for every case.
+- burgee's `eslint.config.mjs` loses five of the six blocks on its next
+  dependency bump.
+
+## Open questions
+
+- `no-insecure-comparison` treats every `token` as a credential. In a parser
+  a token is a lexeme; in an auth layer it is a bearer secret. Nothing in the
+  AST distinguishes them, and the closed vocabulary is what makes the rule's
+  precision defensible. Whether to offer the vocabulary as an option that
+  REPLACES the default — the answer this repo gave `require-data-minimization`
+  — is a separate decision with its own corpus measurement.
+- The maintainability `no-unhandled-promise` twin lacks the
+  `isPromiseDelegatedToCaller` arm its reliability sibling has (`return
+p.then(…)` reports in one plugin and not the other — `commander-command.ts:909`).
+  Same class of drift as FP 10, found while measuring; not this intent's scope.

--- a/packages/eslint-plugin-conventions/src/rules/conventions/prefer-dependency-version-strategy.ts
+++ b/packages/eslint-plugin-conventions/src/rules/conventions/prefer-dependency-version-strategy.ts
@@ -20,6 +20,20 @@ import { createRule } from '@interlace/eslint-devkit';
 
 type VersionStrategy = 'caret' | 'tilde' | 'exact' | 'range' | 'any';
 
+/**
+ * Does this string read as something npm accepts where a version goes?
+ *
+ * Semver and its ranges (`1.2.3`, `^1.2`, `>=1 <2`, `1.0.0 - 2.0.0`, `1.x`),
+ * the `*` and `x` wildcards, the dist-tags npm itself documents, and the
+ * protocol specifiers this rule's options already name. Used only to decide
+ * whether an object literal IS a dependency map; what a value should look like
+ * once it is one is `checkVersion`'s question.
+ *
+ * @vocabulary npm — https://docs.npmjs.com/cli/configuring-npm/package-json#dependencies
+ */
+const VERSION_SPECIFIER =
+  /^(?:[\^~<>=]*\s*\d|[*x]$|latest$|next$|(?:workspace|file|link|npm|git\+[a-z]+|github|https?):)/i;
+
 export interface Options {
   strategy?: VersionStrategy;
   allowWorkspace?: boolean;
@@ -266,22 +280,30 @@ export const preferDependencyVersionStrategy = createRule<
 
       // Also check object literals (for testing and general use)
       ObjectExpression(node: TSESTree.ObjectExpression) {
-        // Only check if it looks like a dependencies object (has string keys and version-like values)
-        const hasVersionLikeValues = node.properties.some(
-          (prop: TSESTree.Property | TSESTree.SpreadElement) => {
-            if (prop.type === 'Property' && prop.value.type === 'Literal') {
-              const value = String(prop.value.value);
-              // Check if value looks like a version (starts with ^, ~, or is a semantic version)
-              return (
-                /^[\^~]?\d+\.\d+\.\d+/.test(value) ||
-                value.startsWith('workspace:')
-              );
-            }
-            return false;
-          },
-        );
+        // A dependency map is keyed by package name and EVERY value is a
+        // version specifier. This used to ask whether ANY value looked like a
+        // version, which made a package.json fixture in a test —
+        // `{ name: 'x', version: '1.0.0', main: 'index.js' }` — and a vendoring
+        // record carrying `version: '1.0.0'` beside a repo URL and a commit
+        // count both report `Dependency "version" should use caret`. One value
+        // that is not a specifier — a name, a path, a date, a number, an array
+        // — says the object is something else. A spread says nothing either
+        // way. The `dependencies` selector above still reads the real map
+        // inside a manifest.
+        let sawSpecifier = false;
+        for (const prop of node.properties) {
+          if (prop.type !== 'Property') continue;
+          if (
+            prop.value.type !== 'Literal' ||
+            typeof prop.value.value !== 'string' ||
+            !VERSION_SPECIFIER.test(prop.value.value)
+          ) {
+            return;
+          }
+          sawSpecifier = true;
+        }
 
-        if (hasVersionLikeValues) {
+        if (sawSpecifier) {
           checkObjectExpression(node);
         }
       },

--- a/packages/eslint-plugin-conventions/src/tests/conventions/prefer-dependency-version-strategy.test.ts
+++ b/packages/eslint-plugin-conventions/src/tests/conventions/prefer-dependency-version-strategy.test.ts
@@ -37,6 +37,7 @@ describe('prefer-dependency-version-strategy', () => {
           },
           // Tilde strategy
           {
+            name: 'a tilde range under the tilde strategy',
             code: 'const deps = { "react": "~18.0.0" };',
             options: [{ strategy: 'tilde' }],
           },
@@ -235,5 +236,61 @@ describe('prefer-dependency-version-strategy', () => {
         invalid: [],
       },
     );
+  });
+
+  /**
+   * The ObjectExpression fallback read ANY object literal holding a
+   * version-like string as a dependency map. In burgee a package.json fixture
+   * written by a test — `{ name: 'x', version: '1.0.0', main: 'index.js' }` —
+   * and a vendoring record carrying `version: '1.0.0'` beside a repo URL and a
+   * commit both reported `Dependency "version" should use caret version`, and
+   * the rule was turned off for every test file. A dependency map is keyed by
+   * package name and EVERY value is a version specifier; one value that is not
+   * says the object is something else. See docs/intents/burgee-false-positives/.
+   */
+  describe('an object with a version field is not a dependency map (burgee)', () => {
+    ruleTester.run('mixed object literals', preferDependencyVersionStrategy, {
+      valid: [
+        {
+          name: 'FP: a package.json fixture written by a test',
+          code: 'writeFileSync(join(plain, "package.json"), JSON.stringify({ name: "x", version: "1.0.0", main: "index.js" }));',
+        },
+        {
+          name: 'FP: a record with a version beside a repo, a tag and a count',
+          code: 'const record = (over) => ({ repo: "r", version: "1.0.0", tag: "v1.0.0", commit: "a".repeat(40), vendored: "2026-09-07", files: 1, internalFiles: [], ...over });',
+        },
+        {
+          name: 'a manifest whose dependencies are correct, with its own version field',
+          code: 'const pkg = { name: "x", version: "1.0.0", dependencies: { react: "^18.0.0" } };',
+        },
+      ],
+      invalid: [
+        {
+          name: 'a homogeneous dependency map still reports the odd one out',
+          code: 'const deps = { react: "18.0.0", lodash: "^4.17.21" };',
+          output: 'const deps = { react: "^18.0.0", lodash: "^4.17.21" };',
+          errors: [{ messageId: 'preferStrategy' }],
+        },
+        {
+          name: 'dist-tags and a wildcard are version specifiers too',
+          code: 'const deps = { react: "18.0.0", foo: "latest", bar: "*" };',
+          output: 'const deps = { react: "^18.0.0", foo: "latest", bar: "*" };',
+          errors: [{ messageId: 'preferStrategy' }],
+        },
+        {
+          name: 'the dependencies block INSIDE a manifest still reports, and the manifest itself does not',
+          code: 'const pkg = { name: "x", version: "1.0.0", dependencies: { react: "18.0.0" } };',
+          output:
+            'const pkg = { name: "x", version: "1.0.0", dependencies: { react: "^18.0.0" } };',
+          errors: [{ messageId: 'preferStrategy' }],
+        },
+        {
+          name: 'a map mixing a workspace link with a bare version',
+          code: 'const deps = { app: "workspace:*", react: "18.0.0" };',
+          output: 'const deps = { app: "workspace:*", react: "^18.0.0" };',
+          errors: [{ messageId: 'preferStrategy' }],
+        },
+      ],
+    });
   });
 });

--- a/packages/eslint-plugin-conventions/src/tests/conventions/prefer-dependency-version-strategy.test.ts
+++ b/packages/eslint-plugin-conventions/src/tests/conventions/prefer-dependency-version-strategy.test.ts
@@ -253,10 +253,12 @@ describe('prefer-dependency-version-strategy', () => {
       valid: [
         {
           name: 'FP: a package.json fixture written by a test',
+          // @found real-source scan (burgee, ofri-peretz/burgee eslint.config.mjs)
           code: 'writeFileSync(join(plain, "package.json"), JSON.stringify({ name: "x", version: "1.0.0", main: "index.js" }));',
         },
         {
           name: 'FP: a record with a version beside a repo, a tag and a count',
+          // @found real-source scan (burgee, ofri-peretz/burgee eslint.config.mjs)
           code: 'const record = (over) => ({ repo: "r", version: "1.0.0", tag: "v1.0.0", commit: "a".repeat(40), vendored: "2026-09-07", files: 1, internalFiles: [], ...over });',
         },
         {

--- a/packages/eslint-plugin-maintainability/src/rules/error-handling/no-missing-error-context.ts
+++ b/packages/eslint-plugin-maintainability/src/rules/error-handling/no-missing-error-context.ts
@@ -41,6 +41,24 @@ function hasErrorMessage(node: TSESTree.ThrowStatement): boolean {
     return false;
   }
 
+  // `throw error;` — re-throwing a caught/named identifier. The original
+  // error already carries its own message + stack; demanding context on the
+  // re-throw is an FP. Same for `throw err`, `throw cause`, etc. Excludes
+  // the literal-like `undefined` / `NaN` / `Infinity` identifiers, which
+  // are typed as global constants but carry no diagnostic value.
+  //
+  // Ported from the reliability twin, which had this arm and this one did
+  // not: burgee's `commander-command.ts` re-throws three caught errors and
+  // reported under this plugin only. Same text in both so the twins agree.
+  if (
+    node.argument.type === 'Identifier' &&
+    node.argument.name !== 'undefined' &&
+    node.argument.name !== 'NaN' &&
+    node.argument.name !== 'Infinity'
+  ) {
+    return true;
+  }
+
   // Check if it's a new Error() with message (includes TypeError, ReferenceError, etc.)
   if (
     node.argument.type === 'NewExpression' &&
@@ -48,7 +66,9 @@ function hasErrorMessage(node: TSESTree.ThrowStatement): boolean {
     (node.argument.callee.name === 'Error' ||
       node.argument.callee.name.endsWith('Error'))
   ) {
-    // Check if first argument is a string (message)
+    // Check if first argument is a string (message) OR ANY expression — a
+    // custom error class like `new UserNotFoundError(userId)` builds its
+    // own message internally; the constructor argument IS the context.
     if (node.argument.arguments.length > 0) {
       const firstArg = node.argument.arguments[0];
       const staticText = staticString(firstArg);
@@ -56,6 +76,16 @@ function hasErrorMessage(node: TSESTree.ThrowStatement): boolean {
         return staticText.length > 0;
       }
       if (firstArg.type === 'TemplateLiteral') {
+        return true;
+      }
+      // Non-string argument to a custom *Error class — accept as context.
+      // The rule's purpose is "throws should carry information"; passing an
+      // identifier/object to the error constructor carries information.
+      // `new UsageError(msg, hint)` in burgee is this shape.
+      if (
+        node.argument.callee.name !== 'Error' &&
+        node.argument.callee.name.endsWith('Error')
+      ) {
         return true;
       }
     }
@@ -83,6 +113,18 @@ function hasErrorMessage(node: TSESTree.ThrowStatement): boolean {
 function hasErrorStack(node: TSESTree.ThrowStatement): boolean {
   if (!node.argument) {
     return false;
+  }
+
+  // `throw error;` — caught/named identifier already has a stack from the
+  // place where it was first thrown. Re-throws preserve the stack. Excludes
+  // `undefined` / `NaN` / `Infinity` global-constant identifiers.
+  if (
+    node.argument.type === 'Identifier' &&
+    node.argument.name !== 'undefined' &&
+    node.argument.name !== 'NaN' &&
+    node.argument.name !== 'Infinity'
+  ) {
+    return true;
   }
 
   // Check if it's a new Error() instance

--- a/packages/eslint-plugin-maintainability/src/rules/error-handling/no-unhandled-promise.ts
+++ b/packages/eslint-plugin-maintainability/src/rules/error-handling/no-unhandled-promise.ts
@@ -160,10 +160,31 @@ export function hasPromiseEvidence(
 
   if (node.callee.type === 'Identifier') {
     if (promiseReturning.has(node.callee.name)) return true;
-    return isAsyncFunctionNode(resolveBinding(node.callee.name));
+    const bound = resolveBinding(node.callee.name);
+    return isAsyncFunctionNode(bound) || isPromiseReturningAnnotation(bound);
   }
 
   return false;
+}
+
+/**
+ * A parameter's own evidence: `save: () => Promise<void>`. The resolver hands
+ * back the parameter's Identifier, and its annotation is what the file says a
+ * call to it returns. A `(s: string) => void` writer says the opposite, and an
+ * unannotated parameter says nothing — neither is a promise.
+ */
+function isPromiseReturningAnnotation(
+  node: TSESTree.Node | null | undefined,
+): boolean {
+  if (node?.type !== 'Identifier') return false;
+  const annotation = node.typeAnnotation?.typeAnnotation;
+  if (annotation?.type !== 'TSFunctionType') return false;
+  const returned = annotation.returnType?.typeAnnotation;
+  return (
+    returned?.type === 'TSTypeReference' &&
+    returned.typeName.type === 'Identifier' &&
+    returned.typeName.name === 'Promise'
+  );
 }
 
 /**
@@ -427,6 +448,25 @@ export const noUnhandledPromise = createRule<RuleOptions, MessageIds>({
         if (variable) {
           const def = variable.defs[0];
           if (!def) return null;
+          // A PARAMETER's `def.node` is the function that DECLARES it, not the
+          // parameter — so `write` inside `async function main(write)` resolved
+          // to `main`, inherited its `async`, and every `write(…)` in the body
+          // reported as an unhandled promise. Burgee's `report.ts` drew three
+          // per run on a `write: (s: string) => void`. What the file says about
+          // a parameter is its default and its annotation, so hand back the
+          // parameter itself and let `hasPromiseEvidence` read those.
+          if (def.type === 'Parameter') {
+            const pattern = (
+              def.name as TSESTree.Node & { parent?: TSESTree.Node }
+            ).parent;
+            if (
+              pattern?.type === 'AssignmentPattern' &&
+              pattern.left === def.name
+            ) {
+              return pattern.right;
+            }
+            return def.name;
+          }
           if (def.node.type === 'FunctionDeclaration') return def.node;
           if (def.node.type === 'VariableDeclarator') {
             return (def.node as TSESTree.VariableDeclarator).init ?? null;

--- a/packages/eslint-plugin-maintainability/src/rules/maintainability/consistent-function-scoping.ts
+++ b/packages/eslint-plugin-maintainability/src/rules/maintainability/consistent-function-scoping.ts
@@ -22,6 +22,20 @@ export interface Options {
 
 type RuleOptions = [Options?];
 
+/**
+ * Nodes that can sit between a function and the scope it is declared in
+ * without moving it: the declarator and declaration that bind it, and the
+ * TypeScript type operators that only re-describe its type.
+ */
+const BINDING_WRAPPERS: ReadonlySet<string> = new Set([
+  'VariableDeclarator',
+  'VariableDeclaration',
+  'TSAsExpression',
+  'TSSatisfiesExpression',
+  'TSNonNullExpression',
+  'TSTypeAssertion',
+]);
+
 export const consistentFunctionScoping = createRule<RuleOptions, MessageIds>({
   name: 'consistent-function-scoping',
   meta: {
@@ -111,12 +125,17 @@ export const consistentFunctionScoping = createRule<RuleOptions, MessageIds>({
        * them look as though they captured their own binding. Fixing that walk
        * exposed this: four fixtures whose comment described the bug as the
        * reason they were valid.
+       *
+       * A type operator between the function and its binding is stepped over
+       * too. `const noExit = (() => undefined) as unknown as (code: number) =>
+       * never;` sits at module scope exactly as `const noExit = () =>
+       * undefined;` does — `as`, `satisfies`, `!` and `<T>` change what
+       * TypeScript believes about the value and nothing about where it lives.
+       * Stopping at the assertion made the rule tell a consumer to move an
+       * arrow to the scope it was already in.
        */
       let ancestor: TSESTree.Node | undefined = node.parent;
-      while (
-        ancestor?.type === 'VariableDeclarator' ||
-        ancestor?.type === 'VariableDeclaration'
-      ) {
+      while (ancestor && BINDING_WRAPPERS.has(ancestor.type)) {
         ancestor = ancestor.parent;
       }
       if (

--- a/packages/eslint-plugin-maintainability/src/tests/error-handling/no-missing-error-context.test.ts
+++ b/packages/eslint-plugin-maintainability/src/tests/error-handling/no-missing-error-context.test.ts
@@ -141,26 +141,31 @@ describe('no-missing-error-context', () => {
         valid: [
           {
             name: 'FP: a subclass whose first parameter is the message, given a literal and a hint',
+            // @found real-source scan (burgee, ofri-peretz/burgee eslint.config.mjs)
             code: 'class UsageError extends Error { constructor(message: string, readonly hint?: string) { super(message); } }\nfunction g() { throw new UsageError("missing required option", "pass --x"); }',
             filename: 'src/execute.ts',
           },
           {
             name: 'FP: the same subclass given a template message',
+            // @found real-source scan (burgee, ofri-peretz/burgee eslint.config.mjs)
             code: 'class UsageError extends Error { constructor(message: string, readonly hint?: string) { super(message); } }\nfunction f(name: string) { throw new UsageError(`missing required option --${name}`, `pass --${name} <value>`); }',
             filename: 'src/execute.ts',
           },
           {
             name: 'FP: a custom *Error given a non-literal message — the argument IS the context',
+            // @found real-source scan (burgee, ofri-peretz/burgee eslint.config.mjs)
             code: 'function g(msg: string) { throw new UsageError(msg, "pass --x"); }',
             filename: 'src/execute.ts',
           },
           {
             name: 'FP: re-throwing a caught error keeps the message and stack it already has',
+            // @found real-source scan (burgee, ofri-peretz/burgee eslint.config.mjs)
             code: 'try { run(); } catch (err) { if (err.code !== "commander.executeSubCommandAsync") throw err; }',
             filename: 'src/commander-command.ts',
           },
           {
             name: 'FP: a re-throw also satisfies the stack-trace requirement',
+            // @found real-source scan (burgee, ofri-peretz/burgee eslint.config.mjs)
             code: 'const throwing = (err: CommanderError): void => { throw err; };',
             filename: 'src/commander-command.ts',
             options: [{ requireMessage: true, requireStackTrace: true }],

--- a/packages/eslint-plugin-maintainability/src/tests/error-handling/no-missing-error-context.test.ts
+++ b/packages/eslint-plugin-maintainability/src/tests/error-handling/no-missing-error-context.test.ts
@@ -31,6 +31,7 @@ describe('no-missing-error-context', () => {
           options: [{ requireMessage: true }],
         },
         {
+          name: 'a built-in Error subclass with a message',
           code: 'throw new TypeError("Invalid type");',
           options: [{ requireMessage: true }],
         },
@@ -121,5 +122,71 @@ describe('no-missing-error-context', () => {
         },
       ],
     });
+  });
+
+  /**
+   * Burgee's `UsageError extends Error { constructor(message, readonly hint?) }`
+   * is thrown with a literal message and a hint, and re-throws caught errors —
+   * and turned this rule off for two files. The reliability twin already
+   * accepted both shapes (a custom *Error given any argument; a re-thrown
+   * identifier) and the maintainability twin did not. The cases are the same in
+   * both files so the twins cannot drift apart again.
+   * See docs/intents/burgee-false-positives/.
+   */
+  describe('a custom Error subclass carries its own context (burgee)', () => {
+    ruleTester.run(
+      'custom error classes and re-throws',
+      noMissingErrorContext,
+      {
+        valid: [
+          {
+            name: 'FP: a subclass whose first parameter is the message, given a literal and a hint',
+            code: 'class UsageError extends Error { constructor(message: string, readonly hint?: string) { super(message); } }\nfunction g() { throw new UsageError("missing required option", "pass --x"); }',
+            filename: 'src/execute.ts',
+          },
+          {
+            name: 'FP: the same subclass given a template message',
+            code: 'class UsageError extends Error { constructor(message: string, readonly hint?: string) { super(message); } }\nfunction f(name: string) { throw new UsageError(`missing required option --${name}`, `pass --${name} <value>`); }',
+            filename: 'src/execute.ts',
+          },
+          {
+            name: 'FP: a custom *Error given a non-literal message — the argument IS the context',
+            code: 'function g(msg: string) { throw new UsageError(msg, "pass --x"); }',
+            filename: 'src/execute.ts',
+          },
+          {
+            name: 'FP: re-throwing a caught error keeps the message and stack it already has',
+            code: 'try { run(); } catch (err) { if (err.code !== "commander.executeSubCommandAsync") throw err; }',
+            filename: 'src/commander-command.ts',
+          },
+          {
+            name: 'FP: a re-throw also satisfies the stack-trace requirement',
+            code: 'const throwing = (err: CommanderError): void => { throw err; };',
+            filename: 'src/commander-command.ts',
+            options: [{ requireMessage: true, requireStackTrace: true }],
+          },
+        ],
+        invalid: [
+          {
+            name: 'a non-string argument to the BASE Error class proves nothing',
+            code: 'throw new Error(someVar);',
+            filename: 'src/execute.ts',
+            errors: [{ messageId: 'missingErrorContext' }],
+          },
+          {
+            name: '`throw undefined` is an identifier with no diagnostic value',
+            code: 'throw undefined;',
+            filename: 'src/execute.ts',
+            errors: [{ messageId: 'missingErrorContext' }],
+          },
+          {
+            name: 'an empty Error beside the subclass still reports',
+            code: 'class UsageError extends Error {}\nfunction g() { throw new Error(); }',
+            filename: 'src/execute.ts',
+            errors: [{ messageId: 'missingErrorContext' }],
+          },
+        ],
+      },
+    );
   });
 });

--- a/packages/eslint-plugin-maintainability/src/tests/error-handling/no-unhandled-promise.test.ts
+++ b/packages/eslint-plugin-maintainability/src/tests/error-handling/no-unhandled-promise.test.ts
@@ -30,6 +30,7 @@ describe('no-unhandled-promise', () => {
           code: 'fetch(url).then(r => r.json()).catch(e => console.error(e));',
         },
         {
+          name: 'a bare .catch with a handler settles the chain',
           code: 'promise.catch(error => handleError(error));',
         },
         // Await in async function
@@ -132,6 +133,56 @@ describe('no-unhandled-promise', () => {
         {
           code: 'void fetch(url);',
           options: [{ ignoreVoidExpressions: false }],
+          errors: [{ messageId: 'unhandledPromise' }],
+        },
+      ],
+    });
+  });
+
+  /**
+   * A function-typed PARAMETER is not an async function. `resolveBinding`
+   * returned `def.node` for every definition, and for a parameter that node is
+   * the ENCLOSING function — so inside `async function main(write)` every
+   * `write(…)` inherited `main`'s `async` and reported as an unhandled promise.
+   * Burgee's compat-oracle `report.ts` (`write: (s: string) => void`) drew three
+   * per run and turned both twins off for the file. What the file shows about a
+   * parameter is its annotation and its default, and only those count.
+   * See docs/intents/burgee-false-positives/.
+   */
+  describe('a parameter is not the function it belongs to (burgee)', () => {
+    ruleTester.run('parameter callees', noUnhandledPromise, {
+      valid: [
+        {
+          name: 'FP: a void-typed writer parameter called inside an async function',
+          code: 'export async function main(argv: string[], write: (s: string) => void): Promise<number> { write("hello"); return 0; }',
+        },
+        {
+          name: 'FP: an untyped parameter called inside an async function says nothing about promises',
+          code: 'async function main(write) { write("x"); }',
+        },
+        {
+          name: 'FP: a parameter of an async arrow, called in its body',
+          code: 'const run = async (write: (s: string) => void) => { write("x"); };',
+        },
+        {
+          name: 'a function-typed parameter of a non-async function — the control, always quiet',
+          code: 'function main(write: (s: string) => void) { write("x"); }',
+        },
+      ],
+      invalid: [
+        {
+          name: 'a parameter whose annotation returns a Promise is evidence the file shows',
+          code: 'async function main(save: () => Promise<void>) { save(); }',
+          errors: [{ messageId: 'unhandledPromise' }],
+        },
+        {
+          name: 'a parameter defaulted to an async arrow is evidence the file shows',
+          code: 'async function main(save = async () => {}) { save(); }',
+          errors: [{ messageId: 'unhandledPromise' }],
+        },
+        {
+          name: 'a local async function called and forgotten still reports beside a quiet parameter',
+          code: 'async function save() {}\nasync function main(write: (s: string) => void) { write("x"); save(); }',
           errors: [{ messageId: 'unhandledPromise' }],
         },
       ],

--- a/packages/eslint-plugin-maintainability/src/tests/error-handling/no-unhandled-promise.test.ts
+++ b/packages/eslint-plugin-maintainability/src/tests/error-handling/no-unhandled-promise.test.ts
@@ -154,14 +154,17 @@ describe('no-unhandled-promise', () => {
       valid: [
         {
           name: 'FP: a void-typed writer parameter called inside an async function',
+          // @found real-source scan (burgee, ofri-peretz/burgee eslint.config.mjs)
           code: 'export async function main(argv: string[], write: (s: string) => void): Promise<number> { write("hello"); return 0; }',
         },
         {
           name: 'FP: an untyped parameter called inside an async function says nothing about promises',
+          // @found real-source scan (burgee, ofri-peretz/burgee eslint.config.mjs)
           code: 'async function main(write) { write("x"); }',
         },
         {
           name: 'FP: a parameter of an async arrow, called in its body',
+          // @found real-source scan (burgee, ofri-peretz/burgee eslint.config.mjs)
           code: 'const run = async (write: (s: string) => void) => { write("x"); };',
         },
         {

--- a/packages/eslint-plugin-maintainability/src/tests/maintainability/consistent-function-scoping.test.ts
+++ b/packages/eslint-plugin-maintainability/src/tests/maintainability/consistent-function-scoping.test.ts
@@ -253,10 +253,12 @@ function helper() {
       valid: [
         {
           name: 'FP: a module-scope arrow cast through `as unknown as T`',
+          // @found real-source scan (burgee, ofri-peretz/burgee eslint.config.mjs)
           code: `const noExit = (() => undefined) as unknown as (code: number) => never;`,
         },
         {
           name: 'FP: the same cast on an exported binding',
+          // @found real-source scan (burgee, ofri-peretz/burgee eslint.config.mjs)
           code: `export const noExit = (() => undefined) as unknown as (code: number) => never;`,
         },
         {
@@ -277,6 +279,7 @@ function helper() {
         },
         {
           name: 'FP: a trivial callback written inline as a property of an argument object, inside a test body (3.0.3 reported it)',
+          // @found real-source scan (burgee, ofri-peretz/burgee eslint.config.mjs)
           code: `it('lists commands', () => { const program = defineProgram({ commands: [defineCommand({ name: 'status', run: () => 'ok' })] }); expect(program).toBeDefined(); });`,
         },
       ],

--- a/packages/eslint-plugin-maintainability/src/tests/maintainability/consistent-function-scoping.test.ts
+++ b/packages/eslint-plugin-maintainability/src/tests/maintainability/consistent-function-scoping.test.ts
@@ -35,6 +35,7 @@ describe('consistent-function-scoping', () => {
         },
         // Module-level arrow function
         {
+          name: 'an arrow bound at module scope has nowhere higher to go',
           code: `
             const helper = () => 'value';
           `,
@@ -227,6 +228,78 @@ function helper() {
               return helper();
             }
           `,
+            }],
+          }],
+        },
+      ],
+    });
+  });
+
+  /**
+   * Burgee's `help.test.ts` wrote `const noExit = (() => undefined) as unknown
+   * as (code: number) => never;` at module scope and the rule told it to move
+   * the arrow to module scope. The walk from the function to `Program` stepped
+   * over `VariableDeclarator` and `VariableDeclaration` only, so a type
+   * assertion between the arrow and its binding — `as`, `satisfies`, `!`,
+   * `<T>` — hid the fact that the arrow was already at the top. A type
+   * operator changes what TypeScript believes about a value and nothing about
+   * where it lives. The consumer's other shape, `defineCommand({ run: () =>
+   * 'ok' })`, is the `Property` exemption already on main; it is pinned here
+   * because 3.0.3, the version the consumer ran, reported it.
+   * See docs/intents/burgee-false-positives/.
+   */
+  describe('a type assertion does not move a function off module scope (burgee)', () => {
+    ruleTester.run('asserted module-scope functions', consistentFunctionScoping, {
+      valid: [
+        {
+          name: 'FP: a module-scope arrow cast through `as unknown as T`',
+          code: `const noExit = (() => undefined) as unknown as (code: number) => never;`,
+        },
+        {
+          name: 'FP: the same cast on an exported binding',
+          code: `export const noExit = (() => undefined) as unknown as (code: number) => never;`,
+        },
+        {
+          name: 'a module-scope arrow checked with `satisfies`',
+          code: `const ok = (() => 'ok') satisfies () => string;`,
+        },
+        {
+          name: 'a module-scope arrow behind a non-null assertion',
+          code: `const ok = (() => 'ok')!;`,
+        },
+        {
+          name: 'a module-scope arrow in the angle-bracket assertion spelling',
+          code: `const ok = <() => string>(() => 'ok');`,
+        },
+        {
+          name: 'a module-scope function EXPRESSION cast the same way',
+          code: `const ok = (function () { return 'ok'; }) as unknown as () => string;`,
+        },
+        {
+          name: 'FP: a trivial callback written inline as a property of an argument object, inside a test body (3.0.3 reported it)',
+          code: `it('lists commands', () => { const program = defineProgram({ commands: [defineCommand({ name: 'status', run: () => 'ok' })] }); expect(program).toBeDefined(); });`,
+        },
+      ],
+      invalid: [
+        {
+          name: 'the same cast INSIDE a function still reports — the assertion is not what makes it movable',
+          code: `function outer() { const f = (() => 'ok') as unknown as () => string; return f(); }`,
+          errors: [{
+            messageId: 'inconsistentFunctionScoping',
+            suggestions: [{
+              messageId: 'moveToModuleScope',
+              output: `function outer() { const f = (// TODO: Move this function to module scope - it doesn't capture outer variables\n() => 'ok') as unknown as () => string; return f(); }`,
+            }],
+          }],
+        },
+        {
+          name: 'a satisfies-checked arrow inside a function reports too',
+          code: `function outer() { const f = (() => 'ok') satisfies () => string; return f(); }`,
+          errors: [{
+            messageId: 'inconsistentFunctionScoping',
+            suggestions: [{
+              messageId: 'moveToModuleScope',
+              output: `function outer() { const f = (// TODO: Move this function to module scope - it doesn't capture outer variables\n() => 'ok') satisfies () => string; return f(); }`,
             }],
           }],
         },

--- a/packages/eslint-plugin-operability/src/rules/operability/require-data-minimization.ts
+++ b/packages/eslint-plugin-operability/src/rules/operability/require-data-minimization.ts
@@ -14,10 +14,11 @@ import {
   AST_NODE_TYPES,
   createRule,
   formatLLMMessage,
+  isStaticExpression,
   MessageIcons,
   objectKeyName,
 } from '@interlace/eslint-devkit';
-import type { TSESTree } from '@interlace/eslint-devkit';
+import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
 
 type MessageIds = 'violationDetected';
 
@@ -56,6 +57,34 @@ export interface Options {
 }
 
 type RuleOptions = [Required<Options>];
+
+/**
+ * A value no run-time input reaches: a literal, a constant declared in the
+ * file, or an array or object built only from such values. `isStaticExpression`
+ * answers for the leaves; this adds the two containers it does not walk,
+ * because a configuration literal is mostly containers of literals.
+ */
+function isStaticValue(
+  node: TSESTree.Node,
+  scope: TSESLint.Scope.Scope,
+): boolean {
+  if (node.type === AST_NODE_TYPES.ArrayExpression) {
+    return node.elements.every(
+      (element) =>
+        element !== null &&
+        element.type !== AST_NODE_TYPES.SpreadElement &&
+        isStaticValue(element, scope),
+    );
+  }
+  if (node.type === AST_NODE_TYPES.ObjectExpression) {
+    return node.properties.every(
+      (property) =>
+        property.type === AST_NODE_TYPES.Property &&
+        isStaticValue(property.value, scope),
+    );
+  }
+  return isStaticExpression({ node, scope });
+}
 
 export const requireDataMinimization = createRule<RuleOptions, MessageIds>({
   name: 'require-data-minimization',
@@ -127,7 +156,14 @@ export const requireDataMinimization = createRule<RuleOptions, MessageIds>({
           const name = objectKeyName(p);
           return name !== null && piiFields.has(name);
         });
-        if (carriesPersonalData) report(node);
+        if (!carriesPersonalData) return;
+        // Collection means a value read from SOMEWHERE — a request, a form, a
+        // row, an argument. An object whose every value is a literal, or a
+        // container of literals, collects nothing: it is configuration.
+        // Burgee's exported test-suite metadata — eleven literal fields, one
+        // of them `name` — reported as excessive data collection.
+        if (isStaticValue(node, context.sourceCode.getScope(node))) return;
+        report(node);
       },
     };
   },

--- a/packages/eslint-plugin-operability/src/tests/operability/require-data-minimization.test.ts
+++ b/packages/eslint-plugin-operability/src/tests/operability/require-data-minimization.test.ts
@@ -129,6 +129,7 @@ ruleTester.run('require-data-minimization — a static literal collects nothing'
   valid: [
     {
       name: 'FP: exported test-suite metadata — every value is a literal, nothing is collected',
+      // @found real-source scan (burgee, ofri-peretz/burgee eslint.config.mjs)
       code: HOSTS,
       options: [...HOST_PII],
     },

--- a/packages/eslint-plugin-operability/src/tests/operability/require-data-minimization.test.ts
+++ b/packages/eslint-plugin-operability/src/tests/operability/require-data-minimization.test.ts
@@ -111,3 +111,45 @@ ruleTester.run('require-data-minimization', requireDataMinimization, {
     },
   ],
 });
+
+/**
+ * A static literal collects nothing. Burgee's compat-oracle `hosts.ts` exports
+ * the metadata of the test suites it grades — `{ name, repo, testDir, testGlob,
+ * imports, runner, target, status, note, … }`, eleven literal fields — and with
+ * `name` in `piiFields` the rule read it as excessive data collection. Data
+ * collection means a value read from SOMEWHERE — a request, a form, a row, an
+ * argument; an object whose every value is a literal, or an array or object of
+ * literals, is configuration. See docs/intents/burgee-false-positives/.
+ */
+const HOSTS =
+  'export const HOSTS = [{ name: "commander", repo: "https://github.com/tj/commander.js", testDir: "tests", testGlob: "*.test.js", imports: [{ upstream: "../index.js", subpath: "", reexportDefault: false }], surfaceFiles: ["typings/index.d.ts"], runner: "node:test", target: "burgee/commander", status: "active", note: "graded by its own suite", preamble: "setup.js" }];';
+const HOST_PII = [{ piiFields: ['name', 'email'] }] as const;
+
+ruleTester.run('require-data-minimization — a static literal collects nothing', requireDataMinimization, {
+  valid: [
+    {
+      name: 'FP: exported test-suite metadata — every value is a literal, nothing is collected',
+      code: HOSTS,
+      options: [...HOST_PII],
+    },
+    {
+      name: 'a static literal whose values are constants declared in the file',
+      code: 'const REPO = "https://github.com/tj/commander.js"; const HOST = { name: "commander", repo: REPO, testDir: "tests", testGlob: "*.test.js", imports: [], surfaceFiles: [], runner: "node:test", target: "burgee/commander", status: "active", note: "n", preamble: "p" };',
+      options: [...HOST_PII],
+    },
+  ],
+  invalid: [
+    {
+      name: 'one collected value among ten literals is still collection',
+      code: 'const profile = { name: "commander", repo: "r", testDir: "t", testGlob: "g", imports: [], surfaceFiles: [], runner: "node:test", target: "x", status: "active", note: "n", email: input.email };',
+      options: [...HOST_PII],
+      errors: 1,
+    },
+    {
+      name: 'a row assembled from a request is collection even beside literal defaults',
+      code: 'const row = { name: req.body.name, email: req.body.email, age: req.body.age, city: req.body.city, zip: req.body.zip, phone: req.body.phone, address: req.body.address, country: "US", state: "CA", company: "x", job: "y" };',
+      options: [...HOST_PII],
+      errors: 1,
+    },
+  ],
+});

--- a/packages/eslint-plugin-reliability/src/rules/error-handling/no-unhandled-promise.ts
+++ b/packages/eslint-plugin-reliability/src/rules/error-handling/no-unhandled-promise.ts
@@ -303,10 +303,31 @@ export function hasPromiseEvidence(
 
   if (node.callee.type === 'Identifier') {
     if (promiseReturning.has(node.callee.name)) return true;
-    return isAsyncFunctionNode(resolveBinding(node.callee.name));
+    const bound = resolveBinding(node.callee.name);
+    return isAsyncFunctionNode(bound) || isPromiseReturningAnnotation(bound);
   }
 
   return false;
+}
+
+/**
+ * A parameter's own evidence: `save: () => Promise<void>`. The resolver hands
+ * back the parameter's Identifier, and its annotation is what the file says a
+ * call to it returns. A `(s: string) => void` writer says the opposite, and an
+ * unannotated parameter says nothing — neither is a promise.
+ */
+function isPromiseReturningAnnotation(
+  node: TSESTree.Node | null | undefined,
+): boolean {
+  if (node?.type !== 'Identifier') return false;
+  const annotation = node.typeAnnotation?.typeAnnotation;
+  if (annotation?.type !== 'TSFunctionType') return false;
+  const returned = annotation.returnType?.typeAnnotation;
+  return (
+    returned?.type === 'TSTypeReference' &&
+    returned.typeName.type === 'Identifier' &&
+    returned.typeName.name === 'Promise'
+  );
 }
 
 export function isLikelyPromiseExpression(node: TSESTree.Node): boolean {
@@ -627,6 +648,25 @@ export const noUnhandledPromise = createRule<RuleOptions, MessageIds>({
         if (variable) {
           const def = variable.defs[0];
           if (!def) return null;
+          // A PARAMETER's `def.node` is the function that DECLARES it, not the
+          // parameter — so `write` inside `async function main(write)` resolved
+          // to `main`, inherited its `async`, and every `write(…)` in the body
+          // reported as an unhandled promise. Burgee's `report.ts` drew three
+          // per run on a `write: (s: string) => void`. What the file says about
+          // a parameter is its default and its annotation, so hand back the
+          // parameter itself and let `hasPromiseEvidence` read those.
+          if (def.type === 'Parameter') {
+            const pattern = (
+              def.name as TSESTree.Node & { parent?: TSESTree.Node }
+            ).parent;
+            if (
+              pattern?.type === 'AssignmentPattern' &&
+              pattern.left === def.name
+            ) {
+              return pattern.right;
+            }
+            return def.name;
+          }
           if (def.node.type === 'FunctionDeclaration') return def.node;
           if (def.node.type === 'VariableDeclarator') {
             return (def.node as TSESTree.VariableDeclarator).init ?? null;

--- a/packages/eslint-plugin-reliability/src/rules/reliability/no-missing-null-checks.ts
+++ b/packages/eslint-plugin-reliability/src/rules/reliability/no-missing-null-checks.ts
@@ -420,9 +420,10 @@ export function hasNullCheck(
       p.type === 'ConditionalExpression' &&
       (p as TSESTree.ConditionalExpression).consequent === cur
     ) {
+      const test = (p as TSESTree.ConditionalExpression).test;
       if (
-        sourceCode.getText((p as TSESTree.ConditionalExpression).test) ===
-        objectText
+        sourceCode.getText(test) === objectText ||
+        narrowsToObject(test, node.object, sourceCode)
       ) {
         return true;
       }
@@ -635,6 +636,96 @@ function hasExplicitNullCheck(
 }
 
 /**
+ * The root an expression is rooted in — `a.b.c` and `a.b()` both root at `a`.
+ */
+function rootText(
+  expr: TSESTree.Node,
+  sourceCode: TSESLint.SourceCode,
+): string {
+  let base: TSESTree.Node = expr;
+  for (;;) {
+    if (base.type === 'MemberExpression') base = base.object;
+    else if (base.type === 'CallExpression') base = base.callee;
+    else break;
+  }
+  return sourceCode.getText(base);
+}
+
+/**
+ * Does `root` guard `object`? The same value, or a chain that starts with it —
+ * checking `response` protects `response.data.items`, as the truthy branch of
+ * isNullCheckForObject already reads it.
+ */
+function rootGuards(
+  root: string,
+  object: TSESTree.Expression,
+  sourceCode: TSESLint.SourceCode,
+): boolean {
+  const objectText = sourceCode.getText(object);
+  return root === objectText || objectText.startsWith(`${root}.`);
+}
+
+/**
+ * An optional chain rooted at `object`: `found?.[1]`, `hit?.meta`, `x?.f()`.
+ */
+function isOptionalChainRootedAt(
+  expr: TSESTree.Node,
+  object: TSESTree.Expression,
+  sourceCode: TSESLint.SourceCode,
+): boolean {
+  return (
+    expr.type === 'ChainExpression' &&
+    rootGuards(rootText(expr.expression, sourceCode), object, sourceCode)
+  );
+}
+
+/**
+ * Tests that prove `object` is an object WHEN THEY PASS — two forms TypeScript
+ * narrows on that the truthy and `!== null` checks below do not read:
+ *
+ *   'value' in token            `in` throws on null and undefined, so the
+ *                               consequent runs only with an object. Only the
+ *                               RIGHT operand is narrowed; the left is a key.
+ *   found?.[1] !== undefined    an optional chain is non-nullish only when its
+ *   if (found?.[1])             root was — TypeScript narrows `found` here and
+ *                               this file did not, so `found[1]` on the next
+ *                               line reported.
+ *
+ * Both came from burgee, a CLI framework linted without type information,
+ * where `'value' in token ? token.value : undefined` and `if (found?.[1] !==
+ * undefined) … found[1]` were the correct rewrites that "did not satisfy" the
+ * rule. Equality to null/undefined is deliberately NOT here: `found?.[1] ===
+ * undefined` passes when found is null.
+ */
+function narrowsToObject(
+  test: TSESTree.Expression,
+  object: TSESTree.Expression,
+  sourceCode: TSESLint.SourceCode,
+): boolean {
+  if (test.type === 'BinaryExpression' && test.operator === 'in') {
+    return rootGuards(sourceCode.getText(test.right), object, sourceCode);
+  }
+  if (isOptionalChainRootedAt(test, object, sourceCode)) {
+    return true;
+  }
+  if (
+    test.type === 'BinaryExpression' &&
+    (test.operator === '!==' || test.operator === '!=')
+  ) {
+    const isNil = (e: TSESTree.Node): boolean =>
+      (e.type === 'Literal' && e.value === null) ||
+      (e.type === 'Identifier' && e.name === 'undefined');
+    if (isNil(test.right)) {
+      return isOptionalChainRootedAt(test.left, object, sourceCode);
+    }
+    if (isNil(test.left)) {
+      return isOptionalChainRootedAt(test.right, object, sourceCode);
+    }
+  }
+  return false;
+}
+
+/**
  * Check if a test expression is a null check for a specific object
  */
 function isNullCheckForObject(
@@ -643,6 +734,10 @@ function isNullCheckForObject(
   sourceCode: TSESLint.SourceCode,
 ): boolean {
   const objectText = sourceCode.getText(object);
+
+  if (narrowsToObject(test, object, sourceCode)) {
+    return true;
+  }
 
   // Truthy check: `if (obj)` or `if (obj.prop)` — direct truthy guard proves
   // non-null. Also covers nested chains: `if (response) { response.data.items }`

--- a/packages/eslint-plugin-reliability/src/tests/error-handling/no-missing-error-context.test.ts
+++ b/packages/eslint-plugin-reliability/src/tests/error-handling/no-missing-error-context.test.ts
@@ -240,4 +240,66 @@ describe('no-missing-error-context', () => {
       });
     });
   });
+
+  /**
+   * Burgee's `UsageError extends Error { constructor(message, readonly hint?) }`
+   * is thrown with a literal message and a hint, and re-throws caught errors —
+   * and turned this rule off for two files. The reliability twin already
+   * accepted both shapes (a custom *Error given any argument; a re-thrown
+   * identifier) and the maintainability twin did not. The cases are the same in
+   * both files so the twins cannot drift apart again.
+   * See docs/intents/burgee-false-positives/.
+   */
+  describe('a custom Error subclass carries its own context (burgee)', () => {
+    ruleTester.run('custom error classes and re-throws', noMissingErrorContext, {
+      valid: [
+        {
+          name: 'FP: a subclass whose first parameter is the message, given a literal and a hint',
+          code: 'class UsageError extends Error { constructor(message: string, readonly hint?: string) { super(message); } }\nfunction g() { throw new UsageError("missing required option", "pass --x"); }',
+          filename: 'src/execute.ts',
+        },
+        {
+          name: 'FP: the same subclass given a template message',
+          code: 'class UsageError extends Error { constructor(message: string, readonly hint?: string) { super(message); } }\nfunction f(name: string) { throw new UsageError(`missing required option --${name}`, `pass --${name} <value>`); }',
+          filename: 'src/execute.ts',
+        },
+        {
+          name: 'FP: a custom *Error given a non-literal message — the argument IS the context',
+          code: 'function g(msg: string) { throw new UsageError(msg, "pass --x"); }',
+          filename: 'src/execute.ts',
+        },
+        {
+          name: 'FP: re-throwing a caught error keeps the message and stack it already has',
+          code: 'try { run(); } catch (err) { if (err.code !== "commander.executeSubCommandAsync") throw err; }',
+          filename: 'src/commander-command.ts',
+        },
+        {
+          name: 'FP: a re-throw also satisfies the stack-trace requirement',
+          code: 'const throwing = (err: CommanderError): void => { throw err; };',
+          filename: 'src/commander-command.ts',
+          options: [{ requireMessage: true, requireStackTrace: true }],
+        },
+      ],
+      invalid: [
+        {
+          name: 'a non-string argument to the BASE Error class proves nothing',
+          code: 'throw new Error(someVar);',
+          filename: 'src/execute.ts',
+          errors: [{ messageId: 'missingErrorContext' }],
+        },
+        {
+          name: '`throw undefined` is an identifier with no diagnostic value',
+          code: 'throw undefined;',
+          filename: 'src/execute.ts',
+          errors: [{ messageId: 'missingErrorContext' }],
+        },
+        {
+          name: 'an empty Error beside the subclass still reports',
+          code: 'class UsageError extends Error {}\nfunction g() { throw new Error(); }',
+          filename: 'src/execute.ts',
+          errors: [{ messageId: 'missingErrorContext' }],
+        },
+      ],
+    });
+  });
 });

--- a/packages/eslint-plugin-reliability/src/tests/error-handling/no-missing-error-context.test.ts
+++ b/packages/eslint-plugin-reliability/src/tests/error-handling/no-missing-error-context.test.ts
@@ -255,26 +255,31 @@ describe('no-missing-error-context', () => {
       valid: [
         {
           name: 'FP: a subclass whose first parameter is the message, given a literal and a hint',
+          // @found real-source scan (burgee, ofri-peretz/burgee eslint.config.mjs)
           code: 'class UsageError extends Error { constructor(message: string, readonly hint?: string) { super(message); } }\nfunction g() { throw new UsageError("missing required option", "pass --x"); }',
           filename: 'src/execute.ts',
         },
         {
           name: 'FP: the same subclass given a template message',
+          // @found real-source scan (burgee, ofri-peretz/burgee eslint.config.mjs)
           code: 'class UsageError extends Error { constructor(message: string, readonly hint?: string) { super(message); } }\nfunction f(name: string) { throw new UsageError(`missing required option --${name}`, `pass --${name} <value>`); }',
           filename: 'src/execute.ts',
         },
         {
           name: 'FP: a custom *Error given a non-literal message — the argument IS the context',
+          // @found real-source scan (burgee, ofri-peretz/burgee eslint.config.mjs)
           code: 'function g(msg: string) { throw new UsageError(msg, "pass --x"); }',
           filename: 'src/execute.ts',
         },
         {
           name: 'FP: re-throwing a caught error keeps the message and stack it already has',
+          // @found real-source scan (burgee, ofri-peretz/burgee eslint.config.mjs)
           code: 'try { run(); } catch (err) { if (err.code !== "commander.executeSubCommandAsync") throw err; }',
           filename: 'src/commander-command.ts',
         },
         {
           name: 'FP: a re-throw also satisfies the stack-trace requirement',
+          // @found real-source scan (burgee, ofri-peretz/burgee eslint.config.mjs)
           code: 'const throwing = (err: CommanderError): void => { throw err; };',
           filename: 'src/commander-command.ts',
           options: [{ requireMessage: true, requireStackTrace: true }],

--- a/packages/eslint-plugin-reliability/src/tests/error-handling/no-unhandled-promise.test.ts
+++ b/packages/eslint-plugin-reliability/src/tests/error-handling/no-unhandled-promise.test.ts
@@ -36,6 +36,7 @@ describe('no-unhandled-promise', () => {
           code: 'fetch(url).then(r => r.json()).catch(e => console.error(e));',
         },
         {
+          name: 'a bare .catch with a handler settles the chain',
           code: 'promise.catch(error => handleError(error));',
         },
         // A `.then` chain that ends in `.catch`. Bare `promise.then(cb)` with
@@ -438,6 +439,56 @@ describe('no-unhandled-promise', () => {
         'useTryCatch',
         'useAwait',
       ]);
+    });
+  });
+
+  /**
+   * A function-typed PARAMETER is not an async function. `resolveBinding`
+   * returned `def.node` for every definition, and for a parameter that node is
+   * the ENCLOSING function — so inside `async function main(write)` every
+   * `write(…)` inherited `main`'s `async` and reported as an unhandled promise.
+   * Burgee's compat-oracle `report.ts` (`write: (s: string) => void`) drew three
+   * per run and turned both twins off for the file. What the file shows about a
+   * parameter is its annotation and its default, and only those count.
+   * See docs/intents/burgee-false-positives/.
+   */
+  describe('a parameter is not the function it belongs to (burgee)', () => {
+    ruleTester.run('parameter callees', noUnhandledPromise, {
+      valid: [
+        {
+          name: 'FP: a void-typed writer parameter called inside an async function',
+          code: 'export async function main(argv: string[], write: (s: string) => void): Promise<number> { write("hello"); return 0; }',
+        },
+        {
+          name: 'FP: an untyped parameter called inside an async function says nothing about promises',
+          code: 'async function main(write) { write("x"); }',
+        },
+        {
+          name: 'FP: a parameter of an async arrow, called in its body',
+          code: 'const run = async (write: (s: string) => void) => { write("x"); };',
+        },
+        {
+          name: 'a function-typed parameter of a non-async function — the control, always quiet',
+          code: 'function main(write: (s: string) => void) { write("x"); }',
+        },
+      ],
+      invalid: [
+        {
+          name: 'a parameter whose annotation returns a Promise is evidence the file shows',
+          code: 'async function main(save: () => Promise<void>) { save(); }',
+          errors: [{ messageId: 'unhandledPromise' }],
+        },
+        {
+          name: 'a parameter defaulted to an async arrow is evidence the file shows',
+          code: 'async function main(save = async () => {}) { save(); }',
+          errors: [{ messageId: 'unhandledPromise' }],
+        },
+        {
+          name: 'a local async function called and forgotten still reports beside a quiet parameter',
+          code: 'async function save() {}\nasync function main(write: (s: string) => void) { write("x"); save(); }',
+          errors: [{ messageId: 'unhandledPromise' }],
+        },
+      ],
     });
   });
 });

--- a/packages/eslint-plugin-reliability/src/tests/error-handling/no-unhandled-promise.test.ts
+++ b/packages/eslint-plugin-reliability/src/tests/error-handling/no-unhandled-promise.test.ts
@@ -457,14 +457,17 @@ describe('no-unhandled-promise', () => {
       valid: [
         {
           name: 'FP: a void-typed writer parameter called inside an async function',
+          // @found real-source scan (burgee, ofri-peretz/burgee eslint.config.mjs)
           code: 'export async function main(argv: string[], write: (s: string) => void): Promise<number> { write("hello"); return 0; }',
         },
         {
           name: 'FP: an untyped parameter called inside an async function says nothing about promises',
+          // @found real-source scan (burgee, ofri-peretz/burgee eslint.config.mjs)
           code: 'async function main(write) { write("x"); }',
         },
         {
           name: 'FP: a parameter of an async arrow, called in its body',
+          // @found real-source scan (burgee, ofri-peretz/burgee eslint.config.mjs)
           code: 'const run = async (write: (s: string) => void) => { write("x"); };',
         },
         {

--- a/packages/eslint-plugin-reliability/src/tests/reliability/no-missing-null-checks.test.ts
+++ b/packages/eslint-plugin-reliability/src/tests/reliability/no-missing-null-checks.test.ts
@@ -1141,22 +1141,27 @@ describe('no-missing-null-checks', () => {
       valid: [
         {
           name: 'FP: `"k" in x` as a ternary test proves x is an object in the consequent',
+          // @found real-source scan (burgee, ofri-peretz/burgee eslint.config.mjs)
           code: 'function f(tokens: any[]) { const token = tokens.find((t) => t.kind === "x"); const value = "value" in token ? token.value : undefined; return value; }',
         },
         {
           name: 'FP: `"k" in x` as an if test guards its consequent',
+          // @found real-source scan (burgee, ofri-peretz/burgee eslint.config.mjs)
           code: 'function f(rows: any[]) { const hit = rows.find((r) => r.ok); if ("name" in hit) { return hit.name; } return "x"; }',
         },
         {
           name: 'FP: `x?.[1] !== undefined` proves x non-null for the read that follows',
+          // @found real-source scan (burgee, ofri-peretz/burgee eslint.config.mjs)
           code: 'function hint(token: string) { const found = RE.exec(token); if (found?.[1] !== undefined) return "did you mean --" + found[1]; return undefined; }',
         },
         {
           name: 'FP: a truthy optional chain rooted at x guards x',
+          // @found real-source scan (burgee, ofri-peretz/burgee eslint.config.mjs)
           code: 'function hint(token: string) { const found = RE.exec(token); if (found?.[1]) return found[1]; return undefined; }',
         },
         {
           name: 'FP: an optional-chain `!= null` test guards a dotted read',
+          // @found real-source scan (burgee, ofri-peretz/burgee eslint.config.mjs)
           code: 'function f(rows: any[]) { const hit = rows.find((r) => r.ok); if (hit?.meta != null) return hit.meta.name; return ""; }',
         },
         {
@@ -1173,18 +1178,22 @@ describe('no-missing-null-checks', () => {
         },
         {
           name: 'FP: an optional-chain `!== undefined` ternary test guards its consequent',
+          // @found real-source scan (burgee, ofri-peretz/burgee eslint.config.mjs)
           code: 'function hint(token: string) { const found = RE.exec(token); return found?.[1] !== undefined ? found[1] : undefined; }',
         },
         {
           name: 'FP: `if (m === null) return` before a computed read `m[1]` — reported by 4.1.3, understood since 4.1.4',
+          // @found real-source scan (burgee, ofri-peretz/burgee eslint.config.mjs)
           code: 'function firstGroup(pattern: RegExp, line: string): string | undefined { const m = pattern.exec(line); if (m === null) return undefined; const group = m[1]; return group; }',
         },
         {
           name: 'FP: `if (m === null) return` before `m.at(1)`',
+          // @found real-source scan (burgee, ofri-peretz/burgee eslint.config.mjs)
           code: 'function f(pattern: RegExp, line: string) { const m = pattern.exec(line); if (m === null) return undefined; return m.at(1); }',
         },
         {
           name: 'FP: the burgee token loop — a for-of variable carries no nullability evidence, and the `in` test narrows it besides',
+          // @found real-source scan (burgee, ofri-peretz/burgee eslint.config.mjs)
           code: 'type Token = { kind: string; value?: string };\nfunction splitPositionals(tokens: readonly Token[]) { const positionals: string[] = []; for (const token of tokens) { const { kind } = token; const value = "value" in token ? token.value : undefined; if (kind === "positional" && typeof value === "string") positionals.push(value); } return positionals; }',
         },
       ],

--- a/packages/eslint-plugin-reliability/src/tests/reliability/no-missing-null-checks.test.ts
+++ b/packages/eslint-plugin-reliability/src/tests/reliability/no-missing-null-checks.test.ts
@@ -35,6 +35,7 @@ describe('no-missing-null-checks', () => {
           code: 'obj?.property;',
         },
         {
+          name: 'optional chaining on every link of a method chain',
           code: 'obj?.property?.method();',
         },
         {
@@ -1123,6 +1124,102 @@ describe('no-missing-null-checks', () => {
       };
       expect(() => check(call)).not.toThrow();
       expect(reportCalls).toBe(1);
+    });
+  });
+
+  /**
+   * Burgee — a CLI framework linted with this rule and NO type information —
+   * turned the rule off over shapes TypeScript accepts as narrowing and this
+   * file did not: `'value' in token ? token.value : …`, `if (found?.[1] !==
+   * undefined) … found[1]`, and the early-return `if (m === null) return` before
+   * `m[1]`. The third was already understood on main (4.1.4) and is pinned here
+   * against the 4.1.3 the consumer ran; the `in` and optional-chain shapes fail
+   * on the unfixed rule. See docs/intents/burgee-false-positives/.
+   */
+  describe('narrowing the consumer wrote and TypeScript accepts (burgee)', () => {
+    ruleTester.run('in-narrowing and optional-chain guards', noMissingNullChecks, {
+      valid: [
+        {
+          name: 'FP: `"k" in x` as a ternary test proves x is an object in the consequent',
+          code: 'function f(tokens: any[]) { const token = tokens.find((t) => t.kind === "x"); const value = "value" in token ? token.value : undefined; return value; }',
+        },
+        {
+          name: 'FP: `"k" in x` as an if test guards its consequent',
+          code: 'function f(rows: any[]) { const hit = rows.find((r) => r.ok); if ("name" in hit) { return hit.name; } return "x"; }',
+        },
+        {
+          name: 'FP: `x?.[1] !== undefined` proves x non-null for the read that follows',
+          code: 'function hint(token: string) { const found = RE.exec(token); if (found?.[1] !== undefined) return "did you mean --" + found[1]; return undefined; }',
+        },
+        {
+          name: 'FP: a truthy optional chain rooted at x guards x',
+          code: 'function hint(token: string) { const found = RE.exec(token); if (found?.[1]) return found[1]; return undefined; }',
+        },
+        {
+          name: 'FP: an optional-chain `!= null` test guards a dotted read',
+          code: 'function f(rows: any[]) { const hit = rows.find((r) => r.ok); if (hit?.meta != null) return hit.meta.name; return ""; }',
+        },
+        {
+          name: 'an optional chain through a CALL is rooted at x too — `hit?.get() != null`',
+          code: 'function f(rows: any[]) { const hit = rows.find((r) => r.ok); if (hit?.get() != null) return hit.name; return ""; }',
+        },
+        {
+          name: 'the nil literal on the LEFT of `!==` reads the same — `undefined !== found?.[1]`',
+          code: 'function hint(token: string) { const found = RE.exec(token); if (undefined !== found?.[1]) return found[1]; return undefined; }',
+        },
+        {
+          name: '`"k" in x` also guards a chain that STARTS with x — `hit.meta.name`',
+          code: 'function f(rows: any[]) { const hit = rows.find((r) => r.ok); return "meta" in hit ? hit.meta.name : ""; }',
+        },
+        {
+          name: 'FP: an optional-chain `!== undefined` ternary test guards its consequent',
+          code: 'function hint(token: string) { const found = RE.exec(token); return found?.[1] !== undefined ? found[1] : undefined; }',
+        },
+        {
+          name: 'FP: `if (m === null) return` before a computed read `m[1]` — reported by 4.1.3, understood since 4.1.4',
+          code: 'function firstGroup(pattern: RegExp, line: string): string | undefined { const m = pattern.exec(line); if (m === null) return undefined; const group = m[1]; return group; }',
+        },
+        {
+          name: 'FP: `if (m === null) return` before `m.at(1)`',
+          code: 'function f(pattern: RegExp, line: string) { const m = pattern.exec(line); if (m === null) return undefined; return m.at(1); }',
+        },
+        {
+          name: 'FP: the burgee token loop — a for-of variable carries no nullability evidence, and the `in` test narrows it besides',
+          code: 'type Token = { kind: string; value?: string };\nfunction splitPositionals(tokens: readonly Token[]) { const positionals: string[] = []; for (const token of tokens) { const { kind } = token; const value = "value" in token ? token.value : undefined; if (kind === "positional" && typeof value === "string") positionals.push(value); } return positionals; }',
+        },
+      ],
+      invalid: [
+        {
+          name: '`in` on a DIFFERENT object says nothing about this one',
+          code: 'function f(rows: any[], other: object) { const hit = rows.find((r) => r.ok); return "name" in other ? hit.name : "x"; }',
+          errors: [{ messageId: 'missingNullCheck' }],
+        },
+        {
+          name: 'x on the LEFT of `in` is a key being looked up, not an object being narrowed',
+          code: 'function f(rows: any[], bag: object) { const hit = rows.find((r) => r.ok); return hit in bag ? hit.name : "x"; }',
+          errors: [{ messageId: 'missingNullCheck' }],
+        },
+        {
+          name: 'the `in` test narrows the consequent, never the alternate',
+          code: 'function f(rows: any[]) { const hit = rows.find((r) => r.ok); return "name" in hit ? "x" : hit.name; }',
+          errors: [{ messageId: 'missingNullCheck' }],
+        },
+        {
+          name: 'an optional chain compared to a value that is not nil proves nothing — `found?.[1] !== 0` passes when found is null',
+          code: 'function hint(token: string) { const found = RE.exec(token); if (found?.[1] !== 0) return found[1]; return undefined; }',
+          errors: [{ messageId: 'missingNullCheck' }],
+        },
+        {
+          name: 'an optional chain compared EQUAL to undefined does not prove non-null',
+          code: 'function hint(token: string) { const found = RE.exec(token); if (found?.[1] === undefined) return found[1]; return undefined; }',
+          errors: [{ messageId: 'missingNullCheck' }],
+        },
+        {
+          name: 'an optional chain rooted elsewhere guards nothing here',
+          code: 'function hint(token: string, other: any) { const found = RE.exec(token); if (other?.[1] !== undefined) return found[1]; return undefined; }',
+          errors: [{ messageId: 'missingNullCheck' }],
+        },
+      ],
     });
   });
 });

--- a/packages/eslint-plugin-secure-coding/src/rules/no-insecure-comparison/no-insecure-comparison.test.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/no-insecure-comparison/no-insecure-comparison.test.ts
@@ -42,6 +42,7 @@ describe('no-insecure-comparison', () => {
           code: 'const result = a === b ? 1 : 0;',
         },
         {
+          name: 'a nil check compares against nothing secret',
           code: 'if (value !== null && value !== undefined) {}',
         },
         {
@@ -962,5 +963,42 @@ describe('namesIn resolution arms', () => {
         ],
       },
     ],
+  });
+
+  /**
+   * Burgee turned this rule off over `spec.env === undefined`, `fromEnv !==
+   * undefined` and `option.envVar in process.env`, read as "timing-unsafe
+   * secret comparisons because the identifiers contain env". Verified against
+   * main: every one of those is QUIET — `env` is not in the secret vocabulary,
+   * a comparison against `undefined` is exempt, and `in` is not a comparison
+   * this rule reads. Pinned so the shapes stay quiet. What the consumer's file
+   * actually reports is `token === '--'` on a parseArgs lexeme named `token`,
+   * which is the closed vocabulary meeting a word with a second meaning and is
+   * recorded, not fixed, in docs/intents/burgee-false-positives/design.md.
+   */
+  describe('environment lookups are presence checks, not secret comparisons (burgee)', () => {
+    ruleTester.run('env presence', noInsecureComparison, {
+      valid: [
+        {
+          name: 'an option spec asked whether it declares an env var, then the var compared to undefined',
+          code: 'function apply(spec, env, values, name) { const fromEnv = spec.env === undefined ? undefined : env[spec.env]; if (values[name] === undefined && fromEnv !== undefined) { values[name] = fromEnv; } }',
+        },
+        {
+          name: '`in` asks whether a variable is set; it compares nothing',
+          code: 'function has(option) { return option.envVar in process.env; }',
+        },
+        {
+          name: 'a secret-named env var compared to undefined is a presence check',
+          code: 'if (process.env.ANTHROPIC_API_KEY === undefined) { skip(); }',
+        },
+      ],
+      invalid: [
+        {
+          name: 'the same env var compared to a caller-supplied value is the finding',
+          code: 'function check(presented) { return presented === process.env.ANTHROPIC_API_KEY; }',
+          errors: [{ messageId: 'timingUnsafeComparison', suggestions: [{ messageId: 'useTimingSafeEqual', output: 'function check(presented) { return crypto.timingSafeEqual(Buffer.from(presented), Buffer.from(process.env.ANTHROPIC_API_KEY)); }' }] }],
+        },
+      ],
+    });
   });
 });


### PR DESCRIPTION
## Seven false positives burgee had to work around, fixed at the rule

burgee (`ofri-peretz/burgee`) documents every Interlace-plugin false positive it meets in its `eslint.config.mjs` with an FP number. This branch fixes them upstream, each proven red first (intent + design at `docs/intents/burgee-false-positives/`, with the red/green table).

| FP | Rule | Fix |
| :-- | :-- | :-- |
| 1 | `reliability/no-missing-null-checks` | `'k' in x` and optional chains rooted at `x` count as guards in `if` tests and ternary consequents; `===` nil and the alternate arm still report |
| 8 | `maintainability/` + `reliability/no-unhandled-promise` | a function-typed *parameter* is not the enclosing async function; only an annotation returning `Promise` (or an async default) is evidence |
| 9 | `conventions/prefer-dependency-version-strategy` | an object literal is a dependency map only when every value is a version specifier; `dependencies` keys untouched |
| 10 | `maintainability/no-missing-error-context` | an `Error` subclass whose first argument is the message carries context (ported from the reliability twin) |
| 11 | `operability/require-data-minimization` | a static literal collects nothing |
| 12 | `maintainability/consistent-function-scoping` | a type assertion (`as`, `satisfies`, `!`, `<T>`) does not move a function off module scope |
| 7 | `secure-coding/no-insecure-comparison` | **not changed** — the `env` shapes are already quiet on main; burgee's real report was `token === '--'` (`token` is in the secret vocabulary); every fix option is a recall loss, documented in the design |

Changesets: patch for reliability, maintainability, conventions, operability. Gates green per package (reliability 487, maintainability 494 at 100% coverage, conventions 538, operability 138, secure-coding 3724), whole-graph typecheck, rule-audit, case-registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
