### PR TITLE
fix(secure-coding): a CSS class is not a credential

### DIFF
--- a/.changeset/a-style-token-is-not-a-secret.md
+++ b/.changeset/a-style-token-is-not-a-secret.md
@@ -1,0 +1,9 @@
+---
+'eslint-plugin-secure-coding': patch
+---
+
+fix: `no-hardcoded-credentials` no longer reports CSS as a credential
+
+`pass: "text-[var(--success)]"` — a Tailwind class map — reported at CWE-798 / CVSS 9.8. The key is credential-shaped, and the value cleared the shape guards, so the name promoted it.
+
+A secret is written to be unreadable; `var(--x)`, a custom-property name, and a Tailwind arbitrary value are all written to be read. `isStyleToken` recognises those three shapes and returns before the entropy test. A bare `#0a0a0a` with no CSS context around it still reports — that shape is a short key.

--- a/packages/eslint-plugin-secure-coding/src/rules/no-hardcoded-credentials/a-style-token-is-not-a-secret.test.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/no-hardcoded-credentials/a-style-token-is-not-a-secret.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * A CSS class is not a credential, whatever the object key is called.
+ *
+ * Found dogfooding on `apps/engage` in ofri-peretz/blog, the first time that
+ * app was ever linted (#943). Reported at CWE-798 / CVSS 9.8 / CRITICAL:
+ *
+ *   apps/engage/src/app/queue/page.tsx:16
+ *     const TONE: Record<Gate, string> = {
+ *       pass: "text-[var(--success)]",
+ *       "below-bar": "text-[var(--warning)]",
+ *       unscored: "text-[var(--muted-foreground)]",
+ *     };
+ *
+ * `pass` is a gate outcome. The value is a Tailwind arbitrary-value class
+ * wrapping a CSS custom property. Nothing in it is a secret, and a reader who
+ * trusts a 9.8 stops what they are doing to look at a colour token.
+ *
+ * The rule's own doctrine is that it "decides on the *value*, never on the key
+ * name alone" — so the miss is in the value guards, not the name gate, exactly
+ * as it was for `mtls_incompatible_client_auth` and `<rootDir>/…`. A value
+ * carrying CSS syntax — `var(--x)`, a bracketed arbitrary value, a `--custom`
+ * property — is a style token, and style tokens are written to be read.
+ */
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { afterAll, describe, it } from 'vitest';
+
+import { noHardcodedCredentials } from './index';
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('a style token is not a secret', noHardcodedCredentials, {
+  valid: [
+    {
+      name: 'the exact map that reported 9.8 in engage',
+      code: `
+        const TONE = {
+          pass: "text-[var(--success)]",
+          "below-bar": "text-[var(--warning)]",
+          unscored: "text-[var(--muted-foreground)]",
+        };
+      `,
+    },
+    {
+      name: 'a bare CSS custom property under a credential-shaped key',
+      code: `const theme = { secret: "var(--brand-orange)" };`,
+    },
+    {
+      name: 'a Tailwind arbitrary value under a credential-shaped key',
+      code: `const styles = { token: "bg-[#0a0a0a]" };`,
+    },
+    {
+      name: 'a custom-property declaration under a credential-shaped key',
+      code: `const vars = { key: "--container-prose" };`,
+    },
+  ],
+  invalid: [
+    {
+      /*
+       * The control. Widening the value guards must not stop the rule finding
+       * a real secret that happens to sit in an object — otherwise the fix
+       * trades a false positive for a false negative, which is the worse of
+       * the two for a security rule. The value is deliberately NOT shaped like
+       * any provider's key (no `sk_live_` etc) — GitHub push protection blocks
+       * a push containing one even when the value is invented.
+       */
+      name: 'a real committed secret in the same shape still reports',
+      code: `const config = { apiKey: "Xq7vT2mKp9wRzB4nHc6LdF8sJ3yA5eU1" };`,
+      errors: 1,
+    },
+  ],
+});

--- a/packages/eslint-plugin-secure-coding/src/rules/no-hardcoded-credentials/index.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/no-hardcoded-credentials/index.ts
@@ -414,6 +414,44 @@ const CONTEXT_FREE_RANDOM_LENGTH = 32;
  * repeated here would be unreachable, and an unreachable guard reads as a
  * check that runs.
  */
+/**
+ * CSS syntax — a style token, not a secret.
+ *
+ * Reported at CWE-798 / CVSS 9.8 on `pass: "text-[var(--success)]"`, a
+ * Tailwind class map in ofri-peretz/blog's engage app (#943). `pass` is a
+ * credential-shaped key and the value cleared the shape guards, so the name
+ * promoted it — the same "gap in the value guards, not the name gate" as
+ * `mtls_incompatible_client_auth` and `<rootDir>/…`.
+ *
+ * A secret is written to be unreadable. Every marker below is the opposite:
+ * it exists so a human or a stylesheet can read it.
+ *
+ *   var(--success)          a CSS custom-property reference
+ *   --container-prose       a custom-property name
+ *   text-[var(--warning)]   a Tailwind arbitrary value
+ *   bg-[#0a0a0a]            …including a colour literal inside one
+ *
+ * Only ONE call site: Command not found: looksRandom
+Did you mean one of these? is unreachable for these values because
+ * the gate below returns first, and the package is gated at 100% coverage —
+ * which is how the speculative second call was caught.
+ *
+ * Deliberately NOT matching a bare `#0a0a0a`: a six-hex-digit string with no
+ * CSS context around it is exactly the shape of a short key, and this rule's
+ * job is to keep finding those.
+ */
+export function isStyleToken(value: string): boolean {
+  // `var(--x)` / `env(--x)` — a property reference anywhere in the string.
+  if (/\b(?:var|env)\(\s*--[\w-]+/.test(value)) return true;
+  // A custom-property NAME, alone or leading a declaration.
+  if (/^--[a-z][\w-]*$/i.test(value)) return true;
+  // A Tailwind arbitrary value: `utility-[…]`, where the utility is a
+  // hyphenated word run. The bracket is what makes it unambiguous — a
+  // credential does not carry one.
+  if (/^[a-z][\w-]*-\[[^\]]+\]$/i.test(value)) return true;
+  return false;
+}
+
 function isUrlOrPath(value: string): boolean {
   if (/^[A-Za-z][A-Za-z0-9+.-]*:\/\//.test(value)) {
     return !/^[^/]*\/\/[^/@]*:[^/@]*@/.test(value);
@@ -520,6 +558,8 @@ export function isSecretShaped(value: string, minLength: number): boolean {
   // structurally by `looksLikeCredential` and returns before shape is ever
   // consulted, and `isUrlOrPath` rejects a URL carrying userinfo regardless.
   if (isUrlOrPath(value)) return false;
+  // CSS is written to be read; see isStyleToken.
+  if (isStyleToken(value)) return false;
   // Pure word strings are identifiers / i18n keys / message constants.
   if (isNaturalWordString(value)) return false;
   // A credential mixes at least two character classes, or — for single-charset

--- a/packages/eslint-plugin-secure-coding/src/rules/no-hardcoded-credentials/no-hardcoded-credentials.test.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/no-hardcoded-credentials/no-hardcoded-credentials.test.ts
@@ -74,6 +74,9 @@ describe('no-hardcoded-credentials', () => {
           code: 'const password = process.env.DATABASE_PASSWORD;',
         },
         {
+          // The value is read at runtime, so there is no literal to leak —
+          // which is the shape the rule exists to steer people toward.
+          name: 'a credential-named property fed from the environment',
           code: 'const config = { apiKey: process.env.API_KEY };',
         },
         // Short strings (below minLength)


### PR DESCRIPTION
## Summary

- `no-hardcoded-credentials` reported **CWE-798 / CVSS 9.8 / CRITICAL** on a Tailwind class map — found dogfooding `apps/engage` in `ofri-peretz/blog` (#943):

  ```ts
  const TONE: Record<Gate, string> = {
    pass: "text-[var(--success)]",
    "below-bar": "text-[var(--warning)]",
  };
  ```

  `pass` is a gate outcome; the value is an arbitrary-value class wrapping a CSS custom property. A reader who trusts a 9.8 stops what they are doing to look at a colour token.

- The rule's doctrine is that it decides on the **value**, never the key name alone — so the miss is in the value guards, the same place as `mtls_incompatible_client_auth` and `<rootDir>/…`. New `isStyleToken` recognises the three shapes that exist only to be read: a `var(--x)` / `env(--x)` reference, a `--custom-property` name, and a `utility-[…]` arbitrary value. Wired into the value gate ahead of the entropy test.

- Deliberately **not** matching a bare `#0a0a0a` — six hex digits with no CSS context is exactly the shape of a short key, and finding those is the rule's job.

## Test plan

- [x] New lock `a-style-token-is-not-a-secret.test.ts` — 4 valid cases plus **an invalid control**: a high-entropy `apiKey` value in the same object shape still reports `errors: 1`. Trading a false positive for a false negative is the worse deal for a security rule, so the control is the assertion that matters.
- [x] `vitest run packages/eslint-plugin-secure-coding` — 84 files / 3,729 tests green, coverage back at the gated **100%**.
- [x] One previously-undescribed case named, per the description ratchet.

Note: the control's value is deliberately not shaped like any provider's key. An earlier `sk_live_…` literal — invented, not real — was blocked by GitHub push protection.

## After merge

Closes the first of the three dogfooding FPs in #943. The other two were already fixed on `main` and only await a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)