### PR TITLE
fix: two rules that could not report anything

### DIFF
--- a/.changeset/rules-that-could-not-report.md
+++ b/.changeset/rules-that-could-not-report.md
@@ -1,0 +1,12 @@
+---
+'eslint-plugin-react-features': patch
+'eslint-plugin-reliability': patch
+---
+
+fix: two rules that could not report anything
+
+**`react-features/static-property-placement` now works.** Its grouping check ended in an empty `if` — the `context.report` had been deleted alongside a genuinely unreachable branch beside it, leaving a condition whose answer nobody used. The rule ships under two export names, so a config that enables every rule of every plugin got it at `error` and never heard from it. Its 21 `valid` cases all passed, and none of them could have failed: a rule with no `context.report` satisfies every valid case ever written for it.
+
+The question it asked was wrong too. Two **adjacent** static properties from different groups is what correct grouping looks like; the defect is a group **resuming** after another group came between it and its earlier members. That is now what it reports. A static property belonging to no configured group does not break a group — nothing says it does not belong there. `static [propTypes] = {}` is also no longer read as the property `propTypes`; a computed key is whatever the variable holds.
+
+**`reliability/no-jsdoc-terminator-in-example` is deprecated.** It looks for `*/` inside a JSDoc `@example`, and a block comment ends at its _first_ `*/` — so a comment's value can never contain one. Constructing the case produces a parse error, not a finding. Nothing you can write will make this rule fire, which is why it has no defect cases. Remove it from your config; `findTerminatorsInExamples` remains exported and unit-tested.

--- a/packages/eslint-plugin-react-features/src/rules/react/static-property-placement.ts
+++ b/packages/eslint-plugin-react-features/src/rules/react/static-property-placement.ts
@@ -25,7 +25,13 @@ export interface Options {
 const DEFAULT_GROUPS = [
   {
     name: 'propTypes',
-    properties: ['propTypes', 'defaultProps', 'childContextTypes', 'contextTypes', 'contextType'],
+    properties: [
+      'propTypes',
+      'defaultProps',
+      'childContextTypes',
+      'contextTypes',
+      'contextType',
+    ],
   },
   {
     name: 'lifecycle',
@@ -70,7 +76,8 @@ export const staticPropertyPlacement = createRule<[Options], MessageIds>({
         description: 'Static properties should be grouped together',
         severity: 'LOW',
         fix: 'Group static properties together by category',
-        documentationLink: 'https://react.dev/reference/react/Component#static-properties',
+        documentationLink:
+          'https://react.dev/reference/react/Component#static-properties',
       }),
     },
   },
@@ -92,14 +99,18 @@ export const staticPropertyPlacement = createRule<[Options], MessageIds>({
       if (!node.superClass) return false;
 
       if (node.superClass.type === 'Identifier') {
-        return node.superClass.name === 'Component' || node.superClass.name === 'PureComponent';
+        return (
+          node.superClass.name === 'Component' ||
+          node.superClass.name === 'PureComponent'
+        );
       }
 
       if (node.superClass.type === 'MemberExpression') {
         return (
           node.superClass.object.type === 'Identifier' &&
           node.superClass.object.name === 'React' &&
-          (propertyName(node.superClass) === 'Component' || propertyName(node.superClass) === 'PureComponent')
+          (propertyName(node.superClass) === 'Component' ||
+            propertyName(node.superClass) === 'PureComponent')
         );
       }
 
@@ -108,10 +119,14 @@ export const staticPropertyPlacement = createRule<[Options], MessageIds>({
 
     function checkStaticPropertyPlacement(
       node: TSESTree.ClassDeclaration,
-      groups: NonNullable<Options['propertyGroups']>
+      groups: NonNullable<Options['propertyGroups']>,
     ) {
       const members = node.body.body;
-      const staticProperties: Array<{ name: string; index: number; node: TSESTree.PropertyDefinition | TSESTree.MethodDefinition }> = [];
+      const staticProperties: Array<{
+        name: string;
+        index: number;
+        node: TSESTree.PropertyDefinition | TSESTree.MethodDefinition;
+      }> = [];
 
       // Collect static properties
       for (let i = 0; i < members.length; i++) {
@@ -126,49 +141,74 @@ export const staticPropertyPlacement = createRule<[Options], MessageIds>({
 
       if (staticProperties.length < 2) return;
 
-      // Check if properties are properly grouped
-      for (let i = 1; i < staticProperties.length; i++) {
-        const current = staticProperties[i];
-        const previous = staticProperties[i - 1];
+      // "Grouped together" means CONTIGUOUS. A group is broken when one of its
+      // members appears after something else came between it and the previous
+      // member of the same group — `propTypes`, something else, `defaultProps`.
+      //
+      // The previous implementation asked `!areInSameGroup(current, previous)`,
+      // which is a different and wrong question: two ADJACENT properties from
+      // different groups are exactly what correct grouping looks like. It then
+      // did nothing with the answer — the report had been deleted along with an
+      // unreachable branch beside it, leaving an empty `if` and a rule that
+      // could not fire. Both plugin exports shipped that way.
+      // A member of NO known group never breaks anything: nothing here says it
+      // does not belong with whatever surrounds it, and guessing is how a rule
+      // starts reporting code it cannot read. Only resuming a group after a
+      // member of a DIFFERENT known group is a break we can prove.
+      const seen = new Set<string>();
+      let previousGroup: string | null = null;
 
-        if (!areInSameGroup(current.name, previous.name, groups)) {
-          // `staticProperties` holds every named static member in source
-          // order, so the members strictly between `previous` and `current`
-          // are either non-static or computed-key statics (no name). The
-          // historical implementation walked that gap looking for a named
-          // static property to report — a provably unreachable path (a named
-          // static in the gap would itself already be in `staticProperties`).
-          // That dead branch was deleted rather than coverage-ignored.
+      for (const property of staticProperties) {
+        const group = groupOf(property.name, groups);
+        if (group === null) continue;
+
+        if (seen.has(group) && previousGroup !== group) {
+          context.report({
+            node: property.node,
+            messageId: 'staticPropertyPlacement',
+          });
         }
+        seen.add(group);
+        previousGroup = group;
       }
     }
 
+    /** The name of the group this property belongs to, or null if it is in none. */
     // oxlint-disable-next-line consistent-function-scoping
-    function isStaticProperty(member: TSESTree.ClassBody['body'][0]): member is TSESTree.PropertyDefinition | TSESTree.MethodDefinition {
-      return (
-        // Handle PropertyDefinition and MethodDefinition
-        (member.type === 'PropertyDefinition' || member.type === 'MethodDefinition') &&
-        member.static
-      );
-    }
-
-    // oxlint-disable-next-line consistent-function-scoping
-    function getPropertyName(member: TSESTree.PropertyDefinition | TSESTree.MethodDefinition): string | null {
-      if (member.key.type === 'Identifier') {
-        return member.key.name;
+    function groupOf(
+      name: string,
+      groups: NonNullable<Options['propertyGroups']>,
+    ): string | null {
+      for (const group of groups) {
+        if (group.properties.includes(name)) return group.name;
       }
       return null;
     }
 
     // oxlint-disable-next-line consistent-function-scoping
-    function areInSameGroup(name1: string, name2: string, groups: NonNullable<Options['propertyGroups']>): boolean {
-      for (const group of groups) {
-        if (group.properties.includes(name1) && group.properties.includes(name2)) {
-          return true;
-        }
-      }
-      return false;
+    function isStaticProperty(
+      member: TSESTree.ClassBody['body'][0],
+    ): member is TSESTree.PropertyDefinition | TSESTree.MethodDefinition {
+      return (
+        // Handle PropertyDefinition and MethodDefinition
+        (member.type === 'PropertyDefinition' ||
+          member.type === 'MethodDefinition') &&
+        member.static
+      );
     }
 
+    // oxlint-disable-next-line consistent-function-scoping
+    function getPropertyName(
+      member: TSESTree.PropertyDefinition | TSESTree.MethodDefinition,
+    ): string | null {
+      // `static [propTypes] = {}` is a property whose name is whatever the
+      // VARIABLE `propTypes` holds — not the property `propTypes`. Reading the
+      // identifier through a computed key was the same mistake in miniature as
+      // the one this rule's grouping check made.
+      if (!member.computed && member.key.type === 'Identifier') {
+        return member.key.name;
+      }
+      return null;
+    }
   },
 });

--- a/packages/eslint-plugin-react-features/src/tests/react/static-property-placement.reports.test.ts
+++ b/packages/eslint-plugin-react-features/src/tests/react/static-property-placement.reports.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * This rule could not report. It shipped that way, under two export names.
+ *
+ * `checkStaticPropertyPlacement` asked `!areInSameGroup(current, previous)` and
+ * then did nothing with the answer — an empty `if` left behind when a report was
+ * deleted alongside a genuinely unreachable branch next to it. 21 `valid` cases
+ * passed, and none of them could have failed: a rule with no `context.report`
+ * satisfies every `valid` case ever written for it.
+ *
+ * The ledger caught it as `rules that claim no defect at all` — zero TP and zero
+ * FN cases. That is the shape of a rule nobody has proven does anything.
+ *
+ * The question it asked was also the wrong one. Two ADJACENT properties from
+ * different groups is what correct grouping looks like; the defect is a group
+ * RESUMING after another group came between.
+ */
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { describe, it, afterAll } from 'vitest';
+import parser from '@typescript-eslint/parser';
+import { staticPropertyPlacement } from '../../rules/react/static-property-placement';
+
+RuleTester.afterAll = afterAll;
+RuleTester.it = it;
+RuleTester.itOnly = it.only;
+RuleTester.describe = describe;
+
+const ruleTester = new RuleTester({
+  languageOptions: { parser, ecmaVersion: 2022, sourceType: 'module' },
+});
+
+describe('static-property-placement — it reports', () => {
+  ruleTester.run('a group broken by another group', staticPropertyPlacement, {
+    valid: [
+      {
+        name: 'one group, contiguous',
+        code: 'class A extends Component { static propTypes = {}; static defaultProps = {}; render() { return null; } }',
+      },
+      {
+        name: 'two groups, each contiguous — adjacency across groups is correct, not a defect',
+        code: 'class A extends Component { static propTypes = {}; static defaultProps = {}; static getDerivedStateFromProps() {} render() { return null; } }',
+      },
+      {
+        name: 'a member of no known group between two members of one — unprovable, so not reported',
+        code: 'class A extends Component { static propTypes = {}; static unrelated = 1; static defaultProps = {}; render() { return null; } }',
+      },
+      {
+        name: 'a computed key is not the property it spells',
+        code: 'class A extends Component { static propTypes = {}; static [defaultProps] = {}; static contextType = {}; render() { return null; } }',
+      },
+      {
+        name: 'not a React component at all',
+        code: 'class A { static propTypes = {}; static getDerivedStateFromProps() {} static defaultProps = {}; }',
+      },
+    ],
+    invalid: [
+      {
+        name: 'propTypes group resumes after the lifecycle group',
+        code: 'class A extends Component { static propTypes = {}; static getDerivedStateFromProps() {} static defaultProps = {}; render() { return null; } }',
+        errors: [{ messageId: 'staticPropertyPlacement' as const }],
+      },
+      {
+        name: 'the same, on React.Component',
+        code: 'class A extends React.Component { static contextType = {}; static getDerivedStateFromError() {} static propTypes = {}; render() { return null; } }',
+        errors: [{ messageId: 'staticPropertyPlacement' as const }],
+      },
+      {
+        name: 'the same, on PureComponent',
+        code: 'class A extends PureComponent { static propTypes = {}; static getDerivedStateFromProps() {} static childContextTypes = {}; render() { return null; } }',
+        errors: [{ messageId: 'staticPropertyPlacement' as const }],
+      },
+      {
+        name: 'a group interrupted twice reports each resumption',
+        code: 'class A extends Component { static propTypes = {}; static getDerivedStateFromProps() {} static defaultProps = {}; static getDerivedStateFromError() {} static contextType = {}; render() { return null; } }',
+        errors: [
+          { messageId: 'staticPropertyPlacement' as const },
+          { messageId: 'staticPropertyPlacement' as const },
+          { messageId: 'staticPropertyPlacement' as const },
+        ],
+      },
+    ],
+  });
+});

--- a/packages/eslint-plugin-reliability/src/rules/reliability/no-jsdoc-terminator-in-example.ts
+++ b/packages/eslint-plugin-reliability/src/rules/reliability/no-jsdoc-terminator-in-example.ts
@@ -25,7 +25,6 @@ import {
 
 type MessageIds = 'jsdocTerminatorInExample' | 'wrapInQuotes';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type, @typescript-eslint/no-empty-interface -- Rule has no configurable options
 export interface Options {}
 
 type RuleOptions = [Options?];
@@ -96,6 +95,17 @@ export const noJsdocTerminatorInExample = createRule<RuleOptions, MessageIds>({
   name: 'no-jsdoc-terminator-in-example',
   meta: {
     type: 'problem',
+    // DEPRECATED: this rule cannot fire on any parseable file.
+    //
+    // It looks for `*/` inside a JSDoc `@example`. A block comment ends at its
+    // FIRST `*/`, so a comment's value can never contain one — the text after it
+    // is code, not comment. Constructing the case gives a parse error
+    // ("Unterminated regular expression literal"), not a finding.
+    //
+    // The ledger surfaced it as `rules that claim no defect at all`: zero TP and
+    // zero FN cases, because none can exist. `findTerminatorsInExamples` is still
+    // exported and unit-tested directly, which is the only reachable surface.
+    deprecated: true,
     docs: {
       url: 'https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-reliability/docs/rules/no-jsdoc-terminator-in-example.md',
       description:
@@ -116,7 +126,7 @@ export const noJsdocTerminatorInExample = createRule<RuleOptions, MessageIds>({
         icon: MessageIcons.INFO,
         issueName: 'Wrap Pattern in Quotes',
         description:
-          "Wrap the `*/` pattern in single quotes to prevent premature JSDoc termination",
+          'Wrap the `*/` pattern in single quotes to prevent premature JSDoc termination',
         severity: 'LOW',
         fix: "Replace `*/` with `'*/'` (single-quoted) inside the @example block",
         documentationLink: 'https://jsdoc.app/tags-example',
@@ -141,10 +151,7 @@ export const noJsdocTerminatorInExample = createRule<RuleOptions, MessageIds>({
           const commentText = comment.value;
 
           // Quick bail-out: no @example or no `*/` inside → nothing to check
-          if (
-            !/@example\b/i.test(commentText) ||
-            !commentText.includes('*/')
-          ) {
+          if (!/@example\b/i.test(commentText) || !commentText.includes('*/')) {
             continue;
           }
 
@@ -154,7 +161,11 @@ export const noJsdocTerminatorInExample = createRule<RuleOptions, MessageIds>({
             // Calculate the absolute position in the source file.
             // comment.range[0] points to the opening `/*`, so the content
             // starts at range[0] + 2.
-            const absoluteStart = (comment as TSESTree.Comment & { range: [number, number] }).range[0] + 2 + offset;
+            const absoluteStart =
+              (comment as TSESTree.Comment & { range: [number, number] })
+                .range[0] +
+              2 +
+              offset;
             const absoluteEnd = absoluteStart + 2; // length of `*/`
 
             context.report({


### PR DESCRIPTION
## What

The case ledger flags **`rules that claim no defect at all`** — zero TP and zero FN cases. A rule with no classified defect is a rule nobody has proven does anything. There were two, and neither could report. For different reasons.

## 1. `react-features/static-property-placement` — a coding mistake

Its grouping check ended in an **empty `if`**:

```ts
if (!areInSameGroup(current.name, previous.name, groups)) {
  // a comment explaining a DIFFERENT, genuinely unreachable branch
}
```

The `context.report` had been deleted alongside a real dead branch beside it, and the condition was left computing an answer nobody used. The rule ships under **two** export names, so a config that enables every rule of every plugin gets it at `error` and never hears from it.

Its 21 `valid` cases passed the whole time — and none of them *could* have failed. A rule with no `context.report` satisfies every valid case ever written for it. That is exactly the hole the ledger's TP/FN count exists to find.

**The question it asked was also wrong.** `!areInSameGroup(current, previous)` treats two *adjacent* properties from different groups as a defect, which is what correct grouping looks like. The defect is a group **resuming** after another came between:

```js
static propTypes = {};                  // group A
static getDerivedStateFromProps() {}    // group B
static defaultProps = {};               // group A again  ← reported
```

A property in no configured group does not break a group — nothing says it does not belong there, and guessing is how a rule starts reporting code it cannot read.

While in there: `getPropertyName` read `static [propTypes] = {}` as the property `propTypes`. A computed key is whatever the variable holds, so it now returns `null` unless `!member.computed`.

## 2. `reliability/no-jsdoc-terminator-in-example` — unreachable by the grammar

It looks for `*/` inside a JSDoc `@example`. A block comment ends at its **first** `*/`, so a comment's value can never contain one. I tried to construct the case:

```
AssertionError: A fatal parsing error occurred:
  Parsing error: Unterminated regular expression literal.
```

Not a finding — a parse error. The rule's own docstring already said this and nothing had acted on it.

Marked `deprecated`, which is the mechanism by which a consumer's "every non-deprecated rule" config stops enabling a no-op. `findTerminatorsInExamples` stays exported and unit-tested — the only reachable surface it ever had. Deprecating rather than deleting keeps existing configs that name it from erroring.

## Ledger movement

| | before | after |
| :--- | ---: | ---: |
| rules that claim no defect at all | 2 | **1** |
| rules without a described TP and TN | 2 | **1** |
| rules under 3 classified cases a side | 3 | **2** |

The one remaining in each is the deprecated rule, which cannot honestly acquire a TP.

## Test plan

- [x] New `static-property-placement.reports.test.ts` — **4 invalid cases**, the thing this rule has never had. Plus 5 valid: contiguous groups, adjacent different groups, an unclassified member between two of a group, a computed key, and a non-React class.
- [x] `eslint-plugin-react-features` — 1368 pass. Coverage gap is `no-arbitrary-token-class` only, identical on `main`.
- [x] `eslint-plugin-reliability` — 543 pass.
- [x] Pre-commit gates green: oxlint, scope-audit, spellings, key-vocabulary, case-descriptions, case-registry, shim-drift, format-drift.
- [x] Also drops a dead `eslint-disable` reported as unused (pre-existing, in a file this PR already edits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `static-property-placement` so it reports static property groups that incorrectly resume after another configured group.
  - Improved handling of computed property names and properties outside configured groups.

- **Deprecation**
  - Deprecated `no-jsdoc-terminator-in-example`, as valid source comments cannot contain the terminator pattern this rule checks for.

- **Release**
  - Published patch updates for the React Features and Reliability ESLint plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->