### PR TITLE
chore(docs): sync generated data

### DIFF
--- a/apps/docs/src/data/articles.json
+++ b/apps/docs/src/data/articles.json
@@ -33,7 +33,7 @@
       "page_views_count": 0,
       "public_reactions_count": 5,
       "positive_reactions_count": 5,
-      "comments_count": 0,
+      "comments_count": 1,
       "tag_list": [
         "security",
         "javascript",
@@ -1745,6 +1745,6 @@
     }
   ],
   "total": 85,
-  "lastUpdated": "2026-09-06T03:52:05.028Z",
+  "lastUpdated": "2026-09-10T00:12:11.106Z",
   "source": "public"
 }

--- a/apps/docs/src/data/changelog.json
+++ b/apps/docs/src/data/changelog.json
@@ -1,7 +1,7 @@
 {
-  "releaseCount": 657,
+  "releaseCount": 661,
   "packageCount": 35,
-  "entryCount": 2047,
+  "entryCount": 2055,
   "oldestYear": 2024,
   "releases": [
     {
@@ -16565,6 +16565,21 @@
       ]
     },
     {
+      "package": "eslint-plugin-conventions",
+      "short": "eslint-plugin-conventions",
+      "version": "5.3.5",
+      "date": null,
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "`consistent-existence-index-check` no longer autofixes between checks that are not equivalent",
+          "pr": null
+        }
+      ]
+    },
+    {
       "package": "eslint-plugin-jwt-security",
       "short": "eslint-plugin-jwt-security",
       "version": "2.2.9",
@@ -16680,6 +16695,26 @@
         {
           "kind": "other",
           "title": "Ofri Peretz",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-maintainability",
+      "short": "eslint-plugin-maintainability",
+      "version": "3.2.5",
+      "date": null,
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "`no-missing-error-context` reads three more shapes of throw",
+          "pr": null
+        },
+        {
+          "kind": "fix",
+          "title": "`no-unhandled-promise` no longer reports a promise whose value is used",
           "pr": null
         }
       ]
@@ -16805,6 +16840,51 @@
         {
           "kind": "other",
           "title": "Ofri Peretz",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-reliability",
+      "short": "eslint-plugin-reliability",
+      "version": "4.1.6",
+      "date": null,
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "`no-missing-null-checks` follows four more guards it already meant to follow",
+          "pr": null
+        },
+        {
+          "kind": "fix",
+          "title": "`no-missing-error-context` reads three more shapes of throw",
+          "pr": null
+        },
+        {
+          "kind": "fix",
+          "title": "`no-unhandled-promise` no longer reports a promise whose value is used",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-secure-coding",
+      "short": "eslint-plugin-secure-coding",
+      "version": "5.3.5",
+      "date": null,
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "`no-insecure-comparison` stops reading two public values as secrets",
+          "pr": null
+        },
+        {
+          "kind": "fix",
+          "title": "`no-unchecked-loop-condition` exempts `for (;;)` with a break, as it does `while (true)`",
           "pr": null
         }
       ]

--- a/apps/docs/src/data/plugin-stats.json
+++ b/apps/docs/src/data/plugin-stats.json
@@ -21,7 +21,7 @@
       "rules": 33,
       "description": "ESLint plugin for secure coding — detects LDAP, XPath, XXE, GraphQL and template injection, unsafe deserialization, ReDoS, missing authentication, and PII in logs",
       "category": "security",
-      "version": "5.3.4",
+      "version": "5.3.5",
       "published": true
     },
     {
@@ -181,7 +181,7 @@
       "rules": 15,
       "description": "ESLint plugin for team code conventions — enforces filename case, magic-number bans, commented-out code, expiring TODOs, and deprecated-API usage",
       "category": "quality",
-      "version": "5.3.4",
+      "version": "5.3.5",
       "published": true
     },
     {
@@ -189,7 +189,7 @@
       "rules": 12,
       "description": "ESLint plugin for maintainable code — limits cognitive complexity, nesting depth, parameter counts, duplicate functions, and unhandled or silent errors",
       "category": "quality",
-      "version": "3.2.4",
+      "version": "3.2.5",
       "published": true
     },
     {
@@ -197,7 +197,7 @@
       "rules": 9,
       "description": "ESLint plugin for runtime reliability — enforces error handling, network timeouts, null checks, and safe type narrowing",
       "category": "quality",
-      "version": "4.1.5",
+      "version": "4.1.6",
       "published": true
     },
     {
@@ -244,5 +244,5 @@
   "totalRules": 477,
   "totalPlugins": 30,
   "allPluginsCount": 30,
-  "generatedAt": "2026-09-08"
+  "generatedAt": "2026-09-10"
 }


### PR DESCRIPTION
Regenerated apps/docs/src/data/ (trigger: push). Opened by the Docs Data Sync workflow; contents come entirely from the apps/docs/scripts/sync-* scripts, so review the diff rather than hand-editing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated article comment information and refreshed documentation data.
  - Added changelog entries for new plugin releases, including fixes related to existence checks, promise analysis, null checks, insecure comparisons, and loop conditions.
  - Updated release and entry totals in the changelog.

- **Plugin Updates**
  - Updated documented versions for the conventions, maintainability, reliability, and secure-coding plugins.
  - Refreshed plugin statistics and generation timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->