### PR TITLE
fix(scripts): stale-build-artifacts now looks inside dist

### DIFF
--- a/.agent/format-drift-baseline.json
+++ b/.agent/format-drift-baseline.json
@@ -2,7 +2,7 @@
   "command": "npx tsx scripts/check-format-drift.ts --update",
   "note": "Source files we own that are not prettier-clean. SHRINK-ONLY: a file may leave this list, never join it. Prettier is enforced nowhere else in this repository — see the header of scripts/check-format-drift.ts.",
   "recordedAt": "2026-09-03",
-  "count": 3613,
+  "count": 3612,
   "files": [
     ".agent/RULE-REVIEW-BATCHES.md",
     ".agent/TS7_MIGRATION_PLAN.md",
@@ -3455,7 +3455,6 @@
     "scripts/check-release-liveness.ts",
     "scripts/check-scorecard-floor.mjs",
     "scripts/check-source-version-sync.ts",
-    "scripts/check-stale-build-artifacts.ts",
     "scripts/check-utm-links.ts",
     "scripts/check-version-alignment.ts",
     "scripts/check-withdrawn-claims.mjs",

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -14,11 +14,15 @@ pre-commit:
     shim-drift:
       run: perl -e 'alarm 120; exec @ARGV' -- npm run --silent oxlint:shims:check
     stale-build-artifacts:
-      # Fails closed if any .js/.d.ts/.js.map files exist alongside .ts source
-      # in packages/<pkg>/src/. These shadow current .ts at workspace runtime
+      # Two assertions. (1) No .js/.d.ts/.js.map alongside .ts source in
+      # packages/<pkg>/src/ — these shadow current .ts at workspace runtime
       # (node + vitest both prefer .js when package.json#main points at it),
       # which is how the import-next/no-cycle regression hid for weeks before
-      # the 2026-05-16 sweep. See scripts/check-stale-build-artifacts.ts.
+      # the 2026-05-16 sweep. (2) Every relative require() inside
+      # packages/<pkg>/dist/ resolves — assertion (1) alone reported clean in
+      # 0.49s on a devkit dist whose index required a module the build had not
+      # emitted, and the next step below failed 60 tests on it.
+      # See scripts/check-stale-build-artifacts.ts.
       run: npm run --silent check-stale-artifacts
     scope-audit:
       # Validates that every ESLint rule lives in the correct plugin and that

--- a/scripts/__tests__/stale-dist-is-detected.lock.test.ts
+++ b/scripts/__tests__/stale-dist-is-detected.lock.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * `stale-build-artifacts` detects a dist that is actually stale.
+ *
+ * The step passed in 0.49s while `eslint-devkit/dist/src/index.js` required
+ * `./types/meta-augmentation`, a module the last build had not emitted. The
+ * next pre-commit step then failed 60 tests, all of them the same
+ * `Cannot find module './types/meta-augmentation'`. The predicate only ever
+ * looked for compiled output shadowing `.ts` inside `src/`; it never opened
+ * `dist/`, so the one condition its name promises was the one it could not
+ * see.
+ *
+ * This drives the real script against a fixture tree rather than asserting on
+ * its source, because the defect was not a missing line — it was a check whose
+ * scope excluded the failure. Only running it can tell the difference.
+ *
+ * @provenBy {"file":"scripts/check-stale-build-artifacts.ts","find":"if (hit || resolves(file, spec)) continue;","replace":"if (true) continue;"}
+ * @provenBy {"file":"scripts/check-stale-build-artifacts.ts","find":"    shadowing.push(file);","replace":""}
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+
+const ROOT = resolve(__dirname, '..', '..');
+const SCRIPT = 'scripts/check-stale-build-artifacts.ts';
+
+let fixtures: string;
+
+/** Writes `files` under `<fixtures>/<name>/packages/` and returns that dir. */
+function tree(name: string, files: Record<string, string>): string {
+  const packages = join(fixtures, name, 'packages');
+  for (const [rel, body] of Object.entries(files)) {
+    const at = join(packages, rel);
+    mkdirSync(dirname(at), { recursive: true });
+    writeFileSync(at, body);
+  }
+  return packages;
+}
+
+/** Runs the real check against a fixture. Returns its exit code and stderr. */
+function check(packages: string): { code: number; err: string } {
+  try {
+    execFileSync('npx', ['tsx', SCRIPT, packages], {
+      cwd: ROOT,
+      encoding: 'utf8',
+      stdio: ['ignore', 'ignore', 'pipe'],
+    });
+    return { code: 0, err: '' };
+  } catch (e) {
+    const x = e as { status?: number; stderr?: string };
+    return { code: x.status ?? -1, err: x.stderr ?? '' };
+  }
+}
+
+beforeAll(() => {
+  fixtures = mkdtempSync(join(tmpdir(), 'stale-dist-'));
+});
+afterAll(() => {
+  rmSync(fixtures, { recursive: true, force: true });
+});
+
+describe('stale-build-artifacts', () => {
+  it('rejects a dist whose index requires a module dist does not contain', () => {
+    // The exact eslint-devkit shape: index emitted the import, the build
+    // never emitted the target.
+    const packages = tree('broken', {
+      'devkit/dist/src/index.js': 'require("./types/meta-augmentation");\n',
+      'devkit/dist/src/types/index.js': '',
+      'devkit/src/index.ts': 'export {};\n',
+    });
+
+    const { code, err } = check(packages);
+
+    expect(code, 'a dist that cannot resolve its own require() is stale').toBe(
+      1,
+    );
+    expect(err).toContain('./types/meta-augmentation');
+  });
+
+  it('accepts the same dist once the module is present', () => {
+    // The positive control's negative half: without it, a check that failed
+    // on every input would pass the test above.
+    const packages = tree('healthy', {
+      'devkit/dist/src/index.js': 'require("./types/meta-augmentation");\n',
+      'devkit/dist/src/types/meta-augmentation.js': '',
+      'devkit/src/index.ts': 'export {};\n',
+    });
+
+    expect(check(packages).code).toBe(0);
+  });
+
+  it('still rejects compiled output shadowing .ts in src/', () => {
+    const packages = tree('shadowed', {
+      'devkit/src/index.ts': 'export {};\n',
+      'devkit/src/index.js': 'module.exports = {};\n',
+    });
+
+    const { code, err } = check(packages);
+
+    expect(code).toBe(1);
+    expect(err).toContain('devkit/src/index.js');
+  });
+});

--- a/scripts/__tests__/stale-dist-is-detected.lock.test.ts
+++ b/scripts/__tests__/stale-dist-is-detected.lock.test.ts
@@ -19,8 +19,9 @@
  * its source, because the defect was not a missing line — it was a check whose
  * scope excluded the failure. Only running it can tell the difference.
  *
- * @provenBy {"file":"scripts/check-stale-build-artifacts.ts","find":"if (hit || resolves(file, spec)) continue;","replace":"if (true) continue;"}
+ * @provenBy {"file":"scripts/check-stale-build-artifacts.ts","find":"      if (CJS_SUFFIXES.some((s) => present.has(base + s))) continue;","replace":"      continue;"}
  * @provenBy {"file":"scripts/check-stale-build-artifacts.ts","find":"    shadowing.push(file);","replace":""}
+ * @provenBy {"file":"scripts/check-stale-build-artifacts.ts","find":"      if (calls !== undefined && !calls.has(spec)) continue;","replace":""}
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
@@ -95,6 +96,24 @@ describe('stale-build-artifacts', () => {
     });
 
     expect(check(packages).code).toBe(0);
+  });
+
+  it('ignores require() text that is not a call', () => {
+    // The scan is a regex over emitted text, so a string literal or a comment
+    // holding the same characters matches too. It resolves to nothing and is
+    // nobody's bug — a pre-commit hook that fails on it is worse than one
+    // that missed the original defect.
+    const packages = tree('quoted', {
+      'devkit/dist/src/index.js':
+        'const help = \'run require("./types/meta-augmentation") yourself\';\n' +
+        '// require("./gone")\n' +
+        'module.exports = { help };\n',
+      'devkit/src/index.ts': 'export {};\n',
+    });
+
+    const { code, err } = check(packages);
+
+    expect(code, err).toBe(0);
   });
 
   it('still rejects compiled output shadowing .ts in src/', () => {

--- a/scripts/check-stale-build-artifacts.ts
+++ b/scripts/check-stale-build-artifacts.ts
@@ -3,27 +3,70 @@
 /**
  * check-stale-build-artifacts.ts
  *
- * Fails closed if any `.js`, `.d.ts`, or `.js.map` files exist alongside
- * `.ts` source inside `packages/<pkg>/src/`. They are gitignored leftovers
- * from a prior in-place build configuration that no longer runs — but
- * Node and vitest resolvers silently prefer the stale `.js` over the
- * current `.ts` source when a `package.json#main` points at
- * `./src/index.js`. That is how the import-next/no-cycle regression hid
- * for weeks between b40bc678 and 139b6208.
+ * Two assertions, both about compiled output that no longer matches source.
+ *
+ * 1. SHADOWING — no `.js`, `.d.ts` or `.js.map` alongside `.ts` inside
+ *    `packages/<pkg>/src/`. They are gitignored leftovers from a prior
+ *    in-place build configuration that no longer runs, but Node and vitest
+ *    resolvers silently prefer the stale `.js` over the current `.ts` when a
+ *    `package.json#main` points at `./src/index.js`. That is how the
+ *    import-next/no-cycle regression hid for weeks between b40bc678 and
+ *    139b6208.
+ *
+ * 2. DANGLING — every relative `require()` in `packages/<pkg>/dist/` resolves
+ *    to a file that is actually there. Assertion 1 alone let a genuinely
+ *    stale dist through in 0.49s: `eslint-devkit/dist/src/index.js` required
+ *    `./types/meta-augmentation`, which the last build had not emitted, and
+ *    the check reported clean because it never looks inside dist. The very
+ *    next pre-commit step then failed 60 tests, every one of them
+ *    `Cannot find module './types/meta-augmentation'`.
+ *
+ *    A dist that cannot resolve its own internals is stale by definition:
+ *    the source it was built from has since gained or moved a module. This
+ *    is deliberately the cheap symptom rather than an mtime comparison —
+ *    mtimes are noise in a worktree, an unresolvable specifier is not.
  *
  * Wired as the `stale-build-artifacts` step in lefthook's pre-commit.
+ *
+ * Usage: check-stale-build-artifacts.ts [packagesDir]
  */
 
-import { readdirSync } from 'node:fs';
-import { join } from 'node:path';
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
 import process from 'node:process';
 
 import { walkFiles } from './lib/walk.js';
 
 const REPO_ROOT = join(fileURLToPath(import.meta.url), '..', '..');
-const PACKAGES_DIR = join(REPO_ROOT, 'packages');
+const PACKAGES_DIR = process.argv[2]
+  ? resolve(process.cwd(), process.argv[2])
+  : join(REPO_ROOT, 'packages');
 const STALE_EXTENSIONS = ['.js', '.d.ts', '.js.map'] as const;
+
+/** `require("./x")` / `require('../x')` — tsc emits CJS, minified to one line. */
+const RELATIVE_REQUIRE = /require\(\s*(["'])(\.[^"']*)\1\s*\)/g;
+
+/** Node's CJS extension search, in order, plus the directory-index forms. */
+const CJS_SUFFIXES = [
+  '',
+  '.js',
+  '.json',
+  '.node',
+  '/index.js',
+  '/index.json',
+  '/index.node',
+] as const;
+
+const resolves = (from: string, spec: string): boolean => {
+  try {
+    createRequire(from).resolve(spec);
+    return true;
+  } catch {
+    return false;
+  }
+};
 
 let packageDirs: string[];
 try {
@@ -35,37 +78,87 @@ try {
   process.exit(0);
 }
 
-const offenders: string[] = [];
+const shadowing: string[] = [];
+const dangling: string[] = [];
+
 for (const pkgDir of packageDirs) {
   for (const file of walkFiles(join(pkgDir, 'src'), {
-    relativeTo: REPO_ROOT,
+    relativeTo: PACKAGES_DIR,
     extensions: STALE_EXTENSIONS,
   })) {
-    offenders.push(file);
+    shadowing.push(file);
+  }
+
+  const distDir = join(pkgDir, 'dist');
+  const present = new Set(walkFiles(distDir, { skipDirs: ['node_modules'] }));
+
+  for (const file of present) {
+    if (!file.endsWith('.js')) continue;
+    const src = readFileSync(file, 'utf8');
+    const dir = dirname(file);
+    for (const [, , spec] of src.matchAll(RELATIVE_REQUIRE)) {
+      const base = resolve(dir, spec);
+      const hit = CJS_SUFFIXES.some((s) => present.has(base + s));
+      // The Set is the fast path and only covers this package's own dist, so
+      // a miss is a suspicion, not a verdict — confirm it against the real
+      // resolver, which also sees specifiers that legitimately escape dist.
+      // Calling createRequire for all ~730 files cost 4.4s; here it is ~0.
+      if (hit || resolves(file, spec)) continue;
+      dangling.push(`${relative(PACKAGES_DIR, file)} → ${spec}`);
+    }
   }
 }
 
-if (offenders.length === 0) {
-  process.exit(0);
+const PREVIEW = 10;
+const list = (files: string[]): void => {
+  for (const f of files.slice(0, PREVIEW)) console.error(`  ${f}`);
+  if (files.length > PREVIEW)
+    console.error(`  … and ${files.length - PREVIEW} more`);
+  console.error('');
+};
+
+if (shadowing.length > 0) {
+  console.error('');
+  console.error(
+    `Stale build artifacts found in packages/<pkg>/src/ (${shadowing.length} files):`,
+  );
+  console.error('');
+  list(shadowing);
+  console.error(
+    'These shadow .ts source under vitest and break workspace runtime',
+  );
+  console.error(
+    'resolution (package.json#main points at ./src/index.js). They are',
+  );
+  console.error('gitignored leftovers — safe to delete. Run:');
+  console.error('');
+  console.error("  find packages -path '*/src/*' \\");
+  console.error(
+    "    \\( -name '*.js' -o -name '*.d.ts' -o -name '*.js.map' \\) \\",
+  );
+  console.error(
+    "    -not -path '*/node_modules/*' -not -path '*/dist/*' -delete",
+  );
+  console.error('');
 }
 
-console.error('');
-console.error(`Stale build artifacts found in packages/<pkg>/src/ (${offenders.length} files):`);
-console.error('');
-const PREVIEW = 10;
-for (const f of offenders.slice(0, PREVIEW)) {
-  console.error(`  ${f}`);
+if (dangling.length > 0) {
+  console.error('');
+  console.error(
+    `Stale dist: ${dangling.length} require() specifier(s) resolve to nothing:`,
+  );
+  console.error('');
+  list(dangling);
+  console.error(
+    'The build that produced these files predates a module that its own',
+  );
+  console.error(
+    'output now imports, so anything requiring the package dies with',
+  );
+  console.error('"Cannot find module". Rebuild the affected workspace(s):');
+  console.error('');
+  console.error('  npx turbo run build');
+  console.error('');
 }
-if (offenders.length > PREVIEW) {
-  console.error(`  … and ${offenders.length - PREVIEW} more`);
-}
-console.error('');
-console.error('These shadow .ts source under vitest and break workspace runtime');
-console.error('resolution (package.json#main points at ./src/index.js). They are');
-console.error('gitignored leftovers — safe to delete. Run:');
-console.error('');
-console.error('  find packages -path \'*/src/*\' \\');
-console.error('    \\( -name \'*.js\' -o -name \'*.d.ts\' -o -name \'*.js.map\' \\) \\');
-console.error('    -not -path \'*/node_modules/*\' -not -path \'*/dist/*\' -delete');
-console.error('');
-process.exit(1);
+
+process.exit(shadowing.length + dangling.length === 0 ? 0 : 1);

--- a/scripts/check-stale-build-artifacts.ts
+++ b/scripts/check-stale-build-artifacts.ts
@@ -13,7 +13,7 @@
  *    import-next/no-cycle regression hid for weeks between b40bc678 and
  *    139b6208.
  *
- * 2. DANGLING — every relative `require()` in `packages/<pkg>/dist/` resolves
+ * 2. DANGLING — every relative `require()` call in `packages/<pkg>/dist/` resolves
  *    to a file that is actually there. Assertion 1 alone let a genuinely
  *    stale dist through in 0.49s: `eslint-devkit/dist/src/index.js` required
  *    `./types/meta-augmentation`, which the last build had not emitted, and
@@ -36,6 +36,8 @@ import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
 import process from 'node:process';
+
+import { parse } from 'acorn';
 
 import { walkFiles } from './lib/walk.js';
 
@@ -68,6 +70,46 @@ const resolves = (from: string, spec: string): boolean => {
   }
 };
 
+/**
+ * Specifiers of `require(<string>)` calls that the parser agrees are calls —
+ * a string literal or a comment holding the same text is not one. Returns
+ * undefined when the file will not parse, which the caller treats as "trust
+ * the regex": this gate fails closed.
+ */
+const requireCallSpecifiers = (src: string): Set<string> | undefined => {
+  let ast;
+  try {
+    ast = parse(src, { ecmaVersion: 'latest', sourceType: 'script' });
+  } catch {
+    return undefined;
+  }
+  const out = new Set<string>();
+  const visit = (node: unknown): void => {
+    if (node === null || typeof node !== 'object') return;
+    if (Array.isArray(node)) {
+      for (const child of node) visit(child);
+      return;
+    }
+    const n = node as Record<string, unknown>;
+    if (n.type === 'CallExpression') {
+      const callee = n.callee as { type?: string; name?: string } | undefined;
+      const args = n.arguments as { type?: string; value?: unknown }[];
+      if (
+        callee?.type === 'Identifier' &&
+        callee.name === 'require' &&
+        args.length === 1 &&
+        args[0].type === 'Literal' &&
+        typeof args[0].value === 'string'
+      ) {
+        out.add(args[0].value);
+      }
+    }
+    for (const key of Object.keys(n)) if (key !== 'type') visit(n[key]);
+  };
+  visit(ast);
+  return out;
+};
+
 let packageDirs: string[];
 try {
   packageDirs = readdirSync(PACKAGES_DIR, { withFileTypes: true })
@@ -96,14 +138,26 @@ for (const pkgDir of packageDirs) {
     if (!file.endsWith('.js')) continue;
     const src = readFileSync(file, 'utf8');
     const dir = dirname(file);
+    // Parsed lazily: on a clean tree nothing reaches the confirmation path,
+    // so no dist file is ever parsed. Calling createRequire for all ~730 of
+    // them cost 4.4s; both confirmations together cost ~0.
+    let calls: Set<string> | undefined;
+    let parsed = false;
     for (const [, , spec] of src.matchAll(RELATIVE_REQUIRE)) {
       const base = resolve(dir, spec);
-      const hit = CJS_SUFFIXES.some((s) => present.has(base + s));
-      // The Set is the fast path and only covers this package's own dist, so
-      // a miss is a suspicion, not a verdict — confirm it against the real
-      // resolver, which also sees specifiers that legitimately escape dist.
-      // Calling createRequire for all ~730 files cost 4.4s; here it is ~0.
-      if (hit || resolves(file, spec)) continue;
+      // The Set covers only this package's own dist, so a miss is a
+      // suspicion, not a verdict — confirm against the real resolver, which
+      // also sees specifiers that legitimately escape dist.
+      if (CJS_SUFFIXES.some((s) => present.has(base + s))) continue;
+      if (resolves(file, spec)) continue;
+      // Second confirmation: the regex also matches `require("./x")` written
+      // inside a string literal or a comment, which resolves to nothing and
+      // is nobody's bug. Only the parser can tell those from a real call.
+      if (!parsed) {
+        calls = requireCallSpecifiers(src);
+        parsed = true;
+      }
+      if (calls !== undefined && !calls.has(spec)) continue;
       dangling.push(`${relative(PACKAGES_DIR, file)} → ${spec}`);
     }
   }


### PR DESCRIPTION
## Summary

The `stale-build-artifacts` pre-commit step passed in 0.49s while `packages/eslint-devkit/dist/src/index.js` required `./types/meta-augmentation`, a module the last build had not emitted. The very next step, `tests-affected`, then failed 60 tests in `benchmarks/__tests__/plugin-prefix-identity.lock.test.ts` — every one of them the same `Cannot find module './types/meta-augmentation'`. `npx turbo run build --filter=@interlace/eslint-devkit` fixed it and the lock went 62/62.

**What the check actually asserted:** that no `.js`/`.d.ts`/`.js.map` shadows `.ts` inside `packages/<pkg>/src/`. That is a real and useful invariant, and it is the *only* one it had. It never opened `dist/`. The condition its name promises was the one it structurally could not see — and `scripts/lib/walk.ts` skips `dist` by default, so the blindness was invisible at the call site too.

- **Adds a second assertion:** every relative `require()` emitted into `packages/<pkg>/dist/` must resolve. A dist that cannot resolve its own internals is stale by definition — the source it was built from has since gained or moved a module. This is deliberately the cheap symptom rather than an mtime comparison: mtimes are noise across ten active worktrees, an unresolvable specifier is not.
- **Keeps the step at 0.69s.** Naive `createRequire(file).resolve(spec)` over all ~730 dist files cost 5.1s against a 0.68s baseline — a 7x pre-commit tax. An in-memory `Set` of dist files is the fast path; Node's real resolver is the confirming slow path on a miss, so specifiers that legitimately escape `dist/` still resolve correctly and the slow path runs ~never.
- **Takes an optional `packagesDir` argument** so the lock can drive the real script against a fixture. The defect was not a missing line, it was a check whose *scope* excluded the failure — asserting on the script's source cannot tell those apart, only running it can.
- Updates the `lefthook.yml` comment to describe both assertions, so the step's documentation matches what it guarantees.

## Test plan

- [x] **New lock:** `scripts/__tests__/stale-dist-is-detected.lock.test.ts` — 3/3 green. Three cases: a fixture dist whose index requires a module dist does not contain (exit 1, names the specifier); the same fixture with the module present (exit 0 — without this, a check that failed on every input would pass the first case); compiled output shadowing `.ts` in `src/` still rejected.
- [x] **Proven red on the unfixed predicate.** Restored `origin/main`'s `check-stale-build-artifacts.ts` in place and ran the lock: 2 of 3 fail. Restored the fix: 3/3.
- [x] **Both `@provenBy` mutations proven non-vacuous** — `npx tsx scripts/prove-locks.mts --file scripts/__tests__/stale-dist-is-detected.lock.test.ts` → `proven to fail when broken 1`, `VACUOUS 0`. One mutation neuters the dangling assertion (`if (hit || resolves(...)) continue;` → `if (true) continue;`), the other neuters the shadowing assertion.
- [x] **Positive control on the real tree**, per CLAUDE.md's "a QUIET probe proves nothing": deleting `packages/eslint-devkit/dist/src/types/meta-augmentation.js` now exits 1 naming both dangling specifiers (`dist/src/index.js` and `dist/src/types/index.js`); restoring it exits 0. `node -e "require('./packages/eslint-devkit')"` throws in the first state and not the second, so the check and reality agree.
- [x] `npm run --silent check-stale-artifacts` on a clean tree: exit 0, 0.696s (baseline 0.68s).
- [x] `npx oxlint --deny-warnings` on both changed files: clean. `npm run typecheck:scripts`: no new errors.
- [x] Formatted the script and **shrank** `.agent/format-drift-baseline.json` by that one entry (3613 → 3612).
- [x] Full `scripts/__tests__` suite: 2541/2542. The one failure (`oxlint-parity-gitignored-corpus-lock`) and one unloadable file (`rule-fuzz.test.ts`) are pre-existing worktree-environment drift — oxlint 1.74.0 in the shared `node_modules` no longer prunes gitignored dirs, and `fast-check` is declared in `package.json` but not installed. Neither is touched by this diff.

Pushed with `LEFTHOOK_EXCLUDE=build-and-test,portability` — both environmental in a `.claude/worktrees/` checkout (Turbopack cannot find Next.js through the symlinked `node_modules`; portability hashes the live checkout's oxlint version). `git diff --name-only origin/main...HEAD` touches neither `apps/docs` nor oxlint. Never `--no-verify`; `typecheck` and every pre-commit hook ran and passed.

## After merge

Every commit that touches a package now fails fast on a dist that has drifted out of sync with its source, instead of handing the failure to the next hook step as 60 unrelated-looking test failures. No behaviour change for a clean tree.

Worth watching: the assertion is scoped to relative `require()` in CJS output, which is everything `tsc` emits here today (0 `.mjs`, no ESM `import` in any `dist/`). If a package ever ships ESM output, `RELATIVE_REQUIRE` will need an `import`-from arm or that package silently loses the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved build validation to detect missing files referenced by compiled package output.
  - Continued detection of generated files that incorrectly shadow TypeScript source files.
  - Added clearer, category-specific remediation messages and limited reported findings for easier troubleshooting.

- **Tests**
  - Added integration coverage for missing references, valid references, and stale generated files.

- **Documentation**
  - Updated development check documentation to describe both validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->