### PR TITLE
fix(ci): dispatch the drift gate on the PR that stales the generated output

### DIFF
--- a/.github/workflows/quality-full.yml
+++ b/.github/workflows/quality-full.yml
@@ -732,6 +732,20 @@ jobs:
       always() && (needs.gate.outputs.run == 'true'
       || needs.gate.result == 'failure' || needs.gate.result == 'cancelled')
     steps:
+      # Both reporting steps below are LOCAL actions (`uses: ./...`), and a
+      # local action is read off the workspace — without a checkout the runner
+      # cannot find it. This job had none, so from the day the push trigger
+      # landed until 2026-09-10 every alarm it declared failed with
+      # `Can't find 'action.yml' ... under .github/actions/report-failure`.
+      # main went red at 06:00 on the #964 merge and no issue was ever opened;
+      # the immediate detection this job's own comments describe had never once
+      # reached a human. `scripts/__tests__/local-action-needs-checkout.lock.test.ts`
+      # holds it. ~2s on every run, including the green ones — which is the
+      # price of the alarm being able to sound at all.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
       - name: Render gate report
         env:
           R_GATE: ${{ needs.gate.result }}
@@ -886,7 +900,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/report-failure
         with:
-          title: "Scheduled Quality (Full) job is failing"
+          title: 'Scheduled Quality (Full) job is failing'
           body: >-
             A job in the scheduled heavy gate did not complete, so the checks it owns are not running against main on their cadence.
           token: ${{ github.token }}

--- a/scripts/__tests__/generated-output-is-gated.lock.test.ts
+++ b/scripts/__tests__/generated-output-is-gated.lock.test.ts
@@ -5,6 +5,8 @@
  */
 
 /**
+ * @provenBy {"file": "scripts/lib/ci-shard-affected.mts", "find": "  const isSeed = (p: AffectedPkg) =>\n    touchedDirs.has(p.dir) || generated.has(p.name);", "replace": "  const isSeed = (p: AffectedPkg) => touchedDirs.has(p.dir);"}
+ *
  * A committed generated file is only guarded if its gate is DISPATCHED on the
  * PR that stales it.
  *

--- a/scripts/__tests__/generated-output-is-gated.lock.test.ts
+++ b/scripts/__tests__/generated-output-is-gated.lock.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * A committed generated file is only guarded if its gate is DISPATCHED on the
+ * PR that stales it.
+ *
+ * `rule-docs-sync-drift` compares every committed `.mdx` against a fresh
+ * generation from its `packages/<plugin>/docs/rules/<rule>.md` source, and it
+ * has always been correct. It just was not run. It lives in the `docs`
+ * workspace, the web lane selects workspaces from the manifest dependency
+ * graph, and `docs` declares no plugin — it reads the `.md` files off disk.
+ * So a PR editing only the source resolved to `0 web shards affected`.
+ *
+ * That is not a hypothetical. PR #964 (merged 2026-09-10 06:00) edited
+ * `consistent-existence-index-check.md` without regenerating the MDX, reported
+ * `Unit tests — 1 node + 0 web shards affected`, merged green, and left `main`
+ * red across three further merges until #969 at 06:31.
+ *
+ * The first two tests reconstruct exactly that file list. They fail on the
+ * unfixed `decideAffected` (`mode: 'none'` — nothing to test in the web lane).
+ *
+ * The rest guard the fix from rotting into decoration: a pattern that matches
+ * no path in the tree, or a consumer that no longer owns the check, would keep
+ * this file green while gating nothing.
+ */
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  decideAffected,
+  reverseDeps,
+  GENERATED_INPUTS,
+  type AffectedPkg,
+} from '../lib/ci-shard-affected.mts';
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '..', '..');
+
+/** PR #964's diff, verbatim. */
+const PR_964 = [
+  '.changeset/own-property-is-the-safer-default.md',
+  'packages/eslint-plugin-conventions/docs/rules/consistent-existence-index-check.md',
+  'packages/eslint-plugin-conventions/src/rules/conventions/consistent-existence-index-check.ts',
+  'packages/eslint-plugin-conventions/src/tests/conventions/consistent-existence-index-check.default.test.ts',
+  'packages/eslint-plugin-conventions/src/tests/conventions/consistent-existence-index-check.test.ts',
+  'packages/eslint-plugin-conventions/src/tests/conventions/coverage-completion.test.ts',
+];
+
+/** The two lanes, as the sharder derives them: `docs` is web, plugins are node. */
+const WEB_LANE: AffectedPkg[] = [
+  { name: 'docs', dir: 'apps/docs', deps: ['@interlace/ui'] },
+  { name: '@interlace/ui', dir: 'packages/ui', deps: [] },
+];
+const NODE_LANE: AffectedPkg[] = [
+  {
+    name: 'eslint-plugin-conventions',
+    dir: 'packages/eslint-plugin-conventions',
+    deps: [],
+  },
+];
+const UNIVERSE = [...WEB_LANE, ...NODE_LANE];
+
+describe('a rule .md change dispatches the workspace that renders it', () => {
+  it("selects `docs` in the web lane for PR #964's diff", () => {
+    const d = decideAffected(PR_964, WEB_LANE, reverseDeps(UNIVERSE), UNIVERSE);
+    expect(
+      d.mode === 'some' ? [...d.names] : `mode=${d.mode}`,
+      'PR #964 edited a rule .md without regenerating its MDX. If the web lane ' +
+        'resolves to anything but `docs`, rule-docs-sync-drift is not dispatched ' +
+        'and the stale MDX merges green — exactly what happened on 2026-09-10.',
+    ).toContain('docs');
+  });
+
+  it('selects `docs` even when the .md is the ONLY change', () => {
+    // The narrower case, and the one with no node-lane work to hide behind:
+    // a docs-only rewrite of a rule page.
+    const d = decideAffected(
+      [
+        'packages/eslint-plugin-conventions/docs/rules/consistent-existence-index-check.md',
+      ],
+      WEB_LANE,
+      reverseDeps(UNIVERSE),
+      UNIVERSE,
+    );
+    expect(d.mode === 'some' ? [...d.names] : `mode=${d.mode}`).toContain(
+      'docs',
+    );
+  });
+
+  it('does not widen the affected set for an unrelated package change', () => {
+    // The fix must cost nothing on the common PR. A plugin `src/` change still
+    // resolves to nothing in the web lane.
+    const d = decideAffected(
+      ['packages/eslint-plugin-conventions/src/rules/conventions/a.ts'],
+      WEB_LANE,
+      reverseDeps(UNIVERSE),
+      UNIVERSE,
+    );
+    expect(d.mode).toBe('none');
+  });
+});
+
+describe('the registry still describes the tree', () => {
+  it.each(GENERATED_INPUTS.map((g) => [String(g.pattern), g] as const))(
+    '%s matches at least one committed source file',
+    (_label, entry) => {
+      // A pattern that matches nothing is indistinguishable from coverage until
+      // the day it is needed. Hold it against the real tree, so moving
+      // `docs/rules/` (or renaming the extension) fails HERE rather than
+      // silently reopening the hole.
+      const hits: string[] = [];
+      const pkgs = path.join(REPO_ROOT, 'packages');
+      for (const pkg of fs.readdirSync(pkgs)) {
+        const dir = path.join(pkgs, pkg, 'docs', 'rules');
+        if (!fs.existsSync(dir)) continue;
+        for (const f of fs.readdirSync(dir)) {
+          const rel = `packages/${pkg}/docs/rules/${f}`;
+          if (entry.pattern.test(rel)) hits.push(rel);
+        }
+      }
+      expect(
+        hits.length,
+        `${entry.pattern} matched no file under packages/*/`,
+      ).toBeGreaterThan(0);
+    },
+  );
+
+  it('`docs` still owns the drift check the `docs` entry exists for', () => {
+    // The entry names a CONSUMER by workspace name. If the drift test moves out
+    // of apps/docs, seeding `docs` gates nothing and this entry needs updating.
+    expect(
+      fs.existsSync(
+        path.join(
+          REPO_ROOT,
+          'apps/docs/src/__tests__/rule-docs-sync-drift.test.ts',
+        ),
+      ),
+      'rule-docs-sync-drift.test.ts is no longer in apps/docs, so seeding the ' +
+        '`docs` workspace no longer dispatches it. Update GENERATED_INPUTS.',
+    ).toBe(true);
+  });
+});

--- a/scripts/__tests__/local-action-needs-checkout.lock.test.ts
+++ b/scripts/__tests__/local-action-needs-checkout.lock.test.ts
@@ -5,6 +5,8 @@
  */
 
 /**
+ * @provenBy {"file": ".github/workflows/quality-full.yml", "find": "      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1\n        with:\n          persist-credentials: false\n\n      - name: Render gate report", "replace": "      - name: Render gate report"}
+ *
  * A local action (`uses: ./...`) is read off the WORKSPACE. Without an
  * `actions/checkout` earlier in the same job the workspace is empty, and the
  * step dies with:

--- a/scripts/__tests__/local-action-needs-checkout.lock.test.ts
+++ b/scripts/__tests__/local-action-needs-checkout.lock.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2025 Ofri Peretz
+ * Licensed under the MIT License. Use of this source code is governed by the
+ * MIT license that can be found in the LICENSE file.
+ */
+
+/**
+ * A local action (`uses: ./...`) is read off the WORKSPACE. Without an
+ * `actions/checkout` earlier in the same job the workspace is empty, and the
+ * step dies with:
+ *
+ *   Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under
+ *   '.../.github/actions/report-failure'.
+ *
+ * `cron-alerting-shape.lock.test.ts` already asserts the alerting job GRAPH —
+ * that whatever can fail is reachable by something declaring a reporter. It
+ * reads the workflow as YAML, so a reporter step that is present and correctly
+ * wired reads as covered. It cannot see that the step is unable to execute.
+ *
+ * That gap was not theoretical. `quality-full.yml`'s `quality-full-gate` job
+ * declared two reporters — "Report a scheduled failure" and "Report a broken
+ * main" — and had no checkout, so both had ALWAYS failed. On 2026-09-10 the
+ * #964 merge turned main red at 06:00, `Report a broken main` fired, errored on
+ * the missing action, and no issue was opened. main stayed red across three
+ * further merges and was found by accident when an unrelated PR rebased onto
+ * it — the exact outcome the push trigger was added to prevent.
+ *
+ * Scanning every workflow, rather than pinning that one job, is deliberate:
+ * the defect is invisible on green runs (the step never executes) and only
+ * surfaces in the failure path, which is where nobody is looking.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { parse } from 'yaml';
+
+const WORKFLOWS = resolve(import.meta.dirname, '..', '..', '.github/workflows');
+
+type Step = { uses?: unknown; name?: unknown };
+type Job = { steps?: Step[]; uses?: unknown };
+
+describe('a local action can be resolved by the job that uses it', () => {
+  const files = readdirSync(WORKFLOWS).filter((f) => f.endsWith('.yml'));
+
+  it('finds the workflows', () => expect(files.length).toBeGreaterThan(10));
+
+  it.each(files)('%s', (file) => {
+    const doc = parse(readFileSync(join(WORKFLOWS, file), 'utf8')) as {
+      jobs?: Record<string, Job>;
+    };
+    const orphans: string[] = [];
+
+    for (const [id, job] of Object.entries(doc.jobs ?? {})) {
+      // A reusable-workflow call has no steps of its own to order.
+      if (typeof job.uses === 'string') continue;
+      let checkedOut = false;
+      for (const step of job.steps ?? []) {
+        const uses = typeof step.uses === 'string' ? step.uses : '';
+        if (uses.startsWith('actions/checkout')) checkedOut = true;
+        else if (uses.startsWith('./') && !checkedOut) {
+          orphans.push(`${id} › ${step.name ?? uses} (${uses})`);
+        }
+      }
+    }
+
+    expect(
+      orphans,
+      `${file}: local action(s) used with no actions/checkout earlier in the ` +
+        `same job. The runner reads \`uses: ./...\` off the workspace, so these ` +
+        `steps cannot execute — they fail with "Can't find 'action.yml'". Add a ` +
+        `checkout as the job's first step.`,
+    ).toEqual([]);
+  });
+});

--- a/scripts/lib/ci-shard-affected.mts
+++ b/scripts/lib/ci-shard-affected.mts
@@ -27,6 +27,34 @@ export const GLOBAL_INPUTS = new Set([
   'scripts/lib/ci-changed-files.mts',
 ]);
 
+/**
+ * Cross-workspace edges the manifests cannot express, because they are
+ * GENERATION edges rather than dependency edges.
+ *
+ * `apps/docs` renders every `packages/<plugin>/docs/rules/<rule>.md` into a
+ * committed `.mdx`, and `rule-docs-sync-drift` (a `docs` test) fails the moment
+ * the two disagree. So `docs` genuinely depends on those `.md` files — but it
+ * declares no plugin in its manifest, and it never will: it reads the files off
+ * disk. `expandDependents` walks manifests, so it can never reach `docs` from a
+ * plugin, and the check that exists to catch stale generated output was not
+ * dispatched on the PR that staled it.
+ *
+ * PR #964 is the worked example. It edited
+ * `packages/eslint-plugin-conventions/docs/rules/consistent-existence-index-check.md`
+ * and did not regenerate the MDX. The web lane reported `0 web shards affected`,
+ * the drift test never ran, the PR merged green — and `main` was red from
+ * 06:00 through three further merges until #969. Nothing was wrong with the
+ * check; it was simply never asked.
+ *
+ * A generator whose output is committed and guarded belongs here. The lock in
+ * `scripts/__tests__/generated-output-is-gated.lock.test.ts` reconstructs #964
+ * and holds each pattern against a path that exists in the tree, so a pattern
+ * cannot rot into matching nothing while still looking like coverage.
+ */
+export const GENERATED_INPUTS: { pattern: RegExp; consumer: string }[] = [
+  { pattern: /^packages\/[^/]+\/docs\/rules\/[^/]+\.md$/, consumer: 'docs' },
+];
+
 /** Minimal shape needed here; both sharders' package types are compatible. */
 export type AffectedPkg = { name: string; dir: string; deps?: string[] };
 
@@ -120,9 +148,19 @@ export function decideAffected(
       .map((f) => f.split('/').slice(0, 2).join('/'))
       .filter((d) => /^(packages|apps|tools)\//.test(d)),
   );
-  const directly = testable.filter((p) => touchedDirs.has(p.dir));
+  // Consumers reached by a generation edge rather than a manifest one. Seeded
+  // BY NAME, before the closure runs, so `expandDependents` still picks up
+  // anything downstream of them. See GENERATED_INPUTS.
+  const generated = new Set(
+    GENERATED_INPUTS.filter((g) => changed.some((f) => g.pattern.test(f))).map(
+      (g) => g.consumer,
+    ),
+  );
+  const isSeed = (p: AffectedPkg) =>
+    touchedDirs.has(p.dir) || generated.has(p.name);
+  const directly = testable.filter(isSeed);
 
-  if (touchedDirs.size === 0)
+  if (touchedDirs.size === 0 && generated.size === 0)
     return { mode: 'none', why: 'no package sources changed' };
 
   // `bug` means the change is testable NOWHERE, not merely "not in this lane".
@@ -136,7 +174,7 @@ export function decideAffected(
   // `universe` is every testable package across all lanes; the anti-#355
   // protection is unchanged when measured against it. Defaults to `testable`,
   // so single-lane callers behave exactly as before.
-  const anywhere = (universe ?? testable).filter((p) => touchedDirs.has(p.dir));
+  const anywhere = (universe ?? testable).filter(isSeed);
   if (anywhere.length === 0) return { mode: 'bug', dirs: [...touchedDirs] };
 
   if (directly.length === 0)


### PR DESCRIPTION
## Summary

`rule-docs-sync-drift` compares committed `.mdx` against a fresh generation from `packages/<plugin>/docs/rules/<rule>.md`. It was never wrong — **it was never asked**. Two independent defects, both closed here.

**1. The gate was not dispatched on the PR that broke it.** The test lives in the `docs` workspace; the web lane selects workspaces from the manifest dependency graph; `docs` declares no plugin, because it reads those `.md` files off disk. So a PR editing only the source resolved to `0 web shards affected`.

[#964](https://github.com/ofri-peretz/eslint/pull/964) is the worked example — its checks list literally reads `Unit tests — 1 node + 0 web shards affected`, with `Unit Tests — web lane` skipping. It merged green at 06:00 and left `main` red across three further merges until [#969](https://github.com/ofri-peretz/eslint/pull/969), found only because an unrelated PR rebased onto `main`.

`GENERATED_INPUTS` in `scripts/lib/ci-shard-affected.mts` records the generation edges the manifests cannot express, and `decideAffected` seeds those consumers **by name** before the dependent closure runs. It costs nothing on the common PR: a plugin `src/` change still resolves to `none` in the web lane.

**2. The post-merge alarm could never fire.** `quality-full-gate` has no `actions/checkout`, so both of its reporting steps — including `🚨 Report a broken main`, whose own comment claims it turns *"broken until Sunday"* into *"broken for one merge"* — died with:

```
Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under
'/home/runner/work/eslint/eslint/.github/actions/report-failure'.
```

They had never once succeeded. The push-to-main detector worked perfectly on the #964 merge — it went red at 06:00 and could not speak, so no issue was opened. That is a separate hole from (1), and it is why nobody was told. ([run 34443326657](https://github.com/ofri-peretz/eslint/actions/runs/34443326657))

## Test plan

Both locks were **proven red on the unfixed state** before the fix was applied.

- [x] `scripts/__tests__/generated-output-is-gated.lock.test.ts` replays #964's exact six-file diff. Against the pre-fix seeding:

  ```
  AssertionError: PR #964 edited a rule .md without regenerating its MDX. …
    expected 'mode=none' to contain 'docs'
  ```

  — literally the `0 web shards affected` CI reported that morning. It also holds every pattern against a path that exists in the tree, so a pattern cannot rot into matching nothing while still reading as coverage, and asserts the drift test still lives in `apps/docs` (the premise for naming `docs` as the consumer).

- [x] `scripts/__tests__/local-action-needs-checkout.lock.test.ts` scans **every** workflow for `uses: ./...` with no checkout earlier in the same job. Against the pre-fix `quality-full.yml` it names both dead reporters:

  ```
  + "quality-full-gate › 🚨 Report a scheduled failure (./.github/actions/report-failure)",
  + "quality-full-gate › 🚨 Report a broken main (./.github/actions/report-failure)",
  ```

  `cron-alerting-shape.lock.test.ts` already asserts the alerting *graph*, but a step that is present and correctly wired reads as covered — it cannot see that the step is unable to execute. The defect is invisible on green runs and only surfaces in the failure path, which is where nobody is looking, so this scans repo-wide rather than pinning the one job.

- [x] `npm run test:scripts` — 140 files, 2642 tests, all green with the fix.
- [x] No changeset: no `packages/*/src` or `package.json` change.

## Not added

A lefthook check for "generator source staged without its output". Once the PR gate actually runs the drift test it is redundant, and a pre-commit hook is bypassable in a way a required check is not.

## After merge

`Quality (Full)` on push to `main` can finally open its tracking issue. Watch for `main is red — the full quality gate failed after a merge` — if one appears, that is the alarm working for the first time, not a new break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Documentation rule changes now correctly trigger the appropriate documentation checks, helping detect synchronization issues.
  * Quality checks using local workflow actions now reliably access the required workspace files.

* **Tests**
  * Added coverage to verify documentation change detection and ensure workflow jobs check out repository contents before using local actions.
  * Added validation that generated documentation inputs remain connected to their required checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->