### PR TITLE
fix(benchmarks): retention keeps the snapshots documents cite

### DIFF
--- a/benchmarks/FP_FN_REMEDIATION_TRACKER.md
+++ b/benchmarks/FP_FN_REMEDIATION_TRACKER.md
@@ -22,7 +22,7 @@ This document is the **active agenda** for false-positive and false-negative wor
 | [`audits/2026-05-03.md`](./audits/2026-05-03.md) | Per-rule misbehaviour ranking, P0/P1/P2 backlog, what landed in the 3 audit iterations | hand-rolled per audit |
 | [`benchmark-results/scorecard.md`](../benchmark-results/scorecard.md) | Top-line F1/precision/recall per bench + plugin-activation table + inter-rater κ | `npm run ilb:scorecard` |
 | [`results/ilb-arena/2026-05-03.json`](./results/ilb-arena/2026-05-03.json) | Per-fixture, per-plugin verdicts on the 18-plugin head-to-head | `npm run ilb:arena` |
-| [`results/ilb-cwe-corpus/2026-05-03.json`](./results/ilb-cwe-corpus/2026-05-03.json) | Per-CWE TP/FP/FN on the synthetic corpus | `npm run ilb:cwe-corpus` |
+| [`results/ilb-cwe-corpus/2026-08-26.json`](./results/ilb-cwe-corpus/2026-08-26.json) | Per-CWE TP/FP/FN on the synthetic corpus | `npm run ilb:cwe-corpus` |
 | [`results/ilb-arena-quality/2026-05-03.json`](./results/ilb-arena-quality/2026-05-03.json) | Per-fixture quality verdicts (FNs in `falseNegatives`, FPs in `cleanAnalysis.byRule`) | `npm run ilb:arena:quality` |
 | [`benchmark-results/2026-05-03/per-repo/*/per-rule.json`](../benchmark-results/2026-05-03/per-repo/) | Per-rule hit counts on 22 real OSS repos (Edge candidates live here) | `npm run ilb:wild` |
 | [`baseline.json`](../benchmark-results/baseline.json) | Regression baseline — `npm run ilb:regression` fails CI on F1 drops or new FPs | `npm run ilb:regression -- --update` |
@@ -626,7 +626,7 @@ jq '.plugins.interlace.summary, .plugins.interlace.safeAnalysis.byFunction, .plu
 
 # CWE-Corpus: every FP by CWE + fixture + rule
 jq '.plugins.interlace.perCwe | to_entries[] | {cwe: .key, fps: [.value.fixtures[] | select(.expectedVulnerable==false and .findings>0) | {file, ruleHits}]}' \
-  benchmarks/results/ilb-cwe-corpus/2026-05-03.json
+  benchmarks/results/ilb-cwe-corpus/2026-08-26.json
 
 # Quality: 29 FPs broken down by rule
 jq '.plugins."interlace-quality".cleanAnalysis.byRule' \

--- a/scripts/__tests__/cited-benchmark-results-survive-pruning.lock.test.ts
+++ b/scripts/__tests__/cited-benchmark-results-survive-pruning.lock.test.ts
@@ -1,0 +1,148 @@
+/**
+ * @provenBy {"file":"scripts/prune-benchmark-results.ts","find":"if (isCited(REPO_ROOT, suite.name, file)) {","replace":"if (false) {"}
+ */
+
+/*
+ * Retention must not delete a snapshot a document cites.
+ *
+ * Two schedules run against `benchmarks/results/` and neither knows about
+ * the other: `weekly-benchmark.yml` keeps the three most recent dated
+ * snapshots per suite, and documents cite individual snapshots as the
+ * evidence behind a claim. `CLAIMS.md` links twenty of them. They have
+ * already collided — `.agent/flagship-rules.md` cited
+ * `ilb-flagship/2026-05-10.json`, the snapshot aged out, and the dead link
+ * landed in an unrelated automated PR (#925) whose author had touched
+ * neither the doc nor the file.
+ *
+ * `.agent` docs answer this by being forbidden to cite the directory at all
+ * (`agent-doc-links-expire.lock.test.ts`). For an evidence ledger that rule
+ * is wrong — the specific file IS the claim — so the pin runs the other way
+ * and retention has to honour it.
+ *
+ * The third case is the one that would have caught the live defect: a
+ * citation whose file retention already removed. That is not hypothetical
+ * — `benchmarks/FP_FN_REMEDIATION_TRACKER.md` pointed at
+ * `ilb-cwe-corpus/2026-05-03.json`, deleted weeks before this lock existed.
+ */
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const PRUNER = path.join(REPO_ROOT, 'scripts', 'prune-benchmark-results.ts');
+
+const SNAPSHOTS = [
+  '2026-01-01.json',
+  '2026-02-01.json',
+  '2026-03-01.json',
+  '2026-04-01.json',
+  '2026-05-01.json',
+];
+
+/**
+ * A checkout with five dated snapshots in one suite and a document citing
+ * `doc`. git, not the filesystem, is the source of truth for "tracked".
+ */
+const checkoutCiting = (cited: string): string => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'prune-cited-'));
+  const suite = path.join(root, 'benchmarks', 'results', 'ilb-demo');
+  fs.mkdirSync(suite, { recursive: true });
+  for (const name of SNAPSHOTS) fs.writeFileSync(path.join(suite, name), '{}');
+  fs.writeFileSync(
+    path.join(root, 'EVIDENCE.md'),
+    `Measured once: [run](./benchmarks/results/ilb-demo/${cited})\n`,
+  );
+  const git = (...a: string[]) =>
+    execFileSync('git', a, { cwd: root, stdio: 'ignore' });
+  git('init', '-q');
+  git('config', 'user.email', 'test@example.com');
+  git('config', 'user.name', 'test');
+  git('add', '-A');
+  git('commit', '-qm', 'fixture');
+  return root;
+};
+
+const prune = (root: string): void => {
+  execFileSync('npx', ['tsx', PRUNER, '--keep=3', `--root=${root}`], {
+    cwd: REPO_ROOT,
+    stdio: 'ignore',
+  });
+};
+
+const survivors = (root: string): string[] =>
+  fs.readdirSync(path.join(root, 'benchmarks', 'results', 'ilb-demo')).sort();
+
+describe('retention honours a citation', () => {
+  it('keeps the oldest snapshot when a tracked document cites it', () => {
+    const root = checkoutCiting('2026-01-01.json');
+    prune(root);
+    // Fourth and fifth oldest by age, but the first is spoken for.
+    expect(survivors(root)).toEqual([
+      '2026-01-01.json',
+      '2026-03-01.json',
+      '2026-04-01.json',
+      '2026-05-01.json',
+    ]);
+  });
+
+  it('still deletes the snapshots nothing cites', () => {
+    // Without this the pin could be unconditional and the first case would
+    // pass just as well.
+    const root = checkoutCiting('2026-05-01.json'); // newest — never at risk
+    prune(root);
+    expect(survivors(root)).toEqual([
+      '2026-03-01.json',
+      '2026-04-01.json',
+      '2026-05-01.json',
+    ]);
+  });
+});
+
+/**
+ * Markdown links only, and only outside `benchmarks/results/` itself.
+ *
+ * The pin in `lib/benchmark-citations.ts` matches any occurrence in tracked
+ * text on purpose; here the predicate has to be narrow, because prose that
+ * records a deletion ("Deleted `…/2026-05-11.json` (51 MB dead file)") names
+ * a path that is *supposed* to be gone. A link is the narrower thing: a
+ * promise that the file resolves.
+ */
+const LINK = /\[[^\]]*\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
+const stripCode = (t: string): string =>
+  t.replace(/```[\s\S]*?```/g, '').replace(/`[^`\n]*`/g, '');
+
+describe('every snapshot this repo links to is present', () => {
+  it('has no citation pointing at a pruned file', () => {
+    const docs = execFileSync('git', ['ls-files', '*.md', '*.mdx'], {
+      cwd: REPO_ROOT,
+      encoding: 'utf-8',
+      maxBuffer: 32 * 1024 * 1024,
+    })
+      .split('\n')
+      .filter((d) => d && !d.startsWith('benchmarks/results/'));
+
+    const dead: string[] = [];
+    for (const doc of docs) {
+      const text = stripCode(
+        fs.readFileSync(path.join(REPO_ROOT, doc), 'utf-8'),
+      );
+      for (const m of text.matchAll(LINK)) {
+        const raw = m[1];
+        if (/^(https?:|mailto:|file:|#|<|\$)/.test(raw)) continue;
+        const target = raw.split('#')[0];
+        if (!target) continue;
+        const abs = path.resolve(
+          path.dirname(path.join(REPO_ROOT, doc)),
+          target,
+        );
+        const rel = path.relative(REPO_ROOT, abs);
+        if (!rel.startsWith(`benchmarks${path.sep}results${path.sep}`))
+          continue;
+        if (!fs.existsSync(abs)) dead.push(`${doc} → ${raw}`);
+      }
+    }
+    expect(dead).toEqual([]);
+  });
+});

--- a/scripts/lib/benchmark-citations.ts
+++ b/scripts/lib/benchmark-citations.ts
@@ -1,0 +1,58 @@
+/**
+ * Which benchmark snapshots a document has promised will still be there.
+ *
+ * `weekly-benchmark.yml` prunes `benchmarks/results/<suite>/` to the three
+ * most recent dated snapshots. Documents cite individual snapshots as the
+ * evidence behind a claim — `CLAIMS.md` alone links twenty of them — so
+ * retention and citation are two schedules that know nothing about each
+ * other. They already collided once: `.agent/flagship-rules.md` linked to
+ * `ilb-flagship/2026-05-10.json`, the snapshot aged out, and the dead link
+ * surfaced in an unrelated automated PR (#925).
+ *
+ * `.agent` docs are forbidden from citing this directory at all — see
+ * `agent-doc-links-expire.lock.test.ts`. That is the right rule for an
+ * operational doc, and the wrong one for an evidence ledger, where the
+ * specific file IS the claim. So for every other document the pin runs the
+ * other way: a cited snapshot is not prunable.
+ *
+ * Within a document the match is deliberately broad — any occurrence, prose
+ * and code fences included, not just markdown links. Over-matching only
+ * costs retention (a snapshot named in a jq drill is one a reader will run),
+ * and pinning a path that no longer exists is a no-op.
+ *
+ * Documents only, though. Source files mention these paths while *reasoning*
+ * about retention — this predicate's own lock test names a snapshot in a
+ * comment, and so does `agent-doc-links-expire.lock.test.ts` — and a pin that
+ * counted those would keep a file alive because something described it. A
+ * document is where a citation is a promise to a reader.
+ */
+import { execFileSync } from 'node:child_process';
+
+/**
+ * `<suite>/<file>` rather than the repo-relative path: citations are written
+ * relative to the citing document (`./results/…`, `../results/…`,
+ * `benchmarks/results/…`) and only the tail is common to all three.
+ */
+export function isCited(root: string, suite: string, file: string): boolean {
+  try {
+    execFileSync(
+      'git',
+      [
+        'grep',
+        '--quiet',
+        '--fixed-strings',
+        `${suite}/${file}`,
+        '--',
+        '*.md',
+        '*.mdx',
+        ':(exclude)benchmarks/results',
+      ],
+      { cwd: root, stdio: 'ignore' },
+    );
+    return true;
+  } catch {
+    // exit 1 = no match. Any other failure (not a checkout, no git) also
+    // lands here, and prunes as before rather than pinning everything.
+    return false;
+  }
+}

--- a/scripts/prune-benchmark-results.ts
+++ b/scripts/prune-benchmark-results.ts
@@ -17,22 +17,33 @@
  * `latest.json`, `baseline.json`, and subdirectories like `backups/` are
  * left untouched.
  *
+ * A snapshot a tracked document cites is also left untouched, however old.
+ * Retention counts weeks and knows nothing about the claims resting on the
+ * data; a citation is a promise the file resolves. See
+ * `lib/benchmark-citations.ts`.
+ *
  * Usage:
  *   tsx scripts/prune-benchmark-results.ts             # prune (default N=3)
  *   tsx scripts/prune-benchmark-results.ts --dry-run   # preview only
  *   tsx scripts/prune-benchmark-results.ts --keep=5    # custom N
+ *   tsx scripts/prune-benchmark-results.ts --root=DIR  # another checkout
  */
 
 import { readdirSync, statSync, unlinkSync, existsSync } from 'node:fs';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const HERE = dirname(fileURLToPath(import.meta.url));
-const REPO_ROOT = resolve(HERE, '..');
-const RESULTS_DIR = join(REPO_ROOT, 'benchmarks', 'results');
+import { isCited } from './lib/benchmark-citations';
 
+const HERE = dirname(fileURLToPath(import.meta.url));
 const args = process.argv.slice(2);
 const DRY_RUN = args.includes('--dry-run');
+
+const rootArg = args.find((a) => a.startsWith('--root='));
+const REPO_ROOT = rootArg
+  ? resolve(rootArg.slice('--root='.length))
+  : resolve(HERE, '..');
+const RESULTS_DIR = join(REPO_ROOT, 'benchmarks', 'results');
 
 const keepArg = args.find((a) => a.startsWith('--keep='));
 const KEEP = keepArg ? parseInt(keepArg.split('=')[1], 10) : 3;
@@ -46,6 +57,7 @@ if (!existsSync(RESULTS_DIR)) {
 
 let deletedCount = 0;
 let deletedBytes = 0;
+let pinnedCount = 0;
 
 for (const suite of readdirSync(RESULTS_DIR, { withFileTypes: true })) {
   if (!suite.isDirectory()) continue;
@@ -66,8 +78,15 @@ for (const suite of readdirSync(RESULTS_DIR, { withFileTypes: true })) {
   for (const file of toDelete) {
     const filePath = join(suiteDir, file);
     const size = statSync(filePath).size;
+    if (isCited(REPO_ROOT, suite.name, file)) {
+      console.log(`  kept ${file} — cited by a tracked document`);
+      pinnedCount++;
+      continue;
+    }
     if (DRY_RUN) {
-      console.log(`  [dry-run] would delete ${file} (${(size / 1024).toFixed(0)} KB)`);
+      console.log(
+        `  [dry-run] would delete ${file} (${(size / 1024).toFixed(0)} KB)`,
+      );
     } else {
       unlinkSync(filePath);
       console.log(`  deleted ${file} (${(size / 1024).toFixed(0)} KB)`);
@@ -79,5 +98,6 @@ for (const suite of readdirSync(RESULTS_DIR, { withFileTypes: true })) {
 
 const prefix = DRY_RUN ? '[dry-run] ' : '';
 console.log(
-  `\n${prefix}Pruned ${deletedCount} files, ${(deletedBytes / (1024 * 1024)).toFixed(1)} MiB freed.`,
+  `\n${prefix}Pruned ${deletedCount} files, ${(deletedBytes / (1024 * 1024)).toFixed(1)} MiB freed.` +
+    (pinnedCount > 0 ? ` Kept ${pinnedCount} cited snapshot(s).` : ''),
 );


### PR DESCRIPTION
## Summary

Two schedules run against `benchmarks/results/` and neither knows about the other.
`weekly-benchmark.yml` keeps the three most recent dated snapshots per suite and
deletes the rest; documents cite individual snapshots as the evidence behind a
claim. They have already collided — `.agent/flagship-rules.md` cited a flagship
snapshot, it aged out, and the dead link surfaced in an unrelated automated PR
(#925) whose author had touched neither the doc nor the file.

Scanning all 1,818 tracked markdown files: **33 links point into
`benchmarks/results/`**, 20 of them from `CLAIMS.md`. One was **already dead** —
`benchmarks/FP_FN_REMEDIATION_TRACKER.md` pointed at an `ilb-cwe-corpus`
snapshot retention removed weeks ago, in both its data-sources table and a jq
drill.

- `scripts/lib/benchmark-citations.ts` — `isCited()`, a `git grep` over tracked
  documents. Matches `<suite>/<file>` rather than the repo-relative path, because
  citations are written relative to the citing document (`./results/…`,
  `../results/…`, `benchmarks/results/…`) and only the tail is common to all three.
- `scripts/prune-benchmark-results.ts` — skips a cited snapshot, reports it as
  `kept … — cited by a tracked document`, and counts it in the summary line.
  Also gains `--root=DIR` so the lock can drive it against a fixture checkout.
- `benchmarks/FP_FN_REMEDIATION_TRACKER.md` — the dead citation repointed to the
  current snapshot, which the pin now holds.

### Why not just forbid the citation

`.agent` docs already answer this by being forbidden to cite the directory at all
(`agent-doc-links-expire.lock.test.ts`, added in #925). That is right for an
operational doc and wrong for an evidence ledger, where the specific file *is* the
claim — replacing twenty `CLAIMS.md` citations with one pointer to
`history.ndjson` would destroy the claim-to-evidence mapping. So for every other
document the pin runs the other way and retention honours it. The two mechanisms
are complementary, not competing.

### Why documents only

Source files name these paths while *reasoning* about retention — this change's
own lock does, and so does the agent-doc lock. A pin that counted those would keep
a snapshot alive because something described it; the comment in
`agent-doc-links-expire.lock.test.ts` alone would have pinned a 2.6 MB file
forever. Within a document the match stays broad (prose and code fences included,
not just links), because a snapshot named in a jq drill is one a reader will run,
and pinning a path that no longer exists is a no-op.

## Test plan

New lock: `scripts/__tests__/cited-benchmark-results-survive-pruning.lock.test.ts`
(3 cases). Each mutation fails exactly its own case and nothing else:

| mutation | result |
| --- | --- |
| pin removed (the `@provenBy`) | cited snapshot deleted — case 1 fails |
| pin unconditional | uncited snapshots survive — case 2 fails (not vacuous) |
| citation reverted | resolve check reports the dead link — case 3 fails |

- [x] `npx vitest run scripts/__tests__/` — 2,572 passed across 134 files.
- [x] `npx tsx scripts/prove-locks.mts` — 14 proven, 0 vacuous, exit 0.
- [x] `npx prettier --check` + `npx oxlint` on the three TS files — clean.
- [x] `npm run typecheck:scripts` — 7 errors, all in four files this PR does not
      touch (pre-existing on `main`).
- [x] Behaviour on the real repo: at production `--keep=3` nothing changes; at
      `--keep=1` the pruner reports `Kept 3 cited snapshot(s)` that would
      otherwise have been deleted.

## After merge

The weekly benchmark stops deleting snapshots the docs stand on. The
resolve-check arm also means a citation that goes stale for any other reason
fails CI on the PR that breaks it, rather than weeks later in someone else's.

Follow-up, filed separately: lefthook's `stale-build-artifacts` step passed in
0.49 s on a genuinely stale `eslint-devkit/dist` during this PR's first commit
attempt, and the next hook step then failed with 60 test failures rooted in that
one file. A check named for the condition it did not detect deserves its own lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)