### PR TITLE
fix(rules): FP/FN sweep 2026-09-10 — 2 findings

### DIFF
--- a/.changeset/fpfn-sweep-detect-object-injection.md
+++ b/.changeset/fpfn-sweep-detect-object-injection.md
@@ -1,0 +1,13 @@
+---
+'eslint-plugin-secure-coding': patch
+---
+
+fix: `detect-object-injection` no longer flags `Object.assign(Object.create(null), source)`
+
+A prototype-less target has no prototype for a merged-in `__proto__` key to reach, so
+there is nothing to report — and flagging it was counterproductive, because
+`Object.create(null)` is the remedy this rule's own docs prescribe. `isPrototypelessObject`
+now recognises the inlined call as well as the `const o = Object.create(null)` form.
+
+A tainted target still reports, and `Object.assign(Object.create(proto), source)` with a
+non-null prototype still reports.

--- a/.changeset/fpfn-sweep-import-default.md
+++ b/.changeset/fpfn-sweep-import-default.md
@@ -1,0 +1,15 @@
+---
+'eslint-plugin-import-next': patch
+---
+
+fix: `default` no longer reports default imports of `export =` / CJS-interop modules
+
+The rule mapped the import specifier to the TypeScript `ImportClause` container, for which
+`getSymbolAtLocation` returns `undefined` unconditionally — so the symbol check never did
+anything and the rule fell back to a `Default`-key lookup that `export =` modules never
+satisfy. It fired on every default import of a CJS-interop or JSON module, `node:process`
+included.
+
+The symbol is now resolved from the specifier's own identifier and unwrapped through
+`getAliasedSymbol`, matching the sibling `named` rule. Default imports from modules that
+genuinely have no default export still report.

--- a/packages/eslint-plugin-import-next/src/files/export-equals.ts
+++ b/packages/eslint-plugin-import-next/src/files/export-equals.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+// TS `export =` / CJS-interop module, the same shape as Node's own builtins
+// (@types/node declares `declare module 'node:process' { ... export = process; }`)
+// which is what makes packages/burgee/src/commander-command.ts:19,
+// packages/flagstaff/src/cursor.ts:19, packages/flagstaff/src/log-update.ts:21
+// and packages/flagstaff/src/ora.ts:18 (all `import process from 'node:process'`)
+// false positives under the unfixed rule.
+class Widget {
+  render(): string {
+    return 'widget';
+  }
+}
+
+export = Widget;

--- a/packages/eslint-plugin-import-next/src/rules/default.ts
+++ b/packages/eslint-plugin-import-next/src/rules/default.ts
@@ -12,7 +12,7 @@ import {
   hasParserServices,
   getParserServices,
 } from '@interlace/eslint-devkit';
-import { loadTypeScript } from '../utils/typescript-peer';
+import { loadTypeScript, aliasSymbolFlag } from '../utils/typescript-peer';
 
 type MessageIds = 'noDefaultExport';
 
@@ -54,8 +54,35 @@ export const defaultRule = createRule<RuleOptions, MessageIds>({
         )
           return;
 
-        const tsNode = services.esTreeNodeToTSNodeMap.get(node);
-        const symbol = checker?.getSymbolAtLocation?.(tsNode);
+        // `esTreeNodeToTSNodeMap` maps an ESTree `ImportDefaultSpecifier` to
+        // the TS `ImportClause` container node, not to the identifier inside
+        // it, and `checker.getSymbolAtLocation()` unconditionally returns
+        // `undefined` for an `ImportClause` (valid or invalid alike). Map the
+        // specifier's own `local` identifier instead, the same way `named.ts`
+        // resolves `node.imported` for named specifiers.
+        const tsNode = services.esTreeNodeToTSNodeMap.get(node.local);
+        let symbol = checker?.getSymbolAtLocation?.(tsNode);
+
+        // Resolve alias to the binding it actually points at. This is what
+        // lets a default import backed by TS `export =` / CJS interop (e.g.
+        // Node builtins, JSON modules) resolve to a real symbol instead of
+        // being treated as missing.
+        if (symbol && symbol.flags & aliasSymbolFlag()) {
+          try {
+            symbol = checker?.getAliasedSymbol?.(symbol);
+          } catch {
+            // If resolving alias fails, symbol implies broken import
+            symbol = undefined;
+          }
+        }
+
+        // A default import with no matching export still resolves to a
+        // symbol (the local binding), just not a useful one: TS aliases it
+        // to its synthetic "unknown" symbol. Treat that the same as "no
+        // symbol" so the check below still catches a genuine missing default.
+        if (symbol && symbol.escapedName === 'unknown') {
+          symbol = undefined;
+        }
 
         const moduleNode = services.esTreeNodeToTSNodeMap.get(
           node.parent.source,

--- a/packages/eslint-plugin-import-next/src/tests/coverage-batch-a.test.ts
+++ b/packages/eslint-plugin-import-next/src/tests/coverage-batch-a.test.ts
@@ -18,6 +18,7 @@
  */
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { describe, it, expect, afterAll, vi } from 'vitest';
+import ts from 'typescript';
 import type { TSESLint } from '@interlace/eslint-devkit';
 import { createWithMockContext } from '@interlace/eslint-devkit';
 
@@ -228,6 +229,42 @@ describe('default rule — Layer 2 (mock parser services)', () => {
             tsNode === source ? moduleSymbol : undefined,
         }),
       },
+      esTreeNodeToTSNodeMap: { get: (n: unknown) => n },
+    };
+    const { listeners, reports } = createWithParserServices(
+      defaultRule,
+      services,
+    );
+    (
+      listeners.ImportDefaultSpecifier as (n: unknown) => void
+    )(node);
+    expect(reports).toHaveLength(1);
+    expect(reports[0]).toMatchObject({ messageId: 'noDefaultExport' });
+  });
+
+  it('treats an alias whose resolution throws as broken, and still reports when the module lacks a default export', () => {
+    // Same shape as `node:process`/`export =` resolution succeeding, except
+    // `getAliasedSymbol` throws instead of returning a real symbol — proves
+    // the try/catch degrades to "unresolved" (matching named.ts's identical
+    // pattern) rather than leaking the exception or silently treating the
+    // import as valid.
+    const source = { type: 'Literal', value: 'mod' };
+    const node = {
+      type: 'ImportDefaultSpecifier',
+      local: { type: 'Identifier', name: 'x' },
+      parent: { type: 'ImportDeclaration', importKind: 'value', source },
+    };
+    const aliasSymbol = { flags: ts.SymbolFlags.Alias, escapedName: 'x' };
+    const moduleSymbol = { exports: new Map([['named', {}]]) };
+    const checker = {
+      getSymbolAtLocation: (tsNode: unknown) =>
+        tsNode === source ? moduleSymbol : aliasSymbol,
+      getAliasedSymbol: () => {
+        throw new Error('unresolved alias');
+      },
+    };
+    const services = {
+      program: { getTypeChecker: () => checker },
       esTreeNodeToTSNodeMap: { get: (n: unknown) => n },
     };
     const { listeners, reports } = createWithParserServices(

--- a/packages/eslint-plugin-import-next/src/tests/default.test.ts
+++ b/packages/eslint-plugin-import-next/src/tests/default.test.ts
@@ -51,10 +51,32 @@ ruleTester.run('default', defaultRule, {
         name: 'Valid default import from file with default export',
         filename: 'src/valid_default.ts'
     },
-    { 
+    {
         code: `import { bar } from './files/foo.ts';`,
         name: 'Valid named import',
          filename: 'src/valid_named.ts'
+    },
+    {
+        // A default import of a module that has no ESM default export, but
+        // resolves via TS `export =` / CJS interop (esModuleInterop). Node's
+        // own builtins are declared this way (@types/node: `declare module
+        // 'node:process' { ... export = process; }`), so `moduleSymbol.exports`
+        // carries `ExportEquals`, never `Default`. We can't exercise a real
+        // `node:process` import here because this suite's RuleTester
+        // `allowDefaultProject` ad-hoc program doesn't resolve @types/node
+        // ambient modules, so this fixture reproduces the identical shape
+        // (`export =`) locally via ./files/export-equals.ts — `tsc --noEmit`
+        // accepts both with zero errors.
+        //
+        // Burgee provenance (all false-positived by the unfixed rule against
+        // real `node:process` imports, verified with a clean `tsc --noEmit`):
+        //   packages/burgee/src/commander-command.ts:15,17,18,19
+        //   packages/flagstaff/src/cursor.ts:19
+        //   packages/flagstaff/src/log-update.ts:21
+        //   packages/flagstaff/src/ora.ts:18
+        code: `import Widget from './files/export-equals.ts';`,
+        name: 'Valid default import of an export= / CJS-interop module',
+        filename: 'src/valid_export_equals_default.ts'
     },
   ],
   

--- a/packages/eslint-plugin-import-next/src/tests/entrypoints.test.ts
+++ b/packages/eslint-plugin-import-next/src/tests/entrypoints.test.ts
@@ -16,6 +16,7 @@ import { describe, it, expect } from 'vitest';
 import { plugin } from '../index';
 import foo, { bar } from '../files/foo';
 import { foo as noDefaultFoo } from '../files/no-default';
+import Widget from '../files/export-equals';
 import * as typeBarrel from '../types/index';
 
 describe('oxlint sub-export', () => {
@@ -50,6 +51,10 @@ describe('src/files fixture modules', () => {
 
   it('no-default.ts exposes only a named const', () => {
     expect(noDefaultFoo).toBe('bar');
+  });
+
+  it('export-equals.ts exposes a class via `export =` / CJS interop', () => {
+    expect(new Widget().render()).toBe('widget');
   });
 });
 

--- a/packages/eslint-plugin-secure-coding/src/rules/detect-object-injection/detect-object-injection.test.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/detect-object-injection/detect-object-injection.test.ts
@@ -1303,6 +1303,34 @@ describe('detect-object-injection', () => {
     );
 
     ruleTester.run(
+      'Object.assign onto an inline Object.create(null) target is safe -- the docs\' own prescribed fix',
+      detectObjectInjection,
+      {
+        valid: [
+          // The rule's own docs (docs/rules/detect-object-injection.md, "Correct"
+          // section) prescribe Object.create(null) as THE fix for object
+          // injection, because a prototype-less object has no __proto__ /
+          // constructor / prototype to pollute. An inline Object.create(null)
+          // passed directly as the Object.assign target must therefore be
+          // treated exactly like a fresh `{}` literal target: safe regardless
+          // of source taint.
+          //
+          // Burgee provenance: packages/burgee/src/yargs-parser.ts:126
+          {
+            name: 'inline Object.create(null) target (burgee: packages/burgee/src/yargs-parser.ts:126)',
+            code: `
+              declare const source: Record<string, unknown>;
+              function mergeOptions() {
+                return Object.assign(Object.create(null), source);
+              }
+            `,
+          },
+        ],
+        invalid: [],
+      },
+    );
+
+    ruleTester.run(
       'Object.assign onto a non-literal target with an untrusted source is flagged',
       detectObjectInjection,
       {

--- a/packages/eslint-plugin-secure-coding/src/rules/detect-object-injection/index.ts
+++ b/packages/eslint-plugin-secure-coding/src/rules/detect-object-injection/index.ts
@@ -1018,6 +1018,22 @@ export const detectObjectInjection = createRule<RuleOptions, MessageIds>({
      * or is derived from an array spread/copy pattern
      */
     const isPrototypelessObject = (objectNode: TSESTree.Node): boolean => {
+      // Inline Object.create(null) used directly as the node itself (e.g.
+      // the `target` argument of `Object.assign(Object.create(null), src)`)
+      // rather than through an intermediate variable.
+      if (
+        objectNode.type === AST_NODE_TYPES.CallExpression &&
+        objectNode.callee.type === AST_NODE_TYPES.MemberExpression &&
+        objectNode.callee.object.type === AST_NODE_TYPES.Identifier &&
+        objectNode.callee.object.name === 'Object' &&
+        propertyName(objectNode.callee) === 'create' &&
+        objectNode.arguments.length > 0 &&
+        objectNode.arguments[0].type === AST_NODE_TYPES.Literal &&
+        objectNode.arguments[0].value === null
+      ) {
+        return true;
+      }
+
       if (objectNode.type !== AST_NODE_TYPES.Identifier) {
         return false;
       }
@@ -2201,6 +2217,12 @@ export const detectObjectInjection = createRule<RuleOptions, MessageIds>({
       if (!objectIsObject || !propIsAssign) return;
       // Object.assign({}, …) — first arg is fresh literal, no taint risk.
       if (node.arguments[0]?.type === AST_NODE_TYPES.ObjectExpression) return;
+      // Object.assign(Object.create(null), …) — the target is
+      // prototype-less (whether inline or via a variable declared with
+      // Object.create(null)), so there is no prototype for a merged-in
+      // `__proto__` key to reach. This is the fix the rule's own docs
+      // prescribe for object injection; it must not be flagged itself.
+      if (node.arguments[0] && isPrototypelessObject(node.arguments[0])) return;
       // Sources are arguments[1...]. Any non-literal source is an
       // assumed taint source. Literals are safe (they're inline data).
       const sources = node.arguments.slice(1);


### PR DESCRIPTION
Two rule defects found by replaying the burgee corpus against every rule at `error`, each verified adversarially before it earned a line of code.

**A note on scope.** This run originally confirmed six findings. While it was in flight, #957 landed on `main` and independently fixed four of them — the `consistent-existence-index-check` autofix boundary, `no-missing-error-context` on `Error()` without `new`, `no-insecure-comparison`, and `no-unchecked-loop-condition` for `for (;;)`. I rebased onto current `main`, dropped the duplicates, and re-confirmed the two below still fail on today's `main`. #957's version of the `in`/own-property fix is strictly better than mine — it also closes the dispatch boundary and surplus-argument cases — so mine is discarded, not merged.

---

## 1. `secure-coding/detect-object-injection` — false positive

**burgee:** `packages/burgee/src/yargs-parser.ts:126` and `:150`

```ts
declare const source: Record<string, unknown>;
function mergeOptions() {
  return Object.assign(Object.create(null), source);
}
```

**Documented contract**, `docs/rules/detect-object-injection.md`, "✅ Correct":

> ```
> // Use Object.create(null) for clean objects
> const safeObj = Object.create(null);
> safeObj[userKey] = value; // Safe because no prototype
> ```

The rule flagged the exact remedy its own docs prescribe. A prototype-less target has no prototype for a merged-in `__proto__` key to reach, so there is nothing to report — and flagging it pushes readers away from the fix.

**What changed.** `checkObjectAssignSpread` only treated a literal `{}` target as safe and never consulted the existing `isPrototypelessObject` helper; that helper also gated on the target being an `Identifier`, so it saw `const o = Object.create(null)` but not the inlined call. It now reads both.

**No false negative** — verified by execution, not assumed:

| input | before | after |
| --- | --- | --- |
| `Object.assign(Object.create(null), src)` | REPORT | silent |
| `Object.assign(target, src)` | REPORT | REPORT |
| `Object.assign(Object.create(proto), src)` | REPORT | REPORT |

A non-null prototype still reports. The fixture failed before the fix and passes after; all 201 `detect-object-injection` tests are green.

---

## 2. `import-next/default` — false positive

**burgee:** `packages/burgee/src/commander-command.ts:15,17,18,19` and `packages/flagstaff/src/{cursor.ts:19, log-update.ts:21, ora.ts:18, ora.ts:23, plugin.ts:9}`

All 9 occurrences in the corpus were false positives — confirmed with `tsc --noEmit` (zero errors) and by driving the TypeScript compiler API directly.

```ts
// files/export-equals.ts
class Widget {}
export = Widget;

// consumer
import Widget from './files/export-equals';
```

**Documented contract**, `docs/rules/default.md`:

> Ensure a default export is present, given a default import

The rule reported "No default export found" on modules that demonstrably have one.

**Mechanism.** `@typescript-eslint` maps an ESTree `ImportDefaultSpecifier` to the TS **`ImportClause`** container, not the identifier inside it, and `getSymbolAtLocation` returns `undefined` for an `ImportClause` unconditionally — for valid and invalid imports alike. With the guard written as `moduleSymbol && !symbol`, `!symbol` was always true, collapsing the check to `moduleSymbol.exports.has(Default)`, which is false for `export =` modules whose key is `ExportEquals`. It therefore fired on every default import of a CJS-interop or JSON module, `node:process` included.

**What changed.** The symbol is resolved from `node.local` and unwrapped via `getAliasedSymbol`, mirroring how the sibling `named` rule already maps `node.imported`.

**No false negative.** The first attempt at this fix *did* introduce one — TS binds a local symbol even for an unresolved default import, aliasing it to the synthetic `unknown` symbol, which silently made genuine missing-default cases pass. That case is now mapped back to "unresolved". A default import from a module with no default export still reports, including when `getAliasedSymbol` throws, which degrades to "unresolved" rather than passing.

---

## Sweep result

Re-running the corpus after the fixes, against the pre-fix baseline — no other rule's count moved and no new rule started firing:

| rule | before | after |
| --- | --- | --- |
| `import-next/default` | 9 | **0** |
| `secure-coding/detect-object-injection` | 115 | 113 |

Zero parse errors both runs.

## Screened and rejected

Recorded so future runs don't re-litigate them:

- **`secure-coding/no-insecure-comparison`** on `token.kind !== 'option'` — the word `token` means a parser token here, not a credential. Rejected: the keyword list is a deliberate recall-over-precision trade, already logged in `docs/intents/burgee-false-positives/design.md`, and every narrowing (skip string literals, skip `.kind`/`.type`, require string type) reopens a materially worse false negative.
- **`no-missing-error-context`** on non-literal message arguments (`new Error(msg)`, `msg ?? 'fb'`, `a + b`) — rejected as deliberate design, locked by an existing test literally named *"a non-string argument to the BASE Error class proves nothing"*. The rule is pure-AST and cannot prove such a value is a non-empty string. Only the `new`-less half was real, and #957 has since fixed it.
- **`conventions/consistent-existence-index-check`** missing `indexOf(...) !== -1` — the docs lead with that pattern but the rule registers no visitor that can ever see an `indexOf` call. Root-caused as a **docs bug**, not a rule defect: the rule's name, option schema, messages and entire test suite are self-consistent around `in`/`hasOwnProperty`/`Object.hasOwn`. The doc file appears templated from a different, array-oriented rule. Left alone per the rule against changing behaviour on an ambiguous contract.
- **`import-next/no-unused-modules`** on CLI entrypoints, **`no-nodejs-modules`** on Node-only packages, **`operability/no-process-exit`** on burgee's single `Runtime.exit` seam — all match their documented behaviour; consumer-config concerns, not rule defects.
- **`no-redos-vulnerable-regex`** — 4 of 6 hits empirically confirmed quadratic (timed to 32k chars); the flat ones are defensible on static ambiguity.

## Known gaps, not addressed here

- Three findings were confirmed but deferred: `no-improper-type-validation` (a cross-statement early-return null guard is invisible to `hasNullGuard`, which only reads the same `&&` chain — the narrow fix needs real dominance analysis to avoid opening a false negative), `no-extraneous-dependencies` (colon-namespaced virtual specifiers like `fumadocs-mdx:collections/server` are split on `/` rather than `:`), and `detect-object-injection` on a `forEach` `index` parameter.
- Several rules' `docs/rules/*.md` are unfilled templates (`[Specific issue]`, `// Example of incorrect usage`) — `no-missing-error-context`, `no-unsafe-type-narrowing`, `no-silent-errors`, `react-render-optimization`, `no-unnecessary-rerenders`. FP/FN claims against those rules have to lean on the rule source rather than a published contract, which weakens this whole routine.
- `eslint-plugin-conventions` fails its own 100% branch-coverage gate on `main` (`utm-taxonomy.ts:156`, a `cooked ?? raw` fallback that only executes on certain `@typescript-eslint` versions). Unrelated to this PR, but it blocks any commit touching that package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
