### PR TITLE
fix(docs): regenerate the conventions rule MDX after #964

### DIFF
--- a/apps/docs/content/docs/quality/plugin-conventions/rules/consistent-existence-index-check.mdx
+++ b/apps/docs/content/docs/quality/plugin-conventions/rules/consistent-existence-index-check.mdx
@@ -1,6 +1,6 @@
 ---
 title: consistent-existence-index-check
-description: "Enforce consistent style for checking if an element exists in an array"
+description: "Enforce one form for checking whether an object has a property"
 tags: ['quality', 'conventions']
 category: quality
 autofix: suggestions
@@ -12,50 +12,81 @@ import { FalseNegativeCTA, WhenNotToUse, RuleBadges } from "@/components/RuleCom
 
 <RuleBadges typeAware={false} typeAwareStatus="unaware" />
 
-Enforce consistent style for checking if an element exists in an array. This rule is part of [`eslint-plugin-conventions`](https://www.npmjs.com/package/eslint-plugin-conventions).
+Enforce one form for checking whether an object has a property — `Object.hasOwn`, `in`, or one of the `hasOwnProperty` spellings. This rule is part of [`eslint-plugin-conventions`](https://www.npmjs.com/package/eslint-plugin-conventions).
+
+> **The name is about property existence, not array indexing.** Despite `index` in
+> the rule id, this rule never looks at `indexOf` or `includes`. It reads
+> `key in obj`, `obj.hasOwnProperty(key)`,
+> `Object.prototype.hasOwnProperty.call(obj, key)` and `Object.hasOwn(obj, key)`.
 
 ## Quick Summary
 
-| Aspect         | Details                                                              |
-| -------------- | -------------------------------------------------------------------- |
-| **Severity**   | Warning (code quality)                                               |
-| **Auto-Fix**   | ✅ Yes (converts pattern)                                            |
-| **Category**   | Quality |
-| **ESLint MCP** | ✅ Optimized for ESLint MCP integration                              |
-| **Best For**   | Code consistency, modern JavaScript practices                        |
+| Aspect         | Details                                                   |
+| -------------- | --------------------------------------------------------- |
+| **Severity**   | Warning (code quality)                                    |
+| **Auto-Fix**   | ⚠️ One conversion only — see below                        |
+| **Category**   | Quality                                                   |
+| **ESLint MCP** | ✅ Optimized for ESLint MCP integration                   |
+| **Best For**   | Consistency, and keeping prototype lookups out by default |
 
 ## Rule Details
 
-Prefer `includes()` over `indexOf() !== -1` for existence checks.
+JavaScript has four ways to ask whether an object has a property, and they do not
+all answer the same question. This rule picks one and reports the others.
+
+| Form                                             | Answers for an inherited key | Looks the method up on `obj` |
+| ------------------------------------------------ | ---------------------------- | ---------------------------- |
+| `Object.hasOwn(obj, key)`                        | no                           | no                           |
+| `Object.prototype.hasOwnProperty.call(obj, key)` | no                           | no                           |
+| `obj.hasOwnProperty(key)`                        | no                           | **yes**                      |
+| `key in obj`                                     | **yes**                      | no                           |
 
 ### Why This Matters
 
-| Issue                     | Impact                          | Solution                  |
-| ------------------------- | ------------------------------- | ------------------------- |
-| 📖 **Readability**        | `!== -1` is less clear          | Use includes()            |
-| 🎯 **Intent**             | indexOf suggests index needed   | Clear existence check     |
-| 🔄 **Consistency**        | Mixed patterns in codebase      | Standardize               |
+| Issue                  | Impact                                                    | Solution                    |
+| ---------------------- | --------------------------------------------------------- | --------------------------- |
+| 🛡️ **Prototype chain** | `in` is true for inherited keys — the pollution direction | Default to `Object.hasOwn`  |
+| 💥 **Dispatch**        | `obj.hasOwnProperty` throws on a null-prototype object    | Never call it through `obj` |
+| 🔄 **Consistency**     | Four spellings of one question                            | Standardize on one          |
 
 ## Examples
+
+The default preference is `Object.hasOwn`.
 
 ### ❌ Incorrect
 
 ```typescript
-obj.hasOwnProperty("key")
+key in obj; // answers true for INHERITED keys
+obj.hasOwnProperty(key); // looks the method up ON obj
+Object.prototype.hasOwnProperty.call(obj, key); // the long way round
 ```
 
 ### ✅ Correct
 
 ```typescript
-if (array.includes(item)) { }
-if (string.includes(substring)) { }
-
-// indexOf is fine when you need the actual index
-const index = array.indexOf(item);
-if (index !== -1) {
-  array.splice(index, 1);  // Using the index
-}
+Object.hasOwn(obj, key);
 ```
+
+### What is and is not autofixed
+
+Only `Object.prototype.hasOwnProperty.call(obj, key)` → `Object.hasOwn(obj, key)`.
+Those two ask the same question through the same dispatch, so the rewrite is safe.
+
+Everything else is **reported without a fix**, because rewriting it would change
+what the code does:
+
+- `in` walks the prototype chain and the own-property checks do not, so the two
+  disagree on an inherited key.
+- `obj.hasOwnProperty(key)` looks the method up on `obj`: it throws on a
+  null-prototype object and calls whatever a shadowing own property points at.
+
+### Options
+
+`preferred: 'Object.hasOwn' | 'in' | 'hasOwnProperty'` — default `'Object.hasOwn'`.
+
+Set `'in'` when a prototype-chain lookup is what the code means. It is a choice
+worth making deliberately; it is not a good default, which is why it is no longer
+one.
 
 ## Configuration Examples
 
@@ -64,18 +95,24 @@ if (index !== -1) {
 ```javascript
 {
   rules: {
-    'conventions/consistent-existence-index-check': 'warn'
+    // Default: preferred is 'Object.hasOwn'
+    'conventions/consistent-existence-index-check': 'warn',
+
+    // Or state a different preference deliberately
+    // 'conventions/consistent-existence-index-check': ['warn', { preferred: 'in' }],
   }
 }
 ```
 
 ## Related Rules
 
-- [`prefer-at`](./prefer-at) - Modern array access
+- [`prefer-object-has-own`](https://eslint.org/docs/latest/rules/prefer-object-has-own) — eslint core, same direction
 
 ## Further Reading
 
-- **[Array.includes() - MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes)** - MDN reference
+- **[Object.hasOwn() - MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn)** — why it was added
+- **[in operator - MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in)** — including the prototype-chain behaviour
+
 <WhenNotToUse />
 
 <FalseNegativeCTA />


### PR DESCRIPTION
## Summary

**`main` is currently red.** `rule-docs-sync-drift` fails on it, and it is my regression from [#964](https://github.com/ofri-peretz/eslint/pull/964).

That PR rewrote `packages/eslint-plugin-conventions/docs/rules/consistent-existence-index-check.md` — the page had described a completely different rule — but did not regenerate the MDX the docs site serves from it. The two have been out of sync since the merge.

```
AssertionError: 1 rule page(s) differ from their .md source.
Run `npm run sync:rules --workspace=docs` and commit the result
— do not hand-edit the generated MDX.
```

## How it surfaced

Not by anything watching `main`. It appeared when I rebased #959 onto the new main and its web lane went red — the failure had been sitting on `main` for three merges before anything reported it.

## Test plan

- [x] Reproduced on a clean checkout of `main` — `rule-docs-sync-drift` fails there, 1 failed / 2 passed.
- [x] Regenerated with `npm run sync:rules --workspace=docs`. Generated output only; nothing hand-edited.
- [x] `rule-docs-sync-drift` now passes 3/3.

No changeset: generated docs output, no consumer-visible package change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)