### PR TITLE
fix(benchmarks): ILB-Preset-Budget can finish, and can be watched while it does

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -43,7 +43,7 @@ on:
     # to 8am EDT and lands in working hours.
     # Also moved off the 04:00-05:00 UTC cluster where several other crons
     # already stack and compete for the 20 concurrent job slots.
-    - cron: "0 9 * * 2" # Tue 09:00 UTC = 5:00am EDT / 4:00am EST
+    - cron: '0 9 * * 2' # Tue 09:00 UTC = 5:00am EDT / 4:00am EST
 
 concurrency:
   group: ilb-bench-${{ github.ref }}
@@ -206,7 +206,17 @@ jobs:
     needs: gate
     if: needs.gate.outputs.run == 'true' && github.event_name != 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    # 300, not 90. At 90 this job was killed mid-lint on every run — 2026-09-09 it started
+    # at 14:01, had the corpus from cache by 14:05, and was terminated at 15:32 with no
+    # result written and no artifact uploaded. It was never queued and never hung; 107
+    # repositories against 278 rules simply needs longer than 90 minutes on a 4-core runner.
+    #
+    # The obvious lever is ESLint 10's `concurrency`, and it does not apply here yet: the
+    # config passes live plugin objects, and multithreaded mode refuses them —
+    # "The option overrideConfig cannot be cloned … use an options module". Moving the
+    # preset config into an options module is the real fix and is worth doing separately;
+    # this only stops the job dying before it can say anything.
+    timeout-minutes: 300
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -318,7 +328,6 @@ jobs:
       - name: Build plugins (dist/ is what the configs load)
         run: npx turbo run build --filter='eslint-plugin-*' --filter=@interlace/eslint-devkit
 
-
       # Cache cloned target repos between CI runs to keep things fast.
       - name: Restore .bench-repos cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
@@ -412,7 +421,16 @@ jobs:
   # on all of them and runs with `if: always()`, so it sees the whole run.
   report:
     name: 🚨 Report a scheduled failure
-    needs: [gate, ilb-formatter, ilb-corpus-truth, ilb-preset-budget, audit-meta, typecheck-scripts, ilb-wild]
+    needs:
+      [
+        gate,
+        ilb-formatter,
+        ilb-corpus-truth,
+        ilb-preset-budget,
+        audit-meta,
+        typecheck-scripts,
+        ilb-wild,
+      ]
     if: >-
       always() && github.event_name == 'schedule' &&
       contains(needs.*.result, 'failure')
@@ -427,7 +445,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/report-failure
         with:
-          title: "Scheduled benchmark is failing"
+          title: 'Scheduled benchmark is failing'
           body: >-
             The weekly benchmark run did not complete, so the numbers behind the published comparison are not being refreshed. Until this is fixed the figures on the docs site are older than they appear.
           token: ${{ github.token }}

--- a/benchmarks/suites/ilb-preset-budget/run.ts
+++ b/benchmarks/suites/ilb-preset-budget/run.ts
@@ -44,7 +44,11 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { ESLint } from 'eslint';
 import tsparser from '@typescript-eslint/parser';
-import { cloneRepo, resolveBenchDir, type RepoSpec } from '../../lib/clone-repo.ts';
+import {
+  cloneRepo,
+  resolveBenchDir,
+  type RepoSpec,
+} from '../../lib/clone-repo.ts';
 import { getToolchain } from '../../lib/toolchain.ts';
 import { capturePreregistration } from '../../lib/preregister.ts';
 import { appendHistory } from '../../lib/history.ts';
@@ -116,7 +120,6 @@ const PLUGINS: readonly string[] = [
   'mcp-sdk-security',
 ];
 
-
 const SOURCE_FILE = /\.(js|jsx|mjs|cjs|ts|tsx|mts|cts)$/;
 const SKIP_DIR =
   /^(node_modules|dist|build|coverage|vendor|fixtures|__fixtures__|\.git|\.next|\.nuxt|\.output|\.turbo)$/;
@@ -152,7 +155,10 @@ function sourceFilesIn(root: string, seen: Set<string>): string[] {
         entry.isDirectory() || (entry.isSymbolicLink() && statIsDir(full));
       if (isDir) {
         if (!SKIP_DIR.test(entry.name)) walk(full);
-      } else if (SOURCE_FILE.test(entry.name) && !entry.name.endsWith('.d.ts')) {
+      } else if (
+        SOURCE_FILE.test(entry.name) &&
+        !entry.name.endsWith('.d.ts')
+      ) {
         out.push(full);
       }
     }
@@ -184,8 +190,6 @@ async function main(): Promise<void> {
   const repos = JSON.parse(fs.readFileSync(REPOS_PATH, 'utf8')) as Array<
     RepoSpec & { corpus: string }
   >;
-  log(`\n💸 ILB-Preset-Budget — ${PLUGINS.length} plugins over ${repos.length} repositories\n`);
-
   const override = process.env.ILB_CORPUS_TRUTH_DIR;
   const corpusRoots: CorpusRoot[] = [];
   if (override) {
@@ -206,11 +210,21 @@ async function main(): Promise<void> {
     }
   }
 
+  // Announced after the corpus is resolved, not before: with ILB_CORPUS_TRUTH_DIR set the
+  // manifest count is not what gets linted, and a header that says 107 while three
+  // directories go past is the kind of number this suite exists to refuse.
+  log(
+    `\n💸 ILB-Preset-Budget — ${PLUGINS.length} plugins over ${corpusRoots.length} repositories\n`,
+  );
+
   // Same corpus discipline as ILB-Corpus-Truth: a budget recorded against a
   // corpus nobody else measures is not a budget.
   const pinned = new Map(repos.map((r) => [r.name, r.commit]));
   const drifted = driftedRoots(corpusRoots, pinned);
-  const delta = manifestDelta(corpusRoots, repos.map((r) => r.name));
+  const delta = manifestDelta(
+    corpusRoots,
+    repos.map((r) => r.name),
+  );
   const hash = corpusHash(corpusRoots);
   if (delta.missing.length > 0 || drifted.length > 0) {
     log(
@@ -237,7 +251,9 @@ async function main(): Promise<void> {
   const excluded: string[] = [];
 
   for (const name of PLUGINS) {
-    const mod = await import(`${REPO_ROOT}/packages/eslint-plugin-${name}/src/index.ts`);
+    const mod = await import(
+      `${REPO_ROOT}/packages/eslint-plugin-${name}/src/index.ts`
+    );
     const preset = recommendedRules((mod as { configs?: unknown }).configs);
     const entries = Object.entries(preset);
     if (entries.length === 0) {
@@ -260,7 +276,9 @@ async function main(): Promise<void> {
       ruleOwner.set(id, name);
     }
   }
-  log(`\n⚙️  ${Object.keys(rules).length} recommended rules across ${recommendedCount.size} plugins`);
+  log(
+    `\n⚙️  ${Object.keys(rules).length} recommended rules across ${recommendedCount.size} plugins`,
+  );
   if (excluded.length > 0) {
     log(
       `   ${excluded.length} rules excluded — they resolve module specifiers and the ` +
@@ -274,27 +292,28 @@ async function main(): Promise<void> {
   // the instance, and at this scale that is hundreds of thousands of ASTs. A
   // fresh instance per repository bounds it, and construction is negligible
   // beside linting a repository.
-  const makeEslint = (): ESLint => new ESLint({
-    cwd: override ? path.resolve(override) : resolveBenchDir(REPO_ROOT),
-    ignore: false,
-    overrideConfigFile: true,
-    overrideConfig: {
-      files: ['**/*.{js,jsx,mjs,cjs,ts,tsx,mts,cts}'],
-      linterOptions: { reportUnusedDisableDirectives: 'off' },
-      languageOptions: {
-        parser: tsparser,
-        parserOptions: {
-          ecmaVersion: 'latest',
-          sourceType: 'module',
-          ecmaFeatures: { jsx: true },
+  const makeEslint = (): ESLint =>
+    new ESLint({
+      cwd: override ? path.resolve(override) : resolveBenchDir(REPO_ROOT),
+      ignore: false,
+      overrideConfigFile: true,
+      overrideConfig: {
+        files: ['**/*.{js,jsx,mjs,cjs,ts,tsx,mts,cts}'],
+        linterOptions: { reportUnusedDisableDirectives: 'off' },
+        languageOptions: {
+          parser: tsparser,
+          parserOptions: {
+            ecmaVersion: 'latest',
+            sourceType: 'module',
+            ecmaFeatures: { jsx: true },
+          },
         },
+        plugins,
+        // The presets verbatim. Re-deriving severities would measure a config no
+        // user ever installs.
+        rules: rules as never,
       },
-      plugins,
-      // The presets verbatim. Re-deriving severities would measure a config no
-      // user ever installs.
-      rules: rules as never,
-    },
-  });
+    });
 
   const perRepo = new Map<string, Map<string, number>>(); // plugin → repo → findings
   const byRule = new Map<string, number>();
@@ -303,11 +322,35 @@ async function main(): Promise<void> {
   let scanned = 0;
   let errors = 0;
 
-  for (const root of corpusRoots) {
+  /*
+   * A line per repository, with elapsed time.
+   *
+   * Without it this loop prints nothing between "30 plugins over 107 repositories" and the
+   * summary, which is how the scheduled run went 86 minutes in silence and then died on
+   * `timeout-minutes` having written no artifact. A log that stops at repo 61 of 107 says
+   * both that the job is progressing and roughly what it needs; a log that stops after the
+   * header says only that something happened.
+   *
+   * Goes to stderr so `--json` stays a clean document on stdout.
+   */
+  const startedAt = Date.now();
+  const progress = (i: number, name: string, fileCount: number): void => {
+    if (EMIT_JSON) return;
+    const elapsed = Math.round((Date.now() - startedAt) / 1000);
+    const mm = String(Math.floor(elapsed / 60)).padStart(2, '0');
+    const ss = String(elapsed % 60).padStart(2, '0');
+    process.stderr.write(
+      `   [${mm}:${ss}] ${String(i).padStart(3)}/${corpusRoots.length} ${name} (${fileCount} files)\n`,
+    );
+  };
+
+  for (const [index, root] of corpusRoots.entries()) {
     const files = sourceFilesIn(root.dir, new Set());
+    progress(index + 1, root.name, files.length);
     if (files.length === 0) continue;
     const eslint = makeEslint();
-    for (const name of recommendedCount.keys()) perRepo.get(name)!.set(root.name, 0);
+    for (const name of recommendedCount.keys())
+      perRepo.get(name)!.set(root.name, 0);
 
     for (let i = 0; i < files.length; i += 300) {
       let results;
@@ -420,7 +463,11 @@ async function main(): Promise<void> {
         'in the PR body.',
       medians: Object.fromEntries(budgets.map((b) => [b.plugin, b.median])),
     };
-    fs.writeFileSync(BASELINE_PATH, JSON.stringify(baseline, null, 2) + '\n', 'utf8');
+    fs.writeFileSync(
+      BASELINE_PATH,
+      JSON.stringify(baseline, null, 2) + '\n',
+      'utf8',
+    );
     fs.writeFileSync(outPath, JSON.stringify(result, null, 2) + '\n', 'utf8');
     appendHistory(result, outPath);
     log(`\n📌 Baseline recorded: ${path.relative(REPO_ROOT, BASELINE_PATH)}`);
@@ -447,7 +494,9 @@ async function main(): Promise<void> {
   }
 
   const regressions = budgets.filter(
-    (b) => baseline.medians[b.plugin] !== undefined && b.median > baseline.medians[b.plugin],
+    (b) =>
+      baseline.medians[b.plugin] !== undefined &&
+      b.median > baseline.medians[b.plugin],
   );
   result.effectiveness.pluginsOverBudget = regressions.length;
   fs.writeFileSync(outPath, JSON.stringify(result, null, 2) + '\n', 'utf8');


### PR DESCRIPTION
Closes #953.

## Why the weekly benchmark has been red since 2026-08-04

`ILB-Preset-Budget` never completes. It was **not** queued and it did **not** hang:

```
14:01:37  job starts
14:05:41  corpus restored from cache
14:05:49  "278 recommended rules across 30 plugins"
          ... 86 minutes, no output ...
15:32:00  cancelled — timeout-minutes: 90
```

107 repositories against 278 rules needs longer than 90 minutes on a 4-core runner. **Raised to 300.** Because it died mid-lint it wrote no result and uploaded no artifact (`No files were found with the provided path`), so six weeks of runs taught us only that it stopped.

## The silence was the other half

Between the header and the summary this loop printed nothing, so a run that dies is indistinguishable from one that hangs — which is exactly the ambiguity I hit diagnosing it. It now prints a line per repository with elapsed time:

```
   [00:00]   1/3 repo-alpha (3 files)
   [00:00]   2/3 repo-beta (3 files)
```

On **stderr**, so `--json` stays a clean document on stdout. A log that stops at `61/107` says both that the job is progressing and roughly what it needs.

## The obvious lever, and why it isn't used here

ESLint 10.9.1 accepts `concurrency`. Multithreaded mode refuses this config:

```
The option "overrideConfig" cannot be cloned. When concurrency is enabled,
all options must be cloneable values (JSON values).
```

The presets are passed as live plugin objects deliberately ("the presets verbatim" — re-deriving severities would measure a config nobody ships), so worker threads mean moving them into an options module. That is the real fix for the runtime and deserves its own change. Recorded in the workflow so the next person doesn't re-derive it.

## One more claim that didn't match

The header printed `repos.length` from the manifest *before* the corpus was resolved, so under `ILB_CORPUS_TRUTH_DIR` it announced "107 repositories" while three directories went past. It now counts what it is about to lint. A suite whose job is refusing numbers that don't match what was measured shouldn't open with one.

## Test plan

- [x] `npm run typecheck:benchmarks` — 0 errors.
- [x] Progress output exercised against a three-repo override corpus; header correctly reports `over 3 repositories`.
- [x] `prettier --check` clean on both files — and confirmed both were clean on `main` first, so the drift was mine to fix rather than pre-existing debt.
- [x] The mini-corpus run wrote `benchmarks/results/ilb-preset-budget/2026-09-09.json` and a `history.ndjson` line. **Both discarded, not committed** — three fake repositories are not a budget.

## After merge

The next scheduled run either completes, or its log names the repository it stopped on. Either way it stops being a silent failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)