### PR TITLE
chore(docs): sync generated data

### DIFF
--- a/apps/docs/src/data/changelog.json
+++ b/apps/docs/src/data/changelog.json
@@ -1,7 +1,7 @@
 {
-  "releaseCount": 661,
+  "releaseCount": 670,
   "packageCount": 35,
-  "entryCount": 2055,
+  "entryCount": 2075,
   "oldestYear": 2024,
   "releases": [
     {
@@ -16645,6 +16645,76 @@
       ]
     },
     {
+      "package": "eslint-plugin-conventions",
+      "short": "eslint-plugin-conventions",
+      "version": "6.0.0",
+      "date": null,
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "breaking",
+          "title": "`consistent-existence-index-check` defaults to `Object.hasOwn`, not `in`",
+          "pr": null
+        },
+        {
+          "kind": "fix",
+          "title": "`consistent-existence-index-check` will not splice a sequence expression",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-import-next",
+      "short": "eslint-plugin-import-next",
+      "version": "2.7.8",
+      "date": null,
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "`consistent-type-specifier-style` no longer deletes a default import",
+          "pr": null
+        },
+        {
+          "kind": "fix",
+          "title": "`enforce-import-order`'s fixer no longer moves `@ts-nocheck` below an import",
+          "pr": null
+        },
+        {
+          "kind": "fix",
+          "title": "`default` no longer reports default imports of `export =` / CJS-interop modules",
+          "pr": null
+        },
+        {
+          "kind": "fix",
+          "title": "`no-internal-modules` keeps parent traversal, and no longer crashes on a template-literal `require`",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-jwt-security",
+      "short": "eslint-plugin-jwt-security",
+      "version": "3.3.0",
+      "date": null,
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "only `algorithms` counts as an algorithm whitelist, and a byte-wrapped secret is still a secret",
+          "pr": null
+        },
+        {
+          "kind": "feature",
+          "title": "cover jose's JWS-level verify entry points",
+          "pr": null
+        }
+      ]
+    },
+    {
       "package": "eslint-plugin-jwt-security",
       "short": "eslint-plugin-jwt-security",
       "version": "2.2.9",
@@ -16760,6 +16830,66 @@
         {
           "kind": "other",
           "title": "Ofri Peretz",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-maintainability",
+      "short": "eslint-plugin-maintainability",
+      "version": "3.2.6",
+      "date": null,
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "`consistent-function-scoping` sees destructured bindings and `this`",
+          "pr": null
+        },
+        {
+          "kind": "fix",
+          "title": "`nested-complexity-hotspots` no longer counts `else if` as a nesting level",
+          "pr": null
+        },
+        {
+          "kind": "fix",
+          "title": "`identical-functions` stops calling private accessors identical",
+          "pr": null
+        },
+        {
+          "kind": "fix",
+          "title": "`no-lonely-if` requires the `if` to actually be alone",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-node-security",
+      "short": "eslint-plugin-node-security",
+      "version": "5.5.0",
+      "date": null,
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "feature",
+          "title": "detect Diffie-Hellman and ECDH parameters below a safe strength",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-operability",
+      "short": "eslint-plugin-operability",
+      "version": "4.1.3",
+      "date": null,
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "`no-console-log`'s `remove` and `comment` strategies no longer change control flow",
           "pr": null
         }
       ]
@@ -16885,6 +17015,66 @@
         {
           "kind": "other",
           "title": "Ofri Peretz",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-react-features",
+      "short": "eslint-plugin-react-features",
+      "version": "1.7.5",
+      "date": null,
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "two rules that could not report anything",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-reliability",
+      "short": "eslint-plugin-reliability",
+      "version": "4.1.7",
+      "date": null,
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "`no-unsafe-type-narrowing`'s `allowWithComment` no longer disarms the whole file",
+          "pr": null
+        },
+        {
+          "kind": "fix",
+          "title": "two rules that could not report anything",
+          "pr": null
+        }
+      ]
+    },
+    {
+      "package": "eslint-plugin-secure-coding",
+      "short": "eslint-plugin-secure-coding",
+      "version": "5.4.0",
+      "date": null,
+      "isApp": false,
+      "isPrivate": false,
+      "entries": [
+        {
+          "kind": "fix",
+          "title": "`detect-object-injection` sees a copy loop keyed by `Object.keys`",
+          "pr": null
+        },
+        {
+          "kind": "fix",
+          "title": "`detect-object-injection` accepts an `as const` lookup table",
+          "pr": null
+        },
+        {
+          "kind": "fix",
+          "title": "`detect-object-injection` no longer flags `Object.assign(Object.create(null), source)`",
           "pr": null
         }
       ]

--- a/apps/docs/src/data/plugin-stats.json
+++ b/apps/docs/src/data/plugin-stats.json
@@ -13,7 +13,7 @@
       "rules": 43,
       "description": "ESLint plugin for Node.js security — detects command injection, path traversal, SSRF, zip slip, and weak crypto (MD5/SHA-1, ECB, static IV) in fs, child_process, vm, and crypto",
       "category": "security",
-      "version": "5.4.4",
+      "version": "5.5.0",
       "published": true
     },
     {
@@ -21,7 +21,7 @@
       "rules": 33,
       "description": "ESLint plugin for secure coding — detects LDAP, XPath, XXE, GraphQL and template injection, unsafe deserialization, ReDoS, missing authentication, and PII in logs",
       "category": "security",
-      "version": "5.3.5",
+      "version": "5.4.0",
       "published": true
     },
     {
@@ -45,7 +45,7 @@
       "rules": 13,
       "description": "ESLint plugin for JWT security — detects algorithm confusion (CVE-2022-23540), alg:none, weak or hardcoded secrets, and decode-without-verify",
       "category": "security",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "published": true
     },
     {
@@ -173,7 +173,7 @@
       "rules": 55,
       "description": "ESLint plugin for imports and module boundaries — drop-in replacement for eslint-plugin-import, 3.1x faster end-to-end, zero-config migration",
       "category": "architecture",
-      "version": "2.7.7",
+      "version": "2.7.8",
       "published": true
     },
     {
@@ -181,7 +181,7 @@
       "rules": 15,
       "description": "ESLint plugin for team code conventions — enforces filename case, magic-number bans, commented-out code, expiring TODOs, and deprecated-API usage",
       "category": "quality",
-      "version": "5.3.5",
+      "version": "6.0.0",
       "published": true
     },
     {
@@ -189,7 +189,7 @@
       "rules": 12,
       "description": "ESLint plugin for maintainable code — limits cognitive complexity, nesting depth, parameter counts, duplicate functions, and unhandled or silent errors",
       "category": "quality",
-      "version": "3.2.5",
+      "version": "3.2.6",
       "published": true
     },
     {
@@ -197,7 +197,7 @@
       "rules": 9,
       "description": "ESLint plugin for runtime reliability — enforces error handling, network timeouts, null checks, and safe type narrowing",
       "category": "quality",
-      "version": "4.1.6",
+      "version": "4.1.7",
       "published": true
     },
     {
@@ -213,7 +213,7 @@
       "rules": 6,
       "description": "ESLint plugin for production operability — bans debug code and console logging in production, verbose error messages, and process.exit calls",
       "category": "quality",
-      "version": "4.1.2",
+      "version": "4.1.3",
       "published": true
     },
     {
@@ -229,7 +229,7 @@
       "rules": 61,
       "description": "ESLint plugin for React — hooks, prop-types, JSX correctness, render performance, and class-to-hooks migration rules for modern React codebases",
       "category": "react",
-      "version": "1.7.4",
+      "version": "1.7.5",
       "published": true
     },
     {


### PR DESCRIPTION
Regenerated apps/docs/src/data/ (trigger: push). Opened by the Docs Data Sync workflow; contents come entirely from the apps/docs/scripts/sync-* scripts, so review the diff rather than hand-editing.