### PR TITLE
chore(docs): sync generated data

### DIFF
--- a/apps/docs/src/data/articles.json
+++ b/apps/docs/src/data/articles.json
@@ -13,7 +13,7 @@
       "page_views_count": 0,
       "public_reactions_count": 5,
       "positive_reactions_count": 5,
-      "comments_count": 0,
+      "comments_count": 1,
       "tag_list": [
         "javascript",
         "webdev",
@@ -1745,6 +1745,6 @@
     }
   ],
   "total": 85,
-  "lastUpdated": "2026-09-10T00:12:11.106Z",
+  "lastUpdated": "2026-09-10T06:24:02.839Z",
   "source": "public"
 }

--- a/apps/docs/src/data/changelog.json
+++ b/apps/docs/src/data/changelog.json
@@ -5,6 +5,86 @@
   "oldestYear": 2024,
   "releases": [
     {
+      "package": "eslint-plugin-conventions",
+      "short": "eslint-plugin-conventions",
+      "version": "5.3.5",
+      "date": "2026-09-10T00:18:24Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "`consistent-existence-index-check` no longer autofixes between checks that are not equivalent",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-secure-coding",
+      "short": "eslint-plugin-secure-coding",
+      "version": "5.3.5",
+      "date": "2026-09-10T00:18:22Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "`no-insecure-comparison` stops reading two public values as secrets",
+          "pr": null
+        },
+        {
+          "kind": "fix",
+          "title": "`no-unchecked-loop-condition` exempts `for (;;)` with a break, as it does `while (true)`",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-reliability",
+      "short": "eslint-plugin-reliability",
+      "version": "4.1.6",
+      "date": "2026-09-10T00:18:21Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "`no-missing-null-checks` follows four more guards it already meant to follow",
+          "pr": null
+        },
+        {
+          "kind": "fix",
+          "title": "`no-missing-error-context` reads three more shapes of throw",
+          "pr": null
+        },
+        {
+          "kind": "fix",
+          "title": "`no-unhandled-promise` no longer reports a promise whose value is used",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-maintainability",
+      "short": "eslint-plugin-maintainability",
+      "version": "3.2.5",
+      "date": "2026-09-10T00:18:15Z",
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "`no-missing-error-context` reads three more shapes of throw",
+          "pr": null
+        },
+        {
+          "kind": "fix",
+          "title": "`no-unhandled-promise` no longer reports a promise whose value is used",
+          "pr": null
+        }
+      ]
+    },
+    {
       "package": "eslint-plugin-import-next",
       "short": "eslint-plugin-import-next",
       "version": "2.7.7",
@@ -16565,21 +16645,6 @@
       ]
     },
     {
-      "package": "eslint-plugin-conventions",
-      "short": "eslint-plugin-conventions",
-      "version": "5.3.5",
-      "date": null,
-      "isApp": false,
-      "isPrivate": false,
-      "entries": [
-        {
-          "kind": "fix",
-          "title": "`consistent-existence-index-check` no longer autofixes between checks that are not equivalent",
-          "pr": null
-        }
-      ]
-    },
-    {
       "package": "eslint-plugin-jwt-security",
       "short": "eslint-plugin-jwt-security",
       "version": "2.2.9",
@@ -16695,26 +16760,6 @@
         {
           "kind": "other",
           "title": "Ofri Peretz",
-          "pr": null
-        }
-      ]
-    },
-    {
-      "package": "eslint-plugin-maintainability",
-      "short": "eslint-plugin-maintainability",
-      "version": "3.2.5",
-      "date": null,
-      "isApp": false,
-      "isPrivate": false,
-      "entries": [
-        {
-          "kind": "fix",
-          "title": "`no-missing-error-context` reads three more shapes of throw",
-          "pr": null
-        },
-        {
-          "kind": "fix",
-          "title": "`no-unhandled-promise` no longer reports a promise whose value is used",
           "pr": null
         }
       ]
@@ -16840,51 +16885,6 @@
         {
           "kind": "other",
           "title": "Ofri Peretz",
-          "pr": null
-        }
-      ]
-    },
-    {
-      "package": "eslint-plugin-reliability",
-      "short": "eslint-plugin-reliability",
-      "version": "4.1.6",
-      "date": null,
-      "isApp": false,
-      "isPrivate": false,
-      "entries": [
-        {
-          "kind": "fix",
-          "title": "`no-missing-null-checks` follows four more guards it already meant to follow",
-          "pr": null
-        },
-        {
-          "kind": "fix",
-          "title": "`no-missing-error-context` reads three more shapes of throw",
-          "pr": null
-        },
-        {
-          "kind": "fix",
-          "title": "`no-unhandled-promise` no longer reports a promise whose value is used",
-          "pr": null
-        }
-      ]
-    },
-    {
-      "package": "eslint-plugin-secure-coding",
-      "short": "eslint-plugin-secure-coding",
-      "version": "5.3.5",
-      "date": null,
-      "isApp": false,
-      "isPrivate": false,
-      "entries": [
-        {
-          "kind": "fix",
-          "title": "`no-insecure-comparison` stops reading two public values as secrets",
-          "pr": null
-        },
-        {
-          "kind": "fix",
-          "title": "`no-unchecked-loop-condition` exempts `for (;;)` with a break, as it does `while (true)`",
           "pr": null
         }
       ]


### PR DESCRIPTION
Regenerated apps/docs/src/data/ (trigger: push). Opened by the Docs Data Sync workflow; contents come entirely from the apps/docs/scripts/sync-* scripts, so review the diff rather than hand-editing.