### PR TITLE
fix(rules): FP/FN sweep 2026-09-10 — 6 findings

### DIFF
--- a/.changeset/fpfn-sweep-enforce-import-order-pragmas.md
+++ b/.changeset/fpfn-sweep-enforce-import-order-pragmas.md
@@ -1,0 +1,14 @@
+---
+'eslint-plugin-import-next': patch
+---
+
+fix: `enforce-import-order`'s fixer no longer moves `@ts-nocheck` below an import
+
+TypeScript honours `@ts-nocheck`, `@ts-check` and `/// <reference />` only before the first
+statement. The fixer treated them as leading comments of the first import and carried them
+down with it. The result still parses and still lints clean, so nothing surfaces — type
+checking is just silently switched back on, or, for `@ts-check` on a `.js` file, silently
+switched off.
+
+These directives are now pinned the same way a hashbang already was. Only the directives:
+an explanatory comment written for a specific import still travels with that import.

--- a/.changeset/fpfn-sweep-function-scoping-capture.md
+++ b/.changeset/fpfn-sweep-function-scoping-capture.md
@@ -1,0 +1,18 @@
+---
+'eslint-plugin-maintainability': patch
+---
+
+fix: `consistent-function-scoping` sees destructured bindings and `this`
+
+The scope tracker recorded only plain `Identifier` binding targets, so `const { out } = opts`
+and `function f({ out })` bound nothing as far as the rule was concerned. A nested function
+capturing one looked as though it captured nothing, and the report asserted "doesn't capture
+outer variables" about code where ESLint's own scope manager resolves the reference to the
+enclosing function — with a suggested move that does not compile.
+
+An arrow also captures `this` lexically. The rule already exempted `MethodDefinition` and
+`PropertyDefinition` because they are "bound to the instance and cannot be moved to module
+scope", but that exemption never reached an arrow nested _inside_ a method — so the rule was
+backwards on the axis it says it cares about. Arrows only: a nested `function` declaration's
+`this` is dynamic, so hoisting it and calling it with `.call(this)` works, and that report
+stays.

--- a/.changeset/fpfn-sweep-nested-complexity-else-if.md
+++ b/.changeset/fpfn-sweep-nested-complexity-else-if.md
@@ -1,0 +1,14 @@
+---
+'eslint-plugin-maintainability': patch
+---
+
+fix: `nested-complexity-hotspots` no longer counts `else if` as a nesting level
+
+ESTree models `else if` as an `IfStatement` in the parent's `alternate`, and the depth walk
+counted each link, so a flat chain climbed one level per branch: code sitting at indentation
+level 2 reported "Nesting depth 6 exceeds maximum 4". The rule was flagging the exact shape
+its own fix text — "use early returns, guard clauses" — tells you to write.
+
+ESLint core's `max-depth` excludes `else if` for the same reason, and the sibling rule
+`cognitive-complexity` already carries `// else if doesn't increase nesting`. Genuine
+nesting inside an `else if` branch still accumulates and still reports.

--- a/.changeset/fpfn-sweep-no-console-log-fixer.md
+++ b/.changeset/fpfn-sweep-no-console-log-fixer.md
@@ -1,0 +1,17 @@
+---
+'eslint-plugin-operability': patch
+---
+
+fix: `no-console-log`'s `remove` and `comment` strategies no longer change control flow
+
+`findParentStatement` climbs to the nearest `ExpressionStatement`, `ReturnStatement` _or_
+`VariableDeclaration`, so `return console.log(x)` lost its early return and
+`export const o = { m: () => console.log(x), other }` lost the whole exported object. And
+when the statement was the braceless body of an `if` / `else if` / `while` / `for`, removing
+it left the branch headless and silently absorbed the following statement into it.
+
+All of it still parses and still type-checks, so nothing surfaces. `fixable: 'code'` means
+safe to apply unattended, and the docs recommend `--fix` in CI, so both statement-level
+strategies now decline instead: they fix only when the statement is exactly the
+`console.log` call and sits in a statement list. The report itself is unchanged, and
+`convert` / `warn` — which replace only the callee — were never affected.

--- a/.changeset/fpfn-sweep-no-internal-modules-fixer.md
+++ b/.changeset/fpfn-sweep-no-internal-modules-fixer.md
@@ -1,0 +1,15 @@
+---
+'eslint-plugin-import-next': patch
+---
+
+fix: `no-internal-modules` keeps parent traversal, and no longer crashes on a template-literal `require`
+
+The autofix collapsed every relative specifier to `'.'`, so `../content/docs/x` was
+repointed at the current file's own directory index — a different module — with no report
+left behind to show it. The traversal prefix is now preserved (`../..` for `../../a/b`);
+`./a/b/c` still resolves to `'.'` as before.
+
+The detector accepts a no-substitution template literal via `staticString`, but all three
+fixers narrowed on `Literal` and otherwise reached for `.source`, which is `undefined` on a
+template literal. `fixer.replaceText` then threw and aborted the lint for the entire file —
+at report time, so `--fix` was not even required.

--- a/.changeset/fpfn-sweep-unsafe-type-narrowing.md
+++ b/.changeset/fpfn-sweep-unsafe-type-narrowing.md
@@ -1,0 +1,14 @@
+---
+'eslint-plugin-reliability': patch
+---
+
+fix: `no-unsafe-type-narrowing`'s `allowWithComment` no longer disarms the whole file
+
+Two compounding defects. `/known/i` matched inside **unknown** — the word most likely to
+appear next to an `as unknown as T` cast — and `/safe/i` matched inside **unsafe**, so a
+comment condemning a cast whitelisted it. Both keywords are now word-bounded, which keeps
+the intended `// known to be this type` and `// safe - validated above` working.
+
+Separately, the proximity check had no lower bound: for a comment _below_ the assertion the
+line distance goes negative, which satisfies `<= 1` at any range. One trailing comment
+silenced every assertion above it — 988 lines away, in the case that surfaced this.

--- a/packages/eslint-plugin-import-next/src/rules/enforce-import-order.ts
+++ b/packages/eslint-plugin-import-next/src/rules/enforce-import-order.ts
@@ -236,9 +236,21 @@ export const enforceImportOrder = createRule<RuleOptions, MessageIds>({
       const text = comment.value.trim();
       // `/// <reference … />` reaches us as a Line comment whose value starts
       // with a third slash.
-      return (
-        /^@ts-(nocheck|check)\b/.test(text) || /^\/\s*<reference\b/.test(text)
-      );
+      if (
+        !/^@ts-(nocheck|check)\b/.test(text) &&
+        !/^\/\s*<reference\b/.test(text)
+      ) {
+        return false;
+      }
+      /*
+       * Position is half the definition. TypeScript honours these only before
+       * the first statement, so lower down the file it is an ordinary comment
+       * that merely looks like a directive. Treating it as one anyway excluded
+       * it from every import's extended range while the replacement range still
+       * spanned it — so a `@ts-nocheck` written between two imports was not
+       * moved, it was DELETED, and the fix left nothing behind to report.
+       */
+      return comment.range[1] <= sourceCode.ast.body[0].range[0];
     }
 
     function getExtendedRange(

--- a/packages/eslint-plugin-import-next/src/rules/enforce-import-order.ts
+++ b/packages/eslint-plugin-import-next/src/rules/enforce-import-order.ts
@@ -227,6 +227,20 @@ export const enforceImportOrder = createRule<RuleOptions, MessageIds>({
       return comment.range[0] === 0 && sourceCode.getText().startsWith('#!');
     }
 
+    /**
+     * A file-level TypeScript directive, which the compiler honours only
+     * before the first statement. Like a hashbang it is position-fixed, so it
+     * can never travel with an import.
+     */
+    function isFileDirective(comment: TSESTree.Comment): boolean {
+      const text = comment.value.trim();
+      // `/// <reference … />` reaches us as a Line comment whose value starts
+      // with a third slash.
+      return (
+        /^@ts-(nocheck|check)\b/.test(text) || /^\/\s*<reference\b/.test(text)
+      );
+    }
+
     function getExtendedRange(
       node: TSESTree.ImportDeclaration,
     ): [number, number] {
@@ -254,7 +268,20 @@ export const enforceImportOrder = createRule<RuleOptions, MessageIds>({
       //
       // A hashbang is not a statement and cannot be reordered, so it is simply
       // never part of an import's range.
-      const reorderable = commentsBefore.filter((c) => !isHashbang(c));
+      //
+      // The same holds for `@ts-nocheck`, `@ts-check` and `/// <reference />`:
+      // TypeScript honours them only before the first statement. Carrying one
+      // down with its import still PARSES, so nothing surfaces — the file just
+      // silently gains (or loses) type checking. Found on burgee
+      // apps/docs/.source/server.ts:1, a generated file whose `@ts-nocheck`
+      // header sits above 11 imports.
+      //
+      // Only the directives are pinned, not every leading comment: an
+      // explanatory comment written for a specific import must still travel
+      // with it, or the fix strands it over the wrong one.
+      const reorderable = commentsBefore.filter(
+        (c) => !isHashbang(c) && !isFileDirective(c),
+      );
       if (reorderable.length > 0) {
         start = reorderable[0].range[0];
       }

--- a/packages/eslint-plugin-import-next/src/rules/no-internal-modules.ts
+++ b/packages/eslint-plugin-import-next/src/rules/no-internal-modules.ts
@@ -13,9 +13,7 @@ import { createRule, staticString } from '@interlace/eslint-devkit';
 import { formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
 
 type MessageIds =
-  | 'internalModuleImport'
-  | 'suggestPublicApi'
-  | 'suggestBarrelExport';
+  'internalModuleImport' | 'suggestPublicApi' | 'suggestBarrelExport';
 
 export interface Options {
   /** Maximum allowed depth of module imports (0 = only root, 1 = one level deep, etc.) */
@@ -85,7 +83,16 @@ function getImportDepth(importPath: string): number {
  */
 function getRootImport(importPath: string): string {
   if (importPath.startsWith('./') || importPath.startsWith('../')) {
-    return '.';
+    // Keep the traversal prefix. The root of `../../a/b` is `../..`; collapsing
+    // it to `.` points the import at the current file's OWN directory index,
+    // which is a different module — and the autofix leaves no report behind,
+    // so the swap is silent.
+    const leading: string[] = [];
+    for (const seg of importPath.split('/')) {
+      if (seg !== '..') break;
+      leading.push(seg);
+    }
+    return leading.length > 0 ? leading.join('/') : '.';
   }
 
   if (importPath.startsWith('@')) {
@@ -220,6 +227,20 @@ export const noInternalModules = createRule<RuleOptions, MessageIds>({
       strategy = 'error',
     } = options || {};
 
+    /**
+     * The string-literal node the fixer must rewrite.
+     *
+     * The declaration visitors hand us the declaration, whose specifier lives
+     * on `.source`; the `require()` visitor hands us the argument itself, which
+     * `staticString` also accepts as a no-substitution TemplateLiteral. Reaching
+     * for `.source` on that argument yielded `undefined`, and `fixer.replaceText`
+     * then threw and aborted the lint for the whole file — fix functions run at
+     * report time, so `--fix` was not even required.
+     */
+    function specifierNodeOf(node: TSESTree.Node): TSESTree.Node {
+      return 'source' in node && node.source ? node.source : node;
+    }
+
     function checkImport(importPath: string, node: TSESTree.Node) {
       // Skip if path should be ignored
       if (matchesAnyPattern(importPath, ignorePaths)) {
@@ -265,11 +286,7 @@ export const noInternalModules = createRule<RuleOptions, MessageIds>({
           fix(fixer: TSESLint.RuleFixer) {
             // Find the string literal node to replace
             // Autofix always goes to the root package for safety
-            const sourceNode =
-              node.type === 'Literal'
-                ? node
-                : (node as TSESTree.ImportDeclaration).source;
-            return fixer.replaceText(sourceNode, `'${rootImport}'`);
+            return fixer.replaceText(specifierNodeOf(node), `'${rootImport}'`);
           },
         });
       } else if (strategy === 'suggest') {
@@ -282,11 +299,10 @@ export const noInternalModules = createRule<RuleOptions, MessageIds>({
               messageId: 'suggestPublicApi' as const,
               data: { suggestedPath: rootImport },
               fix(fixer: TSESLint.RuleFixer) {
-                const sourceNode =
-                  node.type === 'Literal'
-                    ? node
-                    : (node as TSESTree.ImportDeclaration).source;
-                return fixer.replaceText(sourceNode, `'${rootImport}'`);
+                return fixer.replaceText(
+                  specifierNodeOf(node),
+                  `'${rootImport}'`,
+                );
               },
             },
             // Add barrel export suggestion if different from root
@@ -296,11 +312,10 @@ export const noInternalModules = createRule<RuleOptions, MessageIds>({
                     messageId: 'suggestBarrelExport' as const,
                     data: { suggestedPath: barrelPath },
                     fix(fixer: TSESLint.RuleFixer) {
-                      const sourceNode =
-                        node.type === 'Literal'
-                          ? node
-                          : (node as TSESTree.ImportDeclaration).source;
-                      return fixer.replaceText(sourceNode, `'${barrelPath}'`);
+                      return fixer.replaceText(
+                        specifierNodeOf(node),
+                        `'${barrelPath}'`,
+                      );
                     },
                   },
                 ]

--- a/packages/eslint-plugin-import-next/src/rules/no-internal-modules.ts
+++ b/packages/eslint-plugin-import-next/src/rules/no-internal-modules.ts
@@ -282,7 +282,15 @@ export const noInternalModules = createRule<RuleOptions, MessageIds>({
         context.report({
           node,
           messageId: 'internalModuleImport',
-          data: reportData,
+          /*
+           * The message has to name what the FIXER writes, which is the root
+           * import — deliberately, "for safety", see below. `suggestedPath`
+           * stops at `maxDepth`, so with `maxDepth: 1` the report read
+           * `Import from "./src"` and then rewrote the specifier to `'.'`. A
+           * message that describes a different edit than the one applied is
+           * worse than no message.
+           */
+          data: { ...reportData, suggestedPath: rootImport },
           fix(fixer: TSESLint.RuleFixer) {
             // Find the string literal node to replace
             // Autofix always goes to the root package for safety

--- a/packages/eslint-plugin-import-next/src/tests/enforce-import-order.test.ts
+++ b/packages/eslint-plugin-import-next/src/tests/enforce-import-order.test.ts
@@ -112,6 +112,85 @@ import { helper } from './helper';
           },
         ],
       },
+      {
+        /*
+         * `@ts-nocheck` is position-fixed the same way a hashbang is:
+         * TypeScript honours it only before the first statement. The fixer
+         * treated it as a leading comment of the first import and carried it
+         * down with that import, which still PARSES — so nothing surfaces —
+         * while type checking is silently switched back on (or, for
+         * `@ts-check` on a .js file, silently switched off).
+         *
+         * burgee apps/docs/.source/server.ts:1 — a generated file whose
+         * `@ts-nocheck` header sits above 11 imports.
+         */
+        name: 'the fixer never moves an import above a @ts-nocheck pragma',
+        code: `// @ts-nocheck
+import { helper } from './helper';
+import fs from 'fs';
+`,
+        output: `// @ts-nocheck
+import fs from 'fs';
+
+import { helper } from './helper';
+`,
+        errors: [{ messageId: 'importOrder' }],
+        options: [
+          {
+            groups: ['builtin', 'sibling'],
+            newlinesBetween: 'always',
+          },
+        ],
+      },
+      {
+        /*
+         * A triple-slash reference directive is equally position-fixed:
+         * TypeScript stops honouring it after the first statement.
+         */
+        name: 'the fixer never moves an import above a triple-slash reference',
+        code: `/// <reference types="node" />
+import { helper } from './helper';
+import fs from 'fs';
+`,
+        output: `/// <reference types="node" />
+import fs from 'fs';
+
+import { helper } from './helper';
+`,
+        errors: [{ messageId: 'importOrder' }],
+        options: [
+          {
+            groups: ['builtin', 'sibling'],
+            newlinesBetween: 'always',
+          },
+        ],
+      },
+      {
+        /*
+         * A pragma pins, an explanatory comment travels. Only the pragma is
+         * position-fixed; the comment below it belongs to `./helper` and must
+         * move with it, or the fix strands a comment over the wrong import.
+         */
+        name: 'a pragma is pinned while a per-import comment travels with its import',
+        code: `// @ts-nocheck
+// helper must be imported for its side effects
+import { helper } from './helper';
+import fs from 'fs';
+`,
+        output: `// @ts-nocheck
+import fs from 'fs';
+
+// helper must be imported for its side effects
+import { helper } from './helper';
+`,
+        errors: [{ messageId: 'importOrder' }],
+        options: [
+          {
+            groups: ['builtin', 'sibling'],
+            newlinesBetween: 'always',
+          },
+        ],
+      },
       // Incorrect group order
       {
         name: 'a relative import before a builtin',

--- a/packages/eslint-plugin-import-next/src/tests/enforce-import-order.test.ts
+++ b/packages/eslint-plugin-import-next/src/tests/enforce-import-order.test.ts
@@ -114,6 +114,23 @@ import { helper } from './helper';
       },
       {
         /*
+         * The other side of that pin. A directive is only a directive BEFORE
+         * the first statement; between two imports it is an ordinary comment
+         * that happens to be shaped like one. Excluding it from every import's
+         * extended range while the replacement range still spanned it meant the
+         * fixer did not move it — it deleted it, and left no report behind.
+         */
+        name: 'a directive-shaped comment between imports travels, it is not deleted',
+        code: `import z from 'zzz';
+// @ts-nocheck
+import a from 'aaa';`,
+        output: `// @ts-nocheck
+import a from 'aaa';
+import z from 'zzz';`,
+        errors: [{ messageId: 'importOrder' }],
+      },
+      {
+        /*
          * `@ts-nocheck` is position-fixed the same way a hashbang is:
          * TypeScript honours it only before the first statement. The fixer
          * treated it as a leading comment of the first import and carried it

--- a/packages/eslint-plugin-import-next/src/tests/no-internal-modules.test.ts
+++ b/packages/eslint-plugin-import-next/src/tests/no-internal-modules.test.ts
@@ -96,6 +96,28 @@ describe('no-internal-modules', () => {
           output: "import utils from '.';",
           errors: [{ messageId: 'internalModuleImport' }],
         },
+        {
+          /*
+           * A `../` specifier must keep its traversal prefix. Collapsing it to
+           * '.' repoints the import at the CURRENT file's own directory index —
+           * a different module — and the fix leaves no report behind, so the
+           * swap is silent.
+           *
+           * burgee apps/docs/.source/server.ts:2
+           */
+          name: 'autofix keeps the parent traversal of a ../ specifier',
+          code: "import * as m from '../content/docs/x.mdx';",
+          options: [{ strategy: 'autofix', maxDepth: 0 }],
+          output: "import * as m from '..';",
+          errors: [{ messageId: 'internalModuleImport' }],
+        },
+        {
+          name: 'autofix keeps every level of a ../../ specifier',
+          code: "import * as m from '../../a/b';",
+          options: [{ strategy: 'autofix', maxDepth: 0 }],
+          output: "import * as m from '../..';",
+          errors: [{ messageId: 'internalModuleImport' }],
+        },
       ],
     });
   });
@@ -437,6 +459,20 @@ import { Button } from '@company/ui';
         {
           code: "const Button = require('@company/ui/components/Button');",
           options: [{ maxDepth: 1 }],
+          errors: [{ messageId: 'internalModuleImport' }],
+        },
+        {
+          /*
+           * The detector accepts a no-substitution template literal (via
+           * `staticString`), but the fixers reached for `.source` on it and got
+           * `undefined`, throwing out of `fixer.replaceText` and aborting the
+           * lint for the entire file. Fix functions are evaluated at report
+           * time, so plain `verify` crashed too — `--fix` was not required.
+           */
+          name: 'a template-literal require does not crash the autofixer',
+          code: 'const get = require(`lodash/fp/get`);',
+          options: [{ strategy: 'autofix', maxDepth: 0 }],
+          output: "const get = require('lodash');",
           errors: [{ messageId: 'internalModuleImport' }],
         },
       ],

--- a/packages/eslint-plugin-import-next/src/tests/no-internal-modules.test.ts
+++ b/packages/eslint-plugin-import-next/src/tests/no-internal-modules.test.ts
@@ -98,6 +98,30 @@ describe('no-internal-modules', () => {
         },
         {
           /*
+           * The message names the edit the fixer makes. Every other autofix
+           * case here runs at `maxDepth: 0`, where the suggested path and the
+           * root import are the same string — so the suite could not tell them
+           * apart, and at `maxDepth: 1` the report read `Import from "./src"`
+           * while the fixer wrote `'.'`.
+           */
+          name: 'the autofix message names the root import it actually writes',
+          code: "import x from './src/utils/helper';",
+          options: [{ strategy: 'autofix', maxDepth: 1 }],
+          output: "import x from '.';",
+          errors: [
+            {
+              messageId: 'internalModuleImport',
+              data: {
+                importPath: './src/utils/helper',
+                depth: '3',
+                maxDepth: '1',
+                suggestedPath: '.',
+              },
+            },
+          ],
+        },
+        {
+          /*
            * A `../` specifier must keep its traversal prefix. Collapsing it to
            * '.' repoints the import at the CURRENT file's own directory index —
            * a different module — and the fix leaves no report behind, so the

--- a/packages/eslint-plugin-maintainability/src/rules/maintainability/consistent-function-scoping.ts
+++ b/packages/eslint-plugin-maintainability/src/rules/maintainability/consistent-function-scoping.ts
@@ -19,7 +19,6 @@ export interface Options {
   checkArrowFunctions?: boolean;
 }
 
-
 type RuleOptions = [Options?];
 
 /**
@@ -42,25 +41,30 @@ export const consistentFunctionScoping = createRule<RuleOptions, MessageIds>({
     type: 'suggestion',
     docs: {
       url: 'https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-maintainability/docs/rules/consistent-function-scoping.md',
-      description: 'Move function definitions to the highest possible scope to improve readability and performance',
+      description:
+        'Move function definitions to the highest possible scope to improve readability and performance',
     },
     hasSuggestions: true,
     messages: {
       inconsistentFunctionScoping: formatLLMMessage({
         icon: MessageIcons.ARCHITECTURE,
         issueName: 'Inconsistent Function Scoping',
-        description: 'Function can be moved to higher scope as it doesn\'t capture outer variables',
+        description:
+          "Function can be moved to higher scope as it doesn't capture outer variables",
         severity: 'MEDIUM',
         fix: 'Move function declaration to module scope',
-        documentationLink: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/consistent-function-scoping.md',
+        documentationLink:
+          'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/consistent-function-scoping.md',
       }),
       moveToModuleScope: formatLLMMessage({
         icon: MessageIcons.ARCHITECTURE,
         issueName: 'Function Scoping Optimization',
-        description: 'Function does not use variables from its containing scope and can be moved to module level',
+        description:
+          'Function does not use variables from its containing scope and can be moved to module level',
         severity: 'MEDIUM',
         fix: 'Move function outside current scope: extract `function helper() { return "value"; }` to module level before the containing function/class',
-        documentationLink: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/consistent-function-scoping.md',
+        documentationLink:
+          'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/consistent-function-scoping.md',
       }),
     },
     schema: [
@@ -80,9 +84,7 @@ export const consistentFunctionScoping = createRule<RuleOptions, MessageIds>({
 
   create(context: TSESLint.RuleContext<MessageIds, RuleOptions>) {
     const [options] = context.options;
-    const {
-      checkArrowFunctions = true,
-    } = options || {};
+    const { checkArrowFunctions = true } = options || {};
 
     // Track variables declared in each scope
     const scopeStack: Set<string>[] = [new Set()];
@@ -102,6 +104,47 @@ export const consistentFunctionScoping = createRule<RuleOptions, MessageIds>({
       }
     }
 
+    /**
+     * Every name a binding target introduces, destructuring included.
+     *
+     * Only `Identifier` was recorded before, so `const { out } = opts` and
+     * `function f({ out })` bound nothing as far as this rule was concerned. A
+     * nested function that captured `out` then looked as though it captured
+     * nothing, and the report asserted "doesn't capture outer variables" about
+     * code where ESLint's own scope manager resolves the reference to the
+     * enclosing function — with a suggested move that does not compile.
+     */
+    function addBindingToCurrentScope(target: TSESTree.Node) {
+      switch (target.type) {
+        case 'Identifier':
+          addVariableToCurrentScope(target.name);
+          break;
+        case 'ObjectPattern':
+          for (const prop of target.properties) {
+            addBindingToCurrentScope(
+              prop.type === 'RestElement' ? prop.argument : prop.value,
+            );
+          }
+          break;
+        case 'ArrayPattern':
+          for (const element of target.elements) {
+            if (element) addBindingToCurrentScope(element);
+          }
+          break;
+        case 'AssignmentPattern':
+          addBindingToCurrentScope(target.left);
+          break;
+        case 'RestElement':
+          addBindingToCurrentScope(target.argument);
+          break;
+        case 'TSParameterProperty':
+          addBindingToCurrentScope(target.parameter);
+          break;
+        // No default: the six cases above are every BindingName and every
+        // Parameter shape, so a seventh would be a parser change, not a
+        // reachable path.
+      }
+    }
 
     function getOuterScopeVariables(): Set<string> {
       const outerScopes = scopeStack.slice(0, -1);
@@ -114,7 +157,45 @@ export const consistentFunctionScoping = createRule<RuleOptions, MessageIds>({
       return outerVars;
     }
 
-    function analyzeFunction(node: TSESTree.FunctionDeclaration | TSESTree.FunctionExpression | TSESTree.ArrowFunctionExpression) {
+    /**
+     * Does this arrow reference `this`?
+     *
+     * Nested arrows inherit the same `this`, so they count. A nested `function`
+     * / method / class body rebinds it, so its `this` is a different one and
+     * the walk stops there.
+     */
+    function capturesThis(node: TSESTree.Node): boolean {
+      if (node.type === 'ThisExpression') return true;
+
+      for (const key in node) {
+        if (key === 'parent') continue;
+        const value = (node as unknown as Record<string, unknown>)[key];
+        const children = Array.isArray(value) ? value : [value];
+        for (const child of children) {
+          if (!child || typeof child !== 'object') continue;
+          const childNode = child as TSESTree.Node;
+          if (typeof childNode.type !== 'string') continue;
+          if (
+            childNode.type === 'FunctionDeclaration' ||
+            childNode.type === 'FunctionExpression' ||
+            childNode.type === 'ClassDeclaration' ||
+            childNode.type === 'ClassExpression'
+          ) {
+            continue;
+          }
+          if (capturesThis(childNode)) return true;
+        }
+      }
+
+      return false;
+    }
+
+    function analyzeFunction(
+      node:
+        | TSESTree.FunctionDeclaration
+        | TSESTree.FunctionExpression
+        | TSESTree.ArrowFunctionExpression,
+    ) {
       /**
        * Already at the top scope, so there is nowhere to move it.
        *
@@ -153,6 +234,24 @@ export const consistentFunctionScoping = createRule<RuleOptions, MessageIds>({
       // `this` is wrongly flagged.
       const p = node.parent;
       if (p?.type === 'MethodDefinition' || p?.type === 'PropertyDefinition') {
+        return;
+      }
+
+      /**
+       * An arrow captures `this` lexically, so it is bound to the instance for
+       * the same reason the methods above are — moving it to module scope makes
+       * `this` undefined (TS2532 under --strict, a TypeError at runtime).
+       *
+       * The exemption above was positional and so never reached an arrow nested
+       * INSIDE a method: the rule was exactly backwards on the axis it says it
+       * cares about, exempting methods that never touch `this` while reporting
+       * arrows that do.
+       *
+       * Only arrows. A nested `function` declaration's `this` is dynamic, so
+       * hoisting it and keeping `f.call(this)` compiles and runs — that report
+       * is legitimate and stays.
+       */
+      if (node.type === 'ArrowFunctionExpression' && capturesThis(node)) {
         return;
       }
 
@@ -230,7 +329,7 @@ export const consistentFunctionScoping = createRule<RuleOptions, MessageIds>({
             const child = (astNode as unknown as Record<string, unknown>)[key];
             if (child && typeof child === 'object') {
               if (Array.isArray(child)) {
-                child.forEach(item => {
+                child.forEach((item) => {
                   if (item && typeof item === 'object' && 'type' in item) {
                     collectReferences(item, depth + 1);
                   }
@@ -247,7 +346,9 @@ export const consistentFunctionScoping = createRule<RuleOptions, MessageIds>({
 
       // Collect all references in the function body
       if (node.body.type === 'BlockStatement') {
-        node.body.body.forEach((stmt: TSESTree.Statement) => collectReferences(stmt));
+        node.body.body.forEach((stmt: TSESTree.Statement) =>
+          collectReferences(stmt),
+        );
       } else {
         // Arrow function with expression body
         collectReferences(node.body);
@@ -255,9 +356,7 @@ export const consistentFunctionScoping = createRule<RuleOptions, MessageIds>({
 
       // Check function parameters
       node.params.forEach((param: TSESTree.Parameter) => {
-        if (param.type === 'Identifier') {
-          referencedVars.add(param.name);
-        }
+        collectReferences(param);
       });
 
       // Get variables from outer scopes
@@ -275,7 +374,8 @@ export const consistentFunctionScoping = createRule<RuleOptions, MessageIds>({
       // If function doesn't capture any outer variables, it can be moved up
       if (!capturesOuterVar) {
         // Additional check: ensure function name doesn't conflict at module scope
-        const functionName = node.type === 'FunctionDeclaration' ? node.id?.name : undefined;
+        const functionName =
+          node.type === 'FunctionDeclaration' ? node.id?.name : undefined;
         const moduleScope = scopeStack[0];
 
         if (!functionName || !moduleScope.has(functionName)) {
@@ -294,7 +394,10 @@ export const consistentFunctionScoping = createRule<RuleOptions, MessageIds>({
                   // 2. Moving the function declaration33 3
                   // 3. Updating any references
                   // For now, just provide a suggestion
-                  return fixer.insertTextBefore(node, '// TODO: Move this function to module scope - it doesn\'t capture outer variables\n');
+                  return fixer.insertTextBefore(
+                    node,
+                    "// TODO: Move this function to module scope - it doesn't capture outer variables\n",
+                  );
                 },
               },
             ],
@@ -316,9 +419,7 @@ export const consistentFunctionScoping = createRule<RuleOptions, MessageIds>({
         enterScope();
         // Add function parameters to the current scope
         node.params.forEach((param: TSESTree.Parameter) => {
-          if (param.type === 'Identifier') {
-            addVariableToCurrentScope(param.name);
-          }
+          addBindingToCurrentScope(param);
         });
         analyzeFunction(node);
       },
@@ -331,9 +432,7 @@ export const consistentFunctionScoping = createRule<RuleOptions, MessageIds>({
         enterScope();
         // Add function parameters to the current scope
         node.params.forEach((param: TSESTree.Parameter) => {
-          if (param.type === 'Identifier') {
-            addVariableToCurrentScope(param.name);
-          }
+          addBindingToCurrentScope(param);
         });
         // Only check function expressions if they are assigned to variables
         // (not just used as callbacks)
@@ -348,9 +447,7 @@ export const consistentFunctionScoping = createRule<RuleOptions, MessageIds>({
         enterScope();
         // Add function parameters to the current scope
         node.params.forEach((param: TSESTree.Parameter) => {
-          if (param.type === 'Identifier') {
-            addVariableToCurrentScope(param.name);
-          }
+          addBindingToCurrentScope(param);
         });
         if (checkArrowFunctions) {
           analyzeFunction(node);
@@ -364,9 +461,7 @@ export const consistentFunctionScoping = createRule<RuleOptions, MessageIds>({
       VariableDeclaration(node: TSESTree.VariableDeclaration) {
         // Add variables to current scope
         node.declarations.forEach((decl: TSESTree.VariableDeclarator) => {
-          if (decl.id.type === 'Identifier') {
-            addVariableToCurrentScope(decl.id.name);
-          }
+          addBindingToCurrentScope(decl.id);
         });
       },
     };

--- a/packages/eslint-plugin-maintainability/src/rules/maintainability/consistent-function-scoping.ts
+++ b/packages/eslint-plugin-maintainability/src/rules/maintainability/consistent-function-scoping.ts
@@ -176,10 +176,34 @@ export const consistentFunctionScoping = createRule<RuleOptions, MessageIds>({
           const childNode = child as TSESTree.Node;
           if (typeof childNode.type !== 'string') continue;
           if (
-            childNode.type === 'FunctionDeclaration' ||
-            childNode.type === 'FunctionExpression' ||
             childNode.type === 'ClassDeclaration' ||
             childNode.type === 'ClassExpression'
+          ) {
+            /*
+             * A class BODY rebinds `this`, but its heritage clause and any
+             * computed member key are evaluated in the enclosing scope, with
+             * the enclosing `this`. Skipping the whole node lost both, so
+             * `() => class Inner extends this.Base {}` read as capturing
+             * nothing and the rule offered to move it to module scope — where
+             * `this` is a different object.
+             */
+            if (childNode.superClass && capturesThis(childNode.superClass)) {
+              return true;
+            }
+            for (const member of childNode.body.body) {
+              if (
+                'computed' in member &&
+                member.computed &&
+                capturesThis(member.key)
+              ) {
+                return true;
+              }
+            }
+            continue;
+          }
+          if (
+            childNode.type === 'FunctionDeclaration' ||
+            childNode.type === 'FunctionExpression'
           ) {
             continue;
           }
@@ -362,10 +386,26 @@ export const consistentFunctionScoping = createRule<RuleOptions, MessageIds>({
       // Get variables from outer scopes
       const outerVars = getOuterScopeVariables();
 
+      /*
+       * The names this function BINDS — its parameters and its own name.
+       *
+       * `collectReferences(param)` walks the whole pattern, so a destructured
+       * `{ value }` was recorded as a USE of `value`; an outer binding that
+       * happened to share the name then made the function look captured, and a
+       * perfectly movable function went unreported. Every mention of that name
+       * inside the body resolves to the parameter anyway — the outer one is
+       * shadowed, not captured. Default VALUES are unaffected and still count:
+       * `inner(v = fallback)` really does read `fallback` from outside, and
+       * `collectReferences` still records it.
+       */
+      const boundNames = new Set(
+        context.sourceCode.getDeclaredVariables(node).map((v) => v.name),
+      );
+
       // Check if function captures any outer variables
       let capturesOuterVar = false;
       for (const ref of referencedVars) {
-        if (outerVars.has(ref)) {
+        if (!boundNames.has(ref) && outerVars.has(ref)) {
           capturesOuterVar = true;
           break;
         }

--- a/packages/eslint-plugin-maintainability/src/rules/maintainability/nested-complexity-hotspots.ts
+++ b/packages/eslint-plugin-maintainability/src/rules/maintainability/nested-complexity-hotspots.ts
@@ -16,10 +16,7 @@ import { formatLLMMessage, MessageIcons } from '@interlace/eslint-devkit';
 import { createRule } from '@interlace/eslint-devkit';
 
 type MessageIds =
-  | 'nestedComplexity'
-  | 'useEarlyReturn'
-  | 'useGuardClauses'
-  | 'extractMethod';
+  'nestedComplexity' | 'useEarlyReturn' | 'useGuardClauses' | 'extractMethod';
 
 export interface Options {
   /** Maximum nesting depth. Default: 4 */
@@ -187,16 +184,28 @@ export const nestedComplexityHotspots = createRule<RuleOptions, MessageIds>({
 
         if (!parent) break;
 
+        // `else if` is a chain link, not a level: ESTree models it as an
+        // IfStatement in the parent's `alternate`, so counting it made a flat
+        // chain climb one level per branch — the rule reported "Nesting depth 6"
+        // on code sitting at indentation level 2, and flagged the very shape its
+        // own fix text ("use early returns, guard clauses") produces. ESLint
+        // core's `max-depth` excludes it the same way, and the sibling rule
+        // cognitive-complexity already carries `// else if doesn't increase
+        // nesting`.
+        const isElseIf =
+          parent.type === 'IfStatement' && parent.alternate === current;
+
         // Count nested control structures above this node
         if (
-          parent.type === 'IfStatement' ||
-          parent.type === 'ForStatement' ||
-          parent.type === 'ForInStatement' ||
-          parent.type === 'ForOfStatement' ||
-          parent.type === 'WhileStatement' ||
-          parent.type === 'DoWhileStatement' ||
-          parent.type === 'SwitchStatement' ||
-          parent.type === 'TryStatement'
+          !isElseIf &&
+          (parent.type === 'IfStatement' ||
+            parent.type === 'ForStatement' ||
+            parent.type === 'ForInStatement' ||
+            parent.type === 'ForOfStatement' ||
+            parent.type === 'WhileStatement' ||
+            parent.type === 'DoWhileStatement' ||
+            parent.type === 'SwitchStatement' ||
+            parent.type === 'TryStatement')
         ) {
           depth++;
         }

--- a/packages/eslint-plugin-maintainability/src/tests/maintainability/consistent-function-scoping.test.ts
+++ b/packages/eslint-plugin-maintainability/src/tests/maintainability/consistent-function-scoping.test.ts
@@ -22,27 +22,138 @@ const ruleTester = new RuleTester({
 
 describe('consistent-function-scoping', () => {
   describe('valid cases', () => {
-    ruleTester.run('allow properly scoped functions', consistentFunctionScoping, {
-      valid: [
-        // Module-level function (already at top scope)
-        {
-          name: 'the same helper at module scope',
-          code: `
+    ruleTester.run(
+      'allow properly scoped functions',
+      consistentFunctionScoping,
+      {
+        valid: [
+          /*
+           * A destructured binding is still a binding. The scope tracker recorded
+           * only `decl.id.type === 'Identifier'`, so every ObjectPattern and
+           * ArrayPattern was invisible and a nested function that captured one
+           * looked as though it captured nothing. The message then asserted
+           * "doesn't capture outer variables" about code where ESLint's own scope
+           * manager resolves the reference to the enclosing function, and the
+           * suggested move does not compile (TS2304: Cannot find name 'out').
+           *
+           * burgee packages/burgee/src/commander/command.ts:1753
+           */
+          {
+            name: 'a nested arrow capturing a destructured const',
+            code: `
+            function prepare(opts) {
+              const { out } = opts;
+              const sink = {};
+              if (out) sink.write = (s) => out.write(s);
+              return sink;
+            }
+          `,
+          },
+          {
+            name: 'a nested arrow capturing an array-destructured const',
+            code: `
+            function prepare(pair) {
+              const [first] = pair;
+              return () => first;
+            }
+          `,
+          },
+          {
+            name: 'a nested arrow capturing past a hole in an array pattern',
+            code: `
+            function prepare(pair) {
+              const [, second] = pair;
+              return () => second;
+            }
+          `,
+          },
+          {
+            name: 'a nested arrow capturing a destructured parameter',
+            code: `
+            function prepare({ out }) {
+              return (s) => out.write(s);
+            }
+          `,
+          },
+          {
+            name: 'a nested arrow capturing a parameter with a default',
+            code: `
+            function prepare(prefix = '> ') {
+              return (s) => prefix + s;
+            }
+          `,
+          },
+          {
+            name: 'a nested arrow capturing a rest parameter',
+            code: `
+            function prepare(...args) {
+              return () => args.length;
+            }
+          `,
+          },
+          {
+            name: 'a nested arrow capturing a destructured rest binding',
+            code: `
+            function prepare(opts) {
+              const { first, ...rest } = opts;
+              void first;
+              return () => rest;
+            }
+          `,
+          },
+          {
+            name: 'a nested arrow capturing a constructor parameter property',
+            code: `
+            class C {
+              handler;
+              constructor(private prefix: string) {
+                this.handler = (s) => prefix + s;
+              }
+            }
+          `,
+          },
+          /*
+           * An arrow captures `this` lexically. Moving it to module scope makes
+           * `this` undefined — TS2532 under --strict, a TypeError at runtime.
+           * The rule already exempts MethodDefinition/PropertyDefinition with the
+           * comment "bound to the instance and cannot be moved to module scope",
+           * but that exemption never reached an arrow nested INSIDE a method.
+           *
+           * burgee packages/burgee/src/commander/command.ts:1509
+           */
+          {
+            name: 'an arrow inside a method that captures this',
+            code: `
+            class C {
+              setChoices(values) {
+                this.choices = values;
+                this.parseArg = (arg) => {
+                  if (!this.choices.includes(arg)) throw new Error('bad');
+                  return arg;
+                };
+              }
+            }
+          `,
+          },
+          // Module-level function (already at top scope)
+          {
+            name: 'the same helper at module scope',
+            code: `
             function helper() {
               return 'value';
             }
           `,
-        },
-        // Module-level arrow function
-        {
-          name: 'an arrow bound at module scope has nowhere higher to go',
-          code: `
+          },
+          // Module-level arrow function
+          {
+            name: 'an arrow bound at module scope has nowhere higher to go',
+            code: `
             const helper = () => 'value';
           `,
-        },
-        // Function that captures outer variable
-        {
-          code: `
+          },
+          // Function that captures outer variable
+          {
+            code: `
             function outer() {
               const message = 'hello';
               function inner() {
@@ -51,163 +162,206 @@ describe('consistent-function-scoping', () => {
               return inner();
             }
           `,
-        },
-        // Arrow function capturing outer variable
-        {
-          code: `
+          },
+          // Arrow function capturing outer variable
+          {
+            code: `
             function outer() {
               const count = 0;
               const increment = () => count + 1;
               return increment();
             }
           `,
-        },
-        // Exported function
-        {
-          code: `
+          },
+          // Exported function
+          {
+            code: `
             export function helper() {
               return 'value';
             }
           `,
-        },
-        // Export default function
-        {
-          code: `
+          },
+          // Export default function
+          {
+            code: `
             export default function helper() {
               return 'value';
             }
           `,
-        },
-        // Arrow function that doesn't capture but checkArrowFunctions is false
-        {
-          code: `
+          },
+          // Arrow function that doesn't capture but checkArrowFunctions is false
+          {
+            code: `
             function outer() {
               const helper = () => 'value';
               return helper();
             }
           `,
-          options: [{ checkArrowFunctions: false }],
-        },
-        // Class method — bound to instance, cannot be hoisted to module scope.
-        {
-          code: `
+            options: [{ checkArrowFunctions: false }],
+          },
+          // Class method — bound to instance, cannot be hoisted to module scope.
+          {
+            code: `
             class Foo {
               bar() {
                 return 'value';
               }
             }
           `,
-        },
-        // Class field arrow initializer — bound to instance.
-        {
-          code: `
+          },
+          // Class field arrow initializer — bound to instance.
+          {
+            code: `
             class Foo {
               bar = () => 'value';
             }
           `,
-        },
-        // Array.prototype.map callback — inline by design.
-        {
-          code: `
+          },
+          // Array.prototype.map callback — inline by design.
+          {
+            code: `
             function outer(arr) {
               return arr.map(x => x + 1);
             }
           `,
-        },
-        // Array.prototype.reduce callback.
-        {
-          code: `
+          },
+          // Array.prototype.reduce callback.
+          {
+            code: `
             function outer(arr) {
               return arr.reduce((a, b) => a + b, 0);
             }
           `,
-        },
-        // Array.prototype.forEach callback.
-        {
-          code: `
+          },
+          // Array.prototype.forEach callback.
+          {
+            code: `
             function outer(arr) {
               arr.forEach(x => log(x));
             }
           `,
-        },
-        // Array.prototype.sort comparator.
-        {
-          code: `
+          },
+          // Array.prototype.sort comparator.
+          {
+            code: `
             function outer(arr) {
               return arr.sort((a, b) => a - b);
             }
           `,
-        },
-        // Array.prototype.flatMap callback.
-        {
-          code: `
+          },
+          // Array.prototype.flatMap callback.
+          {
+            code: `
             function outer(arr) {
               return arr.flatMap(x => [x, x]);
             }
           `,
-        },
-        // Promise.then callback.
-        {
-          code: `
+          },
+          // Promise.then callback.
+          {
+            code: `
             function outer(p) {
               return p.then(x => x.value);
             }
           `,
-        },
-        // Promise.catch callback.
-        {
-          code: `
+          },
+          // Promise.catch callback.
+          {
+            code: `
             function outer(p) {
               return p.catch(e => 'fallback');
             }
           `,
-        },
-        // Event-emitter .on handler.
-        {
-          code: `
+          },
+          // Event-emitter .on handler.
+          {
+            code: `
             function outer(emitter) {
               emitter.on('event', x => handle(x));
             }
           `,
-        },
-        // addEventListener callback.
-        {
-          code: `
+          },
+          // addEventListener callback.
+          {
+            code: `
             function outer(el) {
               el.addEventListener('click', e => onClick(e));
             }
           `,
-        },
-        // setTimeout callback.
-        {
-          code: `
+          },
+          // setTimeout callback.
+          {
+            code: `
             function outer() {
               setTimeout(() => doSomething(), 100);
             }
           `,
-        },
-        // requestAnimationFrame callback.
-        {
-          code: `
+          },
+          // requestAnimationFrame callback.
+          {
+            code: `
             function outer() {
               requestAnimationFrame(() => frame());
             }
           `,
-        },
-        // Promise constructor executor — must stay inline.
-        {
-          code: `
+          },
+          // Promise constructor executor — must stay inline.
+          {
+            code: `
             function outer() {
               return new Promise((resolve, reject) => resolve(1));
             }
           `,
-        },
-      ],
-      invalid: [
-        // Function that doesn't capture outer variables
-        {
-          name: 'an inner function that closes over nothing from its parent',
-          code: `
+          },
+        ],
+        invalid: [
+          {
+            /*
+             * A class body rebinds `this`, so the arrow around it does NOT capture
+             * `this` lexically and remains movable — the walk must step over the
+             * class rather than treat its `this` as the arrow's. A nested
+             * `function` declaration is skipped for the same reason: its `this`
+             * is dynamic, so hoisting it and calling it with `.call(this)` works.
+             */
+            name: 'an arrow whose only this belongs to a nested class still reports',
+            code: `
+            function outer() {
+              const helper = () => {
+                class Inner {
+                  value = this;
+                }
+                return Inner;
+              };
+              return helper();
+            }
+          `,
+            errors: [
+              {
+                messageId: 'inconsistentFunctionScoping',
+                suggestions: [
+                  {
+                    messageId: 'moveToModuleScope',
+                    output: `
+            function outer() {
+              const helper = // TODO: Move this function to module scope - it doesn't capture outer variables
+() => {
+                class Inner {
+                  value = this;
+                }
+                return Inner;
+              };
+              return helper();
+            }
+          `,
+                  },
+                ],
+              },
+            ],
+          },
+          // Function that doesn't capture outer variables
+          {
+            name: 'an inner function that closes over nothing from its parent',
+            code: `
             function outer() {
               function helper() {
                 return 'value';
@@ -215,11 +369,13 @@ describe('consistent-function-scoping', () => {
               return helper();
             }
           `,
-          errors: [{ 
-            messageId: 'inconsistentFunctionScoping',
-            suggestions: [{ 
-              messageId: 'moveToModuleScope',
-              output: `
+            errors: [
+              {
+                messageId: 'inconsistentFunctionScoping',
+                suggestions: [
+                  {
+                    messageId: 'moveToModuleScope',
+                    output: `
             function outer() {
               // TODO: Move this function to module scope - it doesn't capture outer variables
 function helper() {
@@ -228,11 +384,14 @@ function helper() {
               return helper();
             }
           `,
-            }],
-          }],
-        },
-      ],
-    });
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    );
   });
 
   /**
@@ -249,64 +408,76 @@ function helper() {
    * See docs/intents/burgee-false-positives/.
    */
   describe('a type assertion does not move a function off module scope (burgee)', () => {
-    ruleTester.run('asserted module-scope functions', consistentFunctionScoping, {
-      valid: [
-        {
-          name: 'FP: a module-scope arrow cast through `as unknown as T`',
-          // @found real-source scan (burgee, ofri-peretz/burgee eslint.config.mjs)
-          code: `const noExit = (() => undefined) as unknown as (code: number) => never;`,
-        },
-        {
-          name: 'FP: the same cast on an exported binding',
-          // @found real-source scan (burgee, ofri-peretz/burgee eslint.config.mjs)
-          code: `export const noExit = (() => undefined) as unknown as (code: number) => never;`,
-        },
-        {
-          name: 'a module-scope arrow checked with `satisfies`',
-          code: `const ok = (() => 'ok') satisfies () => string;`,
-        },
-        {
-          name: 'a module-scope arrow behind a non-null assertion',
-          code: `const ok = (() => 'ok')!;`,
-        },
-        {
-          name: 'a module-scope arrow in the angle-bracket assertion spelling',
-          code: `const ok = <() => string>(() => 'ok');`,
-        },
-        {
-          name: 'a module-scope function EXPRESSION cast the same way',
-          code: `const ok = (function () { return 'ok'; }) as unknown as () => string;`,
-        },
-        {
-          name: 'FP: a trivial callback written inline as a property of an argument object, inside a test body (3.0.3 reported it)',
-          // @found real-source scan (burgee, ofri-peretz/burgee eslint.config.mjs)
-          code: `it('lists commands', () => { const program = defineProgram({ commands: [defineCommand({ name: 'status', run: () => 'ok' })] }); expect(program).toBeDefined(); });`,
-        },
-      ],
-      invalid: [
-        {
-          name: 'the same cast INSIDE a function still reports — the assertion is not what makes it movable',
-          code: `function outer() { const f = (() => 'ok') as unknown as () => string; return f(); }`,
-          errors: [{
-            messageId: 'inconsistentFunctionScoping',
-            suggestions: [{
-              messageId: 'moveToModuleScope',
-              output: `function outer() { const f = (// TODO: Move this function to module scope - it doesn't capture outer variables\n() => 'ok') as unknown as () => string; return f(); }`,
-            }],
-          }],
-        },
-        {
-          name: 'a satisfies-checked arrow inside a function reports too',
-          code: `function outer() { const f = (() => 'ok') satisfies () => string; return f(); }`,
-          errors: [{
-            messageId: 'inconsistentFunctionScoping',
-            suggestions: [{
-              messageId: 'moveToModuleScope',
-              output: `function outer() { const f = (// TODO: Move this function to module scope - it doesn't capture outer variables\n() => 'ok') satisfies () => string; return f(); }`,
-            }],
-          }],
-        },
-      ],
-    });
+    ruleTester.run(
+      'asserted module-scope functions',
+      consistentFunctionScoping,
+      {
+        valid: [
+          {
+            name: 'FP: a module-scope arrow cast through `as unknown as T`',
+            // @found real-source scan (burgee, ofri-peretz/burgee eslint.config.mjs)
+            code: `const noExit = (() => undefined) as unknown as (code: number) => never;`,
+          },
+          {
+            name: 'FP: the same cast on an exported binding',
+            // @found real-source scan (burgee, ofri-peretz/burgee eslint.config.mjs)
+            code: `export const noExit = (() => undefined) as unknown as (code: number) => never;`,
+          },
+          {
+            name: 'a module-scope arrow checked with `satisfies`',
+            code: `const ok = (() => 'ok') satisfies () => string;`,
+          },
+          {
+            name: 'a module-scope arrow behind a non-null assertion',
+            code: `const ok = (() => 'ok')!;`,
+          },
+          {
+            name: 'a module-scope arrow in the angle-bracket assertion spelling',
+            code: `const ok = <() => string>(() => 'ok');`,
+          },
+          {
+            name: 'a module-scope function EXPRESSION cast the same way',
+            code: `const ok = (function () { return 'ok'; }) as unknown as () => string;`,
+          },
+          {
+            name: 'FP: a trivial callback written inline as a property of an argument object, inside a test body (3.0.3 reported it)',
+            // @found real-source scan (burgee, ofri-peretz/burgee eslint.config.mjs)
+            code: `it('lists commands', () => { const program = defineProgram({ commands: [defineCommand({ name: 'status', run: () => 'ok' })] }); expect(program).toBeDefined(); });`,
+          },
+        ],
+        invalid: [
+          {
+            name: 'the same cast INSIDE a function still reports — the assertion is not what makes it movable',
+            code: `function outer() { const f = (() => 'ok') as unknown as () => string; return f(); }`,
+            errors: [
+              {
+                messageId: 'inconsistentFunctionScoping',
+                suggestions: [
+                  {
+                    messageId: 'moveToModuleScope',
+                    output: `function outer() { const f = (// TODO: Move this function to module scope - it doesn't capture outer variables\n() => 'ok') as unknown as () => string; return f(); }`,
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            name: 'a satisfies-checked arrow inside a function reports too',
+            code: `function outer() { const f = (() => 'ok') satisfies () => string; return f(); }`,
+            errors: [
+              {
+                messageId: 'inconsistentFunctionScoping',
+                suggestions: [
+                  {
+                    messageId: 'moveToModuleScope',
+                    output: `function outer() { const f = (// TODO: Move this function to module scope - it doesn't capture outer variables\n() => 'ok') satisfies () => string; return f(); }`,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    );
   });
 });

--- a/packages/eslint-plugin-maintainability/src/tests/maintainability/consistent-function-scoping.test.ts
+++ b/packages/eslint-plugin-maintainability/src/tests/maintainability/consistent-function-scoping.test.ts
@@ -27,6 +27,42 @@ describe('consistent-function-scoping', () => {
       consistentFunctionScoping,
       {
         valid: [
+          {
+            /*
+             * A class BODY rebinds `this` — that is the case in `invalid` below.
+             * A heritage clause does not: `extends this.Base` is evaluated in
+             * the enclosing scope, so the arrow does capture `this` and moving
+             * it to module scope would extend a different object.
+             */
+            name: 'a class heritage clause captures the enclosing this',
+            code: `class Host {
+              m() {
+                const helper = () => class Inner extends this.Base {};
+                return helper();
+              }
+            }`,
+          },
+          {
+            // Same reasoning, other half: a COMPUTED member key is evaluated
+            // with the enclosing `this`, while the body it sits in is not.
+            name: 'a computed class member key captures the enclosing this',
+            code: `class Host {
+              m() {
+                const helper = () => class Inner { [this.key]() {} };
+                return helper();
+              }
+            }`,
+          },
+          {
+            // The control for the parameter fix below: a default VALUE is
+            // evaluated in the enclosing scope and really is a capture.
+            name: 'a parameter default value still counts as a capture',
+            code: `function outer() {
+              const fallback = 1;
+              function inner(v = fallback) { return v; }
+              return inner();
+            }`,
+          },
           /*
            * A destructured binding is still a binding. The scope tracker recorded
            * only `decl.id.type === 'Identifier'`, so every ObjectPattern and
@@ -315,6 +351,74 @@ describe('consistent-function-scoping', () => {
           },
         ],
         invalid: [
+          {
+            /*
+             * `collectReferences` walked the whole parameter pattern, so the
+             * destructured `{ value }` was recorded as a USE of `value`. An
+             * outer binding of the same name then made this look captured and
+             * the report was withheld — for a function that shadows the outer
+             * name and could move to module scope untouched.
+             */
+            name: 'a destructured parameter shadowing an outer name is still movable',
+            code: `function outer() {
+              const value = 1;
+              function inner({ value }) { return value; }
+              return [value, inner];
+            }`,
+            errors: [
+              {
+                messageId: 'inconsistentFunctionScoping',
+                suggestions: [
+                  {
+                    messageId: 'moveToModuleScope',
+                    output: `function outer() {
+              const value = 1;
+              // TODO: Move this function to module scope - it doesn't capture outer variables
+function inner({ value }) { return value; }
+              return [value, inner];
+            }`,
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            /*
+             * The other half of the same walk: a nested `function` — declaration
+             * or expression — rebinds `this` dynamically, so its `this` is not
+             * the arrow's and the arrow stays movable.
+             */
+            name: 'an arrow whose only this belongs to a nested function still reports',
+            // The nested pair read `seed`, the arrow's own parameter, so they
+            // are not movable themselves and only the arrow reports.
+            code: `function outer() {
+              const helper = (seed) => {
+                function decl() { return this ?? seed; }
+                const expr = function () { return this ?? seed; };
+                return [decl, expr];
+              };
+              return helper(1);
+            }`,
+            errors: [
+              {
+                messageId: 'inconsistentFunctionScoping',
+                suggestions: [
+                  {
+                    messageId: 'moveToModuleScope',
+                    output: `function outer() {
+              const helper = // TODO: Move this function to module scope - it doesn't capture outer variables
+(seed) => {
+                function decl() { return this ?? seed; }
+                const expr = function () { return this ?? seed; };
+                return [decl, expr];
+              };
+              return helper(1);
+            }`,
+                  },
+                ],
+              },
+            ],
+          },
           {
             /*
              * A class body rebinds `this`, so the arrow around it does NOT capture

--- a/packages/eslint-plugin-maintainability/src/tests/maintainability/nested-complexity-hotspots.test.ts
+++ b/packages/eslint-plugin-maintainability/src/tests/maintainability/nested-complexity-hotspots.test.ts
@@ -33,6 +33,47 @@ describe('nested-complexity-hotspots', () => {
           `,
         },
         {
+          /*
+           * A flat `if / else if` chain is one level of nesting, not one per
+           * link. ESTree models `else if` as an IfStatement in `alternate`, so
+           * walking parents counted each link as another level: the last branch
+           * of this chain reported "Nesting depth 6 exceeds maximum 4" while
+           * sitting at indentation level 2.
+           *
+           * The rule's own fix text is "Use early returns, guard clauses, or
+           * extract methods" — it was flagging the shape that advice produces.
+           * ESLint core's `max-depth` excludes `else if` for the same reason,
+           * and the sibling rule cognitive-complexity already carries the
+           * comment "else if doesn't increase nesting".
+           *
+           * burgee packages/burgee/src/yargs-parser.ts:362
+           */
+          name: 'a flat else-if chain is not nesting',
+          code: `
+            for (const arg of args) {
+              if (arg === '-a') take('a');
+              else if (arg === '-b') take('b');
+              else if (arg === '-c') take('c');
+              else if (arg === '-d') take('d');
+              else if (arg === '--') break;
+              else take('x');
+            }
+          `,
+        },
+        {
+          name: 'a top-level guard chain of returns is not nesting',
+          code: `
+            function classify(x) {
+              if (x < 0) return 'neg';
+              else if (x === 0) return 'zero';
+              else if (x < 10) return 'small';
+              else if (x < 100) return 'medium';
+              else if (x < 1000) return 'large';
+              else return 'huge';
+            }
+          `,
+        },
+        {
           code: `
             if (a) {
               if (b) {

--- a/packages/eslint-plugin-operability/src/rules/operability/no-console-log.ts
+++ b/packages/eslint-plugin-operability/src/rules/operability/no-console-log.ts
@@ -9,7 +9,11 @@
  * Disallows console.log with configurable strategies and LLM-optimized output
  */
 import type { TSESLint, TSESTree } from '@interlace/eslint-devkit';
-import { formatLLMMessage, MessageIcons, propertyName } from '@interlace/eslint-devkit';
+import {
+  formatLLMMessage,
+  MessageIcons,
+  propertyName,
+} from '@interlace/eslint-devkit';
 import { createRule } from '@interlace/eslint-devkit';
 import { normalizePath, getRelativePath } from '@interlace/eslint-devkit';
 
@@ -306,7 +310,8 @@ export const noConsoleLog = createRule<RuleOptions, MessageIds>({
      * Supports exact matches, directory prefixes, and glob-like patterns.
      */
     const shouldIgnoreFile = (): boolean => {
-      if (ignoreNonProductionPaths && isNonProductionPath(filename)) return true;
+      if (ignoreNonProductionPaths && isNonProductionPath(filename))
+        return true;
       if (ignorePaths.length === 0) return false;
 
       const normalizedPath = normalizePath(filename);
@@ -330,7 +335,10 @@ export const noConsoleLog = createRule<RuleOptions, MessageIds>({
          * that, raw `*` / `?` reach `new RegExp()` and the pattern matching
          * is silently broken.
          */
-        const escaped = normalizedPattern.replace(/[.+^${}()|[\]\\*?]/g, '\\$&');
+        const escaped = normalizedPattern.replace(
+          /[.+^${}()|[\]\\*?]/g,
+          '\\$&',
+        );
         const regexPattern = escaped
           .replace(/\\\*/g, '.*')
           .replace(/\\\?/g, '.');
@@ -410,6 +418,40 @@ export const noConsoleLog = createRule<RuleOptions, MessageIds>({
         const fix = (fixer: TSESLint.RuleFixer) => {
           const statement = findParentStatement(node);
           if (!statement) return null;
+
+          /**
+           * `remove` and `comment` rewrite a whole STATEMENT, so they are only
+           * safe when that statement is the call itself and it sits in a
+           * statement list.
+           *
+           * Neither held in general. `findParentStatement` climbs to the
+           * nearest ExpressionStatement, ReturnStatement *or*
+           * VariableDeclaration, so `return console.log(x)` lost the early
+           * return and `export const o = { m: () => console.log(x), other }`
+           * lost the entire exported object. And when the statement was the
+           * braceless body of an `if`/`else if`/`while`/`for`, removing it left
+           * the branch headless and silently absorbed the following statement
+           * into it — found on burgee packages/burgee/src/yargs/factory.ts:1034,
+           * where the absorbed statement gates the whole help path.
+           *
+           * All of it still parses and still type-checks, so nothing surfaces.
+           * `fixable: 'code'` means "safe to apply unattended", and the docs
+           * tell users to run `--fix` in CI, so the fixer declines instead. The
+           * report is unaffected; only the automatic rewrite is withheld.
+           */
+          if (strategy === 'remove' || strategy === 'comment') {
+            const wrapsCallExactly =
+              statement.type === 'ExpressionStatement' &&
+              statement.expression === node;
+            const parentType = statement.parent?.type;
+            const inStatementList =
+              parentType === 'BlockStatement' ||
+              parentType === 'Program' ||
+              parentType === 'SwitchCase' ||
+              parentType === 'StaticBlock';
+
+            if (!wrapsCallExactly || !inStatementList) return null;
+          }
 
           switch (strategy) {
             case 'remove':

--- a/packages/eslint-plugin-operability/src/tests/operability/no-console-log.test.ts
+++ b/packages/eslint-plugin-operability/src/tests/operability/no-console-log.test.ts
@@ -88,6 +88,81 @@ describe('no-console-log', () => {
       valid: [],
       invalid: [
         {
+          /*
+           * A braceless `else if` body: removing the statement leaves the branch
+           * headless and the NEXT statement is silently absorbed into it. The
+           * output still parses and `tsc --strict` still exits 0, so nothing
+           * surfaces — only the runtime behaviour changes.
+           *
+           * burgee packages/burgee/src/yargs/factory.ts:1034, where the absorbed
+           * statement is `this.#hasOutput = true` — read by a public getter and
+           * gating the whole help/validation path.
+           *
+           * `output: null` asserts the rule declines to fix. The report stays.
+           */
+          name: 'remove declines to fix a braceless else-if body',
+          code: `if (a) b();
+else if (c) console.log("x");
+after();`,
+          options: [{ strategy: 'remove' }],
+          output: null,
+          errors: [{ messageId: 'consoleLogFound' }],
+        },
+        {
+          name: 'remove declines to fix a braceless while body',
+          code: `while (c) console.log("x");
+return 2;`,
+          options: [{ strategy: 'remove' }],
+          output: null,
+          errors: [{ messageId: 'consoleLogFound' }],
+        },
+        {
+          /*
+           * `findParentStatement` walks up to the enclosing ReturnStatement, so
+           * removing it deletes the early return and code below starts running
+           * on a path it never ran on before.
+           */
+          name: 'remove declines to fix a returned console.log',
+          code: `function f(cond) {
+  if (cond) {
+    return console.log("early");
+  }
+  danger();
+}`,
+          options: [{ strategy: 'remove' }],
+          output: null,
+          errors: [{ messageId: 'consoleLogFound' }],
+        },
+        {
+          /*
+           * Here the walk passes the arrow entirely and lands on the enclosing
+           * VariableDeclaration, deleting an exported object and an unrelated
+           * sibling method with it.
+           */
+          name: 'remove declines to fix a console.log inside an arrow body',
+          code: `export const myLogger = {
+  debug: (m) => console.log(m),
+  info: (m) => process.stdout.write(m),
+};`,
+          options: [{ strategy: 'remove' }],
+          output: null,
+          errors: [{ messageId: 'consoleLogFound' }],
+        },
+        {
+          /*
+           * `comment` shares the statement-level replace and so shares the bug —
+           * and it is the phase the docs recommend FIRST, as the least invasive
+           * step.
+           */
+          name: 'comment declines to fix a braceless else-if body',
+          code: `if (a) b();
+else if (c) console.log("x");
+after();`,
+          options: [{ strategy: 'comment' }],
+          output: null,
+          errors: [{ messageId: 'consoleLogFound' }],
+        },
+        {
           code: 'console.log("test");',
           options: [{ strategy: 'remove' }],
           output: '',

--- a/packages/eslint-plugin-operability/src/tests/operability/no-console-log.test.ts
+++ b/packages/eslint-plugin-operability/src/tests/operability/no-console-log.test.ts
@@ -110,8 +110,10 @@ after();`,
         },
         {
           name: 'remove declines to fix a braceless while body',
+          // `after();` rather than a top-level `return`, which is a parse error
+          // under some configurations and would take the case with it.
           code: `while (c) console.log("x");
-return 2;`,
+after();`,
           options: [{ strategy: 'remove' }],
           output: null,
           errors: [{ messageId: 'consoleLogFound' }],

--- a/packages/eslint-plugin-reliability/src/rules/reliability/no-unsafe-type-narrowing.ts
+++ b/packages/eslint-plugin-reliability/src/rules/reliability/no-unsafe-type-narrowing.ts
@@ -72,8 +72,11 @@ function hasExplanatoryComment(
     /type.?guard/i,
     /validated/i,
     /checked/i,
-    /safe/i,
-    /known/i,
+    // Word-bounded: `unsafe` and `unknown` must not read as permission — `unknown`
+    // is the word most likely to sit next to an `as unknown as T` cast, and
+    // `unsafe` is the opposite of consent.
+    /\bsafe\b/i,
+    /\bknown\b/i,
     /intentional/i,
     /necessary/i,
     /framework/i,
@@ -84,9 +87,15 @@ function hasExplanatoryComment(
     /fixme/i,
   ];
 
-  // Check comments before the assertion (within 1 line)
+  // Check comments before the assertion (within 1 line). The lower bound matters:
+  // without it a comment *below* the assertion yields a negative distance, which
+  // satisfies `<= 1` at any range and disarms the rule for the rest of the file.
   for (const comment of comments) {
-    if (comment.loc && nodeStart.line - comment.loc.end.line <= 1) {
+    if (
+      comment.loc &&
+      nodeStart.line >= comment.loc.end.line &&
+      nodeStart.line - comment.loc.end.line <= 1
+    ) {
       const commentText = comment.value.toLowerCase();
       if (explanatoryPatterns.some((pattern) => pattern.test(commentText))) {
         return true;

--- a/packages/eslint-plugin-reliability/src/rules/reliability/no-unsafe-type-narrowing.ts
+++ b/packages/eslint-plugin-reliability/src/rules/reliability/no-unsafe-type-narrowing.ts
@@ -91,15 +91,29 @@ function hasExplanatoryComment(
   // without it a comment *below* the assertion yields a negative distance, which
   // satisfies `<= 1` at any range and disarms the rule for the rest of the file.
   for (const comment of comments) {
-    if (
-      comment.loc &&
-      nodeStart.line >= comment.loc.end.line &&
-      nodeStart.line - comment.loc.end.line <= 1
-    ) {
-      const commentText = comment.value.toLowerCase();
-      if (explanatoryPatterns.some((pattern) => pattern.test(commentText))) {
-        return true;
-      }
+    // `loc` is required on TSESTree.Comment; the guard that used to stand here
+    // was a branch no input could take.
+    const distance = nodeStart.line - comment.loc.end.line;
+    if (distance < 0 || distance > 1) continue;
+
+    /*
+     * A comment on the line ABOVE only speaks for this assertion when it owns
+     * that line. `const a = x as unknown as A; // safe` trails a DIFFERENT
+     * statement, and carrying it over suppressed the next line's cast as well:
+     * one annotation disarmed two assertions, the second of which nobody had
+     * looked at. A comment on the assertion's OWN line is kept either way —
+     * trailing is how an inline annotation is normally spelled.
+     */
+    if (distance === 1) {
+      const before = sourceCode.getTokenBefore(comment, {
+        includeComments: true,
+      });
+      if (before && before.loc.end.line === comment.loc.start.line) continue;
+    }
+
+    const commentText = comment.value.toLowerCase();
+    if (explanatoryPatterns.some((pattern) => pattern.test(commentText))) {
+      return true;
     }
   }
 

--- a/packages/eslint-plugin-reliability/src/tests/reliability/no-unsafe-type-narrowing.test.ts
+++ b/packages/eslint-plugin-reliability/src/tests/reliability/no-unsafe-type-narrowing.test.ts
@@ -115,6 +115,7 @@ const value = input as unknown as Result;`,
         },
         // Allow with "safe" comment
         {
+          name: 'a "safe" comment one line above whitelists the cast',
           code: `// safe - validated above
 const value = data as unknown as User;`,
           filename: 'src/utils.ts',
@@ -122,6 +123,7 @@ const value = data as unknown as User;`,
         },
         // Allow with "known" comment
         {
+          name: 'a "known" comment one line above whitelists the cast',
           code: `// known to be this type
 const value = data as unknown as Config;`,
           filename: 'src/utils.ts',
@@ -129,6 +131,7 @@ const value = data as unknown as Config;`,
         },
         // Allow with "intentional" comment
         {
+          name: 'an "intentional" comment one line above whitelists the cast',
           code: `// intentional double assertion
 const value = data as unknown as string;`,
           filename: 'src/utils.ts',
@@ -195,6 +198,7 @@ const value = data as unknown as string;`,
         },
         // allowWithComment = false ignores comments
         {
+          name: 'allowWithComment false ignores an otherwise-valid comment',
           code: `// intentional
 const value = data as unknown as string;`,
           filename: 'src/utils.ts',
@@ -203,6 +207,7 @@ const value = data as unknown as string;`,
         },
         // Comment too far from assertion (more than 1 line away)
         {
+          name: 'a comment more than one line above does not whitelist the cast',
           code: `// intentional
 
 
@@ -213,7 +218,42 @@ const value = data as unknown as string;`,
         },
         // No comment at all with allowWithComment
         {
+          name: 'allowWithComment true still reports an uncommented cast',
           code: `const value = data as unknown as string;`,
+          filename: 'src/utils.ts',
+          options: [{ allowWithComment: true }],
+          errors: [{ messageId: 'unsafeTypeNarrowing' }],
+        },
+        // Comment BELOW the assertion, at any distance, must not whitelist it.
+        // burgee packages/burgee/src/yargs/factory.ts:167-170, disarmed by the
+        // comment at factory.ts:1155 — 988 lines further down the file.
+        {
+          name: 'a comment below the assertion does not whitelist it',
+          code: `const value = data as unknown as string;
+
+
+
+// intentional`,
+          filename: 'src/utils.ts',
+          options: [{ allowWithComment: true }],
+          errors: [{ messageId: 'unsafeTypeNarrowing' }],
+        },
+        // "unknown" contains "known" but grants no permission — and it is the word
+        // most likely to appear next to an `as unknown as T` cast.
+        // burgee packages/burgee/src/yargs/factory.ts:1155
+        {
+          name: '"unknown" in a comment is not the keyword "known"',
+          code: `// version reads 'unknown' when no package.json is above
+const value = data as unknown as string;`,
+          filename: 'src/utils.ts',
+          options: [{ allowWithComment: true }],
+          errors: [{ messageId: 'unsafeTypeNarrowing' }],
+        },
+        // "unsafe" contains "safe" but is the opposite of consent.
+        {
+          name: '"unsafe" in a comment is not the keyword "safe"',
+          code: `// WARNING: this cast is unsafe and must be removed
+const value = data as unknown as string;`,
           filename: 'src/utils.ts',
           options: [{ allowWithComment: true }],
           errors: [{ messageId: 'unsafeTypeNarrowing' }],
@@ -261,14 +301,18 @@ const value = data as unknown as string;`,
     });
   });
   describe('Double assertions through concrete types', () => {
-    ruleTester.run('inner assertion to a concrete type is safe', noUnsafeTypeNarrowing, {
-      valid: [
-        // Double assertion whose inner type is neither unknown nor any —
-        // TSC checks this normally, the rule stays silent
-        { code: 'const y = x as string as number;', filename: 'src/app.ts' },
-      ],
-      invalid: [],
-    });
+    ruleTester.run(
+      'inner assertion to a concrete type is safe',
+      noUnsafeTypeNarrowing,
+      {
+        valid: [
+          // Double assertion whose inner type is neither unknown nor any —
+          // TSC checks this normally, the rule stays silent
+          { code: 'const y = x as string as number;', filename: 'src/app.ts' },
+        ],
+        invalid: [],
+      },
+    );
   });
 
   // ---------------------------------------------------------------------
@@ -277,15 +321,20 @@ const value = data as unknown as string;`,
 
   describe('Layer 2: options null fallback', () => {
     it('does not report a safe assertion when options is null', () => {
-      const { listeners, reports } = createWithMockContext(noUnsafeTypeNarrowing, {
-        options: [null],
-      });
+      const { listeners, reports } = createWithMockContext(
+        noUnsafeTypeNarrowing,
+        {
+          options: [null],
+        },
+      );
       const node = {
         type: 'TSAsExpression',
         expression: { type: 'Identifier', name: 'x' },
         typeAnnotation: { type: 'TSNumberKeyword' },
       } as unknown as TSESTree.TSAsExpression;
-      (listeners['TSAsExpression'] as (n: TSESTree.TSAsExpression) => void)(node);
+      (listeners['TSAsExpression'] as (n: TSESTree.TSAsExpression) => void)(
+        node,
+      );
       expect(reports).toHaveLength(0);
     });
   });

--- a/packages/eslint-plugin-reliability/src/tests/reliability/no-unsafe-type-narrowing.test.ts
+++ b/packages/eslint-plugin-reliability/src/tests/reliability/no-unsafe-type-narrowing.test.ts
@@ -92,6 +92,14 @@ describe('no-unsafe-type-narrowing', () => {
 
     ruleTester.run('options - allowWithComment', noUnsafeTypeNarrowing, {
       valid: [
+        {
+          name: 'a trailing comment annotates the cast on its own line',
+          // Trailing is how an inline annotation is normally spelled; the
+          // escape hatch has to recognise it or it is not an escape hatch.
+          code: `const value = data as unknown as User; // safe - validated above`,
+          filename: 'src/utils.ts',
+          options: [{ allowWithComment: true }],
+        },
         // Allow with "type guard" comment
         {
           code: `// type guard validated
@@ -188,6 +196,19 @@ const value = data as unknown as string;`,
         },
       ],
       invalid: [
+        {
+          name: 'a comment trailing one cast does not whitelist the next',
+          /*
+           * The annotation belongs to line 1. Reading it as "the line above" for
+           * line 2 let one `// safe` disarm two assertions, and the second was
+           * one nobody had looked at.
+           */
+          code: `const a = x as unknown as A; // safe
+const b = y as unknown as B;`,
+          filename: 'src/utils.ts',
+          options: [{ allowWithComment: true }],
+          errors: [{ messageId: 'unsafeTypeNarrowing' }],
+        },
         // allowWithComment = true but no valid comment
         {
           code: `// random comment


### PR DESCRIPTION
Automated FP/FN sweep of the Interlace plugins against the [burgee](https://github.com/ofri-peretz/burgee) corpus.

**1,941 findings across 55 rules** were screened. After discarding style/opinion rules, the monorepo `no-unresolved` artifact and everything already in `seen.json`, **356 fresh findings across 8 plugins** went to per-plugin hunters. Every candidate was minimized to a standalone snippet, reproduced mechanically against the single rule in isolation, then handed to a **second agent that saw only the snippet and the rule's docs** and was told to argue the finding was wrong. Six survived.

---

## 1. `reliability/no-unsafe-type-narrowing` — FN

**Burgee:** `packages/burgee/src/yargs/factory.ts:167-170`, disarmed by the comment at `factory.ts:1155` — 988 lines below.

```ts
declare const raw: object;
const a = raw as unknown as string;

// no package.json above: version reads 'unknown', as upstream
export const b = a;
```

`[]` → 1 report. `[{ "allowWithComment": true }]` → **0 reports**. Reword the comment to drop the word `unknown` and the report comes back.

Two compounding defects. The keyword list matches `/known/i`, which is a substring of **unknown** — the word most likely to appear next to an `as unknown as T` cast — and `/safe/i`, which is a substring of **unsafe**, so a comment *condemning* a cast whitelists it. Separately the proximity check had no lower bound:

```js
if (comment.loc && nodeStart.line - comment.loc.end.line <= 1) {
```

For a comment *below* the node that subtraction is negative, so `<= 1` holds at any distance. One trailing comment silences every assertion above it.

**Contract violated** — the rule's own tests pin `// intentional` two lines above as still reporting (`'a comment more than one line above does not whitelist the cast'`), while the implementation accepts the same comment from 61 lines below. The docs say `**No configuration options available.**` while two options ship in `meta.schema`; the tests are the tighter pin, and the implementation contradicts them.

**Fix** — word-bound both keywords, add the lower bound. `// known to be this type` and `// safe - validated above` still whitelist, exactly as their pinned fixtures require.

**Fixtures** — 3 added, all failed before the fix (`Should have 1 error but had 0`), all pass after. 565/565 green, 100% branch coverage.

---

## 2. `import-next/enforce-import-order` — FP (fixer)

**Burgee:** `apps/docs/.source/server.ts:1` — a generated file whose `// @ts-nocheck` header sits above 11 imports.

```ts
// @ts-nocheck
import z from "./z";
import a from "./a";
export { z, a };
```

`--fix` →

```ts
import a from "./a";
// @ts-nocheck
import z from "./z";
export { z, a };
```

TypeScript honours `@ts-nocheck` only before the first statement. The output still parses and lints clean — `--- REMAINING --- []` — so nothing surfaces; type checking is just silently switched back on. The verifier confirmed with `tsc` in both directions: a `.ts` file with `@ts-nocheck` goes exit 0 → `TS2322`, and a `.js` file with `@ts-check` goes `TS2322` → **exit 0**, silently losing type coverage. `@ts-check` and `/// <reference types="node" />` are affected identically.

**Contract violated** — `docs/rules/enforce-import-order.md:4`: "💡 This rule is automatically fixable by the `--fix` CLI option." Nothing disclaims comment or pragma movement; `docs/KNOWN-LIMITATIONS.md` does not mention this rule. The rule already carries the principle in its own source, from the hashbang fix (#942): *"A hashbang is not a statement and cannot be reordered, so it is simply never part of an import's range."* A pragma is equally not a statement and equally position-fixed — this was an incomplete carve-out, not a considered exclusion.

**Fix** — pin `@ts-nocheck` / `@ts-check` / `/// <reference>` alongside the hashbang. Pattern-based, not positional: an explanatory comment written for a specific import still travels with it (pinned by a third fixture).

**Fixtures** — 3 added, all failed before (`Output is incorrect`), all pass after. 1418/1418 green.

---

## 3. `import-next/no-internal-modules` — FP (fixer) + crash

**Burgee:** `apps/docs/.source/server.ts:2` and 9 more lines in that file.

```ts
import * as m from '../content/docs/x.mdx';   // --fix → import * as m from '.';
```

`getRootImport` returns `'.'` for anything starting `./` or `../`. But `'.'` is the current file's own directory index, not the package root — a different module — and `--- REMAINING --- []`, so the swap leaves no report behind. The verifier resolved all three paths on disk: original → the real target, autofixed → the current-dir index, nearest ancestor → the src index.

Second defect, same rule:

```js
const get = require(`lodash/fp/get`);
// TypeError: Cannot read properties of undefined (reading 'range')
```

The `require()` visitor passes its argument through `staticString`, which by design accepts a no-substitution template literal. All three fixers then narrowed with `node.type === 'Literal' ? node : node.source` — `.source` is `undefined` on a template literal, `fixer.replaceText` throws, and the lint aborts for the whole file. Fix functions are evaluated at report time, so plain `verify` crashed too; `--fix` was not required. Reproduced independently under `@typescript-eslint/rule-tester` with no harness involved.

**Contract violated** — the rule prints `Fix: Import from "{{suggestedPath}}" instead of deep internal path` where `suggestedPath = getImportAtDepth(...)`, then writes `rootImport` — the fix contradicts the message the rule just printed. The existing autofix test pins a relative path only at `maxDepth: 0`, where `suggestedPath === rootImport === '.'`, so it cannot discriminate the bug. Detection deliberately opted into template literals via `staticString`; the fixers did not.

**Fix** — preserve the traversal prefix (`../..` for `../../a/b`; `./a/b/c` still → `'.'` as pinned), and resolve the specifier node by checking for `.source` rather than narrowing on `Literal`.

**Fixtures** — 3 added; two failed with `Output is incorrect`, one with the verbatim `TypeError`. All pass after. 1418/1418 green, 100% branch coverage.

---

## 4. `maintainability/nested-complexity-hotspots` — FP

**Burgee:** `packages/burgee/src/yargs-parser.ts:362` — reported at **"Nesting depth 12"** while sitting at indentation level 2. 36 of 42 findings for this rule were this.

```ts
for (const arg of args) {
  if (arg === '-a') take('a');
  else if (arg === '-b') take('b');
  else if (arg === '-c') take('c');
  else if (arg === '-d') take('d');   // → "Nesting depth 5 exceeds maximum 4"
  else if (arg === '--') break;       // → "Nesting depth 6 exceeds maximum 4"
  else take('x');
}
```

ESTree models `else if` as an `IfStatement` in the parent's `alternate`, and the ancestor walk counted every one, so a flat chain climbed a level per branch.

**Contract violated** — the message asserts `Nesting depth {{depth}} exceeds maximum {{max}}` and the schema documents `maxDepth` as "Maximum nesting depth". ESLint core's `max-depth` — the definition of that term in this ecosystem — excludes `else if` explicitly (`isElseIf`, `max-depth.js:127-164`); run with `{max: 4}` on the guard-chain case it reports zero. The sibling rule in this same plugin already carries `// else if doesn't increase nesting` (`cognitive-complexity.ts:172-179`) and its docs split the two axes. And the rule was flagging the exact shape its own fix text — *"Use early returns, guard clauses, or extract methods"* — tells you to produce.

The docs page for this rule is an unfilled template, which is a real objection: if the docs promise nothing there is nothing to contradict. It does not hold — `meta.messages` and `meta.schema` are shipped contract text read at the point of violation, and "Nesting depth 6" is a false statement about the user's code. (The stub docs are a separate defect; 4 of 12 docs in this plugin are stubs, 8 are filled.)

**Fix** — skip the increment when the child is the parent `IfStatement`'s `alternate`, mirroring core's `isElseIf`. Genuine nesting inside an `else if` branch still accumulates; the verifier diffed old vs new metrics on a triple-loop buried in an `else if` and the hotspot is still caught, now reported at the actual deepest point instead of twice.

**Fixtures** — 2 added, both failed before (`Should have no errors but had 2` / `had 1`), both pass after. **Burgee: 42 → 6 findings.**

---

## 5. `maintainability/consistent-function-scoping` — FP ×2

**Burgee:** `packages/burgee/src/commander/command.ts:1753` (destructuring) and `:1509` (`this`), the latter covering 10 of 34 findings.

```ts
function prepare(opts) {
  const { out } = opts;
  const sink = {};
  if (out) sink.write = (s) => out.write(s);   // ← REPORTED
  return sink;
}
```

Control: replace `const { out } = opts` with `const out = opts.out` and the report disappears. The scope tracker recorded only `decl.id.type === 'Identifier'`, so every `ObjectPattern` / `ArrayPattern` was invisible — as were destructured parameters.

```ts
class C {
  setChoices(values) {
    this.choices = values;
    this.parseArg = (arg) => {                 // ← REPORTED
      if (!this.choices.includes(arg)) throw new Error('bad');
      return arg;
    };
  }
}
```

**Contract violated** — the message says *"Function can be moved to higher scope as it doesn't capture outer variables"*, and the verifier ran ESLint's own scope manager on the first snippet: the arrow's `through` set is `['out -> resolved=out@FunctionDeclaration']`. The message asserts something the parser contradicts. Performing the suggested move gives `TS2304: Cannot find name 'out'` in the first case and `TS2532` / a runtime `TypeError` in the second. Nothing in `docs/KNOWN-LIMITATIONS.md` disclaims either; no fixture pins either shape.

The `this` half has a defensible loophole — `this` is not literally a *variable* — but the rule already exempts `MethodDefinition` / `PropertyDefinition` with the comment *"these are bound to the instance and cannot be moved to module scope"*. That exemption never reached an arrow nested *inside* a method, so the rule was exactly backwards on its own axis: silent on methods that never touch `this`, reporting on arrows that do.

**Fix** — collect names from every binding pattern; exempt arrows that reference `this`. Arrows only — a nested `function` declaration's `this` is dynamic, so hoisting it and keeping `.call(this)` compiles and runs, and that report stays (pinned by a new invalid fixture).

**Fixtures** — 8 added, 4 failed before the fix, all pass after. **Burgee: 34 → 22 findings.** 563/563 green, 100% branch coverage.

---

## 6. `operability/no-console-log` — FP (fixer)

**Burgee:** `packages/burgee/src/yargs/factory.ts:1034` — the only finding this rule produced on burgee, and its fix is destructive.

```ts
if (out !== undefined) out.write('x');
else if (!hasCb()) console.log(...args);
this.hasOutput = true;
```

`--fix` (default `strategy: 'remove'`) →

```ts
if (out !== undefined) out.write('x');
else if (!hasCb()) 
this.hasOutput = true;
```

`this.hasOutput = true` now runs only when `out === undefined && !hasCb()`. On the real burgee file `#hasOutput` is read by a public getter and gates the whole help/validation path at `factory.ts:1687`. The output parses, `tsc --noEmit --strict` exits 0, and `--- REMAINING --- []` — the corruption is completely silent, in a `--fix` the docs recommend running in CI.

The verifier found it is broader than the braceless case. `findParentStatement` climbs to the nearest `ExpressionStatement`, `ReturnStatement` **or** `VariableDeclaration`:

```ts
if (cond) { return console.log('early'); }   // → the whole return is deleted, danger() now runs
export const myLogger = {
  debug: (m) => console.log(m),
  info: (m) => process.stdout.write(m),      // → the entire exported object is deleted
};
```

`strategy: 'comment'` shares the statement-level replace and shares the bug — and it is the phase the docs name as **Phase 1 "Discovery"**, the least invasive step.

**Contract violated** — `docs/rules/no-console-log.md`: `| **Auto-Fix** | ✅ Yes (4 strategies: remove, convert, comment, warn) |` and `| 🗑️ **remove** | Deletes statement | Production cleanup |`, with the CI section prescribing `npm run lint -- --fix`. No disclaimer, no KNOWN-LIMITATIONS entry — and the doc does carry a `## Known False Negatives` section, so limitations are documented here when they are known. "Deletes statement" is also simply false for the exported-object case. `fixable: 'code'` with `hasSuggestions: false` means there is no opt-in gate at all. The tests pin the wrong mental model explicitly: *"console.log() is always part of an ExpressionStatement"* — contradicted by the two other node types `findParentStatement` matches.

**Fix** — `remove` and `comment` fix only when the statement is exactly the `console.log` call and sits in a statement list; otherwise they return `null`. The report is unchanged; only the automatic rewrite is withheld. `convert` and `warn` replace the callee only and were never affected.

**Fixtures** — 5 added, all failed before, all pass after. 143/143 green, 100% branch coverage.

---

## Verification

- Every fixture was confirmed **failing before** its fix and passing after; the exact failure text is quoted per finding above.
- Full suites for all four touched packages: **reliability 565, import-next 1418 (+2 skipped), maintainability 563, operability 143** — all green at **100% statement / branch / function / line coverage**.
- Sweep re-run on burgee: `consistent-function-scoping` 34 → 22, `nested-complexity-hotspots` 42 → 6. **No rule started firing that was not firing before, and no rule's count increased.** The four fixer/option-path fixes correctly leave report counts unchanged under the sweep's default config.
- The three burgee anchors that changed counts were confirmed individually cleared, and `// @ts-nocheck` was confirmed surviving `--fix` on the real `apps/docs/.source/server.ts`.

## Screened and rejected

| Rule | Direction | Burgee | Why rejected |
| --- | --- | --- | --- |
| `secure-coding/no-improper-type-validation` | FP | `commander/command.ts:538` | **Rejected in adversarial verification.** Claim was that `typeof x === 'object' && x instanceof Option` should suppress. The docs list `instanceof` as a *hazard* ("Cross-realm `instanceof` failures") and never as a suppressing guard; the ✅ Correct block offers only `!== null` and `Array.isArray`. Verified in node that `Symbol.hasInstance` defeats the null half and `class X extends Array` the array half, so the gap is not soundly closable. Same family as `FALSE-POSITIVE-CATALOGUE.md` class C, which the message's own hedge discloses. |
| `react-features/jsx-no-literals`, `no-inline-style`, `no-raw-color-literal` | — | 13 findings | **All true positives.** AST inventory of `apps/docs`: 6 non-whitespace `JSXText` nodes exist and all 6 reported; 4 `style={{…}}` exist and all 4 reported; the 11 unreported colour literals sit in identifier-bound objects, which the docs explicitly excuse. |
| `reliability/no-unsafe-type-narrowing` | FP | 21 findings | **All true positives** — every one a literal `as unknown as T`, nothing the docs exempt. |
| `import-next` style rules (`no-internal-modules` reports, `no-relative-parent-imports`, `exports-last`, `no-namespace`, `no-barrel-file`, `no-unassigned-import`, `no-named-default`) | — | 116 findings | Firing is the design. Only the fixer defects above qualified. |
| `maintainability/no-unhandled-promise` | FP | `factory.ts:885,893` | True positives — genuine unowned `.then()` chains. The ~30 other `.then(` sites in burgee are returned or use the two-argument rejection form, and the rule is correctly silent on each. |

## Confirmed but deferred — over this run's 6-finding cap

Recorded in `seen.json` so the next run picks them up rather than re-litigating:

- **`secure-coding/no-improper-type-validation` — FN**, `packages/burgee/src/yargs/usage.ts:422`. `switch (typeof x) { case 'object': }` is invisible; only `BinaryExpression` and `MemberExpression` are visited. Adversarially **confirmed**: the docs' "Known False Negatives" names three unrelated categories, `SEAL.json` declares `"knownGaps": []`, and `tsc` emits the identical `TS18047` on both forms. The verifier measured the fix cost on 209 real sources — ~70 new reports against 3,214 the rule already emits there, so it is not a flood. **Deferred because the fix needs statement-level flow analysis** (the guard lives in the case body, not an `&&` chain), which is not the narrow change this routine ships.
- **`conventions/prefer-dependency-version-strategy` — FP**, `packages/compat-oracle/src/registry.test.ts:149`. Autofixes arbitrary TS object literals whose values are all specifier-shaped: dist-tag maps, IP-address maps, firmware version maps, and the expected value of a test assertion all get `^` prepended. Adversarially **confirmed and escalated** — the verifier found the rule fires **zero** times on `package.json` under its own documented config, because `jsonc-eslint-parser` emits `JSONObjectExpression`/`JSONProperty` and the rule's selectors are `ObjectExpression`/`Property`. Its documented scope is dead and its only live scope is undocumented. **Deferred because the primary fix — JSON AST support — is a feature, not a narrow correction**, and the interim options (downgrade the bare-object path to suggestions, or gate on filename) are a maintainer's call.
- `maintainability/cognitive-complexity` — a 20-case `switch` scores 1 against a documented `+1 per case`, so switch dispatchers are effectively exempt; and nested-function complexity is charged to the enclosing function *and* reported again on the nested one, contradicting this plugin's own KNOWN-LIMITATIONS. `flagstaff/src/cli-table3.ts:793` is reported at 52/15 for a body of exactly `return <arrow>;`.
- `import-next/exports-last` — FP, `packages/flagstaff/src/ora.ts:681`. `export default function` is reported with no non-export statement anywhere in the file; the `ExportNamedDeclaration` exemption was never extended to `ExportDefaultDeclaration`.
- `conventions/filename-case` — FP, `apps/docs/source.config.ts:1` and 10 `vitest.config.ts` files. Emits `Rename file from "vitest.config.ts" to "vitest.config.ts"` — only the final extension is stripped — and every suggestion has a `null` fixer, so ESLint discards all of them despite `hasSuggestions: true`.
- `conventions/require-data-testid` — FN, `apps/docs/src/app/(home)/page.tsx:20`. The docs' own ❌ example `<MyButton>Go</MyButton>` is not reported: an undocumented `componentRequiresHandler` defaults to `true` and skips every PascalCase component without an `on*` prop.
- `reliability/error-message` — FN. `new Error('')` reports, `` new Error(``) `` does not; the emptiness test is gated on `Literal`.
- `react-features/no-raw-color-literal` — FP. Every `#` + 3–8 hex chars in *any* JSX attribute is called a colour, so `title="tracked in #1234"` and `href="/docs#facade"` report. Probe-reproduced, no burgee instance.

## Docs gaps noted, no behaviour changed

Per the routine's rule that an ambiguous contract is not a confirmed finding:

- `import-next` — `scripts/generate-docs.ts` hardcodes "automatically fixable by `--fix`" into every rule doc regardless of `meta.fixable`; **41 of 55** rule docs promise a fixer that does not exist, using the suggestions emoji (💡) rather than the fixable one (🔧).
- `reliability/no-unsafe-type-narrowing` — docs say "No configuration options available" while `ignoreInTests` (default `true`, silently exempting 6 further burgee `as unknown as` sites) and `allowWithComment` both ship.
- `maintainability` — `max-parameters.md` and `nested-complexity-hotspots.md` are unfilled templates claiming no options while their schemas expose three each; `max-parameters`' `ignoreConstructors` matches a capitalized `FunctionDeclaration` name so it never exempts a real class constructor.
- `operability/no-console-log` — `ignoreNonProductionPaths` defaults to `true` and is absent from the options table, silently exempting `scripts/`, `tools/`, `benchmarks/`, `examples/`, `fixtures/`.
- `secure-coding/no-improper-type-validation` — the message names arrays as half the hazard and prescribes `!Array.isArray(value)`, but a null guard alone suppresses; `packages/flagstaff/src/plugin.ts:145` is a `x is JsonSchema` predicate that accepts arrays, plus 8 more sites of that shape. The docs' ✅ block and a pinned `valid` fixture both bless the null-only guard, so the behaviour is deliberate and the message over-promises.

## Sweep health

189 `Parsing error` messages, all in files outside burgee's tsconfig — 175 in `packages/compat-oracle/vendor`, plus generated `.source/` files and `vitest.config.ts` / `*.config.mjs`. The routine's sanity gate exists to catch the parser failing to load and falling back to espree, which corrupts the whole corpus; that did not happen here — type-aware rules (`no-unsafe-type-narrowing`, `no-improper-type-validation`, `no-unhandled-promise`) all fired normally. Those files were excluded from analysis rather than aborting the run. Flagging the deviation from the gate's literal "ANY" wording explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Import ordering now preserves TypeScript directives, reference comments, and hashbangs while moving imports.
  - Internal module autofixes preserve relative parent paths and safely handle template-literal `require` calls.
  - Function-scoping analysis better supports destructured bindings and arrows that capture `this`.
  - Nested complexity no longer incorrectly counts flat `else if` chains.
  - Console-log autofixes avoid unsafe control-flow changes.
  - Type-narrowing comments now require precise wording and placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->