### PR TITLE
chore(docs): sync generated data

### DIFF
--- a/apps/docs/src/data/changelog.json
+++ b/apps/docs/src/data/changelog.json
@@ -1,7 +1,7 @@
 {
-  "releaseCount": 651,
+  "releaseCount": 655,
   "packageCount": 35,
-  "entryCount": 2038,
+  "entryCount": 2045,
   "oldestYear": 2024,
   "releases": [
     {
@@ -16460,6 +16460,21 @@
       ]
     },
     {
+      "package": "eslint-plugin-conventions",
+      "short": "eslint-plugin-conventions",
+      "version": "5.3.4",
+      "date": null,
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "`prefer-dependency-version-strategy` no longer reads a manifest as a dependency map",
+          "pr": null
+        }
+      ]
+    },
+    {
       "package": "eslint-plugin-jwt-security",
       "short": "eslint-plugin-jwt-security",
       "version": "2.2.9",
@@ -16575,6 +16590,46 @@
         {
           "kind": "other",
           "title": "Ofri Peretz",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-maintainability",
+      "short": "eslint-plugin-maintainability",
+      "version": "3.2.4",
+      "date": null,
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "`no-missing-error-context` accepts a custom `*Error` argument and a re-throw",
+          "pr": null
+        },
+        {
+          "kind": "fix",
+          "title": "`consistent-function-scoping` sees through a type assertion to module scope",
+          "pr": null
+        },
+        {
+          "kind": "fix",
+          "title": "`no-unhandled-promise` no longer treats a function-typed parameter as its enclosing async function",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-operability",
+      "short": "eslint-plugin-operability",
+      "version": "4.1.2",
+      "date": null,
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "`require-data-minimization` ignores a literal that collects nothing",
           "pr": null
         }
       ]
@@ -16700,6 +16755,26 @@
         {
           "kind": "other",
           "title": "Ofri Peretz",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-reliability",
+      "short": "eslint-plugin-reliability",
+      "version": "4.1.5",
+      "date": null,
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "`no-missing-null-checks` reads `'k' in x` and optional-chain guards as narrowing",
+          "pr": null
+        },
+        {
+          "kind": "fix",
+          "title": "`no-unhandled-promise` no longer treats a function-typed parameter as its enclosing async function",
           "pr": null
         }
       ]

--- a/apps/docs/src/data/plugin-stats.json
+++ b/apps/docs/src/data/plugin-stats.json
@@ -181,7 +181,7 @@
       "rules": 15,
       "description": "ESLint plugin for team code conventions — enforces filename case, magic-number bans, commented-out code, expiring TODOs, and deprecated-API usage",
       "category": "quality",
-      "version": "5.3.3",
+      "version": "5.3.4",
       "published": true
     },
     {
@@ -189,7 +189,7 @@
       "rules": 12,
       "description": "ESLint plugin for maintainable code — limits cognitive complexity, nesting depth, parameter counts, duplicate functions, and unhandled or silent errors",
       "category": "quality",
-      "version": "3.2.3",
+      "version": "3.2.4",
       "published": true
     },
     {
@@ -197,7 +197,7 @@
       "rules": 9,
       "description": "ESLint plugin for runtime reliability — enforces error handling, network timeouts, null checks, and safe type narrowing",
       "category": "quality",
-      "version": "4.1.4",
+      "version": "4.1.5",
       "published": true
     },
     {
@@ -213,7 +213,7 @@
       "rules": 6,
       "description": "ESLint plugin for production operability — bans debug code and console logging in production, verbose error messages, and process.exit calls",
       "category": "quality",
-      "version": "4.1.1",
+      "version": "4.1.2",
       "published": true
     },
     {
@@ -244,5 +244,5 @@
   "totalRules": 477,
   "totalPlugins": 30,
   "allPluginsCount": 30,
-  "generatedAt": "2026-09-07"
+  "generatedAt": "2026-09-08"
 }


### PR DESCRIPTION
Regenerated apps/docs/src/data/ (trigger: push). Opened by the Docs Data Sync workflow; contents come entirely from the apps/docs/scripts/sync-* scripts, so review the diff rather than hand-editing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added four new plugin release entries to the changelog.
  - Updated plugin statistics to reflect the latest versions and generation timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->