### PR TITLE
feat(conventions)!: default consistent-existence-index-check to Object.hasOwn

### DIFF
--- a/.changeset/own-property-is-the-safer-default.md
+++ b/.changeset/own-property-is-the-safer-default.md
@@ -1,0 +1,49 @@
+---
+'eslint-plugin-conventions': minor
+---
+
+feat!: `consistent-existence-index-check` defaults to `Object.hasOwn`, not `in`
+
+A default is what a codebase gets for having no opinion, and this one pointed every such codebase at `in` — the one form of the three that answers `true` for an INHERITED key. That is the direction a prototype-pollution guard is written to avoid.
+
+`Object.hasOwn` exists because `in` and the `hasOwnProperty` dances were each the wrong answer often enough for the language to add a third; eslint core's `prefer-object-has-own` points the same way.
+
+**What changes for a consumer who set no options.** `key in obj` is now reported and `Object.hasOwn(obj, key)` is not — the reverse of before. Nothing is rewritten across that boundary in either direction: `in` and the own-property checks ask different questions, so only the report is made. The single autofix, `Object.prototype.hasOwnProperty.call(obj, key)` → `Object.hasOwn(obj, key)`, is unchanged.
+
+## Migration
+
+If you set no options and want the old behaviour, name it:
+
+```js
+// before — `in` by default
+{
+  rules: {
+    'conventions/consistent-existence-index-check': 'error',
+  },
+}
+
+// after — the same behaviour, stated
+{
+  rules: {
+    'conventions/consistent-existence-index-check': ['error', { preferred: 'in' }],
+  },
+}
+```
+
+If you want the new default, change nothing in your config and fix the reports:
+
+```js
+// before — reported under the new default
+if (key in obj) {
+}
+
+// after
+if (Object.hasOwn(obj, key)) {
+}
+```
+
+`--fix` will not do that second one for you, deliberately: `in` also answers for inherited keys, so a machine cannot know whether your code wanted that. Only `Object.prototype.hasOwnProperty.call(obj, key)` → `Object.hasOwn(obj, key)` is autofixed.
+
+`preferred: 'in'` remains the right setting where a prototype-chain lookup is what the code means. It is now a choice someone makes rather than one they inherit.
+
+The rule's docs carried a `❌ obj.hasOwnProperty` / `✅ array.includes` example pair that described a different rule entirely; they now show the three reported forms, the one safe rewrite, and why the others are report-only.

--- a/.changeset/own-property-is-the-safer-default.md
+++ b/.changeset/own-property-is-the-safer-default.md
@@ -1,5 +1,5 @@
 ---
-'eslint-plugin-conventions': minor
+'eslint-plugin-conventions': major
 ---
 
 feat!: `consistent-existence-index-check` defaults to `Object.hasOwn`, not `in`

--- a/packages/eslint-plugin-conventions/docs/rules/consistent-existence-index-check.md
+++ b/packages/eslint-plugin-conventions/docs/rules/consistent-existence-index-check.md
@@ -8,8 +8,8 @@ autofix: suggestions
 
 > **Keywords:** indexOf, includes, array, consistency, ESLint rule, auto-fix, LLM-optimized
 
-
 <!-- @rule-summary -->
+
 Enforce consistent style for checking if an element exists in an array
 <!-- @/rule-summary -->
 
@@ -17,13 +17,13 @@ Enforce consistent style for checking if an element exists in an array. This rul
 
 ## Quick Summary
 
-| Aspect         | Details                                                              |
-| -------------- | -------------------------------------------------------------------- |
-| **Severity**   | Warning (code quality)                                               |
-| **Auto-Fix**   | ✅ Yes (converts pattern)                                            |
-| **Category**   | Quality |
-| **ESLint MCP** | ✅ Optimized for ESLint MCP integration                              |
-| **Best For**   | Code consistency, modern JavaScript practices                        |
+| Aspect         | Details                                       |
+| -------------- | --------------------------------------------- |
+| **Severity**   | Warning (code quality)                        |
+| **Auto-Fix**   | ✅ Yes (converts pattern)                     |
+| **Category**   | Quality                                       |
+| **ESLint MCP** | ✅ Optimized for ESLint MCP integration       |
+| **Best For**   | Code consistency, modern JavaScript practices |
 
 ## Rule Details
 
@@ -31,32 +31,50 @@ Prefer `includes()` over `indexOf() !== -1` for existence checks.
 
 ### Why This Matters
 
-| Issue                     | Impact                          | Solution                  |
-| ------------------------- | ------------------------------- | ------------------------- |
-| 📖 **Readability**        | `!== -1` is less clear          | Use includes()            |
-| 🎯 **Intent**             | indexOf suggests index needed   | Clear existence check     |
-| 🔄 **Consistency**        | Mixed patterns in codebase      | Standardize               |
+| Issue              | Impact                        | Solution              |
+| ------------------ | ----------------------------- | --------------------- |
+| 📖 **Readability** | `!== -1` is less clear        | Use includes()        |
+| 🎯 **Intent**      | indexOf suggests index needed | Clear existence check |
+| 🔄 **Consistency** | Mixed patterns in codebase    | Standardize           |
 
 ## Examples
+
+The default preference is `Object.hasOwn`.
 
 ### ❌ Incorrect
 
 ```typescript
-obj.hasOwnProperty("key")
+key in obj; // answers true for INHERITED keys
+obj.hasOwnProperty(key); // looks the method up ON obj
+Object.prototype.hasOwnProperty.call(obj, key); // the long way round
 ```
 
 ### ✅ Correct
 
 ```typescript
-if (array.includes(item)) { }
-if (string.includes(substring)) { }
-
-// indexOf is fine when you need the actual index
-const index = array.indexOf(item);
-if (index !== -1) {
-  array.splice(index, 1);  // Using the index
-}
+Object.hasOwn(obj, key);
 ```
+
+### What is and is not autofixed
+
+Only `Object.prototype.hasOwnProperty.call(obj, key)` → `Object.hasOwn(obj, key)`.
+Those two ask the same question through the same dispatch, so the rewrite is safe.
+
+Everything else is **reported without a fix**, because rewriting it would change
+what the code does:
+
+- `in` walks the prototype chain and the own-property checks do not, so the two
+  disagree on an inherited key.
+- `obj.hasOwnProperty(key)` looks the method up on `obj`: it throws on a
+  null-prototype object and calls whatever a shadowing own property points at.
+
+### Options
+
+`preferred: 'Object.hasOwn' | 'in' | 'hasOwnProperty'` — default `'Object.hasOwn'`.
+
+Set `'in'` when a prototype-chain lookup is what the code means. It is a choice
+worth making deliberately; it is not a good default, which is why it is no longer
+one.
 
 ## Configuration Examples
 
@@ -77,6 +95,7 @@ if (index !== -1) {
 ## Further Reading
 
 - **[Array.includes() - MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes)** - MDN reference
+
 ## Known False Negatives
 
 The following patterns are **not detected** due to static analysis limitations:

--- a/packages/eslint-plugin-conventions/docs/rules/consistent-existence-index-check.md
+++ b/packages/eslint-plugin-conventions/docs/rules/consistent-existence-index-check.md
@@ -1,41 +1,54 @@
 ---
 title: consistent-existence-index-check
-description: Enforce consistent style for checking if an element exists in an array
+description: Enforce one form for checking whether an object has a property
 tags: ['quality', 'conventions']
 category: quality
 autofix: suggestions
 ---
 
-> **Keywords:** indexOf, includes, array, consistency, ESLint rule, auto-fix, LLM-optimized
+> **Keywords:** Object.hasOwn, hasOwnProperty, in operator, prototype chain, property existence, ESLint rule, LLM-optimized
 
 <!-- @rule-summary -->
 
-Enforce consistent style for checking if an element exists in an array
+Enforce one form for checking whether an object has a property
 <!-- @/rule-summary -->
 
-Enforce consistent style for checking if an element exists in an array. This rule is part of [`eslint-plugin-conventions`](https://www.npmjs.com/package/eslint-plugin-conventions).
+Enforce one form for checking whether an object has a property — `Object.hasOwn`, `in`, or one of the `hasOwnProperty` spellings. This rule is part of [`eslint-plugin-conventions`](https://www.npmjs.com/package/eslint-plugin-conventions).
+
+> **The name is about property existence, not array indexing.** Despite `index` in
+> the rule id, this rule never looks at `indexOf` or `includes`. It reads
+> `key in obj`, `obj.hasOwnProperty(key)`,
+> `Object.prototype.hasOwnProperty.call(obj, key)` and `Object.hasOwn(obj, key)`.
 
 ## Quick Summary
 
-| Aspect         | Details                                       |
-| -------------- | --------------------------------------------- |
-| **Severity**   | Warning (code quality)                        |
-| **Auto-Fix**   | ✅ Yes (converts pattern)                     |
-| **Category**   | Quality                                       |
-| **ESLint MCP** | ✅ Optimized for ESLint MCP integration       |
-| **Best For**   | Code consistency, modern JavaScript practices |
+| Aspect         | Details                                                   |
+| -------------- | --------------------------------------------------------- |
+| **Severity**   | Warning (code quality)                                    |
+| **Auto-Fix**   | ⚠️ One conversion only — see below                        |
+| **Category**   | Quality                                                   |
+| **ESLint MCP** | ✅ Optimized for ESLint MCP integration                   |
+| **Best For**   | Consistency, and keeping prototype lookups out by default |
 
 ## Rule Details
 
-Prefer `includes()` over `indexOf() !== -1` for existence checks.
+JavaScript has four ways to ask whether an object has a property, and they do not
+all answer the same question. This rule picks one and reports the others.
+
+| Form                                             | Answers for an inherited key | Looks the method up on `obj` |
+| ------------------------------------------------ | ---------------------------- | ---------------------------- |
+| `Object.hasOwn(obj, key)`                        | no                           | no                           |
+| `Object.prototype.hasOwnProperty.call(obj, key)` | no                           | no                           |
+| `obj.hasOwnProperty(key)`                        | no                           | **yes**                      |
+| `key in obj`                                     | **yes**                      | no                           |
 
 ### Why This Matters
 
-| Issue              | Impact                        | Solution              |
-| ------------------ | ----------------------------- | --------------------- |
-| 📖 **Readability** | `!== -1` is less clear        | Use includes()        |
-| 🎯 **Intent**      | indexOf suggests index needed | Clear existence check |
-| 🔄 **Consistency** | Mixed patterns in codebase    | Standardize           |
+| Issue                  | Impact                                                    | Solution                    |
+| ---------------------- | --------------------------------------------------------- | --------------------------- |
+| 🛡️ **Prototype chain** | `in` is true for inherited keys — the pollution direction | Default to `Object.hasOwn`  |
+| 💥 **Dispatch**        | `obj.hasOwnProperty` throws on a null-prototype object    | Never call it through `obj` |
+| 🔄 **Consistency**     | Four spellings of one question                            | Standardize on one          |
 
 ## Examples
 
@@ -83,18 +96,23 @@ one.
 ```javascript
 {
   rules: {
-    'conventions/consistent-existence-index-check': 'warn'
+    // Default: preferred is 'Object.hasOwn'
+    'conventions/consistent-existence-index-check': 'warn',
+
+    // Or state a different preference deliberately
+    // 'conventions/consistent-existence-index-check': ['warn', { preferred: 'in' }],
   }
 }
 ```
 
 ## Related Rules
 
-- [`prefer-at`](./prefer-at.md) - Modern array access
+- [`prefer-object-has-own`](https://eslint.org/docs/latest/rules/prefer-object-has-own) — eslint core, same direction
 
 ## Further Reading
 
-- **[Array.includes() - MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes)** - MDN reference
+- **[Object.hasOwn() - MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn)** — why it was added
+- **[in operator - MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in)** — including the prototype-chain behaviour
 
 ## Known False Negatives
 

--- a/packages/eslint-plugin-conventions/src/rules/conventions/consistent-existence-index-check.ts
+++ b/packages/eslint-plugin-conventions/src/rules/conventions/consistent-existence-index-check.ts
@@ -15,7 +15,20 @@ import { formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
 type MessageIds = 'consistentExistenceCheck';
 
 export interface Options {
-  /** Preferred method for checking property existence */
+  /**
+   * Preferred method for checking property existence. Default: `Object.hasOwn`.
+   *
+   * The default used to be `in`, which pointed every codebase at the one form of
+   * the three that answers `true` for an INHERITED key. That is the direction a
+   * prototype-pollution guard is written to avoid, and it is the opposite of where
+   * the language went: `Object.hasOwn` exists because `in` and the `hasOwnProperty`
+   * dances were both wrong answers, and eslint core's `prefer-object-has-own`
+   * points the same way.
+   *
+   * `in` remains available and is the right answer when a chain lookup is what the
+   * code means — a prototype-based lookup table, a `Symbol.hasInstance` check.
+   * It is a choice to make deliberately rather than one to arrive at by default.
+   */
   preferred?: 'in' | 'hasOwnProperty' | 'Object.hasOwn';
 }
 
@@ -52,18 +65,18 @@ export const consistentExistenceIndexCheck = createRule<
           preferred: {
             type: 'string',
             enum: ['in', 'hasOwnProperty', 'Object.hasOwn'],
-            default: 'in',
+            default: 'Object.hasOwn',
           },
         },
         additionalProperties: false,
       },
     ],
   },
-  defaultOptions: [{ preferred: 'in' }],
+  defaultOptions: [{ preferred: 'Object.hasOwn' }],
 
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>) {
     const [options] = context.options;
-    const { preferred = 'in' } = options || {};
+    const { preferred = 'Object.hasOwn' } = options || {};
 
     function reportInconsistentCheck(
       node: TSESTree.Node,

--- a/packages/eslint-plugin-conventions/src/tests/conventions/consistent-existence-index-check.default.test.ts
+++ b/packages/eslint-plugin-conventions/src/tests/conventions/consistent-existence-index-check.default.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * The default is `Object.hasOwn`, and which form is the default is the whole point.
+ *
+ * It used to be `in` — the one form of the three that answers `true` for an
+ * INHERITED key. A default is what a codebase gets for having no opinion, and this
+ * one pointed every such codebase at the direction a prototype-pollution guard is
+ * written to avoid. `Object.hasOwn` exists because `in` and the `hasOwnProperty`
+ * dances were both the wrong answer often enough for the language to add a third;
+ * eslint core's `prefer-object-has-own` points the same way.
+ *
+ * `in` is still available and still correct where a chain lookup is what the code
+ * MEANS. It is now a choice someone makes rather than one they inherit.
+ */
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { describe, it, afterAll } from 'vitest';
+import parser from '@typescript-eslint/parser';
+import { consistentExistenceIndexCheck } from '../../rules/conventions/consistent-existence-index-check';
+
+RuleTester.afterAll = afterAll;
+RuleTester.it = it;
+RuleTester.itOnly = it.only;
+RuleTester.describe = describe;
+
+const ruleTester = new RuleTester({
+  languageOptions: { parser, ecmaVersion: 2022, sourceType: 'module' },
+});
+
+describe('consistent-existence-index-check — the default is Object.hasOwn', () => {
+  ruleTester.run('with no options at all', consistentExistenceIndexCheck, {
+    valid: [
+      {
+        name: 'Object.hasOwn is what the default asks for, so it is left alone',
+        code: 'if (Object.hasOwn(obj, key)) {}',
+      },
+    ],
+    invalid: [
+      {
+        name: '`in` is reported by default — it answers for inherited keys too',
+        code: 'if (key in obj) {}',
+        // Not rewritten: the two ask different questions. Only the report is made.
+        output: null,
+        errors: [{ messageId: 'consistentExistenceCheck' as const }],
+      },
+      {
+        name: 'the long-hand own-property check is shortened, which is safe',
+        code: 'if (Object.prototype.hasOwnProperty.call(obj, key)) {}',
+        output: 'if (Object.hasOwn(obj, key)) {}',
+        errors: [{ messageId: 'consistentExistenceCheck' as const }],
+      },
+      {
+        name: 'the direct dispatch is reported but never rewritten',
+        code: 'if (obj.hasOwnProperty(key)) {}',
+        output: null,
+        errors: [{ messageId: 'consistentExistenceCheck' as const }],
+      },
+    ],
+  });
+});

--- a/packages/eslint-plugin-conventions/src/tests/conventions/consistent-existence-index-check.test.ts
+++ b/packages/eslint-plugin-conventions/src/tests/conventions/consistent-existence-index-check.test.ts
@@ -21,19 +21,24 @@ const ruleTester = new RuleTester({
 });
 
 describe('consistent-existence-index-check', () => {
-  describe('default (prefer "in")', () => {
+  describe('opting in to "in"', () => {
+    // `in` is no longer the default — it is the one form of the three that answers
+    // `true` for an INHERITED key, which is not where a default should point. These
+    // cases now say so, rather than arriving there by omission.
+    const IN = [{ preferred: 'in' as const }];
+
     ruleTester.run('prefer in operator', consistentExistenceIndexCheck, {
       valid: [
-        // Using 'in' operator (preferred)
-        { name: 'the `in` operator', code: '"key" in obj' },
-        { code: 'if ("prop" in object) {}' },
-        { code: 'const exists = "name" in user;' },
+        { name: 'the `in` operator', code: '"key" in obj', options: IN },
+        { code: 'if ("prop" in object) {}', options: IN },
+        { code: 'const exists = "name" in user;', options: IN },
       ],
       invalid: [
         // hasOwnProperty should be flagged
         {
           name: 'hasOwnProperty walks the prototype question the long way',
           code: 'obj.hasOwnProperty("key")',
+          options: IN,
           // Reported, not rewritten: `in` and an own-property check disagree on an
           // inherited key. See consistent-existence-index-check.own-property.test.ts.
           output: null,
@@ -42,6 +47,7 @@ describe('consistent-existence-index-check', () => {
         // Object.hasOwn should be flagged
         {
           code: 'Object.hasOwn(obj, "key")',
+          options: IN,
           // Reported, not rewritten: `in` and an own-property check disagree on an
           // inherited key. See consistent-existence-index-check.own-property.test.ts.
           output: null,

--- a/packages/eslint-plugin-conventions/src/tests/conventions/coverage-completion.test.ts
+++ b/packages/eslint-plugin-conventions/src/tests/conventions/coverage-completion.test.ts
@@ -177,8 +177,9 @@ describe('consistent-existence-index-check — standalone-parent matrix', () => 
         },
         // The same call under the default `preferred: 'in'` — reported, never rewritten.
         {
-          name: 'the same call under the default `in`, reported and left alone',
+          name: 'the same call with `in` preferred, reported and left alone',
           code: 'Object.prototype.hasOwnProperty.call(obj, "k");',
+          options: [{ preferred: 'in' }],
           errors: [{ messageId: 'consistentExistenceCheck' }],
           output: null,
         },


### PR DESCRIPTION
## What

`consistent-existence-index-check` now defaults to `preferred: 'Object.hasOwn'`. It defaulted to `'in'`.

## Why the default specifically

A default is what a codebase gets for having no opinion. This one pointed every such codebase at `in` — the one form of the three that answers `true` for an **inherited** key. That is the direction a prototype-pollution guard is written to avoid, and it is the opposite of where the language went: `Object.hasOwn` exists because `in` and the `hasOwnProperty` dances were each the wrong answer often enough to warrant a third form. eslint core's `prefer-object-has-own` points the same way.

This is the last item from [#957](https://github.com/ofri-peretz/eslint/pull/957) I deliberately left out of that PR. #957 removed the *dangerous* half — the fixer no longer rewrites across the prototype boundary, so `--fix` can't silently turn an own-property check into an `in`. What remained was the rule still *asking* for the unsafe direction, which is a behaviour change and did not belong in a false-positive fix.

## What a consumer sees

Setting no options, the reported form reverses: `key in obj` now reports, `Object.hasOwn(obj, key)` no longer does.

**Nothing new is autofixed.** The single safe rewrite — `Object.prototype.hasOwnProperty.call(obj, key)` → `Object.hasOwn(obj, key)` — is unchanged. Everything across the `in` boundary stays report-only in both directions, because the two ask different questions and a machine cannot know which one the code meant.

The changeset carries a `## Migration` section with before/after for both paths (keep the old behaviour, or adopt the new one).

## Honest scope

This does **not** clear the exception burgee carries for this rule. burgee's ports use `Object.prototype.hasOwnProperty.call(...)`, which is still reported under the new default — now asking for the shorter `Object.hasOwn`, which *is* autofixable. Whether to take that fix is burgee's call, since it changes ported source. The value here is for consumers who set no options, not for burgee.

## Test plan

- [x] New `consistent-existence-index-check.default.test.ts` pins the default with no options set, so it cannot drift back silently.
- [x] Three existing cases asserted the old default **by omission**; they now pass `preferred: 'in'` explicitly and say why.
- [x] `eslint-plugin-conventions` — 545 pass, 18 skipped. Coverage gap is `utm-taxonomy` only, unchanged from `main`.
- [x] `validate-docs` 8/8, 0 errors.
- [x] Rule docs rewritten: they carried an `❌ obj.hasOwnProperty` / `✅ array.includes` pair describing a **different rule**. They now show the three reported forms, the one safe rewrite, and why the rest are report-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * The existence-check lint rule now prefers `Object.hasOwn` by default.
  * Code using `in` is reported unless the rule is explicitly configured to prefer it.
  * Existing automatic fixes remain limited to safe `hasOwnProperty.call` conversions.

* **Documentation**
  * Updated guidance, examples, migration notes, and configuration details to reflect the new default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->